### PR TITLE
henri new --renderer inertia and henri build for every renderer

### DIFF
--- a/packages/cli/__tests__/build.spec.js
+++ b/packages/cli/__tests__/build.spec.js
@@ -1,0 +1,144 @@
+const fs = require('fs');
+const path = require('path');
+
+const { ENGINES } = require('../scripts/build');
+const { cleanup, exists, henri, read, scaffold } = require('./helpers');
+
+/**
+ * Install a fake view engine in the app: its build() records its arguments
+ * in build.json instead of building anything
+ *
+ * @param {string} app Application directory
+ * @param {string} name Engine module (ex: @usehenri/react/engine)
+ * @param {string} shape 'function' (module.exports.build) or 'static' (class)
+ * @returns {void}
+ */
+const fakeEngine = (app, name, shape) => {
+  const dir = path.join(app, 'node_modules', name);
+  const record = `
+const fs = require('fs');
+const path = require('path');
+const build = async ({ cwd, config }) => {
+  fs.writeFileSync(
+    path.join(cwd, 'build.json'),
+    JSON.stringify({ config, cwd, env: process.env.NODE_ENV, name: '${name}' })
+  );
+  return { built: true };
+};
+`;
+  const code =
+    shape === 'static'
+      ? `${record}\nclass Engine { static build(opts) { return build(opts); } }\nmodule.exports = Engine;\n`
+      : `${record}\nmodule.exports = { build };\n`;
+
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'index.js'), code);
+};
+
+/**
+ * Set the renderer of the app
+ *
+ * @param {string} app Application directory
+ * @param {string} renderer Renderer name
+ * @returns {void}
+ */
+const setRenderer = (app, renderer) => {
+  const file = path.join(app, 'config', 'default.json');
+  const config = JSON.parse(fs.readFileSync(file, 'utf8'));
+
+  fs.writeFileSync(file, JSON.stringify({ ...config, renderer }, null, 2));
+};
+
+describe('henri build', () => {
+  let dir;
+  let app;
+
+  beforeAll(() => {
+    ({ app, dir } = scaffold());
+  });
+
+  afterAll(() => {
+    cleanup(dir);
+  });
+
+  beforeEach(() => {
+    fs.rmSync(path.join(app, 'build.json'), { force: true });
+  });
+
+  test('knows the engines that need a build', () => {
+    expect(ENGINES).toEqual({
+      inertia: '@usehenri/inertia/engine',
+      react: '@usehenri/react/engine',
+    });
+  });
+
+  test('fails clearly when the react engine is not installed', () => {
+    // A clean environment: the test runner's own NODE_OPTIONS/NODE_PATH
+    // would let the child resolve the workspace's @usehenri/react
+    const { status, stderr } = henri(['build'], {
+      cwd: app,
+      env: { HOME: process.env.HOME, PATH: process.env.PATH },
+    });
+
+    expect(status).toBe(1);
+    expect(stderr).toContain(
+      '@usehenri/react is not installed in this project'
+    );
+  });
+
+  test('calls the react engine build without booting henri', () => {
+    fakeEngine(app, '@usehenri/react/engine', 'function');
+
+    const { status, stderr } = henri(['build'], { cwd: app });
+
+    expect(stderr).toBe('');
+    expect(status).toBe(0);
+
+    const call = JSON.parse(read(app, 'build.json'));
+
+    expect(call.name).toBe('@usehenri/react/engine');
+    expect(fs.realpathSync(call.cwd)).toBe(fs.realpathSync(app));
+    expect(call.config.renderer).toBe('react');
+    expect(call.env).toBe('production');
+  });
+
+  test('calls the inertia engine static build', () => {
+    setRenderer(app, 'inertia');
+    fakeEngine(app, '@usehenri/inertia/engine', 'static');
+
+    const { status, stderr } = henri(['build'], { cwd: app });
+
+    expect(stderr).toBe('');
+    expect(status).toBe(0);
+
+    const call = JSON.parse(read(app, 'build.json'));
+
+    expect(call.name).toBe('@usehenri/inertia/engine');
+    expect(call.config.renderer).toBe('inertia');
+  });
+
+  test('has nothing to do for the template renderer', () => {
+    setRenderer(app, 'template');
+
+    const { status, stdout } = henri(['build'], { cwd: app });
+
+    expect(status).toBe(0);
+    expect(stdout).toContain('"template" renderer needs no build');
+    expect(exists(app, 'build.json')).toBe(false);
+  });
+
+  test('reads config/production.json first', () => {
+    setRenderer(app, 'template');
+    fs.writeFileSync(
+      path.join(app, 'config', 'production.json'),
+      JSON.stringify({ renderer: 'inertia' })
+    );
+
+    const { status } = henri(['build'], { cwd: app });
+
+    expect(status).toBe(0);
+    expect(JSON.parse(read(app, 'build.json')).config).toEqual({
+      renderer: 'inertia',
+    });
+  });
+});

