### PR TITLE
Release pipeline with changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,11 +1,35 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": [
+    "@changesets/changelog-github",
+    {
+      "repo": "usehenri/henri"
+    }
+  ],
   "commit": false,
-  "fixed": [],
+  "fixed": [
+    [
+      "henri",
+      "@usehenri/cli",
+      "@usehenri/core",
+      "@usehenri/disk",
+      "@usehenri/mongoose",
+      "@usehenri/mssql",
+      "@usehenri/mysql",
+      "@usehenri/postgresql",
+      "@usehenri/react",
+      "@usehenri/sequelize",
+      "@usehenri/testing",
+      "@usehenri/websocket"
+    ]
+  ],
   "linked": [],
   "access": "public",
   "baseBranch": "master",
   "updateInternalDependencies": "patch",
-  "ignore": ["@usehenri/demo"]
+  "ignore": [],
+  "privatePackages": {
+    "version": false,
+    "tag": false
+  }
 }

--- a/.changeset/revive-on-node-22.md
+++ b/.changeset/revive-on-node-22.md
@@ -1,0 +1,24 @@
+---
+'henri': major
+'@usehenri/cli': major
+'@usehenri/core': major
+'@usehenri/disk': major
+'@usehenri/mongoose': major
+'@usehenri/mssql': major
+'@usehenri/mysql': major
+'@usehenri/postgresql': major
+'@usehenri/react': major
+'@usehenri/sequelize': major
+'@usehenri/testing': major
+'@usehenri/websocket': major
+---
+
+Revive henri on a current toolchain. This is a breaking release.
+
+- Node.js 22 or newer is required.
+- `@usehenri/core`: Express 5, Apollo Server 5 with `@graphql-tools` (`henri.graphql.run()` returns `{ data, errors }`, Apollo error classes are `GraphQLError` subclasses), bcryptjs instead of native bcrypt, passport 0.7 (`req.logout` takes a callback), `henri.server.stop()` closes the server. Model globals are also written to `.henri/globals.json`.
+- `@usehenri/mongoose` and `@usehenri/disk`: Mongoose 9, connect-mongo 6, mongodb-memory-server 11. The disk store is a local MongoDB with on-disk persistence outside test mode.
+- `@usehenri/sequelize`, `@usehenri/mysql`, `@usehenri/postgresql`, `@usehenri/mssql`: Sequelize 6 latest with mysql2 3, pg 8 and tedious 20. The user model overload uses valid Sequelize options (`allowNull`, a `TEXT` roles column with a JSON getter/setter, `hasRole`, re-hash on `beforeUpdate`) and `start()` waits for `sync()`.
+- `@usehenri/react`: Next.js 16 (Turbopack) and React 19. `withHenri` exposes `HenriContext` and `useHenri()` instead of legacy context; forms get `useForm()` and `react-quill-new`. `next` is a peer dependency: apps must depend on `next`, `react` and `react-dom`. The `inferno` and `preact` renderers are gone; `config/next.js` can extend the Next.js config and `config/webpack.js` switches the bundler to webpack.
+- `@usehenri/cli` and `henri`: Node 22 check, prettier 3, `@inquirer/prompts`; `henri new` scaffolds a React 19 app with `next.config.js`, `jsconfig.json`, an ESLint flat config and a `pnpm-workspace.yaml` allowing the build scripts pnpm 10+ blocks.
+- `@usehenri/testing` and `@usehenri/websocket` load again; `@usehenri/mailer` is no longer published (the mailer lives in core).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,45 +2,74 @@ name: release
 
 # Changesets flow:
 # - a push to master with pending changesets opens/updates the "Version Packages" PR
-# - merging that PR publishes the bumped packages to npm and creates GitHub releases
+# - merging that PR publishes the bumped packages to npm (trusted publishing,
+#   environment "npm") and creates GitHub releases
 on:
   push:
     branches: [master]
 
 concurrency: release-${{ github.ref }}
 
-permissions:
-  contents: write
-  pull-requests: write
-  id-token: write
-
 jobs:
-  release:
+  select-mode:
     runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      mode: ${{ steps.select.outputs.mode }}
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+      - uses: changesets/action/select-mode@v2
+        id: select
 
+  version:
+    needs: select-mode
+    if: needs.select-mode.outputs.mode == 'version'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
       - uses: jdx/mise-action@v4
         with:
           cache: true
-
       - run: pnpm install --frozen-lockfile
         env:
           MONGOMS_DISABLE_POSTINSTALL: '1'
