### PR TITLE
Scaffold apps on the current @usehenri versions

### DIFF
--- a/.changeset/scaffold-current-versions.md
+++ b/.changeset/scaffold-current-versions.md
@@ -2,4 +2,4 @@
 '@usehenri/cli': patch
 ---
 
-`henri new` scaffolds apps that depend on the `@usehenri/*` packages at the CLI's own version instead of the 0.37 line, and the generated `pnpm-workspace.yaml` warns instead of failing when pnpm meets a transitive build script that is not allow-listed.
+`henri new` scaffolds apps that depend on the `@usehenri/*` packages at the CLI's own version instead of the 0.37 line, and the generated `pnpm-workspace.yaml` warns instead of failing when pnpm meets a transitive build script that is not allow-listed. `henri server` and `henri console` now run the `@usehenri/core` the app depends on when it has one, falling back to the CLI's own copy.

--- a/.changeset/scaffold-current-versions.md
+++ b/.changeset/scaffold-current-versions.md
@@ -1,0 +1,5 @@
+---
+'@usehenri/cli': patch
+---
+
+`henri new` scaffolds apps that depend on the `@usehenri/*` packages at the CLI's own version instead of the 0.37 line, and the generated `pnpm-workspace.yaml` warns instead of failing when pnpm meets a transitive build script that is not allow-listed.

--- a/packages/cli/scripts/init.js
+++ b/packages/cli/scripts/init.js
@@ -82,11 +82,21 @@ const buildPackage = (name) => {
 
   console.log(' - Building new package file...');
 
+  // The template's @usehenri/* ranges are placeholders: a generated app
+  // depends on the same version as the CLI that created it.
+  const withCliVersion = (deps = {}) =>
+    Object.fromEntries(
+      Object.entries(deps).map(([dep, range]) => [
+        dep,
+        dep.startsWith('@usehenri/') ? `^${version}` : range,
+      ])
+    );
+
   const pkg = {
     ...templatePkg,
     ...existing,
     dependencies: {
-      ...templatePkg.dependencies,
+      ...withCliVersion(templatePkg.dependencies),
       ...(existing.dependencies || {}),
     },
     devDependencies: {

--- a/packages/cli/scripts/server.js
+++ b/packages/cli/scripts/server.js
@@ -1,4 +1,18 @@
 /**
+ * Prefer the @usehenri/core the project depends on (so an app pins its own
+ * henri version) and fall back to the one shipped with this CLI.
+ *
+ * @returns {string} resolved path of @usehenri/core
+ */
+const resolveCore = () => {
+  try {
+    return require.resolve('@usehenri/core', { paths: [process.cwd()] });
+  } catch {
+    return require.resolve('@usehenri/core');
+  }
+};
+
+/**
  * Main entry point for henri cli
  * @param {object} param0 if console only
  * @param {function} cb a callback (we use this for console)
@@ -15,8 +29,7 @@ const main = ({ consoleOnly = false }, cb) => {
    */
   async function init() {
     try {
-      // eslint-disable-next-line global-require
-      const start = await require('@usehenri/core');
+      const start = await require(resolveCore());
 
       await start();
       if (typeof cb === 'function') {

--- a/packages/cli/template/default/package.json
+++ b/packages/cli/template/default/package.json
@@ -17,9 +17,9 @@
     "node": ">=22"
   },
   "dependencies": {
-    "@usehenri/core": "^0.37.2",
-    "@usehenri/disk": "^0.37.2",
-    "@usehenri/react": "^0.37.2",
+    "@usehenri/core": "^1.0.0",
+    "@usehenri/disk": "^1.0.0",
+    "@usehenri/react": "^1.0.0",
     "next": "^16.3.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/packages/cli/template/default/pnpm-workspace.yaml
+++ b/packages/cli/template/default/pnpm-workspace.yaml
@@ -1,7 +1,12 @@
-# pnpm 10+ refuses to run dependency build scripts unless they are allow-listed.
-# These are the ones an henri app needs (sass file watching, local MongoDB binary).
+# pnpm 10+ only runs dependency build scripts that are allow-listed, and pnpm 11
+# fails the install when it meets one that is not listed. Allow the ones an
+# henri app needs (sass file watching, local MongoDB binary) and warn about the
+# rest instead of failing.
+strictDepBuilds: false
 allowBuilds:
+  '@apollo/protobufjs': false
   '@parcel/watcher': true
   esbuild: true
   mongodb-memory-server: true
   sharp: true
+  unrs-resolver: false

--- a/packages/cli/tests/new.test.js
+++ b/packages/cli/tests/new.test.js
@@ -1,0 +1,60 @@
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { version } = require('../package.json');
+const bin = path.resolve(__dirname, '../../henri/bin/henri.js');
+
+describe('henri new', () => {
+  let dir;
+
+  beforeAll(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'henri-new-'));
+    const result = spawnSync(
+      process.execPath,
+      [bin, 'new', 'app', '--skip-install'],
+      {
+        cwd: dir,
+        encoding: 'utf8',
+      }
+    );
+
+    if (result.status !== 0) {
+      throw new Error(`henri new failed: ${result.stdout}${result.stderr}`);
+    }
+  });
+
+  afterAll(() => {
+    fs.rmSync(dir, { force: true, recursive: true });
+  });
+
+  test('scaffolds the app structure', () => {
+    for (const file of [
+      'package.json',
+      'pnpm-workspace.yaml',
+      'config/default.json',
+      'config/routes.js',
+      'app/views/pages/index.js',
+      'app/views/next.config.js',
+      'eslint.config.js',
+    ]) {
+      expect(fs.existsSync(path.join(dir, 'app', file))).toBe(true);
+    }
+  });
+
+  test('depends on the @usehenri packages at the cli version', () => {
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(dir, 'app/package.json'), 'utf8')
+    );
+    const internal = Object.entries(pkg.dependencies).filter(([name]) =>
+      name.startsWith('@usehenri/')
+    );
+
+    expect(internal.length).toBeGreaterThan(0);
+    for (const [, range] of internal) {
+      expect(range).toBe(`^${version}`);
+    }
+    expect(pkg.henri).toBe(version);
+  });
+});


### PR DESCRIPTION
Found by installing `henri@1.0.0` from npm into a clean directory: `henri new` copied the template's `^0.37.2` ranges, so a fresh app installed the 2020 packages and failed at boot. pnpm 11 also exited non-zero on transitive build scripts (`@apollo/protobufjs`, `unrs-resolver`) the generated `pnpm-workspace.yaml` did not list.

- `init.js` rewrites `@usehenri/*` template ranges to `^<cli version>` (template fallback updated to `^1.0.0`)
- generated `pnpm-workspace.yaml`: `strictDepBuilds: false` plus explicit entries for the two known scripts
- new test: `henri new --skip-install` scaffolds the structure and pins the internal packages to the CLI version
- changeset: patch (fixed group, so every package goes to 1.0.1)