--- a/packages/cli/__tests__/new.spec.js
+++ b/packages/cli/__tests__/new.spec.js
@@ -233,3 +233,67 @@ describe('henri init', () => {
     expect(stdout).toContain("already have an 'app' folder");
   });
 });
+
+describe('henri new --renderer inertia', () => {
+  let dir;
+  let app;
+
+  beforeAll(() => {
+    ({ app, dir } = scaffold(['--no-git', '--renderer', 'inertia']));
+  });
+
+  afterAll(() => {
+    cleanup(dir);
+  });
+
+  test('keeps the sample of the inertia template only', () => {
+    expect(JSON.parse(read(app, 'config/default.json')).renderer).toBe(
+      'inertia'
+    );
+
+    for (const file of [
+      'app/models/Tasks.js',
+      'app/controllers/tasks.js',
+      'app/views/pages/tasks/index.jsx',
+      'app/views/vite.config.mjs',
+    ]) {
+      expect(exists(app, file)).toBe(true);
+    }
+
+    // Nothing from the react scaffold generator
+    for (const file of [
+      'app/models/Task.js',
+      'app/views/pages/tasks/index.js',
+      'app/views/pages/tasks/_form.js',
+      'test/tasks.test.js',
+      'vitest.config.js',
+    ]) {
+      expect(exists(app, file)).toBe(false);
+    }
+
+    expect(routesOf(app)).toEqual({
+      'delete /tasks/:id': 'tasks#destroy',
+      'get /': 'main#home',
+      'get /tasks': 'tasks#index',
+      'post /tasks': 'tasks#create',
+    });
+  });
+
+  test('writes a README that matches the template', () => {
+    const readme = read(app, 'README.md');
+
+    expect(readme).toContain('app/views/pages/tasks/index.jsx');
+    expect(readme).toContain('Inertia (React) pages');
+    expect(readme).not.toContain('destroy scaffold Task');
+  });
+
+  test('rejects an unknown renderer with a positive exit code', () => {
+    const { status, stdout } = henri(
+      ['new', 'bad', '--skip-install', '--no-git', '--renderer', 'nope'],
+      { cwd: dir }
+    );
+
+    expect(status).toBe(1);
+    expect(stdout).toContain("Unknown renderer 'nope'");
+  });
+});

