### PR TITLE
feat(mongoose): export types

### DIFF
--- a/packages/mongoose/types.js
+++ b/packages/mongoose/types.js
@@ -1,0 +1,3 @@
+const mongoose = require('mongoose');
+
+module.exports = mongoose.Schema.Types;


### PR DESCRIPTION
For validation in models schemas, you can import mongoose.Schema.Types as:

const types = require('@usehenri/mongoose/types');