### PR TITLE
Install dependencies before changesets select-mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+      - uses: jdx/mise-action@v4
+        with:
+          cache: true
+      # select-mode runs `changeset status`, so the CLI must be installed
+      - run: pnpm install --frozen-lockfile
+        env:
+          MONGOMS_DISABLE_POSTINSTALL: '1'
       - uses: changesets/action/select-mode@v2
         id: select
 


### PR DESCRIPTION
The release workflow's select-mode job failed with `Cannot find module '@changesets/cli/bin.js'` on the first publish run: with no changesets pending it runs `changeset status`, which needs the CLI installed. Adds mise + pnpm install to that job.