--- a/packages/cli/scripts/build.js
+++ b/packages/cli/scripts/build.js
@@ -4,6 +4,15 @@ const { spawnSync } = require('child_process');
 const { readConfig, resolveFrom, validInstall } = require('./utils');
 
 /**
+ * The view engines that need a production build, by renderer. Each module
+ * exports `build({ cwd, config })`, which builds without booting henri.
+ */
+const ENGINES = {
+  inertia: '@usehenri/inertia/engine',
+  react: '@usehenri/react/engine',
+};
+
+/**
  * Build the production views without booting henri (no database needed)
  *
  * @returns {Promise<void>} Resolves when the build is done
@@ -18,8 +27,9 @@ const main = async () => {
   const cwd = process.cwd();
   const config = readConfig(cwd, 'production');
   const renderer = String(config.renderer || 'template').toLowerCase();
+  const name = ENGINES[renderer];
 
-  if (renderer !== 'react') {
+  if (!name) {
     console.log(`> the "${renderer}" renderer needs no build`);
 
     return;
@@ -28,10 +38,10 @@ const main = async () => {
   let engine;
 
   try {
-    engine = require(resolveFrom('@usehenri/react/engine', cwd));
+    engine = require(resolveFrom(name, cwd));
   } catch (error) {
     throw new Error(
-      `@usehenri/react is not installed in this project (${error.message})`,
+      `${name.replace(/\/engine$/, '')} is not installed in this project (${error.message})`,
       { cause: error }
     );
   }
@@ -42,8 +52,14 @@ const main = async () => {
     return;
   }
 
-  // Older @usehenri/react: run `next build` on app/views ourselves
-  await legacyBuild(cwd);
+  if (renderer === 'react') {
+    // Older @usehenri/react: run `next build` on app/views ourselves
+    await legacyBuild(cwd);
+
+    return;
+  }
+
+  throw new Error(`${name} does not export a build() function`);
 };
 
 /**
@@ -78,3 +94,4 @@ const legacyBuild = async (cwd) => {
 };
 
 module.exports = main;
+module.exports.ENGINES = ENGINES;

--- a/packages/cli/scripts/help.js
+++ b/packages/cli/scripts/help.js
@@ -27,8 +27,9 @@ const USAGE = {
     Usage
       $ henri build
 
-    Builds the production views (next.js) without starting the server or
-    the databases. Nothing to do when the renderer is 'template'.`,
+    Builds the production views (next.js for react, the vite client and
+    server bundles for inertia) without starting the server or the
+    databases. Nothing to do when the renderer is 'template'.`,
 
   clean: `
     Usage
@@ -112,21 +113,23 @@ const USAGE = {
 
   init: `
     Usage
-      $ henri init [--force | -f] [--skip-install] [--no-git]
+      $ henri init [--renderer react|inertia] [--force | -f] [--skip-install] [--no-git]
 
     Adds the henri structure to the current directory. The project name is
     the name of the directory.
 
+      -r, --renderer    view engine: react (next.js, default) or inertia (vite)
       -f, --force       write into a directory that already has an app/ folder
       --skip-install    do not install the dependencies
       --no-git          do not run "git init"`,
 
   new: `
     Usage
-      $ henri new <folder> [--force | -f] [--skip-install] [--no-git]
+      $ henri new <folder> [--renderer react|inertia] [--force | -f] [--skip-install] [--no-git]
 
     Creates a new henri application in <folder>.
 
+      -r, --renderer    view engine: react (next.js, default) or inertia (vite)
       -f, --force       write into an existing folder
       --skip-install    do not install the dependencies
       --no-git          do not run "git init"`,

--- a/packages/cli/scripts/init.js
+++ b/packages/cli/scripts/init.js
@@ -33,7 +33,7 @@ const selectRenderer = (args) => {
       Unknown renderer '${wanted}'. Valid values: ${Object.keys(RENDERERS).join(', ')}
     `
     );
-    process.exit(-1);
+    process.exit(1);
   }
 
   renderer = wanted;
@@ -83,7 +83,13 @@ const main = async (args, name) => {
   copyTemplate(pm);
   buildPackage(projectName);
   generateConfig();
-  await sampleResource(force);
+
+  // The react template gets its Task sample from the scaffold generator;
+  // the other templates ship their own sample pages.
+  if (renderer === 'react') {
+    await sampleResource(force);
+  }
+
   createReadme(projectName, pm);
   initGit(skipGit);
 
@@ -183,7 +189,28 @@ const createReadme = (name, pm) => {
  * @param {string} pm Package manager
  * @returns {string} Markdown
  */