-
-      - uses: changesets/action@v2
+      - uses: changesets/action/version@v2
         with:
-          version-script: pnpm changeset:version
-          publish-script: pnpm changeset:publish
+          script: pnpm changeset:version
           commit-message: 'chore(release): version packages'
           pr-title: 'chore(release): version packages'
-          create-github-releases: true
+
+  publish:
+    needs: select-mode
+    if: needs.select-mode.outputs.mode == 'publish'
+    runs-on: ubuntu-latest
+    # Every public package trusts usehenri/henri + release.yml + this environment
+    # on npmjs.com (OIDC); no npm token is involved.
+    environment: npm
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: jdx/mise-action@v4
+        with:
+          cache: true
+      - run: pnpm install --frozen-lockfile
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Optional. Without it, npm uses trusted publishing (OIDC) and every
-          # package needs this repository + workflow registered as a trusted
-          # publisher on npmjs.com.
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          MONGOMS_DISABLE_POSTINSTALL: '1'
+      - uses: changesets/action/publish@v2
+        with:
+          script: pnpm changeset:publish
+          create-github-releases: true
+          push-git-tags: true
+        env:
           NPM_CONFIG_PROVENANCE: 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: release
+
+# Changesets flow:
+# - a push to master with pending changesets opens/updates the "Version Packages" PR
+# - merging that PR publishes the bumped packages to npm and creates GitHub releases
+on:
+  push:
+    branches: [master]
+
+concurrency: release-${{ github.ref }}
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: jdx/mise-action@v4
+        with:
+          cache: true
+
+      - run: pnpm install --frozen-lockfile
+        env:
+          MONGOMS_DISABLE_POSTINSTALL: '1'
+
+      - uses: changesets/action@v2
+        with:
+          version-script: pnpm changeset:version
+          publish-script: pnpm changeset:publish
+          commit-message: 'chore(release): version packages'
+          pr-title: 'chore(release): version packages'
+          create-github-releases: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Optional. Without it, npm uses trusted publishing (OIDC) and every
+          # package needs this repository + workflow registered as a trusted
+          # publisher on npmjs.com.
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,9 +86,11 @@ installing where that download is unwanted.
 
 `.github/workflows/release.yml` runs on pushes to `master`. With pending
 changesets it opens or updates a "Version Packages" pull request; merging that
