### PR TITLE
Declare the repository in every published package

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,9 +2,18 @@
   "name": "@usehenri/cli",
   "version": "1.0.0",
   "description": "henri cli runner",
-  "main": "index.js",
-  "author": "Felix-Antoine Paradis",
   "license": "MIT",
+  "author": "Felix-Antoine Paradis",
+  "homepage": "https://usehenri.io",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/usehenri/henri.git",
+    "directory": "packages/cli"
+  },
+  "bugs": {
+    "url": "https://github.com/usehenri/henri/issues"
+  },
+  "main": "index.js",
   "engines": {
     "node": ">=22"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,12 +2,21 @@
   "name": "@usehenri/core",
   "version": "1.0.0",
   "description": "henri core package",
+  "license": "MIT",
+  "author": "Felix-Antoine Paradis",
+  "homepage": "https://usehenri.io",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/usehenri/henri.git",
+    "directory": "packages/core"
+  },
+  "bugs": {
+    "url": "https://github.com/usehenri/henri/issues"
+  },
   "main": "src/index.js",
   "bin": {
     "henri-core": "src/index.js"
   },
-  "author": "Felix-Antoine Paradis",
-  "license": "MIT",
   "dependencies": {
     "@apollo/server": "^5.2.0",
     "@as-integrations/express5": "^1.1.2",

--- a/packages/disk/package.json
+++ b/packages/disk/package.json
@@ -2,9 +2,18 @@
   "name": "@usehenri/disk",
   "version": "1.0.0",
   "description": "henri disk database connector",
-  "main": "index.js",
-  "author": "Felix-Antoine Paradis",
   "license": "MIT",
+  "author": "Felix-Antoine Paradis",
+  "homepage": "https://usehenri.io",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/usehenri/henri.git",
+    "directory": "packages/disk"
+  },
+  "bugs": {
+    "url": "https://github.com/usehenri/henri/issues"
+  },
+  "main": "index.js",
   "dependencies": {
     "@usehenri/mongoose": "workspace:^",
     "debug": "^4.4.3",

--- a/packages/henri/package.json
+++ b/packages/henri/package.json
@@ -2,6 +2,17 @@
   "name": "henri",
   "version": "1.0.0",
   "description": "henri is an easy to learn rails-like, react server-side rendered framework with a powerful and versatile ORM",
+  "license": "MIT",
+  "author": "Felix-Antoine Paradis",
+  "homepage": "https://github.com/usehenri/henri#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/usehenri/henri.git",
+    "directory": "packages/henri"
+  },
+  "bugs": {
+    "url": "https://github.com/usehenri/henri/issues"
+  },
   "preferGlobal": true,
   "bin": "bin/henri.js",
   "files": [
@@ -12,19 +23,9 @@
   "scripts": {
     "lint": "prettier --check bin/*.js"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/usehenri/henri.git"
-  },
   "engines": {
     "node": ">=22"
   },
-  "author": "Felix-Antoine Paradis",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/usehenri/henri/issues"
-  },
-  "homepage": "https://github.com/usehenri/henri#readme",
   "dependencies": {
     "@usehenri/cli": "workspace:^"
   }

--- a/packages/mongoose/package.json
+++ b/packages/mongoose/package.json
@@ -2,9 +2,18 @@
   "name": "@usehenri/mongoose",
   "version": "1.0.0",
   "description": "henri mongoose database connector",
-  "main": "index.js",
-  "author": "Felix-Antoine Paradis",
   "license": "MIT",