-const readme = (name, pm) => `# ${name}
+const readme = (name, pm) => {
+  const react = renderer === 'react';
+  const sample = react
+    ? `The home page lists the sample \`Task\` resource; add tasks at \`/tasks\`.
+It is a regular scaffold (\`app/models/Task.js\`, \`app/controllers/tasks.js\`,
+\`app/views/pages/tasks/\`, the \`resources tasks\` key of \`config/routes.js\`
+and \`test/tasks.test.js\`): edit it, or remove it with
+\`henri destroy scaffold Task\`.`
+    : `The home page links to the sample tasks page (\`app/models/Tasks.js\`,
+\`app/controllers/tasks.js\`, \`app/views/pages/tasks/index.jsx\` and the
+\`/tasks\` keys of \`config/routes.js\`): edit it, or remove those files.`;
+  const generators = react
+    ? `henri generate scaffold Post title:string! body:text
+henri generate model|controller|worker|test <name>
+henri destroy scaffold Post   # undo a generator`
+    : `henri generate model|controller|worker|test <name>
+henri destroy model Post      # undo a generator`;
+  const pages = react
+    ? 'React pages rendered by next.js                  '
+    : 'Inertia (React) pages, built by vite            ';
+
+  return `# ${name}
 
 A [henri](https://usehenri.io) application: models, controllers, routes and
 server-side rendered React views, Rails style.
@@ -195,11 +222,7 @@ ${pm} install
 henri server          # development server with hot reload
 \`\`\`
 
-The home page lists the sample \`Task\` resource; add tasks at \`/tasks\`.
-It is a regular scaffold (\`app/models/Task.js\`, \`app/controllers/tasks.js\`,
-\`app/views/pages/tasks/\`, the \`resources tasks\` key of \`config/routes.js\`
-and \`test/tasks.test.js\`): edit it, or remove it with
-\`henri destroy scaffold Task\`.
+${sample}
 
 ## Commands
 
@@ -207,9 +230,7 @@ and \`test/tasks.test.js\`): edit it, or remove it with
 henri server                  # start (--production for the production build)
 henri console                 # REPL with henri and the models loaded
 henri routes                  # the routes table from config/routes.js
-henri generate scaffold Post title:string! body:text
-henri generate model|controller|worker|test <name>
-henri destroy scaffold Post   # undo a generator
+${generators}
 henri test                    # run test/**/*.test.js
 henri build                   # build the production views
 ${pm} run lint                # eslint
@@ -221,7 +242,7 @@ ${pm} run lint                # eslint
 | ---------------------- | ------------------------------------------------ |
 | \`app/models\`           | Models, autoloaded and exposed as globals        |
 | \`app/controllers\`      | Controllers (\`name#action\` in the routes)         |
-| \`app/views/pages\`      | React pages rendered by next.js                  |
+| \`app/views/pages\`      | ${pages}|
 | \`app/views/components\` | Shared components (\`import x from 'components/x'\`) |
 | \`app/workers\`          | Background workers started with the server       |
 | \`app/helpers\`          | Server-side helpers                              |
@@ -240,6 +261,7 @@ and roles.
 See the [documentation](https://usehenri.io) for models, routes, views,
 GraphQL, mail and workers.
 `;
+};
 
 /**
  * Copies the template from @usehenri/cli/template


### PR DESCRIPTION
Two integration bugs found while documenting 1.1:

- `henri new --renderer inertia` scaffolded the React `tasks` sample on top of the Inertia template, producing a hybrid app. The sample is now only added for the React template; the Inertia template ships its own model, controller, page and routes. README text follows the renderer; an unknown renderer exits 1.
- `henri build` returned early for anything but React. It now dispatches on `config.renderer` to `@usehenri/react/engine` or `@usehenri/inertia/engine` (`build({ cwd, config })`); the Handlebars renderer needs no build.

New `build.spec.js` and an Inertia block in `new.spec.js`; 88 CLI tests pass. No changeset: the 1.1 changeset already promises `henri build` for Inertia.