-PR publishes to npm with provenance and creates GitHub releases. Publishing
-authenticates with npm trusted publishing (OIDC) or an `NPM_TOKEN` repository
-secret if one is set.
+PR runs the publish job, which publishes to npm with provenance and creates
+GitHub releases. Publishing uses npm trusted publishing (OIDC): every public
+package trusts this repository's `release.yml` running in the `npm` GitHub
+environment. There is no npm token to rotate; a new package needs its trusted
+publisher registered on npmjs.com before its first release.
 
 ## Known gaps
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,100 @@
+# henri
+
+henri is a Rails-like, server-side rendered JavaScript framework for Node.js:
+models, controllers, routes and React views, with real ORMs and hot reload. This
+is the monorepo for the `henri` CLI, `@usehenri/core` and its adapters, and the
+usehenri.io website. It is public and open source (MIT).
+
+## Setup and commands
+
+Tool versions are pinned in `mise.toml` (Node 24, pnpm 11). Node 22 is the
+minimum supported at runtime.
+
+```bash
+mise install                          # node + pnpm from mise.toml
+pnpm install                          # whole workspace; builds @usehenri/react dist
+pnpm test                             # jest 30, all packages (NODE_ENV=test)
+pnpm test packages/core               # one package; flags go after `pnpm test`, not after `--`
+pnpm lint                             # eslint 10 flat config
+pnpm format                           # prettier 3
+pnpm build                            # rollup build of @usehenri/react
+pnpm --filter @usehenri/website dev   # docs site (Astro + Starlight)
+pnpm changeset                        # record a version bump for changed packages
+```
+
+The first test run downloads a MongoDB binary (mongodb-memory-server) into
+`~/.cache/mongodb-binaries`. Set `MONGOMS_DISABLE_POSTINSTALL=1` when
+installing where that download is unwanted.
+
+## Layout
+
+| Path                                    | Package               | Role                                                           |
+| --------------------------------------- | --------------------- | -------------------------------------------------------------- |
+| `packages/henri`                        | `henri`               | The CLI binary users install; delegates to `@usehenri/cli`.    |
+| `packages/cli`                          | `@usehenri/cli`       | `new`, `server`, `generate`, `console`, `build`, the template  |
+| `packages/core`                         | `@usehenri/core`      | The framework: modules, server, router, models, views, users   |
+| `packages/mongoose`                     | `@usehenri/mongoose`  | MongoDB adapter (Mongoose)                                     |
+| `packages/disk`                         | `@usehenri/disk`      | Zero-config local MongoDB (mongodb-memory-server)              |
+| `packages/sequelize`                    | `@usehenri/sequelize` | Shared SQL adapter (Sequelize)                                 |
+| `packages/mysql`, `postgresql`, `mssql` | `@usehenri/*`         | Dialect packages on top of `@usehenri/sequelize`               |
+| `packages/react`                        | `@usehenri/react`     | Next.js view engine, `withHenri`, form components              |
+| `packages/testing`, `websocket`         | `@usehenri/*`         | Small helpers                                                  |
+| `packages/demo`                         | private               | Demo app used by core's tests (`NODE_ENV=test` chdirs into it) |
+| `website`                               | private               | usehenri.io, deployed by Vercel from `website/`                |
+
+## How core works
+
+- `Henri` (`packages/core/src/henri.js`) registers modules, each a class extending
+  `base/module.js` with a unique `name`, a `runlevel` (0 config/logger, 1 graphql
+  and mail, 2 controllers and Express, 3 models and views, 4 users, 5 routes and
+  workers, 6 app modules, 7 tests) and `init()`. Modules on the same level start
+  concurrently; reloadable ones expose `reload()` and are torn down in reverse.
+  Each module is exposed as `henri.<name>`, so names must be unique.
+- The `henri` instance and every model are globals in user apps
+  (`global.henri`, `global.Artwork`). Tests rely on this too.
+- Store adapters implement `new Adapter(name, config, henri)` with
+  `addModel(model, userModelName)`, `getModels()`, `getSessionConnector()`,
+  `start()`, `stop()`. Core loads them from the app cwd with
+  `utils.resolveFrom('@usehenri/<adapter>')`.
+- View engines implement `init()`, `prepare()`, `fallback(router)` and
+  `render(req, res, route, opts)`. The React engine passes `opts` to pages
+  through `req._henri`; the Handlebars engine lives in `core/src/engines/template.js`.
+- App configuration is `config/<NODE_ENV>.json` falling back to `default.json`
+  (`stores`, `secret`, `renderer`, `port`, `graphql`, `mail`, `user`, `baseRole`).
+
+## Conventions
+
+- CommonJS everywhere except `packages/react/src` (ESM compiled by rollup) and
+  `website` (Astro). No TypeScript.
+- pnpm links strictly: every module a package `require()`s must be in that
+  package's `package.json`. Internal dependencies use `workspace:^`.
+- Apps that use the React renderer must depend on `next`, `react` and `react-dom`
+  themselves (Turbopack resolves `next` from the app directory).
+- ESLint rules worth knowing: `sort-keys`, `prefer-template`, `id-length`,
+  `no-nested-ternary`, JSDoc on functions. Prettier: single quotes, es5 commas.
+  `.hbs`, the demo views and `packages/cli/scripts/generate` are excluded from
+  Prettier on purpose (its Handlebars parser mangles JSX inside templates).
+- Tests live in `__tests__/` or `tests/`; snapshot tests exist for most core
+  modules, regenerate them only when the diff is explained by your change.
+- Commits follow Conventional Commits (`feat(core): ...`, `fix(react): ...`).
+  Husky runs lint-staged (prettier + eslint --fix) on commit.
+- Any user-facing change to a public package needs a changeset
+  (`pnpm changeset`). All public packages are versioned together (a `fixed`
+  group in `.changeset/config.json`); private packages are never versioned.
+
+## Releasing
+
+`.github/workflows/release.yml` runs on pushes to `master`. With pending
+changesets it opens or updates a "Version Packages" pull request; merging that
+PR publishes to npm with provenance and creates GitHub releases. Publishing
+authenticates with npm trusted publishing (OIDC) or an `NPM_TOKEN` repository
+secret if one is set.
+
+## Known gaps
+
+- The Vue/Nuxt renderer (`core/src/engines/vue.js`) has not been exercised
+  since 2020.
+- The SQL adapters are tested against sqlite; live MySQL, PostgreSQL and MSSQL
+  connections are not covered.
+- The scaffolded app pins ESLint 9 because `eslint-plugin-react` does not
+  support ESLint 10 yet.