+  "author": "Felix-Antoine Paradis",
+  "homepage": "https://usehenri.io",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/usehenri/henri.git",
+    "directory": "packages/mongoose"
+  },
+  "bugs": {
+    "url": "https://github.com/usehenri/henri/issues"
+  },
+  "main": "index.js",
   "dependencies": {
     "connect-mongo": "^6.0.0",
     "debug": "^4.4.3",

--- a/packages/mssql/package.json
+++ b/packages/mssql/package.json
@@ -2,9 +2,18 @@
   "name": "@usehenri/mssql",
   "version": "1.0.0",
   "description": "henri mssql database connector",
-  "main": "index.js",
-  "author": "Felix-Antoine Paradis",
   "license": "MIT",
+  "author": "Felix-Antoine Paradis",
+  "homepage": "https://usehenri.io",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/usehenri/henri.git",
+    "directory": "packages/mssql"
+  },
+  "bugs": {
+    "url": "https://github.com/usehenri/henri/issues"
+  },
+  "main": "index.js",
   "dependencies": {
     "@usehenri/sequelize": "workspace:^",
     "sequelize": "^6.37.8",

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -2,9 +2,18 @@
   "name": "@usehenri/mysql",
   "version": "1.0.0",
   "description": "henri mariadb/mysql database connector",
-  "main": "index.js",
-  "author": "Felix-Antoine Paradis",
   "license": "MIT",
+  "author": "Felix-Antoine Paradis",
+  "homepage": "https://usehenri.io",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/usehenri/henri.git",
+    "directory": "packages/mysql"
+  },
+  "bugs": {
+    "url": "https://github.com/usehenri/henri/issues"
+  },
+  "main": "index.js",
   "dependencies": {
     "@usehenri/sequelize": "workspace:^",
     "mysql2": "^3.24.3",

--- a/packages/postgresql/package.json
+++ b/packages/postgresql/package.json
@@ -2,9 +2,18 @@
   "name": "@usehenri/postgresql",
   "version": "1.0.0",
   "description": "henri postgresql database connector",
-  "main": "index.js",
-  "author": "Felix-Antoine Paradis",
   "license": "MIT",
+  "author": "Felix-Antoine Paradis",
+  "homepage": "https://usehenri.io",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/usehenri/henri.git",
+    "directory": "packages/postgresql"
+  },
+  "bugs": {
+    "url": "https://github.com/usehenri/henri/issues"
+  },
+  "main": "index.js",
   "dependencies": {
     "@usehenri/sequelize": "workspace:^",
     "pg": "^8.23.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,9 +2,18 @@
   "name": "@usehenri/react",
   "version": "1.0.0",
   "description": "react components and next.js view engine for henri",
-  "main": "index.js",
-  "author": "Felix-Antoine Paradis",
   "license": "MIT",
+  "author": "Felix-Antoine Paradis",
+  "homepage": "https://usehenri.io",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/usehenri/henri.git",
+    "directory": "packages/react"
+  },
+  "bugs": {
+    "url": "https://github.com/usehenri/henri/issues"
+  },
+  "main": "index.js",
   "engines": {
     "node": ">=22"
   },

--- a/packages/sequelize/package.json
+++ b/packages/sequelize/package.json
@@ -2,9 +2,18 @@
   "name": "@usehenri/sequelize",
   "version": "1.0.0",
   "description": "henri sequalize class provider",
-  "main": "index.js",
-  "author": "Felix-Antoine Paradis",
   "license": "MIT",
+  "author": "Felix-Antoine Paradis",
+  "homepage": "https://usehenri.io",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/usehenri/henri.git",
+    "directory": "packages/sequelize"
+  },
+  "bugs": {
+    "url": "https://github.com/usehenri/henri/issues"
+  },
+  "main": "index.js",
   "dependencies": {
     "connect-session-sequelize": "^8.0.6",
     "sequelize": "^6.37.8"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -2,9 +2,18 @@
   "name": "@usehenri/testing",
   "version": "1.0.0",
   "description": "henri testing helpers: jest and a supertest agent bound to the henri express app",
-  "main": "index.js",
-  "author": "Felix-Antoine Paradis",
   "license": "MIT",
+  "author": "Felix-Antoine Paradis",
+  "homepage": "https://usehenri.io",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/usehenri/henri.git",
+    "directory": "packages/testing"
+  },
+  "bugs": {
+    "url": "https://github.com/usehenri/henri/issues"
+  },
+  "main": "index.js",
   "engines": {
     "node": ">=22"
   },

--- a/packages/websocket/package.json
+++ b/packages/websocket/package.json
@@ -2,9 +2,18 @@
   "name": "@usehenri/websocket",
   "version": "1.0.0",
   "description": "henri websocket loader (socket.io) - experimental, not wired into core yet",
-  "main": "index.js",
-  "author": "Felix-Antoine Paradis",
   "license": "MIT",
+  "author": "Felix-Antoine Paradis",
+  "homepage": "https://usehenri.io",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/usehenri/henri.git",
+    "directory": "packages/websocket"
+  },
+  "bugs": {
+    "url": "https://github.com/usehenri/henri/issues"
+  },
+  "main": "index.js",
   "engines": {
     "node": ">=22"
   },


### PR DESCRIPTION
The first publish run authenticated fine with trusted publishing but npm rejected the provenance bundle for packages without a `repository.url`: `Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/usehenri/henri"`. Every public package now declares `repository` (with its `directory`), `homepage` and `bugs`. No version bump needed: the 1.0.0 versions are unpublished and the release workflow will retry them on merge.