--- a/README.md
+++ b/README.md
@@ -673,6 +673,12 @@ The repository is a pnpm workspace (Node.js 22+). Tool versions are pinned in
   pnpm changeset           # record a version bump for the packages you changed
 ```
 
+Releases are automated with [changesets](https://github.com/changesets/changesets):
+add a changeset with your pull request, and once it lands on `master` the
+release workflow opens a "Version Packages" pull request. Merging that one
+publishes the bumped packages to npm and creates the GitHub releases. All
+public packages share one version number.
+
 The first test run downloads a MongoDB binary for the disk adapter
 (`mongodb-memory-server`) into `~/.cache/mongodb-binaries`.
 

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   },
   "lint-staged": {
     "*.{js,jsx,mjs,cjs}": [
-      "prettier --write",
-      "eslint --fix --no-warn-ignored --config eslint.config.js"
+      "eslint --fix --no-warn-ignored --config eslint.config.js",
+      "prettier --write"
     ],
     "*.{json,md,yml,yaml}": [
       "prettier --write"

--- a/package.json
+++ b/package.json
@@ -20,9 +20,10 @@
     "test:ci": "pnpm test --coverage --forceExit --runInBand --verbose --bail",
     "changeset": "changeset",
     "changeset:version": "changeset version",
-    "changeset:publish": "pnpm build && changeset publish"
+    "changeset:publish": "pnpm sync-readme && pnpm build && changeset publish"
   },
   "devDependencies": {
+    "@changesets/changelog-github": "^1.0.0",
     "@changesets/cli": "^3.0.2",
     "@eslint/js": "^10.0.1",
     "cross-env": "^10.1.0",

--- a/packages/core/src/2.server.js
+++ b/packages/core/src/2.server.js
@@ -279,7 +279,6 @@ class Server extends BaseModule {
   async init() {
     const app = (this.app = express());
 
-     
     this.httpServer = require('http').createServer(this.app);
 
     this.port = this.henri.config.has('port')

--- a/packages/core/src/5.router.js
+++ b/packages/core/src/5.router.js
@@ -56,14 +56,13 @@ class Router extends BaseModule {
     this.middlewares();
 
     try {
-       
       this.rawRoutes = require(path.resolve('./config/routes'));
     } catch (error) {
       this.rawRoutes = {};
 
       if (fs.existsSync(path.resolve('./app/routes.js'))) {
         pen.warn('router', 'you should move your routes to `config/routes.js`');
-         
+
         this.rawRoutes = require(path.resolve('./app/routes'));
       } else {
         pen.warn('router', 'unable to load routes from filesystem');

--- a/packages/core/src/engines/vue.js
+++ b/packages/core/src/engines/vue.js
@@ -22,7 +22,6 @@ class VueEngine {
     this.Builder = null;
 
     try {
-       
       let conf = require(
         path.resolve(thisHenri.cwd(), 'config', 'nuxt.config.js')
       );
@@ -47,7 +46,7 @@ class VueEngine {
    */
   init() {
     this.henri.utils.checkPackages(['nuxt']);
-     
+
     const { Nuxt, Builder } = require(
       this.henri.utils.resolveFrom('nuxt', this.henri.cwd())
     );

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -32,7 +32,6 @@ function resolveFrom(request, dir = process.cwd()) {
  */
 function resolvePackageJson(pkgName, dir = process.cwd()) {
   try {
-     
     return require(resolveFrom(`${pkgName}/package.json`, dir));
   } catch (error) {
     // Package uses "exports" without exposing package.json: walk up from main
@@ -42,7 +41,6 @@ function resolvePackageJson(pkgName, dir = process.cwd()) {
       const candidate = path.join(current, 'package.json');
 
       if (fs.existsSync(candidate)) {
-         
         const pkg = require(candidate);
 
         if (pkg.name === pkgName) {
@@ -247,7 +245,6 @@ function checkSyntax(file, source) {
   }
 
   if (ext === '.js' || ext === '.cjs') {
-     
     new vm.Script(source, { filename: file });
 
     return true;

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -4,8 +4,8 @@
   "onboard": true,
   "version": "0.37.2",
   "dependencies": {
-    "@usehenri/core": "^0.37.2",
-    "@usehenri/disk": "^0.37.2"
+    "@usehenri/core": "workspace:^",
+    "@usehenri/disk": "workspace:^"
   },
   "engines": {
     "node": ">=22"

--- a/packages/disk/package.json
+++ b/packages/disk/package.json
@@ -6,7 +6,7 @@
   "author": "Felix-Antoine Paradis",
   "license": "MIT",
   "dependencies": {
-    "@usehenri/mongoose": "^0.37.2",
+    "@usehenri/mongoose": "workspace:^",
     "debug": "^4.4.3",
     "md5": "^2.3.0",
     "mongodb-memory-server": "^11.2.0"

--- a/packages/mssql/package.json
+++ b/packages/mssql/package.json
@@ -6,7 +6,7 @@
   "author": "Felix-Antoine Paradis",
   "license": "MIT",
   "dependencies": {
-    "@usehenri/sequelize": "^0.37.2",
+    "@usehenri/sequelize": "workspace:^",
     "sequelize": "^6.37.8",
     "tedious": "^20.0.0"
   },

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -6,7 +6,7 @@
   "author": "Felix-Antoine Paradis",
   "license": "MIT",
   "dependencies": {
-    "@usehenri/sequelize": "^0.37.2",
+    "@usehenri/sequelize": "workspace:^",
     "mysql2": "^3.24.3",
     "sequelize": "^6.37.8"
   },

--- a/packages/postgresql/package.json
+++ b/packages/postgresql/package.json
@@ -6,7 +6,7 @@
   "author": "Felix-Antoine Paradis",
   "license": "MIT",
   "dependencies": {
-    "@usehenri/sequelize": "^0.37.2",
+    "@usehenri/sequelize": "workspace:^",
     "pg": "^8.23.0",
     "pg-hstore": "^2.3.4",
     "sequelize": "^6.37.8"

--- a/packages/react/engine/index.js
+++ b/packages/react/engine/index.js
@@ -55,7 +55,7 @@ class ReactEngine {
     this.henri = thisHenri;
     this.dir = path.resolve(thisHenri.cwd(), './app/views');
     this.renderer = thisHenri.config.get('renderer').toLowerCase();
-     
+
     this.conf = thisHenri.isTest ? {} : require('./conf');
     this.bundler = loadUserHooks(thisHenri.cwd()).webpack
       ? 'webpack'
@@ -213,11 +213,10 @@ class ReactEngine {
     }
 
     const versions = {
-       
       next: require(
         path.resolve(require.resolve('next'), '../../../package.json')
       ).version,
-       
+
       react: require(this.resolve('react/package.json')).version,
     };
 

--- a/packages/react/src/forms/editor.js
+++ b/packages/react/src/forms/editor.js
@@ -13,7 +13,6 @@ class FormHtmlEditor extends Component {
     super(props);
     this.ReactQuill = null;
     if (typeof window !== 'undefined') {
-       
       const mod = require('react-quill-new');
 
       this.ReactQuill = mod.default || mod;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@changesets/changelog-github':
+        specifier: ^1.0.0
+        version: 1.0.0
       '@changesets/cli':
         specifier: ^3.0.2
         version: 3.0.2
@@ -187,16 +190,16 @@ importers:
   packages/demo:
     dependencies:
       '@usehenri/core':
-        specifier: ^0.37.2
+        specifier: workspace:^
         version: link:../core
       '@usehenri/disk':
-        specifier: ^0.37.2
+        specifier: workspace:^
         version: link:../disk
 
   packages/disk:
     dependencies:
       '@usehenri/mongoose':
-        specifier: ^0.37.2
+        specifier: workspace:^
         version: link:../mongoose
       debug:
         specifier: ^4.4.3
@@ -236,7 +239,7 @@ importers:
   packages/mssql:
     dependencies:
       '@usehenri/sequelize':
-        specifier: ^0.37.2
+        specifier: workspace:^
         version: link:../sequelize
       sequelize:
         specifier: ^6.37.8
@@ -248,7 +251,7 @@ importers:
   packages/mysql:
     dependencies:
       '@usehenri/sequelize':
-        specifier: ^0.37.2
+        specifier: workspace:^
         version: link:../sequelize
       mysql2:
         specifier: ^3.24.3
@@ -260,7 +263,7 @@ importers:
   packages/postgresql:
     dependencies:
       '@usehenri/sequelize':
-        specifier: ^0.37.2
+        specifier: workspace:^
         version: link:../sequelize
       pg:
         specifier: ^8.23.0
@@ -1328,6 +1331,10 @@ packages:
     resolution: {integrity: sha512-3Dst2Ime2Op5nd4XmWJLPIgp11ZFqJqSkVug9izK6TDcIV4YlhPS4ECbEVR+eGI0bk0r1ItogD4j2Oli87bJrA==}
     engines: {node: ^22.11 || ^24 || >=26}
 
+  '@changesets/changelog-github@1.0.0':
+    resolution: {integrity: sha512-PNCSH5CGJrqOKxRjrMp2NLhceQv2QBs6HkjrLvYQqsEE2/ItN5R8GD/mskZZluoNWYvjPYFsY9T6swXfp5E0UA==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
   '@changesets/cli@3.0.2':
     resolution: {integrity: sha512-t/omGJj/I+Jv0kmJAkj5cstYEdUQiJnpip2F+2m3F4lQ3kAZ3o8Exep4/Fm1qq4rvw6ovlhJvZNrKdwLJ4lkuQ==}
     engines: {node: ^22.11 || ^24 || >=26, npm: '>=10.9.0', pnpm: '>=10.0.0', yarn: '>=4.5.2'}
@@ -1347,6 +1354,10 @@ packages:
 
   '@changesets/get-dependents-graph@3.0.0':
     resolution: {integrity: sha512-ji/t5wFA1zREKXRUePE6Qi+Qu2UgxCeSSGQrphezwvQZrp49B7sJ+8+wvM0tA7zPeSxYKCojDy3WWgrl+s+awg==}
+    engines: {node: ^22.11 || ^24 || >=26}
+
+  '@changesets/get-github-info@1.0.0':
+    resolution: {integrity: sha512-nf5zPSqEKW0eXiJ4ltbjyIQ/srUHfxbghkLCjKdOLI3LehKXhiqxXcpja39eGPaj6qqGx2lFCrLJ7VWYUf9H2w==}
     engines: {node: ^22.11 || ^24 || >=26}
 
   '@changesets/git@4.0.1':
@@ -3760,6 +3771,9 @@ packages:
   csso@5.0.5:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
+
+  dataloader@2.2.3:
+    resolution: {integrity: sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -7886,6 +7900,11 @@ snapshots:
     dependencies:
       '@changesets/types': 7.0.0
 
+  '@changesets/changelog-github@1.0.0':
+    dependencies:
+      '@changesets/get-github-info': 1.0.0
+      '@changesets/types': 7.0.0
+
   '@changesets/cli@3.0.2':
     dependencies:
       '@changesets/apply-release-plan': 8.1.0
@@ -7929,6 +7948,10 @@ snapshots:
     dependencies:
       '@changesets/types': 7.0.0
       semver: 7.8.5
+
+  '@changesets/get-github-info@1.0.0':
+    dependencies:
+      dataloader: 2.2.3
 
   '@changesets/git@4.0.1':
     dependencies:
@@ -10144,6 +10167,8 @@ snapshots:
   csso@5.0.5:
     dependencies:
       css-tree: 2.2.1
+
+  dataloader@2.2.3: {}
 
   debug@2.6.9(supports-color@8.1.1):
     dependencies:


### PR DESCRIPTION
Adds the automated release flow on top of the changesets setup from #281, plus a CLAUDE.md for contributors and coding agents.

## Release workflow

`.github/workflows/release.yml` runs on every push to `master`:

- with pending changesets, `changesets/action@v2` opens or updates a "Version Packages" PR (`pnpm changeset:version`, changelogs with PR links via `@changesets/changelog-github`)
- when that PR merges, it publishes with `pnpm changeset:publish` (README synced into the `henri` package, `@usehenri/react` built, `changeset publish` with npm provenance) and creates GitHub releases

Publishing uses npm trusted publishing (OIDC): all 12 public packages trust `usehenri/henri` + `release.yml` running in the `npm` GitHub environment (restricted to `master`). No npm token exists. The workflow is split with `changesets/action/select-mode`, so the publish job only runs once no changesets are pending, and only that job uses the environment.

## Versioning

- All 12 public packages form one `fixed` group and share a version number, as they did under lerna.
- Private packages (`@usehenri/demo`, `@usehenri/website`) are never versioned or tagged.
- Internal dependencies use `workspace:^` everywhere; pnpm rewrites them on publish and changesets bumps them.
- `.changeset/revive-on-node-22.md` records the revival as a **major** bump, so the first release will be **1.0.0**. Edit that file before merging if 0.38.0 is preferred.

Verified locally: `changeset status` resolves every public package to 1.0.0, and a dry run of `changeset version` bumps the 12 packages, leaves the private ones alone and prepends the release notes to each package's CHANGELOG.