### PR TITLE
Docs for 1.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,8 +2,10 @@
 
 henri is a Rails-like, server-side rendered JavaScript framework for Node.js:
 models, controllers, routes and React views, with real ORMs and hot reload. This
-is the monorepo for the `henri` CLI, `@usehenri/core` and its adapters, and the
-usehenri.io website. It is public and open source (MIT).
+is the monorepo for the `henri` CLI, `@usehenri/core` and its adapters, the view
+engines, the testing helpers and the usehenri.io website. It is public and open
+source (MIT). The documentation in `website/src/content/docs` describes what the
+code does: keep both in sync when a behaviour changes.
 
 ## Setup and commands
 
@@ -15,10 +17,11 @@ mise install                          # node + pnpm from mise.toml
 pnpm install                          # whole workspace; builds @usehenri/react dist
 pnpm test                             # vitest 5, all packages (NODE_ENV=test)
 pnpm test packages/core               # one package (path filter); `pnpm test:cover` for coverage
-pnpm lint                             # eslint 10 flat config
-pnpm format                           # prettier 3
+pnpm lint                             # eslint 10 flat config, zero warnings in CI
+pnpm format                           # prettier 3 (`pnpm format:check` in CI)
 pnpm build                            # rollup build of @usehenri/react
-pnpm --filter @usehenri/website dev   # docs site (Astro + Starlight)
+pnpm --filter @usehenri/website dev   # docs site (Astro + Starlight); `build` and `preview` too
+scripts/smoke.sh                      # scaffold an app from the packed workspace and boot it
 pnpm changeset                        # record a version bump for changed packages
 ```
 
@@ -26,63 +29,111 @@ The first test run downloads a MongoDB binary (mongodb-memory-server) into
 `~/.cache/mongodb-binaries`. Set `MONGOMS_DISABLE_POSTINSTALL=1` when
 installing where that download is unwanted.
 
+Applications built with henri run their own tests with `henri test`, which
+spawns the app's Vitest with `NODE_ENV=test`; `@usehenri/testing` boots the
+app inside the test worker (`setup`, `teardown`, `request`, `agent`, `henri`,
+plus `@usehenri/testing/setup-file` for `setupFiles`). `packages/demo` is such
+an app and is what core's tests boot.
+
 ## Layout
 
-| Path                                    | Package               | Role                                                           |
-| --------------------------------------- | --------------------- | -------------------------------------------------------------- |
-| `packages/henri`                        | `henri`               | The CLI binary users install; delegates to `@usehenri/cli`.    |
-| `packages/cli`                          | `@usehenri/cli`       | `new`, `server`, `generate`, `console`, `build`, the template  |
-| `packages/core`                         | `@usehenri/core`      | The framework: modules, server, router, models, views, users   |
-| `packages/mongoose`                     | `@usehenri/mongoose`  | MongoDB adapter (Mongoose)                                     |
-| `packages/disk`                         | `@usehenri/disk`      | Zero-config local MongoDB (mongodb-memory-server)              |
-| `packages/sequelize`                    | `@usehenri/sequelize` | Shared SQL adapter (Sequelize)                                 |
-| `packages/mysql`, `postgresql`, `mssql` | `@usehenri/*`         | Dialect packages on top of `@usehenri/sequelize`               |
-| `packages/react`                        | `@usehenri/react`     | Next.js view engine, `withHenri`, form components              |
-| `packages/testing`, `websocket`         | `@usehenri/*`         | Small helpers                                                  |
-| `packages/demo`                         | private               | Demo app used by core's tests (`NODE_ENV=test` chdirs into it) |
-| `website`                               | private               | usehenri.io, deployed by Vercel from `website/`                |
+| Path                                    | Package               | Role                                                                                                                      |
+| --------------------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `packages/henri`                        | `henri`               | The CLI binary users install; delegates to `@usehenri/cli`.                                                               |
+| `packages/cli`                          | `@usehenri/cli`       | `new`, `init`, `server`, `console`, `routes`, `generate`, `destroy`, `build`, `test`, `clean`, `about`; the app templates |
+| `packages/core`                         | `@usehenri/core`      | The framework: modules, server, router, models, views, users, mail, GraphQL                                               |
+| `packages/mongoose`                     | `@usehenri/mongoose`  | MongoDB adapter (Mongoose 9)                                                                                              |
+| `packages/disk`                         | `@usehenri/disk`      | Zero-config local MongoDB (mongodb-memory-server) on top of mongoose                                                      |
+| `packages/sequelize`                    | `@usehenri/sequelize` | Shared SQL adapter (Sequelize 6)                                                                                          |
+| `packages/mysql`, `postgresql`, `mssql` | `@usehenri/*`         | Dialect packages on top of `@usehenri/sequelize`                                                                          |
+| `packages/react`                        | `@usehenri/react`     | Next.js 16 view engine, `withHenri`, `useHenri`, form components                                                          |
+| `packages/inertia`                      | `@usehenri/inertia`   | Inertia.js view engine on Vite + React 19 (new in 1.1, experimental)                                                      |
+| `packages/testing`                      | `@usehenri/testing`   | Boots an app for Vitest and binds supertest to it                                                                         |
+| `packages/websocket`                    | private               | Not published, never wired into core                                                                                      |
+| `packages/demo`                         | private               | Demo app used by core's tests (`NODE_ENV=test` chdirs into it)                                                            |
+| `website`                               | private               | usehenri.io, deployed by Vercel from `website/`                                                                           |
 
 ## How core works
 
 - `Henri` (`packages/core/src/henri.js`) registers modules, each a class extending
-  `base/module.js` with a unique `name`, a `runlevel` (0 config/logger, 1 graphql
-  and mail, 2 controllers and Express, 3 models and views, 4 users, 5 routes and
-  workers, 6 app modules, 7 tests) and `init()`. Modules on the same level start
-  concurrently; reloadable ones expose `reload()` and are torn down in reverse.
+  `base/module.js` with a unique `name`, a `runlevel` (0 config, 1 mail and
+  graphql, 2 controllers and the Express app, 3 models and the view engine,
+  4 users, 5 router and workers, 6 app modules) and `init()`. Modules on the
+  same level start concurrently; a failing `init()` fails the boot
+  (`henri.init()` rejects with an Error whose `cause` is the module error).
+  Reloadable ones expose `reload()`; `henri.stop()` stops every module even
+  when one fails and resolves with the errors. `pen.fatal()` returns an Error
+  to throw. Level 7 (`7.tests.js`) is legacy and never runs in a normal boot.
   Each module is exposed as `henri.<name>`, so names must be unique.
 - The `henri` instance and every model are globals in user apps
-  (`global.henri`, `global.Artwork`). Tests rely on this too.
-- Store adapters implement `new Adapter(name, config, henri)` with
-  `addModel(model, userModelName)`, `getModels()`, `getSessionConnector()`,
-  `start()`, `stop()`. Core loads them from the app cwd with
-  `utils.resolveFrom('@usehenri/<adapter>')`.
-- View engines implement `init()`, `prepare()`, `fallback(router)` and
-  `render(req, res, route, opts)`. The React engine passes `opts` to pages
-  through `req._henri`; the Handlebars engine lives in `core/src/engines/template.js`.
-- App configuration is `config/<NODE_ENV>.json` falling back to `default.json`
-  (`stores`, `secret`, `renderer`, `port`, `graphql`, `mail`, `user`, `baseRole`).
+  (`global.henri`, `global.Task`). Under `NODE_ENV=test` core does not set the
+  global; `@usehenri/testing` does.
+- Configuration is `config/<NODE_ENV>.json` (`dev.json` when unset) falling
+  back to `default.json`, plus `.env` in the app (`HENRI_SECRET` provides
+  `secret`, `HENRI_HOST` the bind address). Keys: `port`, `host`, `cors`,
+  `renderer`, `inertia`, `experimental`, `stores`, `secret`, `user` (string or
+  `{ model, public, loginPath, afterLogin, sessionMaxAge }`), `baseRole`,
+  `trustProxy`, `csrf`, `graphql`, `mail`.
+- Store adapters implement one contract (JSDoc `HenriAdapter` at the top of
+  `packages/sequelize/index.js` and `packages/mongoose/index.js`):
+  `new Adapter(name, config, henri)`, `addModel(model, userModelName)`,
+  `getModels()`, `start()`, `stop()`, async `getSessionConnector(session)`,
+  `findUserByEmail()`, `findUserById()`, `userId()`, `toPlain()`, `ping()`,
+  `transaction()` and, on SQL, `query()`. Core loads them from the app cwd
+  with `utils.resolveFrom('@usehenri/<adapter>')`. Model files use the henri
+  schema format (`type: 'string'|'text'|'number'|'integer'|'float'|'boolean'|
+'date'|'json'|'uuid'`, `required`, `default`, `enum`, `unique`, `index`),
+  normalized by `schema.js` in each adapter (Sequelize throws on unknown keys,
+  Mongoose passes them through). The user model gets `email` (unique,
+  lowercased), `password` (hashed, not selected by default) and `roles`
+  (stripped from mass assignment; `setRoles()` or `{ unsafe: true }`).
+- The user module (`4.user.js`) mounts express-session (`henri.sid`),
+  passport (`local` and `jwt` strategies), `POST /login`, `POST /logout`
+  (`GET` answers 405), the double-submit CSRF middleware (`base/csrf.js`,
+  cookie `henri.csrf`, header `X-CSRF-Token` or body `_csrf`) and
+  `req.permit()` (`base/params.js`). Views and JSON only ever get
+  `publicUser()` (`{ id, email, roles }` + `config.user.public`).
+- The router (`5.router.js`) expands `config/routes.js`, sets `req._henri`
+  (`csrf`, `localUrl`, `paths`, `query`, `user`) and `res.render()`, which
+  builds the view options (`data` or a `graphql` query, `errors`, role-filtered
+  `paths`) and content-negotiates HTML (the engine) or JSON. `res.boom.*`
+  (`base/boom.js`) answers `{ statusCode, error, message, data }`; 404 and 500
+  are negotiated in `base/http.js`.
+- View engines implement `init()`, `prepare()`, `fallback(router)`,
+  `render(req, res, route, opts)` and optionally `reload()` and `close()`. The
+  Handlebars engine lives in `core/src/engines/template.js`; `react` resolves
+  `@usehenri/react/engine` and `inertia` `@usehenri/inertia/engine` from the app
+  (`core/src/engines/*.js` are the loaders). The React engine passes `opts` to
+  pages through `req._henri`; `withHenri` reads only that on the server.
+  `build({ cwd, config })` on both engines builds without booting henri, which
+  is what `henri build` calls.
 
 ## Conventions
 
-- CommonJS everywhere except `packages/react/src` (ESM compiled by rollup) and
-  `website` (Astro). No TypeScript.
+- CommonJS everywhere except `packages/react/src` (ESM + JSX compiled by rollup
+  to `dist/lib`), `packages/inertia/src` and `vite.mjs` (ESM consumed by Vite)
+  and `website` (Astro). No TypeScript.
 - pnpm links strictly: every module a package `require()`s must be in that
   package's `package.json`. Internal dependencies use `workspace:^`.
 - Apps that use the React renderer must depend on `next`, `react` and `react-dom`
-  themselves (Turbopack resolves `next` from the app directory).
+  themselves (Turbopack resolves `next` from the app directory); Inertia apps on
+  `@inertiajs/react`, `react`, `react-dom`, `vite` and `@vitejs/plugin-react`.
 - ESLint rules worth knowing: `sort-keys`, `prefer-template`, `id-length`,
   `no-nested-ternary`, JSDoc on functions. Prettier: single quotes, es5 commas.
   `.hbs`, the demo views and `packages/cli/scripts/generate` are excluded from
   Prettier on purpose (its Handlebars parser mangles JSX inside templates).
-- Tests live in `__tests__/*.spec.js` (vitest, `globals: true`: no imports for
-  `describe`/`test`/`expect`/`vi`, and `require('vitest')` does not work in
-  CommonJS); snapshot tests exist for most core
-  modules, regenerate them only when the diff is explained by your change.
+- Tests live in `__tests__/*.spec.js` or `*.test.js` (vitest, `globals: true`:
+  no imports for `describe`/`test`/`expect`/`vi`, and `require('vitest')` does
+  not work in CommonJS); core's boot the demo app with the disk adapter.
+  Snapshot tests exist for most core modules, regenerate them only when the diff
+  is explained by your change.
 - Commits follow Conventional Commits (`feat(core): ...`, `fix(react): ...`).
-  Husky runs lint-staged (prettier + eslint --fix) on commit.
+  Husky runs lint-staged (prettier + eslint --fix) and commitlint on commit.
 - Any user-facing change to a public package needs a changeset
-  (`pnpm changeset`). All public packages are versioned together (a `fixed`
-  group in `.changeset/config.json`); private packages are never versioned.
+  (`pnpm changeset`) describing it for the changelog; the docs pages that
+  describe the behaviour change in the same pull request. All public packages
+  are versioned together (a `fixed` group in `.changeset/config.json`);
+  private packages are never versioned.
 
 ## Releasing
 
@@ -92,13 +143,20 @@ PR runs the publish job, which publishes to npm with provenance and creates
 GitHub releases. Publishing uses npm trusted publishing (OIDC): every public
 package trusts this repository's `release.yml` running in the `npm` GitHub
 environment. There is no npm token to rotate; a new package needs its trusted
-publisher registered on npmjs.com before its first release.
+publisher registered on npmjs.com before its first release, and must be added
+to the `fixed` group of `.changeset/config.json`. `scripts/prepublish.js` copies
+the LICENSE and a README into every public package at publish time
+(`packages/henri` gets the root README).
 
 ## Known gaps
 
 - The Vue/Nuxt renderer (`core/src/engines/vue.js`) has not been exercised
-  since 2020.
+  since 2020 and only loads with `experimental.vue: true`.
+- The Inertia engine is new in 1.1 and has had little use; its options may
+  change.
 - The SQL adapters are tested against sqlite; live MySQL, PostgreSQL and MSSQL
-  connections are not covered.
+  connections are not covered. There are no migrations (`sequelize.sync()`).
+- `henri generate scaffold|crud` write Mongoose-only controllers and React-only
+  pages.
 - The scaffolded app pins ESLint 9 because `eslint-plugin-react` does not
   support ESLint 10 yet.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@
 henri is a Rails-like, server-side rendered JavaScript framework for Node.js:
 models backed by real ORMs (MongoDB through Mongoose, MySQL, PostgreSQL and
 MSSQL through Sequelize, or a zero-config local store), thin controllers,
-declarative routes with roles and CRUD, React views rendered by Next.js,
-GraphQL, mail, workers and hot reload, all driven by one CLI.
+declarative routes with roles and CRUD, React views rendered by Next.js or by
+Vite with Inertia.js, GraphQL, mail, workers, tests on Vitest and hot reload,
+all driven by one CLI.
 
 ## Install
 
@@ -30,8 +31,10 @@ henri server
 ## Documentation
 
 Guides, the CLI reference, models, controllers, routes, views and adapters are
-documented at **[usehenri.io](https://usehenri.io)**. Release notes are on the
-[GitHub releases](https://github.com/usehenri/henri/releases) page.
+documented at **[usehenri.io](https://usehenri.io)**. henri was revived in 2026
+on a current toolchain: if you have an application written for 0.37, read
+[usehenri.io/upgrading](https://usehenri.io/upgrading/). Release notes are on
+the [GitHub releases](https://github.com/usehenri/henri/releases) page.
 
 ## Contributing
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -45,7 +45,7 @@ export default defineConfig({
       sidebar: [
         {
           label: 'Start here',
-          items: ['getting-started', 'configuration'],
+          items: ['getting-started', 'configuration', 'upgrading'],
         },
         {
           label: 'Guides',
@@ -53,7 +53,7 @@ export default defineConfig({
         },
         {
           label: 'Reference',
-          items: [{ autogenerate: { directory: 'reference' } }],
+          items: ['reference/cli', 'reference/api', 'reference/under-the-hood'],
         },
       ],
     }),

--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -1,73 +1,86 @@
 ---
 title: Configuration
-description: The config directory, environments, stores, secrets and renderer.
+description: The config directory, environments, .env, stores and the other keys.
 sidebar:
   order: 2
 ---
 
-Configuration is a JSON file in the `config` directory. henri loads the file matching your `NODE_ENV` and falls back to `default.json`, so you can have `default.json`, `production.json`, `test.json` and so on.
+Configuration is JSON in the `config` directory. henri loads `config/<NODE_ENV>.json` and falls back to `config/default.json`; with `NODE_ENV` unset it looks for `config/dev.json` first. A typical application commits `default.json` and adds `production.json` or `test.json` for the keys that differ.
 
 ```json
 {
   "stores": {
     "default": {
       "adapter": "mongoose",
-      "url": "mongodb://user:pass@mongoserver.com:10914/henri-test"
+      "url": "mongodb://localhost:27017/myapp"
     },
-    "dev": {
+    "scratch": {
       "adapter": "disk"
     }
   },
-  "secret": "25bb9ed0b0c44cc3549f1a09fc082a1aa3ec91fbd4ce9a090b",
-  "renderer": "react"
+  "renderer": "react",
+  "user": "user",
+  "baseRole": "guest"
 }
 ```
 
-The file is validated on boot: a syntax error is reported with its line and column instead of a stack trace.
+The file is parsed on boot: a syntax error is reported with its line, and the boot stops when no file can be loaded. The loaded object is frozen.
 
 ## Keys
 
-| Key            | Default       | Description                                                                                                        |
-| -------------- | ------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `port`         | `3000`        | Port to listen on. In development a busy port is replaced by the next free one.                                    |
-| `host`         | see below     | Interface to listen on. `127.0.0.1` outside production, `0.0.0.0` in production; `HENRI_HOST` overrides it.        |
-| `cors`         | off           | `true` enables [cors](https://github.com/expressjs/cors) with its defaults; an object is passed to it as options.  |
-| `renderer`     | `template`    | View engine: `react`, `inertia` or `template` (Handlebars). See [Views](/guides/views/).                           |
-| `inertia`      |               | Options of the `inertia` renderer (`ssr`, `id`, `entry`, `ssrEntry`, `template`). See [Views](/guides/views/).     |
-| `experimental` |               | Opt-in to unmaintained renderers, ex: `{ "vue": true }`.                                                           |
-| `stores`       |               | Named database stores. Models pick one with their `store` key, or use `default`. See [Models](/guides/models/).    |
-| `secret`       |               | Session and JWT secret. Required as soon as you have a user model; `HENRI_SECRET` can provide it.                  |
-| `user`         | `User`        | Name of the model that represents users (login, roles, password hashing), or an object. See [Users](#users).       |
-| `baseRole`     |               | Role given to every new user.                                                                                      |
-| `trustProxy`   | `true`        | Express `trust proxy` setting: `X-Forwarded-*` headers from a reverse proxy are honoured. Set `false` without one. |
-| `csrf`         | `true`        | Set to `false` to disable the CSRF protection described in [Users](#users).                                        |
-| `graphql`      | `/_henri/gql` | Path of the GraphQL endpoint. See [GraphQL](/guides/graphql/).                                                     |
-| `mail`         |               | Nodemailer transport options, or `"test"` for an Ethereal test account. See [Mail](/guides/mail/).                 |
+| Key            | Default       | Description                                                                                                                                    |
+| -------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `port`         | `3000`        | Port to listen on. In development a busy port is replaced by the next free one.                                                                |
+| `host`         | see below     | Interface to bind: `127.0.0.1` outside production, `0.0.0.0` in production. `HENRI_HOST` (what `henri server --host` sets) wins over the file. |
+| `cors`         | off           | `true` enables [cors](https://github.com/expressjs/cors) with its defaults; an object is passed to it as options.                              |
+| `renderer`     | `template`    | View engine: `react`, `inertia` or `template` (Handlebars). `henri new` writes `react`. See [Views](/guides/views/).                           |
+| `inertia`      |               | Options of the Inertia renderer: `ssr`, `id`, `entry`, `ssrEntry`, `template`. See [Views](/guides/views/#inertia).                            |
+| `experimental` |               | Opt-in to unmaintained renderers: `{ "vue": true }`.                                                                                           |
+| `stores`       |               | Named database stores, see below. A model picks one with its `store` key or uses `default`.                                                    |
+| `secret`       |               | Session and token secret. Required as soon as a user model exists; usually provided by `HENRI_SECRET`.                                         |
+| `user`         | `user`        | Name of the user model, or an object (below). See [Users](/guides/users/).                                                                     |
+| `baseRole`     |               | Role, or list of roles, given to every new user.                                                                                               |
+| `trustProxy`   | `true`        | Express `trust proxy` setting: `X-Forwarded-*` headers from a reverse proxy are honoured. Set `false` without one.                             |
+| `csrf`         | `true`        | `false` disables the [CSRF protection](/guides/users/#csrf).                                                                                   |
+| `graphql`      | `/_henri/gql` | Path of the GraphQL endpoint. See [GraphQL](/guides/graphql/).                                                                                 |
+| `mail`         |               | Nodemailer transport options, or `"test"` for an Ethereal test account. See [Mail](/guides/mail/).                                             |
+
+## Stores
+
+Each entry of `stores` names an adapter and how to reach its database. The adapter package (`@usehenri/<adapter>`) must be installed in the application.
+
+| Key                                                | Adapters      | Description                                                                                                         |
+| -------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `adapter`                                          | all           | `disk`, `mongoose`, `mysql`, `mariadb`, `postgresql` or `mssql`.                                                    |
+| `url`                                              | mongoose, SQL | Connection string. Required unless `host` is given (`mariadb://` is accepted by the mysql adapter).                 |
+| `host`, `port`, `database`, `username`, `password` | mongoose, SQL | Alternative to `url`. On mongoose, `host` may also be a full `mongodb://` url.                                      |
+| `opts`                                             | mongoose      | Options passed to `mongoose.connect()`; henri sets `connectTimeoutMS` and `serverSelectionTimeoutMS` to 10 seconds. |
+| `session`                                          | mongoose, SQL | Options of the session store (connect-mongo, whose collection is `henriSessions`, or connect-session-sequelize).    |
+| `path`, `dbName`                                   | disk          | Data directory, relative to the application (`.henri/data`), and database name (`henri`).                           |
+| `logging`, `pool`, `dialectOptions`, ...           | SQL           | Every other key is forwarded to Sequelize. `logging` defaults to the `henri:sequelize` debug namespace.             |
+
+See [Models](/guides/models/#adapters) for each adapter.
 
 ## Environment and `.env`
 
-On boot henri reads `.env` in the application directory (`KEY=value` lines, `#` comments; variables already set in the environment win) and applies these overrides:
+On boot henri reads `.env` in the application directory (`KEY=value` lines, optional `export`, quotes stripped, `#` comments; variables already set in the environment win) and applies these overrides:
 
 | Variable       | Effect                                                                 |
 | -------------- | ---------------------------------------------------------------------- |
 | `HENRI_SECRET` | Provides or replaces `secret`, so the secret can stay out of `config`. |
 | `HENRI_HOST`   | Replaces `host` (what `henri server --host` sets).                     |
+| `NODE_ENV`     | Selects the configuration file. `henri server --production` sets it.   |
 
-## Users
+Nothing else in the configuration is expanded from the environment: for a container, write `config/production.json` at start time (the repository's `docker/entrypoint.sh` does exactly that).
 
-Naming a user model adds `email`, `password` (hashed with bcrypt) and `roles` to it and mounts:
+## The `user` object
 
-- `POST /login`, taking `email` and `password` as JSON or as a form. API clients get `{ user }` back, browsers are redirected to `afterLogin`. On failure: `401` (JSON) or a redirect to `<loginPath>?error=invalid`.
-- `POST /logout`, which destroys the session and answers `{ ok: true }` or redirects to `/`. `GET /logout` is deprecated and does nothing.
-- A session cookie, `henri.sid` (httpOnly, `SameSite=Lax`, `Secure` in production, 30 days), stored in the database of the user model.
-- A CSRF token in the `henri.csrf` cookie. `POST`, `PUT`, `PATCH` and `DELETE` requests that carry a session must send it back in the `X-CSRF-Token` header or a `_csrf` field, otherwise they get a `403`. The React `fetch()` and `hydrate()` helpers do it for you; requests authenticated with a JWT bearer token are exempt.
-
-`user` also accepts an object:
+`user` is the name of the model to treat as the user model. It also accepts an object:
 
 ```json
 {
   "user": {
-    "model": "User",
+    "model": "user",
     "public": ["name", "avatar"],
     "loginPath": "/login",
     "afterLogin": "/",
@@ -76,11 +89,11 @@ Naming a user model adds `email`, `password` (hashed with bcrypt) and `roles` to
 }
 ```
 
-`public` lists the fields, besides `id`, `email` and `roles`, that views and JSON answers may see: `henri.user.publicUser(user)` builds that object and nothing else on the user document leaves the server. `loginPath` is where browsers are sent when a route denies them (default `/login`), `afterLogin` where they land after a form login and `sessionMaxAge` the session lifetime in milliseconds.
+`public` lists the fields, besides `id`, `email` and `roles`, that views and JSON answers may see; `loginPath` is where browsers are sent when a route denies them; `afterLogin` where they land after a form login; `sessionMaxAge` the session lifetime in milliseconds (30 days). See [Users](/guides/users/).
 
 ## Reading the configuration in your code
 
-The configuration is frozen and exposed on the global `henri` object:
+The configuration is exposed on the global `henri` object. Keys use dots (and brackets for arrays):
 
 ```js
 henri.config.get('stores.default.adapter'); // throws if the key is missing

--- a/website/src/content/docs/getting-started.md
+++ b/website/src/content/docs/getting-started.md
@@ -8,82 +8,97 @@ sidebar:
 ## Requirements
 
 - Node.js 22 or newer
-- A package manager: pnpm, npm or yarn all work
+- A package manager: pnpm, npm or yarn. `henri new` uses the one it finds (the `packageManager` field of an existing `package.json`, then pnpm, yarn, npm).
 
 :::note
-henri was revived in 2026 on a modern toolchain (Node 22+, Express 5, Next.js 16, React 19, Mongoose 9, Sequelize 6). Releases published to npm before that revival still target Node 10 to 14; make sure you install a current version.
+henri was revived in 2026 on a modern toolchain (Node 22+, Express 5, Next.js 16, React 19, Mongoose 9, Sequelize 6). Releases published before 1.0 still target Node 10 to 14. If you have an application written for henri 0.37, read [Upgrading](/upgrading/).
 :::
 
 ## Install
 
 ```bash
 pnpm add -g henri
-# or
-npm install -g henri
+# or: npm install -g henri
 ```
 
-## Create a new project
+`henri --version` prints the installed version.
+
+## Create a project
 
 ```bash
-henri new <folder name>
-```
-
-The command creates a directory structure similar to this:
-
-```text
-├── app
-│   ├── controllers
-│   ├── helpers
-│   ├── models
-│   ├── workers
-│   └── views
-│       ├── assets
-│       ├── components
-│       ├── pages
-│       ├── public
-│       └── styles
-├── config
-│   ├── default.json
-│   ├── production.json
-│   ├── routes.js
-│   └── webpack.js            <- extend the Next.js webpack settings
-├── test
-│   ├── controllers
-│   ├── helpers
-│   ├── models
-│   └── views
-└── package.json
-```
-
-If you have a Ruby on Rails background, this should look familiar.
-
-## Start coding
-
-```bash
-cd <folder name>
+henri new my-app
+cd my-app
 henri server
 ```
 
-henri boots its modules in order (configuration, mail, GraphQL, controllers, server, models, views, users, routes, workers, tests), prints the URL it is listening on and watches your files. Saving a controller, a model, a route file, a worker or a configuration file reloads the affected modules without restarting the process.
+`henri new` copies the application skeleton, writes the configuration, scaffolds a sample `Task` resource, writes a README, runs `git init` (unless the folder is already inside a repository) and installs the dependencies. `--skip-install` and `--no-git` skip those two steps; `--renderer inertia` picks the [Inertia](/guides/views/#inertia) view engine instead of React. The result:
 
-While the server runs, the terminal accepts a few shortcuts:
-
-| Key          | Action                                      |
-| ------------ | ------------------------------------------- |
-| `R`          | list the loaded routes                      |
-| `U`          | list the routes whose controller is missing |
-| `Cmd/Ctrl+R` | reload the whole application                |
-| `Cmd/Ctrl+O` | open the app in your browser                |
-| `Cmd/Ctrl+C` | quit                                        |
-
-## Useful flags
-
-```bash
-henri server --production    # same as NODE_ENV=production
-henri server --debug=henri:* # same as DEBUG=henri:*
-henri server --inspect       # start the Node.js inspector
-henri server --skip-workers  # do not start app/workers
-henri server --force-build   # force a production rebuild of the views
+```text
+├── .env                      <- HENRI_SECRET, ignored by git
+├── .gitignore
+├── app
+│   ├── controllers
+│   │   ├── main.js           <- main#home, the landing page
+│   │   └── tasks.js          <- the resources actions of Task
+│   ├── helpers
+│   ├── models
+│   │   └── Task.js           <- the `Task` global
+│   ├── views
+│   │   ├── assets
+│   │   ├── components
+│   │   ├── jsconfig.json     <- lets pages `import x from 'components/x'`
+│   │   ├── next.config.js    <- requires @usehenri/react/engine/conf
+│   │   ├── pages
+│   │   │   ├── _app.js       <- global styles
+│   │   │   ├── index.js
+│   │   │   └── tasks         <- index, new, edit, show and _form
+│   │   ├── public
+│   │   └── styles
+│   └── workers
+├── config
+│   ├── default.json          <- stores, renderer, user model (committed)
+│   └── routes.js             <- 'get /': 'main#home', 'resources tasks': 'tasks'
+├── eslint.config.js
+├── package.json
+├── pnpm-workspace.yaml       <- written for pnpm only
+├── README.md
+├── test
+│   └── tasks.test.js         <- run with `henri test`
+└── vitest.config.js
 ```
 
-See the [CLI reference](/reference/cli/) for every command.
+If you have a Ruby on Rails background, this should look familiar. The sample resource is a regular scaffold (`henri generate scaffold Task name:string! category:string done:boolean` writes the same files); `henri destroy scaffold Task` removes it.
+
+`config/default.json` is committed and holds no secret: the session secret is generated into `.env` as `HENRI_SECRET`, which henri reads on boot. The default store is the [disk adapter](/guides/models/#disk), a local MongoDB persisted under `.henri/data` (ignored by git too), so there is nothing to install to run the application.
+
+## Start coding
+
+`henri server` boots the modules in order (configuration, mail and GraphQL, controllers and the Express app, models and the view engine, users, routes and workers), prints the URL it listens on (`http://localhost:3000/`; development binds to `127.0.0.1`) and watches your files. Saving a controller, a model, `config/routes.js`, a worker or a configuration file reloads the affected modules without restarting the process; Next.js hot reloads the pages itself. Changes to `config/next.js` or `config/webpack.js` need a restart, and the terminal says so.
+
+Open the page, add a task at `/tasks/new`, then read `app/controllers/tasks.js` and `app/views/pages/tasks/index.js` to see the data flow: the controller calls `res.render('/tasks', { data })` and the page receives `data` through `withHenri`.
+
+While the server runs in an interactive terminal:
+
+| Key      | Action                                            |
+| -------- | ------------------------------------------------- |
+| `r`      | list the loaded routes                            |
+| `u`      | list the routes whose controller is missing       |
+| `Ctrl+R` | reload the whole application                      |
+| `Ctrl+O` | open the app in your browser                      |
+| `Ctrl+C` | stop the server (a second `Ctrl+C` exits at once) |
+
+## Everyday commands
+
+```bash
+henri server --production    # build the views once, then serve them
+henri server --debug=henri:* # verbose logs (same as DEBUG=henri:*)
+henri server --inspect       # start the Node.js inspector
+henri server --skip-workers  # do not start app/workers
+henri server --host=0.0.0.0  # listen on every interface
+henri routes                 # the routes table of config/routes.js
+henri console                # a REPL with henri and the models loaded
+henri test                   # run test/**/*.test.js with Vitest
+henri generate scaffold Post title:string! body:text
+```
+
+See the [CLI reference](/reference/cli/) for every command and flag.

--- a/website/src/content/docs/guides/controllers.md
+++ b/website/src/content/docs/guides/controllers.md
@@ -2,77 +2,116 @@
 title: Controllers
 description: Express handlers under app/controllers, autoloaded and reloaded on save.
 sidebar:
-  order: 4
+  order: 2
 ---
 
-Add controllers under `app/controllers`. They are autoloaded, reloaded on save and referenced from routes as `file#action`.
+Controllers live in `app/controllers`. Every `.js` file there is loaded on boot, reloaded on save and referenced from `config/routes.js` as `file#action`; a file in a subdirectory is prefixed with it (`app/controllers/admin/users.js` is `admin/users#index`).
 
-A controller is a plain object of Express handlers. Models are globals, `henri` is a global, and `res.render()` hands data to the view.
+A controller is a plain object of Express handlers, `(req, res)` or `(req, res, next)`, sync or async. Models are globals, `henri` is a global, and `res.render()` hands data to the view.
 
 ```js
-// app/controllers/user.js
+// app/controllers/tasks.js
+const FIELDS = ['name', 'category', 'done'];
 
 module.exports = {
-  info: async (req, res) => {
-    if (!req.isAuthenticated()) {
-      return res.status(403).send("Sorry! You can't see that.");
+  index: async (req, res) => {
+    res.render('/tasks', { data: { tasks: await Task.find() } });
+  },
+
+  show: async (req, res) => {
+    const task = await Task.findById(req.params.id);
+
+    if (!task) {
+      return res.boom.notFound(`Task ${req.params.id} not found`);
     }
 
-    if (await User.countDocuments({ email: 'felix@usehenri.io' })) {
-      await User.updateOne(
-        { email: 'felix@usehenri.io' },
-        { password: 'blue' }
-      );
-      return res.send('user exists.');
-    }
-
-    return res.send('no such user');
+    return res.render('/tasks/show', { data: { task } });
   },
 
   create: async (req, res) => {
-    await User.create({ email: 'felix@usehenri.io', password: 'moo' });
-    res.redirect('/');
-  },
+    let task;
 
-  fetch: async (req, res) => {
-    const users = await User.find();
-    res.send(users);
-  },
+    try {
+      task = await Task.create(req.permit(...FIELDS));
+    } catch (error) {
+      if (error.name !== 'ValidationError') {
+        throw error;
+      }
 
-  postinfo: async (req, res) => {
-    const data = req.isAuthenticated() ? await User.find() : {};
-    res.render('/log', { data });
+      return res.boom.badData(error.message, {
+        errors: Object.fromEntries(
+          Object.entries(error.errors).map(([field, e]) => [field, e.message])
+        ),
+      });
+    }
+
+    return res.format({
+      html: () => res.redirect(`/tasks/${task.id}`),
+      json: () => res.status(201).json({ task }),
+      default: () => res.status(201).json({ task }),
+    });
   },
 };
 ```
 
+This is the shape `henri generate scaffold` writes: `req.permit()` for the input, a `422` with one message per field when validation fails, a `404` when the record does not exist, and `res.format()` so the same action serves a browser (redirect) and an API client (JSON).
+
+Errors thrown or rejected by a controller are logged and answered with a `500`; the message and stack are exposed in development only. Requests nothing claims get a `404`. Both are content negotiated: JSON for API clients (the `res.boom` shape below), an HTML page for browsers.
+
 ## `res.render(route, options)`
 
-`route` is the page to render (`/log` is `app/views/pages/log.js` for React, `app/views/pages/log.hbs` for Handlebars). `options` takes one of:
+`route` is the page to render: `/tasks/show` is `app/views/pages/tasks/show.js` with the React renderer, `pages/tasks/show.jsx` with Inertia, `pages/tasks/show.hbs` with Handlebars. `options` takes one of:
 
 - `data`: an object passed to the page as its `data` prop or template context
 - `graphql`: a query string; its result becomes `data` (see [GraphQL](/guides/graphql/))
 
-The view also receives the logged-in `user` (its public representation: `id`, `email`, `roles` and the fields listed in `config.user.public`), the `paths` allowed for that user, the request `query` and the `csrf` token. If the client asked for `application/json`, the same object is sent as JSON instead of HTML.
+Besides `data`, the view engine receives `user` (the public user or `null`), `paths` (the named routes the user may call), `query` (`req.query`), `csrf` (the CSRF token), `localUrl` (the server url), `errors` (GraphQL errors, if any) and `graphql` (`{ endpoint, query }`). A React page gets all of them as props except `query` (use `router.query`); Inertia pages and Handlebars templates get `query` too. A client asking for `application/json` gets the whole object as JSON instead of HTML; this is what the React helpers use to refresh a page.
+
+`res.hbs(route, options)` renders a Handlebars template whatever the configured renderer, with the same options.
 
 ## `req.permit(...fields)`
 
-Never hand `req.body` to a model as is: a client could set `roles` or any other column. `req.permit()` returns a plain object holding only the fields you list, taken from the query string, the body and the path parameters (a path parameter wins over the body, the body over the query string); fields that were not sent are left out.
+Never hand `req.body` to a model as is: a client could set `roles` or any other column. `req.permit()` returns a plain object holding only the fields you list, taken from the query string, the body and the path parameters (a path parameter wins over the body, the body over the query string). Fields that were not sent are left out, and `__proto__`, `constructor` and `prototype` are never copied.
 
 ```js
-create: async (req, res) => {
-  const user = await User.create(req.permit('email', 'password', 'name'));
-
-  res.status(201).json({ user: henri.user.publicUser(user) });
-},
+const data = req.permit('email', 'password', 'name');
+const same = req.permit(['email', 'password', 'name']); // arrays are flattened
 ```
 
-`henri.params(req).permit([...])` is the same helper for code that does not go through the middleware chain.
+`henri.params(req).permit(...)` is the same helper for code outside the middleware chain, and `henri.params(req).all()` the merged parameters, for reading only.
+
+## `res.boom`
+
+`res.boom.<name>(message, data)` answers a JSON error with a fixed shape. `message` defaults to the reason phrase and `data` is optional:
+
+```js
+res.boom.notFound('No such task', { id: req.params.id });
+// 404 { "statusCode": 404, "error": "Not Found", "message": "No such task", "data": { "id": "..." } }
+```
+
+| Helper              | Status |
+| ------------------- | ------ |
+| `badRequest`        | 400    |
+| `unauthorized`      | 401    |
+| `forbidden`         | 403    |
+| `notFound`          | 404    |
+| `methodNotAllowed`  | 405    |
+| `conflict`          | 409    |
+| `badData`           | 422    |
+| `tooManyRequests`   | 429    |
+| `internal`          | 500    |
+| `notImplemented`    | 501    |
+| `badGateway`        | 502    |
+| `serverUnavailable` | 503    |
+
+The React `Form` reads `data.errors` of a `422` and shows each message under its field, and the `RequestError` thrown by `fetch()` exposes `message`, `statusCode` and `data`.
+
+## `res.format(handlers)`
+
+Express's content negotiation. henri's own answers put `json` before `html` so that a client accepting `*/*` (curl, `fetch()` with no `Accept`) gets JSON and only a browser gets HTML; do the same in your controllers when the order matters, and always give a `default`.
 
 ## What is on `henri`
 
-Inside a controller (or anywhere else) the `henri` global exposes the loaded modules: `henri.config`, `henri.pen` (the logger: `info`, `warn`, `error`, `fatal`), `henri.mail`, `henri.graphql`, `henri.user`, `henri.router`, `henri.server.app` (the Express app) and `henri.validator` ([validator.js](https://github.com/validatorjs/validator.js)).
+Inside a controller (or anywhere else) the `henri` global exposes the loaded modules: `henri.config`, `henri.pen` (the logger), `henri.mail`, `henri.graphql`, `henri.user`, `henri.router`, `henri.server.app` (the Express app), `henri.model.stores`, `henri.validator` ([validator.js](https://github.com/validatorjs/validator.js)) and `henri.gql`. See the [API reference](/reference/api/).
 
-`henri.user` works the same on every database adapter: `findByEmail(email)` (trimmed and lowercased, returns the instance with its password hash), `findById(id)` (without the password) and `publicUser(user)` (what may be sent to a browser).
-
-`henri.addMiddleware(name, fn)` registers a function that receives the router before the routes are mounted, which is how you add your own Express middlewares.
+`henri.addMiddleware(name, fn)` registers a function that receives the router before the routes are mounted, which is how you add your own Express middlewares. It must be called before the router starts (runlevel 5), so from a model file or a custom module rather than a controller.

--- a/website/src/content/docs/guides/graphql.md
+++ b/website/src/content/docs/guides/graphql.md
@@ -2,26 +2,23 @@
 title: GraphQL
 description: Add types and resolvers to your models and query them from controllers.
 sidebar:
-  order: 2
+  order: 6
 ---
 
-Add a `graphql` key to a model and its types and resolvers are loaded, merged with every other model's and served by Apollo Server at `/_henri/gql` (change the path with the `graphql` configuration key).
+Add a `graphql` key to a model and its types and resolvers are loaded, merged with every other model's and served by Apollo Server at `/_henri/gql` (change the path with the `graphql` configuration key). Introspection is on outside production.
 
 ## Definition
 
 ```js
 // app/models/Task.js
-
-const types = require('@usehenri/mongoose/types');
-
 module.exports = {
   schema: {
-    description: { type: types.STRING, required: true },
-    type: { type: types.ObjectId, ref: 'Type', required: true },
-    location: { type: types.ObjectId, ref: 'Location', required: true },
-    reference: { type: types.STRING, required: true },
-    notes: { type: types.STRING },
-    oos: { type: types.BOOLEAN, default: false },
+    description: { type: 'string', required: true },
+    type: { type: 'ObjectId', ref: 'Type', required: true },
+    location: { type: 'ObjectId', ref: 'Location', required: true },
+    reference: { type: 'string', required: true },
+    notes: { type: 'string' },
+    oos: { type: 'boolean', default: false },
   },
   options: {
     timestamps: true,
@@ -34,7 +31,7 @@ module.exports = {
         description: String!
         location: Location
         type: Type
-        notes: String!
+        notes: String
         oos: Boolean
       }
       type Query {
@@ -52,11 +49,13 @@ module.exports = {
 };
 ```
 
-If the merged schema does not compile, the error is printed and the GraphQL service stays off until you fix it. Everything else keeps working.
+If the merged schema does not compile, the error is printed and the GraphQL service stays off until you fix it. Everything else keeps working. The schema is rebuilt when the models reload.
+
+Resolvers receive `{ req, res }` as their context, both for requests hitting the endpoint and for queries run from a controller, so `req.user` is available to them. `henri.graphql.AuthenticationError`, `ForbiddenError`, `UserInputError`, `ValidationError` and `SyntaxError` are `GraphQLError` subclasses carrying the matching `extensions.code`; `henri.graphql.toApolloError(error, code)` wraps any other error.
 
 ## Query
 
-The schema is queryable anywhere with `henri.graphql.run(query)`, and directly as an argument to `res.render()`:
+The schema is queryable anywhere with `henri.graphql.run(query, variables, contextValue)`, which resolves with `{ data, errors }` (or the string `No graphql schema found.` when no model defines one), and directly as an argument to `res.render()`:
 
 ```js
 // app/controllers/tasks.js
@@ -93,4 +92,4 @@ module.exports = {
 };
 ```
 
-The query result becomes the `data` prop of the page, and `errors` is set if the query failed. The page also receives `graphql.endpoint` and `graphql.query`, so the client can rerun the same query later.
+The query result becomes the `data` prop of the page and `errors` holds the GraphQL errors, if any. The page also receives `graphql.endpoint` and `graphql.query`, so the client can rerun the same query later.

--- a/website/src/content/docs/guides/mail.md
+++ b/website/src/content/docs/guides/mail.md
@@ -2,7 +2,7 @@
 title: Mail
 description: Send email with nodemailer through henri.mail.
 sidebar:
-  order: 6
+  order: 7
 ---
 
 henri wraps [nodemailer](https://nodemailer.com). Configure a transport and `henri.mail.send()` is ready.
@@ -20,11 +20,11 @@ henri wraps [nodemailer](https://nodemailer.com). Configure a transport and `hen
 }
 ```
 
-The `mail` object is nodemailer's transport configuration. The transport is verified on boot, so a wrong host or credentials fail early.
+The `mail` object is nodemailer's transport configuration and always goes through `createTransport()` then `verify()` on boot: a wrong host or wrong credentials fail the boot instead of the first `send()`. Without a `mail` key the module logs a warning and `send()` rejects.
 
 Set `"mail": "test"` to use an [Ethereal](https://ethereal.email/) fake account: nothing is delivered, and the console prints a link to every message (the account is cached in `.mailerTestCreds`).
 
-Under `NODE_ENV=test` henri ignores the configuration and uses nodemailer's JSON transport: `henri.mail.send()` works, nothing leaves the machine, and the returned `info.message` is the message as JSON. Set `henri.forceMail = true` before boot to use the configured transport in tests.
+Under `NODE_ENV=test` henri ignores the configuration and uses nodemailer's JSON transport: `henri.mail.send()` works, nothing leaves the machine, and the returned `info.message` is the message as JSON. Set `henri.forceMail = true` on the instance before it boots to use the configured transport in tests.
 
 ## Sending
 
@@ -32,10 +32,10 @@ Under `NODE_ENV=test` henri ignores the configuration and uses nodemailer's JSON
 await henri.mail.send({
   from: '"Henri Server" <foo@example.com>',
   to: 'bar@example.com, baz@example.com',
-  subject: 'Hello ✔',
+  subject: 'Hello',
   text: 'Hello world?',
   html: '<b>Hello world?</b>',
 });
 ```
 
-`henri.mail.nodemailer` is the nodemailer package and `henri.mail.transporter` the configured transport, if you need them directly.
+`send()` resolves with nodemailer's `info` and logs the message id. `henri.mail.nodemailer` is the nodemailer package and `henri.mail.transporter` the configured transport, if you need them directly; the transport is closed when henri stops.

--- a/website/src/content/docs/guides/models.md
+++ b/website/src/content/docs/guides/models.md
@@ -1,75 +1,150 @@
 ---
 title: Models
-description: Define models under app/models and pick a database adapter.
+description: Define models under app/models in one format for every adapter, and pick a database.
 sidebar:
   order: 1
 ---
 
-Add models under `app/models`. They are autoloaded and exposed globally, so `User`, `Task` or `Artwork` are available everywhere in your application, like in Rails.
+Models live in `app/models`. Every `.js` file there (subdirectories included) is loaded on boot, registered with its store adapter and exposed as a global named after the file: `app/models/Task.js` is `Task` everywhere in the application, like in Rails. Two files with the same name, whatever the case, stop the boot. The global is the ORM model itself, so you query it with the [Mongoose](https://mongoosejs.com/) API on MongoDB and the [Sequelize](https://sequelize.org/) API on SQL databases.
 
-henri uses [Mongoose](https://mongoosejs.com/) for MongoDB and [Sequelize](https://sequelize.org/) for SQL databases. The disk adapter is a local MongoDB instance managed for you, so a model written for it moves to a real MongoDB server without changes.
+The model ids are also written to `.henri/globals.json` on boot; the scaffolded `eslint.config.js` reads that file so the linter knows the globals.
 
-You can generate models from the command line:
-
-```bash
-henri g model modelname name:string! age:number notes:string birthday:date!
-```
+## A model file
 
 ```js
-// app/models/User.js
-
-// A model named User is overloaded with email, password and roles.
-// Passwords are hashed before create and update.
-
+// app/models/Task.js
 module.exports = {
-  store: 'dev', // a store name from your configuration
-  name: 'user_collection', // collection or table name, defaults to 'users'
-  schema: {
-    firstName: { type: 'string' },
-    lastName: String,
-    tasks: {},
-  },
-};
-```
-
-```js
-// app/models/Tasks.js
-
-module.exports = {
-  store: 'default',
+  store: 'default', // a store name from your configuration (default: 'default')
+  name: 'tasks', // collection or table name (optional, the ORM names it otherwise)
+  options: { timestamps: true }, // Mongoose schema options, or Sequelize model options
   schema: {
     name: { type: 'string', required: true },
     category: {
       type: 'string',
-      validations: {
-        isIn: ['urgent', 'high', 'medium', 'low'],
-      },
-      defaultsTo: 'low',
+      enum: ['urgent', 'high', 'medium', 'low'],
+      default: 'low',
     },
+    done: { type: 'boolean', default: false },
   },
 };
 ```
 
-The `schema` and `options` keys are handed to the adapter as is, so anything Mongoose or Sequelize accepts is valid there.
+| Key                 | Description                                                                                                 |
+| ------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `schema`            | The fields, in the format below.                                                                            |
+| `options`           | Handed to `new mongoose.Schema()` or `sequelize.define()` as is.                                            |
+| `store`             | The store to use, `default` when omitted. The boot fails when the store is not configured.                  |
+| `name`              | Collection name (Mongoose) or `tableName` (Sequelize).                                                      |
+| `graphql`           | `{ types, resolvers }` merged into the application schema. See [GraphQL](/guides/graphql/).                 |
+| `associate(models)` | Called once every model of the store exists, with the models keyed by global name. Declare relations there. |
+
+```js
+// app/models/Comment.js
+module.exports = {
+  schema: { body: { type: 'text', required: true } },
+  associate(models) {
+    // Sequelize: models.Comment.belongsTo(models.Post)
+    // Mongoose: nothing to do, use { type: 'ObjectId', ref: 'Post' } in the schema
+  },
+};
+```
+
+On SQL, `associate()` runs before `sync()`, so the foreign keys end up in the tables.
+
+## The schema format
+
+A field is `{ type, ...keys }` or a bare type. The type names and the keys below mean the same thing on every adapter, so a model written for the disk adapter moves to MongoDB or PostgreSQL unchanged.
+
+| Type      | Mongoose  | Sequelize |
+| --------- | --------- | --------- |
+| `string`  | `String`  | `STRING`  |
+| `text`    | `String`  | `TEXT`    |
+| `number`  | `Number`  | `DOUBLE`  |
+| `integer` | `Number`  | `INTEGER` |
+| `float`   | `Number`  | `FLOAT`   |
+| `boolean` | `Boolean` | `BOOLEAN` |
+| `date`    | `Date`    | `DATE`    |
+| `json`    | `Mixed`   | `JSON`    |
+| `uuid`    | `String`  | `UUID`    |
+
+| Key        | Description                                                                                        |
+| ---------- | -------------------------------------------------------------------------------------------------- |
+| `required` | `required: true` (Mongoose) or `allowNull: false` (Sequelize).                                     |
+| `default`  | Default value. `Date.now` becomes `NOW` on SQL.                                                    |
+| `enum`     | Allowed values. An `ENUM` column on MySQL, MariaDB and PostgreSQL, an `isIn` validation elsewhere. |
+| `unique`   | Unique index or constraint.                                                                        |
+| `index`    | `index: true` adds an index on the field.                                                          |
+
+What the adapters do with anything else differs:
+
+- **Mongoose** passes every other key and type through, so `{ type: 'ObjectId', ref: 'Post' }`, `[String]`, nested objects, `lowercase`, `trim`, `match`, `select`, `validate` and the JavaScript constructors (`String`, `Number`, `Date`) all work. It also understands the Sequelize spellings `allowNull: false` and `defaultValue`.
+- **Sequelize** accepts its own attribute options (`allowNull`, `defaultValue`, `validate`, `field`, `primaryKey`, `autoIncrement`, `references`, `onDelete`, `onUpdate`, `comment`, `get`, `set`, `values`, ...), its data types (`type: DataTypes.STRING(50)` or the uppercase name as a string, `'STRING'`), the JavaScript constructors (`Object` and `Array` become `JSON`, `Buffer` a `BLOB`), and stores nested objects and arrays as `JSON`. Any other key throws at boot with the list of supported keys, so a typo never becomes a silently ignored option. A field with a known key but no `type` is an error too.
+
+`@usehenri/mongoose/types` and `@usehenri/sequelize/types` export the map above if you need the ORM types themselves.
+
+## Generating a model
+
+```bash
+henri generate model Post title:string! body:text published:boolean views:integer
+```
+
+writes `app/models/Post.js` with `timestamps: true`, one field per `name:type` argument (`string` when the type is omitted, `!` marks it required) and refuses unknown types. `henri generate scaffold` and `crud` start with the same model and add the controller, routes and views; see the [CLI reference](/reference/cli/#generators).
+
+## Querying
+
+The global is the ORM model. Nothing is wrapped:
+
+```js
+// Mongoose (disk, mongoose)
+await Task.find({ done: false }).sort({ createdAt: -1 });
+await Task.findById(id);
+await Task.create(req.permit('name', 'category'));
+
+// Sequelize (mysql, postgresql, mssql)
+await Task.findAll({ where: { done: false } });
+await Task.findByPk(id);
+await Task.create(req.permit('name', 'category'));
+```
+
+Use [`req.permit()`](/guides/controllers/#reqpermitfields) rather than `req.body` when you create or update records.
 
 ## The user model
 
-When a model matches the configured `user` name (`User` by default), henri adds `email`, `password` and `roles` to its schema, hashes the password on save with bcrypt, and registers:
+When a model matches the configured `user` name (`user` by default, so `app/models/User.js`), the adapter adds three fields to it:
 
-- `POST /login` (local strategy, `email` + `password`) and `GET /logout`
-- a session store backed by the same database
-- a JWT strategy reading `Authorization: Bearer <token>`
-- `user.hasRole(roles)` for [route protection](/guides/routes/#roles)
+| Field      | Behaviour                                                                                                                                                                                                                                 |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `email`    | Required, unique, trimmed and lowercased on write, validated as an email address.                                                                                                                                                         |
+| `password` | Required. Hashed with bcrypt before every write, including `updateOne()`, `findByIdAndUpdate()` and bulk operations. Not selected by default: `User.findOne(query).select('+password')` on Mongoose, `User.scope('withPassword')` on SQL. |
+| `roles`    | A list of strings, `config.baseRole` for a new user. Dropped from mass-assigned creates and updates: `User.create(req.body)` cannot grant a role. On SQL it is a `JSON` column (`TEXT` with a JSON getter on MSSQL).                      |
 
-`henri.user.encrypt(password)` and `henri.user.compare(password, hash)` are available if you need them directly.
+and three methods:
+
+```js
+await user.hasRole(['admin']); // true when the user owns every role
+await user.setRoles(['admin', 'editor']); // replaces the roles and saves
+await User.setRoles(id, ['admin']); // same, by id (null when not found)
+```
+
+An operation flagged unsafe may write `roles` directly: `doc.save({ unsafe: true })`, `User.create([doc], { unsafe: true })`, `User.updateOne(filter, update, { unsafe: true })`, or `doc.$locals.unsafe = true` before a save (Mongoose).
+
+Server side, `henri.user.findByEmail(email)` (lowercases its argument and returns the instance with its password hash), `henri.user.findById(id)` (without the hash), `henri.user.publicUser(user)`, `henri.user.encrypt(password)` and `henri.user.compare(password, hash)` work the same on every adapter. Login, sessions, CSRF and roles are described in [Users](/guides/users/).
 
 ## Adapters
 
-Each adapter is a separate package. Install the ones you use in your project.
+Each adapter is a package to install in the application; the name in `stores.<name>.adapter` selects it. All of them implement the same contract, documented in the [API reference](/reference/api/#store-adapters), and expose a few helpers on the store object, `henri.model.stores.<name>`:
+
+```js
+await henri.model.stores.default.ping(); // true when the database answers
+await henri.model.stores.default.transaction(async (t) => { ... }); // Sequelize transaction, or Mongoose session (needs a replica set)
+await henri.model.stores.default.query('SELECT 1 + ?', [1]); // SQL adapters only
+```
+
+Sessions are stored in the database of the user model's store: a `henriSessions` collection on MongoDB, a table created by connect-session-sequelize on SQL (the `session` key of the store configures either).
 
 ### Disk
 
-A MongoDB instance started for you by [mongodb-memory-server](https://github.com/typegoose/mongodb-memory-server), persisted in a temporary directory keyed on your project path. Zero configuration, no server to install. Not for production.
+A MongoDB instance started for you by [mongodb-memory-server](https://github.com/typegoose/mongodb-memory-server), persisted under `.henri/data` in the application directory (`path` changes it, `dbName` the database name, `henri` by default). Under `NODE_ENV=test` the data stays in memory, so every test run starts empty. Zero configuration, no server to install, a warning in production: it is a development store.
 
 ```bash
 pnpm add @usehenri/disk
@@ -78,6 +153,8 @@ pnpm add @usehenri/disk
 ```json
 { "stores": { "default": { "adapter": "disk" } } }
 ```
+
+The first boot downloads the MongoDB binary into `~/.cache/mongodb-binaries`.
 
 ### MongoDB
 
@@ -97,7 +174,7 @@ pnpm add @usehenri/mongoose
 }
 ```
 
-`opts` is passed to `mongoose.connect()`.
+`host`, `port`, `database`, `username` and `password` are accepted instead of `url`. `opts` is passed to `mongoose.connect()`; `serverSelectionTimeoutMS` and `connectTimeoutMS` default to 10 seconds, so a wrong url fails the boot quickly. A store without `url` or `host` fails the boot.
 
 ### MySQL and MariaDB
 
@@ -116,7 +193,7 @@ pnpm add @usehenri/mysql
 }
 ```
 
-Use `"adapter": "mariadb"` with a `mariadb://` URL for MariaDB; the same package handles both.
+Use `"adapter": "mariadb"` with a `mariadb://` url for MariaDB; the same package (mysql2 driver) handles both.
 
 ### PostgreSQL
 
@@ -152,4 +229,8 @@ pnpm add @usehenri/mssql
 }
 ```
 
-For the SQL adapters, every other key in the store (`pool`, `logging`, `dialectOptions`, ...) is forwarded to Sequelize.
+### SQL adapters
+
+The three SQL packages are thin dialects over `@usehenri/sequelize`. `host`, `port`, `database`, `username` and `password` are accepted instead of `url`; a store with none of them fails the boot. Every other key of the store (`pool`, `dialectOptions`, `logging`, ...) is forwarded to Sequelize. `logging` defaults to the `henri:sequelize` debug namespace (`henri server --debug=henri:sequelize` prints the queries) and credentials are redacted from that output.
+
+On boot the adapter authenticates, calls the `associate()` exports and runs `sequelize.sync()`: tables are created or extended from the models. There are no migrations.

--- a/website/src/content/docs/guides/routes.md
+++ b/website/src/content/docs/guides/routes.md
@@ -2,20 +2,19 @@
 title: Routes
 description: config/routes.js, HTTP verbs, roles, crud, resources, scope and omit.
 sidebar:
-  order: 5
+  order: 3
 ---
 
 Routes are defined in `config/routes.js`. Any page in `app/views/pages` is also rendered when no route matches first.
 
-A route is a key (a path, or an HTTP verb and a path) pointing to `controller#action`, or to an object with a `controller` and options.
+A route is a key (a path, or an HTTP verb and a path) pointing to `controller#action`, or to an object with a `controller` and options (`roles`, `scope`, `omit`).
 
 ```js
 // config/routes.js
-
 module.exports = {
   '/test': 'user#info', // defaults to 'get /test'
 
-  '/abc/:id': 'moo#iii', // the controller does not exist: the route is not loaded
+  '/abc/:id': 'moo#iii', // the controller does not exist: see below
 
   '/user/find': 'user#fetch',
 
@@ -24,7 +23,7 @@ module.exports = {
   'post /poo': 'user#create',
 
   'get /secured': {
-    controller: 'secureController#index',
+    controller: 'secure#index',
     roles: ['admin'],
   },
 
@@ -40,13 +39,17 @@ module.exports = {
 };
 ```
 
-In development, routes pointing to a missing controller answer `501 Not Implemented` so you notice; in production they are skipped. `GET /_routes` and `GET /_controllers` list what is loaded (development only, and only from the machine running the server), and pressing `R` or `U` in the terminal prints the same.
+Keys are `verb /path` with any Express verb (`get`, `post`, `put`, `patch`, `delete`, `options`, `head`, ...), or `resources`/`crud` followed by a name. When two keys expand to the same verb and path, the later one wins.
 
-Requests nothing claims get a `404`, and errors thrown (or rejected) by a controller are logged and answered with a `500`. Both are content-negotiated: JSON clients receive `{ statusCode, error, message }`, browsers a page (with the stack in development, only the status in production).
+`henri routes` prints the expanded table (verb, path, controller, path helper and roles) without starting the server. While the server runs, `r` prints the loaded routes and `u` the ones whose controller is missing, and in development `GET /_routes` and `GET /_controllers` return the same as JSON, from the machine running the server only.
+
+In development, a route pointing to a missing controller answers `501 Not Implemented` so you notice; in production it is skipped. Requests nothing claims get a `404`, errors thrown by a controller a `500`; both are content negotiated (JSON `{ statusCode, error, message }` for API clients, an HTML page for browsers, with the stack in development only).
 
 ## Roles
 
-Give a route an array of roles and only authenticated users whose `roles` contain every one of them can reach it. Denied requests get a `401` (not logged in) or a `403` (missing role) JSON answer; browsers asking for HTML are redirected to `config.user.loginPath` (default `/login`). A route with `roles` in an app without a user model logs a warning at boot and answers `401`.
+Give a route an array of roles and only authenticated users whose `roles` contain every one of them can reach it. Denied requests get a `401` (not logged in, `Authentication required`) or a `403` (missing role, with the required `roles` in `data`) as JSON; a browser asking for HTML is redirected to `config.user.loginPath`, `/login` by default. henri mounts `POST /login` but no login page: add one there (see [Users](/guides/users/#login-and-logout)).
+
+A route with `roles` in an application without a user model logs a warning at boot and denies every request.
 
 ## CRUD
 
@@ -80,6 +83,8 @@ GET    /happy/new       => life#new
 GET    /happy/:id       => life#show
 ```
 
+`henri generate scaffold Post` writes the `resources posts` key and a controller with the seven actions; `henri generate crud Post` the `crud posts` key and the four JSON actions.
+
 ## Scope
 
 Add `scope` to prefix the generated routes: `scope: 'api'` turns `/happy` into `/api/happy`.
@@ -90,4 +95,4 @@ Add an `omit` array to skip some of the generated actions: `omit: ['destroy', 'e
 
 ## Named paths
 
-Every loaded route gets a name, `<action>_<controller>_path` (`show_todo_path`, `index_categories_path`), that the views receive in `paths` filtered by the current user's roles. The React helpers `pathFor()` and `getRoute()` build URLs from these names, so a renamed route does not break your links.
+Every loaded route gets a name, `<action>_<controller>_path` (`show_todo_path`, `index_categories_path`), mapping to `{ method, route, roles }`. Pages rendered with `res.render()` (and the JSON answer of the same URL) receive them in `paths`, filtered by the roles of the current user; a page served by the view engine's fallback, without a controller, only gets the routes that need no role. The React and Inertia helpers `pathFor()` and `getRoute()` build URLs from these names, so a renamed route does not break your links.

--- a/website/src/content/docs/guides/testing.md
+++ b/website/src/content/docs/guides/testing.md
@@ -1,0 +1,85 @@
+---
+title: Testing
+description: henri test, Vitest and @usehenri/testing.
+sidebar:
+  order: 9
+---
+
+Tests run on [Vitest](https://vitest.dev). `henri test` spawns the Vitest installed in the application with `NODE_ENV=test` and exits with its code; `@usehenri/testing` boots the application inside the test worker and binds [supertest](https://github.com/ladjs/supertest) to it. `henri new` sets all of this up; in an existing application:
+
+```bash
+pnpm add -D vitest @usehenri/testing
+```
+
+```js
+// vitest.config.js
+const { defineConfig } = require('vitest/config');
+
+module.exports = defineConfig({
+  test: {
+    environment: 'node',
+    fileParallelism: false,
+    globals: true,
+    include: ['test/**/*.{spec,test}.js'],
+    setupFiles: ['@usehenri/testing/setup-file'],
+  },
+});
+```
+
+The setup file boots henri before each test file and stops it after, so `henri` and the models are globals in your tests exactly like in the application, and `request()` hits the in-process server. Each file gets a fresh boot: with the disk adapter that is an empty in-memory database. `fileParallelism: false` keeps one server and one database at a time; `globals: true` gives you `describe`, `test`, `expect` and `vi` without imports.
+
+Under `NODE_ENV=test`, henri loads `config/test.json` (falling back to `default.json`), picks a free port, skips the workers, keeps the disk adapter in memory, uses nodemailer's JSON transport and stays quiet in the console.
+
+## Writing tests
+
+```js
+// test/tasks.test.js
+const { request, setup } = require('@usehenri/testing');
+
+describe('tasks', () => {
+  beforeAll(() => setup()); // a no-op once the setup file booted henri
+
+  test('lists tasks', async () => {
+    await Task.create({ name: 'write tests' });
+
+    const res = await request().get('/tasks').set('Accept', 'application/json');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.tasks).toHaveLength(1);
+  });
+
+  test('rejects an empty task', async () => {
+    const res = await request().post('/tasks').send({ category: 'low' });
+
+    expect(res.status).toBe(422);
+    expect(res.body.data.errors.name).toBeDefined();
+  });
+});
+```
+
+`henri generate test tasks` writes a file like this one, and `henri destroy test tasks` removes it.
+
+For login flows use `agent()`, which keeps the cookies between requests. Requests made with a session cookie must send the CSRF token back: read the `henri.csrf` cookie from the login answer, or set `"csrf": false` in `config/test.json`.
+
+## API
+
+`@usehenri/testing` exports:
+
+- `setup({ workers = false })` boots henri for the application in `process.cwd()` and resolves with the instance. Idempotent: safe in every `beforeAll`.
+- `teardown()` stops it.
+- `request()` a supertest request bound to the running server.
+- `agent()` a supertest agent (keeps cookies between requests).
+- `henri` the running instance (also `global.henri`).
+- `supertest` the underlying module.
+
+Without the setup file, boot from the test file itself with `beforeAll(() => setup())` and `afterAll(() => teardown())`. To boot once for the whole run instead of once per file, use `globalSetup: ['@usehenri/testing/global-setup']`: henri then runs in Vitest's main process, tests only reach it over HTTP through `request()`, and `henri` or the model globals are not available in the workers.
+
+## Running
+
+```bash
+henri test                        # vitest run
+henri test --watch                # vitest in watch mode
+henri test test/tasks.test.js -t lists
+```
+
+Everything after `test` is passed to Vitest, except henri's own flags. The scaffolded `package.json` maps `pnpm test` to `henri test`.

--- a/website/src/content/docs/guides/users.md
+++ b/website/src/content/docs/guides/users.md
@@ -1,0 +1,104 @@
+---
+title: Users
+description: The user model, login and logout, sessions, CSRF, roles and what a browser may see.
+sidebar:
+  order: 5
+---
+
+Add a model named after the `user` configuration key (`user` by default, so `app/models/User.js`) and henri turns authentication on: the [model](/guides/models/#the-user-model) gets `email`, `password` and `roles`, the server gets a session, `POST /login`, `POST /logout` and a CSRF token. None of this loads without a user model; with one, the configuration must provide a `secret` (`HENRI_SECRET` in `.env`).
+
+```js
+// app/models/User.js
+module.exports = {
+  options: { timestamps: true },
+  schema: {
+    name: { type: 'string' },
+  },
+};
+```
+
+## Registering a user
+
+There is no registration endpoint: create the user from a controller. `req.permit()` keeps `roles` (or anything else) out of the record, the adapter hashes the password, and `publicUser()` is what may go back to the browser.
+
+```js
+// app/controllers/users.js
+module.exports = {
+  create: async (req, res) => {
+    const data = req.permit('email', 'password', 'name');
+
+    if (!data.email || !data.password) {
+      return res.boom.badRequest('email and password are required');
+    }
+
+    if (await henri.user.findByEmail(data.email)) {
+      return res.boom.conflict('this email is already registered');
+    }
+
+    const user = await User.create(data);
+
+    return res.status(201).json({ user: henri.user.publicUser(user) });
+  },
+};
+```
+
+`henri.user.encrypt()` refuses passwords shorter than 6 characters; the error surfaces as a rejected `create()`.
+
+## Login and logout
+
+`POST /login` takes `email` and `password`, as JSON or as a form. The email is trimmed and lowercased before the lookup.
+
+- API clients (anything accepting JSON or `*/*`) get `{ user }` back, the public user. On failure: `401` with `{ statusCode, error, message }`, or `400` when a field is missing.
+- Browsers asking for HTML are redirected to `config.user.afterLogin` (`/` by default); on failure to `<loginPath>?error=invalid` (`/login?error=invalid` by default).
+
+`POST /logout` destroys the session and answers `{ ok: true }`, or redirects browsers to `/`. `GET /logout` is deprecated and answers `405`.
+
+Both are mounted before your routes, on every renderer. henri ships no login page: write one at `loginPath` (`app/views/pages/login.js` with the React renderer) that posts to `/login`. A plain HTML form works because a browser that has no session yet needs no CSRF token; from React, `fetch({ route: '/login', method: 'post' }, { email, password })` followed by `hydrate()` does the same without leaving the page.
+
+In a controller, `req.user` is the user instance (without its password) and `req.isAuthenticated()` tells whether someone is logged in. Views get the public user, see below.
+
+## Sessions
+
+The session cookie, `henri.sid`, is `httpOnly`, `SameSite=Lax`, `Secure` in production, lives 30 days (`config.user.sessionMaxAge`, in milliseconds) and is only written once something is stored in it. Sessions are kept in the database of the user model's store and survive model reloads.
+
+## CSRF
+
+Once a user model exists, every response carries a `henri.csrf` cookie (readable by scripts, `SameSite=Lax`). `POST`, `PUT`, `PATCH` and `DELETE` requests that send the session cookie must send that token back in the `X-CSRF-Token` header (`X-XSRF-TOKEN` is accepted as an alias) or a `_csrf` field, otherwise they get a `403` (`Invalid CSRF token`). Requests without a session cookie and requests authenticated with a bearer token are exempt.
+
+The token reaches the views as `csrf`: the React `fetch()` and `hydrate()` helpers and the Inertia `fetch()` helper add the header for you, the Inertia `Form` adds the `_csrf` field, and Inertia's own visits echo the `XSRF-TOKEN` cookie its engine sets; add `<input type="hidden" name="_csrf" value="{{@csrf}}">` to a Handlebars form. Set `"csrf": false` in the configuration to turn the check off.
+
+## Roles
+
+Give a route an array of `roles` and only logged-in users owning every one of them reach it; see [Routes](/guides/routes/#roles). A new user gets `config.baseRole`; change roles with `user.setRoles()` or `User.setRoles(id, roles)`, never through a form (mass assignment drops `roles`).
+
+The `paths` sent to the views are filtered by the roles of the current user, so a page can show a link only when the user may follow it:
+
+```jsx
+const { paths, pathFor } = useHenri();
+
+{
+  paths.admin_users_path && (
+    <Link href={pathFor('admin_users_path')}>Admin</Link>
+  );
+}
+```
+
+## What leaves the server
+
+Only the public representation of a user reaches views, `req._henri.user` and JSON answers: `{ id, email, roles }` plus the fields listed in `config.user.public`. `henri.user.publicUser(user)` builds that object; use it whenever you send a user to a browser yourself.
+
+```json
+{
+  "user": {
+    "model": "user",
+    "public": ["name", "avatar"],
+    "loginPath": "/login",
+    "afterLogin": "/",
+    "sessionMaxAge": 2592000000
+  }
+}
+```
+
+## Bearer tokens
+
+A passport `jwt` strategy is registered on `henri.passport` with the application secret (it reads `Authorization: Bearer <token>` and loads the user from the `id`, `_id` or `sub` claim), but core applies it to no route and issues no token. To accept tokens on a route, add the strategy yourself with `henri.addMiddleware()` or in the controller: `henri.passport.authenticate('jwt', { session: false })`.

--- a/website/src/content/docs/guides/views.md
+++ b/website/src/content/docs/guides/views.md
@@ -2,18 +2,20 @@
 title: Views
 description: React (Next.js), Inertia (Vite + React), Handlebars and Vue renderers, all server-side rendered.
 sidebar:
-  order: 3
+  order: 4
 ---
 
-Pick a renderer in your configuration. All of them are server-side rendered; the React and Inertia renderers also push updates to the browser while you develop.
+Pick a renderer in your configuration. All of them render on the server; the React and Inertia renderers also push updates to the browser while you develop. A view engine is loaded from the application, so its packages must be installed there (`henri new` does it).
 
 ```json
 { "renderer": "react" }
 ```
 
+Whatever the renderer, a controller renders with `res.render(route, { data })` and the page receives `data`, `user`, `paths`, `query`, `csrf`, `localUrl`, `errors` and `graphql` (see [Controllers](/guides/controllers/#resrenderroute-options)). Static files go in `app/views/public`, served at the root.
+
 ## React
 
-[Next.js](https://nextjs.org/) (16, pages router, Turbopack) renders the pages in `app/views/pages` and injects the data sent by your controllers. If none of your routes match a request but a page does, the page is rendered directly.
+[Next.js](https://nextjs.org/) (16, pages router, Turbopack) renders the pages in `app/views/pages` and injects the data sent by your controllers. If none of your routes match a `GET` request but a page does, the page is rendered directly. The App Router is not supported: a page under `app/views/app` would bypass `withHenri` and the controllers, and the engine warns when that directory exists.
 
 Install the peer dependencies in your project (`henri new` already does):
 
@@ -21,7 +23,7 @@ Install the peer dependencies in your project (`henri new` already does):
 pnpm add @usehenri/react next react react-dom sass
 ```
 
-Two small files live next to your pages. `henri new` ships them and the engine creates them on first boot if they are missing:
+Two small files live next to your pages. `henri new` ships them and the engine creates them on first boot when they (or their `.mjs`/`.ts` alternatives) are missing:
 
 ```js
 // app/views/next.config.js
@@ -33,52 +35,114 @@ module.exports = require('@usehenri/react/engine/conf');
 { "compilerOptions": { "baseUrl": "." } }
 ```
 
-```jsx
-// app/views/pages/log.js
+### Pages
 
+```jsx
+// app/views/pages/tasks/index.js
 import Link from 'next/link';
 import withHenri from '@usehenri/react';
 
-const Log = ({ data }) => (
-  <div>
-    <pre>{JSON.stringify(data, null, 2)}</pre>
-    <Link href="/home">Home</Link>
-  </div>
+const Tasks = ({ data: { tasks = [] }, getRoute }) => (
+  <ul>
+    {tasks.map((task) => (
+      <li key={task._id}>
+        <Link href={getRoute('show_tasks_path', String(task._id))}>
+          {task.name}
+        </Link>
+      </li>
+    ))}
+  </ul>
 );
 
-export default withHenri(Log);
+export default withHenri(Tasks);
 ```
 
-`withHenri` gives your page these props:
+`withHenri` wraps a page component. On the server it reads what henri attached to the request (`req._henri`, never the url); on client-side navigation it fetches the same url as JSON. The page receives these props, and nested components read the same values from `useHenri()`:
 
-| Prop       | Description                                                                                      |
-| ---------- | ------------------------------------------------------------------------------------------------ |
-| `data`     | What the controller passed to `res.render()` (or the GraphQL result)                             |
-| `user`     | The logged-in user (`id`, `email`, `roles`, `config.user.public` fields), or `null`              |
-| `paths`    | The routes this user may call, keyed like `index_tasks_path`                                     |
-| `csrf`     | The CSRF token. `fetch()` and `hydrate()` send it; add it as `X-CSRF-Token` to your own requests |
-| `pathFor`  | `pathFor('show_tasks_path', id)` builds a URL from a route name                                  |
-| `getRoute` | Same, returns the plain string                                                                   |
-| `fetch`    | `fetch({ route, method }, body)` calls a controller and resolves its JSON                        |
-| `hydrate`  | Refetches the current page's data and updates `data`                                             |
+| Prop       | Description                                                                                                                                      |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `data`     | What the controller passed to `res.render()`, or the GraphQL result. Follows navigation, and `hydrate()` overrides it until the next navigation. |
+| `user`     | The logged-in user (`id`, `email`, `roles`, the `config.user.public` fields) or `null`                                                           |
+| `paths`    | The routes this user may call, keyed like `index_tasks_path`                                                                                     |
+| `csrf`     | The CSRF token, or `null` without a user model                                                                                                   |
+| `errors`   | GraphQL errors of the render, or `null`                                                                                                          |
+| `graphql`  | `{ endpoint, query }` of the render                                                                                                              |
+| `localUrl` | The url the server listens on                                                                                                                    |
+| `error`    | The error of the last `hydrate()` or client-side fetch, or `null`                                                                                |
+| `pathFor`  | `pathFor('show_tasks_path', id)` builds a url from a route name (see below)                                                                      |
+| `getRoute` | `getRoute('show_tasks_path', id)` returns the url as a string, or `'route-not-found'`                                                            |
+| `fetch`    | `fetch(target, body)` calls a route and resolves with the parsed answer (see below)                                                              |
+| `hydrate`  | Fetches the current url as JSON again and updates `data`; keeps the current data when the answer is not a henri page                             |
+| `router`   | The Next.js router (`withRouter`)                                                                                                                |
 
-Nested components get the same helpers from the `useHenri()` hook (or the `HenriContext` it reads):
+`pathFor(name)` returns the route entry, `{ method, route, roles }`; `pathFor(name, '42')` returns the route as a string with `:id` filled; `pathFor(name, { id: '42' })` returns `{ method, route }` with every parameter filled (the object stringifies to its route). An unknown name returns `undefined` and logs a warning. Parameters are replaced whole, so `:id` never touches `:identifier`.
+
+`fetch(target, body)` takes a url or a `pathFor()` result (its `method` is used) and goes through the native `fetch` with `Accept: application/json`, a JSON body, the same-origin cookies and the `X-CSRF-Token` header when there is a token. It resolves with the parsed body (JSON when the server sends JSON, text otherwise, `null` for a 204). A non-2xx answer rejects with a `RequestError`: `message`, `statusCode`, `error` and `data` from the boom body, `status`, `body` and `response` from the answer.
+
+```jsx
+const destroy = async (id) => {
+  await fetch(pathFor('destroy_tasks_path', { id })); // DELETE /tasks/:id
+  await hydrate();
+};
+```
 
 ```jsx
 // app/views/components/nav.js
+import Link from 'next/link';
 import { useHenri } from '@usehenri/react';
 
 export default function Nav() {
-  const { user, pathFor } = useHenri();
+  const { user, getRoute } = useHenri();
+
   return (
-    <a href={pathFor('index_tasks_path')}>{user ? user.email : 'Tasks'}</a>
+    <Link href={getRoute('index_tasks_path')}>
+      {user ? user.email : 'Tasks'}
+    </Link>
   );
 }
 ```
 
-A set of form components (`Form`, `Input`, `Select`, `Radio`, `Editor`, `Button`, `FormError`) with a `useForm()` hook ships in `@usehenri/react/forms`. `Editor` wraps Quill; import `react-quill-new/dist/quill.snow.css` from the page that uses it.
+Any folder under `app/views` is importable by name (`import Nav from 'components/nav'`, `import styles from 'styles/tasks.module.scss'`), thanks to `jsconfig.json`. Global stylesheets are imported from `app/views/pages/_app.js` (a Next.js rule); `sass` resolves imports from `app/views/styles`, `app/views` and `node_modules`.
 
-`assets`, `components`, `helpers` and `styles` resolve to the matching folders under `app/views`, so `import Nav from 'components/nav'` works from any page. Global stylesheets are imported from `app/views/pages/_app.js` (a Next.js rule); component styles use CSS modules, `import styles from 'styles/tasks.module.scss'`.
+### Forms
+
+`@usehenri/react/forms` exports `Form`, `Input`, `Select`, `Radio`, `Editor`, `Button`, `FormError`, the `useForm()` hook and `FormContext`. A form keeps its fields' data, validates on change with [validator.js](https://github.com/validatorjs/validator.js) rules, sanitizes on submit and posts through `fetch()`.
+
+```jsx
+// app/views/pages/tasks/new.js
+import withHenri from '@usehenri/react';
+import { Button, Form, FormError, Input, Select } from '@usehenri/react/forms';
+
+const NewTask = ({ pathFor, router }) => (
+  <Form
+    action={pathFor('create_tasks_path')}
+    onSuccess={() => router.push('/tasks')}
+  >
+    <FormError />
+    <Input
+      name="name"
+      placeholder="Name"
+      required
+      validation={{ isLength: { min: 1 } }}
+      errorMsg={{ isLength: 'Minimum 1 char' }}
+      sanitation={{ trim: true }}
+    />
+    <Select
+      name="category"
+      placeholder="Category"
+      choices={['low', 'medium', 'high', 'urgent']}
+    />
+    <Button>Create Task</Button>
+  </Form>
+);
+
+export default withHenri(NewTask);
+```
+
+- `Form` props: `action` (a route string or a `pathFor()` result, `POST` by default), `method`, `data` (initial values, followed when the prop changes), `onSuccess(data, result)`, `onError(message, error)`, `onFail` (message when the server sends none), `error` (a message to display), `handleSubmit(action, data, clear)` (replaces the request; not with `action`), `name`, `className`, `debug`. After a successful submission the form calls `hydrate()`, then `onSuccess`, then clears itself; it stays disabled until the request settles.
+- Field props: `name` (nested names like `address.street` work), `validation` (`{ isEmail: true, isLength: { min: 3 } }`, any validator.js function), `sanitation` (`{ trim: true, escape: true }`, applied in order), `errorMsg` (`{ rule: message }`), `required`, `disabled`, `placeholder`, `className`, plus anything the underlying element accepts. `Select` takes `choices` (strings, or objects read through `displayProp`, `name` by default, valued by `_id`, `id` or `value`) and renders `placeholder` as a real first option. `Radio` takes `group` (the data key) and `name` (the value it sets). `Editor` is a [Quill](https://quilljs.com/) rich text field loaded in the browser only, controlled by the form data; import `react-quill-new/dist/quill.snow.css` from the page that uses it.
+- A `422` answer whose `data.errors` maps field names to messages (what the scaffolded controllers send) shows each message under its field; any other error goes to `FormError`.
+- `useForm()` gives a custom field `data`, `errors`, `error`, `disabled`, `modified`, `handleChange(event, validation)`, `handleSubmit()`, `clear()` and `addSanitizer(name, rules)`.
 
 ### Extending Next.js
 
@@ -91,29 +155,32 @@ module.exports = {
 };
 ```
 
-If you need webpack-specific hooks, export a `webpack` function from `config/webpack.js`. Its presence switches the engine from Turbopack to webpack:
+If you need webpack-specific hooks, export a `webpack` function from `config/webpack.js`. Its presence switches the engine from Turbopack to webpack. The function must be synchronous and return the configuration it received (a missing `module.rules` or `resolve` fails the build with an explanation):
 
 ```js
 // config/webpack.js
-
 module.exports = {
-  webpack: async (config, { dev }, webpack) => {
+  webpack: (config, { dev }, webpack) => {
     config.plugins.push(
-      new webpack.ProvidePlugin({
-        $: 'jquery',
-        jQuery: 'jquery',
-      })
+      new webpack.ProvidePlugin({ $: 'jquery', jQuery: 'jquery' })
     );
+
     return config;
   },
 };
 ```
 
+Both files are read once, at boot and by `next build`. Saving them triggers a reload that changes nothing; the terminal asks for a restart.
+
 ### Production
 
-`henri server --production` (or `NODE_ENV=production`) builds the pages once and serves the optimized build. `henri build` runs the build on its own, for example in a Docker image. `--force-build` rebuilds even if a build exists.
+`henri server --production` (or `NODE_ENV=production`) builds the pages once, when `app/views/.next/BUILD_ID` (or the `distDir` of your `config/next.js`) is missing, and serves the optimized build. `--force-build` rebuilds even if a build exists. `henri build` runs `next build` on its own without booting henri, so it needs neither a database nor the stores: use it in a Docker build stage (the repository's `docker/Dockerfile` does).
 
 ## Inertia
+
+:::caution
+New in 1.1 and experimental: the engine, the scaffold and the helpers work end to end, but they have had far less use than the React renderer and their options may change.
+:::
 
 The `inertia` renderer speaks the [Inertia.js](https://inertiajs.com/) protocol: your controllers keep rendering routes with `res.render()`, the page is a React 19 component bundled by [Vite](https://vite.dev/), and navigation between pages happens without a full page load. The first visit is server-side rendered; the Inertia client then asks for page objects (JSON) and swaps the component.
 
@@ -127,12 +194,12 @@ henri new my-app --renderer inertia
 pnpm add @usehenri/inertia @inertiajs/react react react-dom vite @vitejs/plugin-react sass
 ```
 
-The engine reads four files from `app/views`. `henri new --renderer inertia` ships them and the engine creates them on first boot when they are missing:
+The engine reads four files from `app/views`. `henri new --renderer inertia` ships them and the engine creates the missing ones on first boot:
 
 | File              | Role                                                                                              |
 | ----------------- | ------------------------------------------------------------------------------------------------- |
 | `index.html`      | The html shell. `<!--head-->` and `<!--body-->` receive the rendered page.                        |
-| `main.jsx`        | The browser entry: `createInertiaApp` resolving `pages/**/*.jsx`.                                 |
+| `main.jsx`        | The browser entry: `createInertiaApp` resolving `pages/**/*.jsx` with `resolvePage()`.            |
 | `ssr.jsx`         | The server entry: `render(page)` resolves to `{ head, body }`.                                    |
 | `vite.config.mjs` | Re-exports the shared configuration (`@usehenri/inertia/vite`): React plugin, aliases and builds. |
 
@@ -143,11 +210,11 @@ The engine reads four files from `app/views`. `henri new --renderer inertia` shi
 import { Form, Link, useHenri } from '@usehenri/inertia';
 
 export default function Tasks() {
-  const { data, user, pathFor, getRoute } = useHenri();
+  const { data, pathFor, getRoute } = useHenri();
 
   return (
     <div>
-      <Form action={pathFor('create_tasks_path')}>
+      <Form action={pathFor('create_tasks_path')} resetOnSuccess>
         {({ errors, processing }) => (
           <>
             <input name="name" />
@@ -167,17 +234,19 @@ export default function Tasks() {
 }
 ```
 
-`useHenri()` returns the same keys as the React renderer's `withHenri` (`data`, `user`, `paths`, `pathFor`, `getRoute`, `fetch`, `hydrate`, `localUrl`) plus `errors`, `csrf` and `query`. They are the props of the Inertia page object, so `usePage().props` from `@inertiajs/react` holds the raw values.
+`useHenri()` returns the same keys as the React renderer's `withHenri` (`data`, `user`, `paths`, `csrf`, `localUrl`, `errors`, `graphql`, `pathFor`, `getRoute`, `fetch`, `hydrate`) plus `query`. They are the props of the Inertia page object, so `usePage().props` from `@inertiajs/react` holds the raw values. `hydrate()` is an Inertia partial reload of `data`; `fetch(target, payload)` is a JSON request outside the Inertia lifecycle (`GET` data goes in the query string) that sends the CSRF header and rejects with an error carrying `status` and `response`.
 
-Forms submit through Inertia's router: a controller answers with a redirect (`res.redirect('/tasks')`; the engine turns it into a 303 after PUT, PATCH and DELETE) and the client lands on the next page. To show validation errors, render the page again after `res.inertia.errors({ name: 'required' })`: they arrive in `errors`. `res.inertia.location(url)` redirects to an external URL.
+Forms submit through Inertia's router: a controller answers with a redirect (`res.redirect('/tasks')`; the engine turns it into a `303` after `PUT`, `PATCH` and `DELETE`) and the client lands on the next page. To show validation errors, render the page again after `res.inertia.errors({ name: 'required' })`: they arrive in `errors`. `res.inertia.location(url)` redirects to an external url.
 
-`Link`, `Head`, `router`, `usePage` and `useForm` are re-exported from `@inertiajs/react`. `assets`, `components`, `helpers` and `styles` resolve to the matching folders under `app/views`; global stylesheets are imported from `main.jsx`.
+`Form` wraps Inertia's form component: `action` accepts a `pathFor()` result, the method defaults to `POST`, and a hidden `_csrf` field carrying the page's token is added to its children (`csrf={false}` skips it, `csrf="..."` overrides it), so submissions pass henri's [CSRF check](/guides/users/#csrf) in an application with a user model; `fetch()` sends the `X-CSRF-Token` header, and the engine sets an `XSRF-TOKEN` cookie that Inertia's client echoes as `X-XSRF-TOKEN` (an alias henri accepts), so visits made directly with `router.post()` or `useForm().post()` pass as well. `Link`, `Head`, `router`, `usePage` and `useForm` are re-exported from `@inertiajs/react`. `assets`, `components`, `helpers` and `styles` resolve to the matching folders under `app/views`; global stylesheets are imported from `main.jsx`.
 
-Options go under the `inertia` key of your configuration: `ssr: false` renders everything in the browser (the page object is still embedded in the html), `id` changes the root element id, `entry`, `ssrEntry` and `template` rename the files above. `henri server --production` builds the client (`app/views/dist/client`, with a manifest) and the server bundle (`app/views/dist/ssr`) once; `henri build` runs the two Vite builds on their own. Hot module replacement in development rides on henri's http server, no second port.
+Options go under the `inertia` key of your configuration: `ssr: false` renders everything in the browser (the page object is still embedded in the html), `id` changes the root element id (`app`), `entry`, `ssrEntry` and `template` rename the three files above. Hot module replacement in development rides on henri's http server, no second port; in development a page that fails to render on the server answers a `500` with the stack, in production it falls back to client rendering.
+
+`henri server --production` builds the client (`app/views/dist/client`, with a manifest whose hash is the Inertia asset version) and the server bundle (`app/views/dist/ssr`) on the first boot when the manifest is missing, or when `--force-build` is given, then serves `dist/client` with immutable cache headers. `henri build` runs the two Vite builds on their own, without booting henri.
 
 ## Handlebars
 
-The `template` renderer serves the `.html` and `.hbs` files under `app/views/pages` and registers everything under `app/views/partials` as partials. It has no build step and no client-side JavaScript of its own.
+The `template` renderer serves the `.hbs`, `.html` and `.htm` files under `app/views/pages` and registers everything under `app/views/partials` as partials, named by their path without extension (`{{> menu/left}}` for `partials/menu/left.hbs`). It has no build step and no client-side JavaScript of its own.
 
 ```json
 { "renderer": "template" }
@@ -191,13 +260,14 @@ The `template` renderer serves the `.html` and `.hbs` files under `app/views/pag
   <body>
     {{> somePartials }}
     <li>Some data: {{hello}}</li>
+    <p>{{@user.email}} may go to {{@paths.index_artwork_path.route}}</p>
   </body>
 </html>
 ```
 
-The object passed as `data` to `res.render()` is the template context. The other view options are available as data variables: `{{@user.email}}`, `{{@paths.index_artwork_path.route}}`, `{{@query.page}}`.
+The object passed as `data` to `res.render()` is the template context. The other view options are data variables: `{{@user.email}}`, `{{@paths.index_artwork_path.route}}`, `{{@query.page}}`, `{{@localUrl}}`, `{{@csrf}}` (put it in a hidden `_csrf` field of your forms), `{{@errors}}`, `{{@graphql.endpoint}}`.
 
-A route resolves to exactly one file: `/artwork` is `pages/artwork.{hbs,html,htm}`, then `pages/artwork/index.{hbs,html,htm}`, and `/` is `pages/index.*`. A route without a page is a `404`; a template that fails while rendering is a `500` with the stack in the console. Templates are compiled once and recompiled when the file changes.
+A route resolves to exactly one file: `/artwork` is `pages/artwork.{hbs,html,htm}`, then `pages/artwork/index.{hbs,html,htm}`, and `/` is `pages/index.*`. A route without a page is a `404`; a template that fails while rendering is a `500` with the stack logged (and shown in development). Templates are compiled once, recompiled when the file changes and dropped on reload; a partial that does not compile is reported and skipped.
 
 ## Vue
 
@@ -213,4 +283,4 @@ The Vue renderer was written for Nuxt 2 and has not been exercised since the 202
 
 ## Fetching data again
 
-Every controller that renders a view also answers with JSON. Request the same URL with an `Accept: application/json` header and you get the `data`, `user`, `paths` and `graphql` keys the page was rendered with. This is what `hydrate()` and `fetch()` use under the hood.
+Every controller that renders a view also answers with JSON. Request the same url with an `Accept: application/json` header and you get `{ csrf, data, errors, graphql, localUrl, paths, query, user }`, the object the page was rendered with. This is what `hydrate()` and client-side navigation use under the hood.

--- a/website/src/content/docs/guides/workers.md
+++ b/website/src/content/docs/guides/workers.md
@@ -2,24 +2,36 @@
 title: Workers
 description: Background jobs under app/workers with start and stop hooks.
 sidebar:
-  order: 7
+  order: 8
 ---
 
-Files under `app/workers` are autoloaded, watched and reloaded. If a worker exports `start()` and `stop()`, they are called when the application boots, reloads and shuts down.
+Files under `app/workers` (subdirectories included) are loaded when the application boots, in alphabetical order, and reloaded when they change. A worker exports `start(henri)` and `stop(henri)`; `start` is awaited before the next worker starts, `stop` is called on reload and on shutdown. A `name` is used in the logs instead of the file name.
+
+```bash
+henri generate worker heartbeat   # writes app/workers/heartbeat.js
+henri destroy worker heartbeat
+```
 
 ```js
 // app/workers/heartbeat.js
+let timer = null;
 
-let timer;
+module.exports = {
+  name: 'heartbeat',
 
-const start = (henri) => {
-  henri.pen.info('heartbeat', 'worker started');
-  timer = setInterval(() => henri.pen.warn('heartbeat', 'still alive'), 5000);
+  start: async (henri) => {
+    henri.pen.info('heartbeat', 'started');
+    timer = setInterval(() => henri.pen.info('heartbeat', 'tick'), 60000);
+  },
+
+  stop: async (henri) => {
+    clearInterval(timer);
+    timer = null;
+    henri.pen.info('heartbeat', 'stopped');
+  },
 };
-
-const stop = () => clearInterval(timer);
-
-module.exports = { start, stop };
 ```
 
-Both hooks receive the `henri` instance. `henri server --skip-workers` (or `SKIP_WORKERS=1`) boots without them, which is handy when a worker talks to an external service you do not want to hit while developing.
+A worker without a `start` function is loaded and reported, not started. A `stop` that throws is logged and does not prevent the others from stopping.
+
+`henri server --skip-workers` (or `SKIP_WORKERS=1`) boots without them, which is handy when a worker talks to an external service you do not want to hit while developing. `@usehenri/testing` skips them too unless `setup({ workers: true })` is called.

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -31,9 +31,9 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
     know Ruby on Rails, you already know where everything goes.
   </Card>
   <Card title="Server-side rendered React" icon="rocket">
-    Pages live in `app/views/pages` and are rendered by Next.js. Controllers
-    hand them data with `res.render()`; the same endpoint answers JSON when
-    asked for it.
+    Pages live in `app/views/pages` and are rendered by Next.js, or by Vite with
+    Inertia.js. Controllers hand them data with `res.render()`; the same
+    endpoint answers JSON when asked for it.
   </Card>
   <Card title="Real ORMs" icon="document">
     Mongoose for MongoDB, Sequelize for MySQL, MariaDB, PostgreSQL and MSSQL. A
@@ -45,11 +45,11 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
   </Card>
   <Card title="Hot reload everything" icon="setting">
     Controllers, models, routes, workers and configuration reload on save. Press
-    `R` in the terminal to list the loaded routes.
+    `r` in the terminal to list the loaded routes.
   </Card>
-  <Card title="Generators" icon="pencil">
-    `henri new`, `henri generate model`, `henri generate scaffold`. Users get
-    password hashing, sessions and roles for free.
+  <Card title="Generators and tests" icon="pencil">
+    `henri new`, `henri generate scaffold`, `henri test` on Vitest. Users get
+    password hashing, sessions, CSRF and roles for free.
   </Card>
 </CardGrid>
 
@@ -72,7 +72,7 @@ module.exports = {
     res.render('/tasks', { data: { tasks: await Task.find() } });
   },
   create: async (req, res) => {
-    await Task.create(req.body);
+    await Task.create(req.permit('name'));
     res.redirect('/');
   },
 };

--- a/website/src/content/docs/reference/api.md
+++ b/website/src/content/docs/reference/api.md
@@ -1,0 +1,100 @@
+---
+title: API
+description: What an application touches, the henri global, the request and response helpers, the model file, the adapter and view engine contracts.
+sidebar:
+  order: 2
+---
+
+## The `henri` global
+
+`henri` is the running instance (`global.henri`; under `NODE_ENV=test` it is `@usehenri/testing` that sets it). Every module is exposed under its name.
+
+| Property            | Description                                                                                                                                                                                                                                                       |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `henri.config`      | `get(key, safe = false)` throws on a missing key unless `safe`; `has(key)`. Keys use dots: `stores.default.adapter`. See [Configuration](/configuration/).                                                                                                        |
+| `henri.pen`         | The logger: `info(name, ...args)`, `warn`, `error`, `debug`, `verbose`, `silly` print one line; `fatal(name, summary, full, obj)` prints the error and returns an `Error` to throw; `line(n)` prints blank lines; `notify(title, message)` prints in development. |
+| `henri.user`        | `encrypt(password, rounds = 10)` (rejects strings shorter than 6), `compare(password, hash)` (rejects on mismatch), `findByEmail(email)`, `findById(id)`, `publicUser(user)`, `settings` (the normalized `config.user`). See [Users](/guides/users/).             |
+| `henri.passport`    | The passport instance holding the `local` and `jwt` strategies (with a user model).                                                                                                                                                                               |
+| `henri.params(req)` | `.permit(...fields)` and `.all()`, the helper behind `req.permit()`.                                                                                                                                                                                              |
+| `henri.mail`        | `send(message)`, `transporter`, `nodemailer`. See [Mail](/guides/mail/).                                                                                                                                                                                          |
+| `henri.graphql`     | `run(query, variables, contextValue)`, `endpoint`, `active`, the error classes. See [GraphQL](/guides/graphql/).                                                                                                                                                  |
+| `henri.router`      | `routes` (the expanded table keyed by `verb path`), `pathForRoles(user)`, `handler` (the Express router the routes are mounted on).                                                                                                                               |
+| `henri.controllers` | `get('name#action')`, `all()`.                                                                                                                                                                                                                                    |
+| `henri.server`      | `app` (the Express application), `httpServer`, `express`, `url`, `host`, `port`.                                                                                                                                                                                  |
+| `henri.model`       | `stores` (the adapter instances by store name), `ids` (the model globals), `getStore(name)`.                                                                                                                                                                      |
+| `henri.view`        | `engine` (the view engine), `renderer`, `hbs` (the Handlebars engine, always available).                                                                                                                                                                          |
+| `henri.workers`     | `workers` (the loaded workers by file) and `files`.                                                                                                                                                                                                               |
+| `henri.validator`   | [validator.js](https://github.com/validatorjs/validator.js).                                                                                                                                                                                                      |
+| `henri.utils`       | `resolveFrom(name, dir)`, `resolvePackageJson(name, dir)`, `checkPackages(names)` (throws with the install command), `detectPackageManager(dir)`, `installCommand(names)`, `loadModules(dir)`, `syntax(file)`, `isLoopback(address)`.                             |
+| `henri.gql`         | A tagged template returning the query string, so editors format GraphQL.                                                                                                                                                                                          |
+
+On the instance itself: `henri.env`, `isProduction`, `isDev`, `isTest`, `release` (the core version), `cwd()`, `init()`, `reload()`, `stop()` (resolves with the errors of the modules that failed to stop), `addMiddleware(name, fn)` (`fn(router)` runs before the routes are mounted; register it before the router starts), `modules.add(module)` (before `init()`), and `forceMail` (use the configured mail transport under `NODE_ENV=test`).
+
+## Request and response
+
+| Member                                                 | Description                                                                                                                                                                                                                           |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `req.permit(...fields)`                                | The listed fields from the query string, body and path parameters (later sources win); missing fields are omitted. See [Controllers](/guides/controllers/#reqpermitfields).                                                           |
+| `req.user`, `req.isAuthenticated()`                    | Passport, with a user model: the user instance (without its password) and whether someone is logged in. `req.logIn(user, cb)` and `req.logout(cb)` take callbacks.                                                                    |
+| `req.session`                                          | The express-session object, with a user model.                                                                                                                                                                                        |
+| `req.csrfToken`                                        | The CSRF token of the request (a string), with a user model.                                                                                                                                                                          |
+| `req._henri`                                           | What the view engine reads: `{ csrf, localUrl, paths, query, user }` for every request, plus `data`, `errors`, `graphql` and the role-filtered `paths` after `res.render()` on the React renderer. Pages read it through `withHenri`. |
+| `req.inertia`                                          | `{ request, errors }` with the Inertia renderer: whether the Inertia client made the request, and the errors set for the next render.                                                                                                 |
+| `res.render(route, options)`                           | Render a page with `{ data }` or `{ graphql }`, or answer the view options as JSON when the client asks for it. See [Controllers](/guides/controllers/#resrenderroute-options).                                                       |
+| `res.hbs(route, options)`                              | Same, through the Handlebars engine whatever the renderer.                                                                                                                                                                            |
+| `res.boom.<name>(message, data)`                       | A JSON error `{ statusCode, error, message, data }`. See [Controllers](/guides/controllers/#resboom).                                                                                                                                 |
+| `res.inertia.errors(obj)`, `res.inertia.location(url)` | With the Inertia renderer: validation errors for the next render, and an external redirect.                                                                                                                                           |
+| `res.format(handlers)`                                 | Express content negotiation; put `json` before `html`.                                                                                                                                                                                |
+
+## The model file
+
+```js
+module.exports = {
+  store: 'default',
+  name: 'tasks',
+  options: {},
+  schema: {},
+  graphql: { types: '', resolvers: {} },
+  associate(models) {},
+};
+```
+
+Core adds `identity` (the lowercased file name) and `globalId` (the file name) before handing the file to the adapter, and exposes the ORM model as `global[globalId]`. See [Models](/guides/models/).
+
+## Store adapters
+
+Core loads `@usehenri/<adapter>` from the application for each store (`adapter` is one of `disk`, `mongoose`, `mysql`, `mariadb`, `postgresql`, `mssql`), builds `new Adapter(name, config, henri)`, calls `addModel()` for every model file of that store, then `start()`. Adapters implement:
+
+| Member                           | Description                                                                                                                                                                                                                                                                                                |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `adapterName`, `name`            | The adapter kind (`mysql`, `disk`, ...) and the store name.                                                                                                                                                                                                                                                |
+| `addModel(model, userModelName)` | Registers a model file and returns the ORM model. The model whose `identity` equals `userModelName` is the user model: it gets `email` (unique, lowercased, trimmed, validated), `password` (hashed, not selected by default) and `roles` (only writable through `setRoles()` or with `{ unsafe: true }`). |
+| `getModels()`                    | The ORM models by global id.                                                                                                                                                                                                                                                                               |
+| `start()`, `stop()`              | Connects (and syncs the schema on SQL), calling the `associate(models)` export of each model once every model exists; disconnects, and `start()` may be called again.                                                                                                                                      |
+| `getSessionConnector(session)`   | Async; resolves with a ready express-session `Store`.                                                                                                                                                                                                                                                      |
+| `findUserByEmail(email)`         | The user with its password hash, or `null`.                                                                                                                                                                                                                                                                |
+| `findUserById(id)`               | The user without its password, or `null` (also for a malformed id).                                                                                                                                                                                                                                        |
+| `userId(user)`, `toPlain(user)`  | The id as a string; the user as a plain object without its password.                                                                                                                                                                                                                                       |
+| `ping()`, `transaction(fn)`      | Resolves `true` when the database answers; runs `fn` in a transaction.                                                                                                                                                                                                                                     |
+| `query(sql, params, options)`    | SQL adapters only: a raw query with `?` or `:name` replacements.                                                                                                                                                                                                                                           |
+
+`@usehenri/sequelize` exports the SQL base class (with `Sequelize`, `DataTypes` and `normalizeSchema` as statics); `@usehenri/mysql`, `postgresql` and `mssql` extend it with a dialect and a driver. `@usehenri/mongoose` exports the Mongoose class and `@usehenri/disk` extends it with a managed local server. Core falls back to Mongoose or Sequelize calls when an adapter lacks one of the four user methods.
+
+## View engines
+
+Core loads the engine named by `renderer`: Handlebars is built in, `react` resolves `@usehenri/react/engine` and `inertia` `@usehenri/inertia/engine` from the application. An engine is `new Engine(henri)` with:
+
+| Method                          | Description                                                                                                        |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `init()`                        | Level 3: check the dependencies and the layout, create the missing files.                                          |
+| `prepare()`                     | Level 5, before the server listens: build in production, start the dev server.                                     |
+| `fallback(router)`              | Register the catch-all that serves pages no route claimed (`GET` and `HEAD` only) and the static assets.           |
+| `render(req, res, route, opts)` | Used by `res.render()`. `opts` holds `data`, `user`, `paths`, `query`, `csrf`, `localUrl`, `errors` and `graphql`. |
+| `reload()`                      | Optional, called on every application reload.                                                                      |
+| `close()`                       | Optional, called by `henri.stop()`.                                                                                |
+
+## Client packages
+
+- `@usehenri/react`: `withHenri` (default), `useHenri`, `HenriContext`, `request`, `RequestError`. `@usehenri/react/forms`: `Form`, `Input`, `Select`, `Radio`, `Editor`, `Button`, `FormError`, `useForm`, `FormContext`, `Validation`, `messageFor`, `sanitize`. `@usehenri/react/engine`: `ReactEngine`, `build({ cwd, config })`, `createNextConfig(cwd)`. See [Views](/guides/views/#react).
+- `@usehenri/inertia`: `useHenri`, `Form`, `useForm`, `Link`, `Head`, `router`, `usePage`, `pathFor`, `getRoute`, `request`, `resolvePage`. `@usehenri/inertia/vite`: `henriViteConfig({ views, entry, react })`. `@usehenri/inertia/engine`: the engine, with a static `build({ cwd, config })`. See [Views](/guides/views/#inertia).
+- `@usehenri/testing`: `setup`, `teardown`, `request`, `agent`, `henri`, `supertest`; `@usehenri/testing/setup-file` and `@usehenri/testing/global-setup` for Vitest. See [Testing](/guides/testing/).

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -9,43 +9,170 @@ sidebar:
 henri <command> [options]
 ```
 
-| Command                | Description                                                                  |
-| ---------------------- | ---------------------------------------------------------------------------- |
-| `new <folder>`         | Create a new project. `-f` / `--force` writes into an existing folder.       |
-| `init`                 | Add the henri structure to the current directory.                            |
-| `server`, `s`          | Start the development server (or production with `--production`).            |
-| `console`              | Boot the application and open a Node.js REPL with models and `henri` loaded. |
-| `generate <what>`, `g` | Generate code, see below.                                                    |
-| `destroy <what>`, `d`  | Remove what a generator created.                                             |
-| `build`                | Build the production views without starting the server.                      |
-| `test`                 | Run the project's Jest tests.                                                |
-| `clean`                | Remove build artifacts (`.next`, caches).                                    |
-| `about`                | Print versions of Node, henri and the installed adapters.                    |
-| `help`                 | Print the help.                                                              |
+`henri` alone prints the help, `henri <command> --help` (or `henri help <command>`) the help of one command without running it, and `henri --version` the installed version. An unknown command prints the help and exits with `1`; a command that fails prints `henri <command> failed: <message>` and exits with `1` (`--debug=henri:*` adds the stack).
+
+| Command                       | Description                                                                  |
+| ----------------------------- | ---------------------------------------------------------------------------- |
+| `new <folder>`                | Create an application in `folder`.                                           |
+| `init`                        | Add the henri structure to the current directory.                            |
+| `server`, `s`                 | Start the application (development mode with hot reload by default).         |
+| `console`                     | Boot the application and open a Node.js REPL.                                |
+| `routes`                      | Print the routes table of `config/routes.js`.                                |
+| `generate <what> <name>`, `g` | Generate code, see below.                                                    |
+| `destroy <what> <name>`, `d`  | Remove what a generator created.                                             |
+| `build`                       | Build the production views without starting the server.                      |
+| `test [files ...]`            | Run the tests with Vitest.                                                   |
+| `clean`                       | Remove build artifacts and caches.                                           |
+| `about`                       | Print the versions of Node, henri and the packages installed in the project. |
+| `help [command]`              | Print the help.                                                              |
+
+`routes`, `generate`, `destroy`, `build` and `clean` refuse to run outside an application (a `package.json` with a `henri` key and an `app/views/pages` directory). `server`, `console` and `test` need an application too.
+
+## `new` and `init`
+
+```bash
+henri new <folder> [--force | -f] [--skip-install] [--no-git] [--renderer react|inertia]
+henri init [--force | -f] [--skip-install] [--no-git] [--renderer react|inertia]
+```
+
+`new` creates the folder and runs `init` in it; it refuses a non-empty folder without `--force`, and `init` refuses a directory that already has an `app` folder. The project is named after the folder. Both:
+
+1. copy the template of the renderer (`react` by default, `-r` is short for `--renderer`) and merge an existing `package.json` into the generated one (dependencies, scripts and name are kept);
+2. write `config/default.json` (`baseRole`, `renderer`, a `disk` default store, `user: "user"`) and `.env` with a random `HENRI_SECRET`;
+3. with the React renderer, scaffold the sample `Task` resource (model, controller, `resources tasks` route, pages and `test/tasks.test.js`);
+4. write a README (an existing one is renamed `README.old.md`);
+5. run `git init` unless `--no-git` is given, the folder is already inside a repository, or git is missing;
+6. install the dependencies with the detected package manager (the `packageManager` field, then pnpm, yarn, npm) unless `--skip-install` is given. `pnpm-workspace.yaml`, which allows the build scripts pnpm needs, is only written for pnpm.
+
+See [Getting started](/getting-started/) for the resulting tree.
+
+## `server`
+
+```bash
+henri server [--production] [--skip-workers] [--force-build] [--host=<ip>]
+```
+
+Boots the application, listens and watches the files in development. The server binds to `127.0.0.1` in development and `0.0.0.0` in production unless `--host`, `HENRI_HOST` or `config.host` says otherwise. See the [global flags](#global-flags).
+
+## `console`
+
+```bash
+henri console [--production]
+```
+
+Boots the application without the view engine and without listening, then opens a REPL named after the project where `henri` and the models are globals:
+
+```text
+my-app> await Task.countDocuments()
+```
+
+## `routes`
+
+```bash
+henri routes [--json]
+```
+
+Expands `config/routes.js` (`resources`, `crud`, `scope`, `omit`) and prints one line per route with its verb, path, controller, path helper and roles, without booting the server. `--json` prints the same as JSON.
+
+```text
+Verb    Path             Controller     Helper
+GET     /                main#home      home_main_path
+GET     /tasks           tasks#index    index_tasks_path
+POST    /tasks           tasks#create   create_tasks_path
+PATCH   /tasks/:id       tasks#update   update_tasks_path
+PUT     /tasks/:id       tasks#update   update_tasks_path
+DELETE  /tasks/:id       tasks#destroy  destroy_tasks_path
+GET     /tasks/:id/edit  tasks#edit     edit_tasks_path
+GET     /tasks/new       tasks#new      new_tasks_path
+GET     /tasks/:id       tasks#show     show_tasks_path
+
+9 routes
+```
 
 ## Generators
 
 ```bash
-henri generate model User name:string birthday:date
-# creates app/models/User.js with these attributes
-
-henri generate controller locations index show gps
-# creates app/controllers/locations.js and routes to those actions
-
-henri g scaffold HighScore game:string score:integer
-# creates a model, a controller with the resources actions
-# and the matching 'resources' route
+henri generate <what> <name> [options] [--force]
+henri g <what> <name> [options] [--force]
 ```
 
-Attribute types follow the adapter: `string`, `number`, `integer`, `boolean`, `date`, `json`. A trailing `!` marks the attribute as required.
+| Generator                          | Writes                                                                                                                                                                                                         |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `model <Name> [field:type ...]`    | `app/models/<Name>.js` with `timestamps: true` and the fields.                                                                                                                                                 |
+| `controller <name> [action ...]`   | `app/controllers/<name>.js` with one `res.boom.notImplemented()` handler per action, and a `get /<name>/<action>` route for each in `config/routes.js`.                                                        |
+| `worker <name>`                    | `app/workers/<name>.js` with `start()` and `stop()`.                                                                                                                                                           |
+| `test <name>`                      | `test/<name>.test.js` requesting `GET /<name>` with `@usehenri/testing`.                                                                                                                                       |
+| `crud <Name> [field:type ...]`     | The model, `app/controllers/<names>.js` with JSON `index`, `create`, `update` and `destroy`, and the `crud <names>` route.                                                                                     |
+| `scaffold <Name> [field:type ...]` | The model, `app/controllers/<names>.js` with the seven `resources` actions answering HTML or JSON, the `resources <names>` route and the React pages `app/views/pages/<names>/{index,new,edit,show,_form}.js`. |
 
-## Flags
+Model and resource names are given in the singular with a capital: `Post` gives the model `Post`, the controller `posts.js`, the route `resources posts` and the pages under `posts/` (`category` gives `categories`, `person` `people`). Existing files are skipped and reported; `--force` overwrites them. Routes are added to `config/routes.js`, which is rewritten (formatted with prettier) with the new keys.
 
-| Flag             | Effect                                                    |
-| ---------------- | --------------------------------------------------------- |
-| `--production`   | same as `NODE_ENV=production`                             |
-| `--debug[=ns]`   | same as `DEBUG=*` or `DEBUG=<ns>`, e.g. `--debug=henri:*` |
-| `--inspect`      | start the Node.js inspector on port 9229                  |
-| `--wait`         | with `--inspect`, wait for a debugger to attach           |
-| `--force-build`  | force a production rebuild of the views                   |
-| `--skip-workers` | do not start `app/workers`                                |
+Fields are `name:type`, `string` when the type is omitted; a trailing `!` (`name:string!` or `name!:string`) makes the field required. Types: `string`, `text`, `number`, `integer`, `float`, `boolean`, `date`, `json`, `uuid`, mapped by each adapter (see [Models](/guides/models/#the-schema-format)); anything else is refused.
+
+```bash
+henri generate model User name:string! birthday:date
+henri generate controller locations index show
+henri g scaffold HighScore game:string! score:integer
+henri g worker cleanup
+henri g test highscores
+```
+
+The scaffolded controllers are written for Mongoose (`findById`, `findByIdAndUpdate`, `findByIdAndDelete`), which the disk and mongoose adapters use; adapt them by hand for a SQL store. The scaffolded pages target the React renderer.
+
+## `destroy`
+
+```bash
+henri destroy <what> <name>
+henri d <what> <name>
+```
+
+| Target              | Removes                                                           |
+| ------------------- | ----------------------------------------------------------------- |
+| `model <Name>`      | `app/models/<Name>.js`                                            |
+| `controller <name>` | `app/controllers/<name>.js` and every route pointing to it        |
+| `route <key>`       | one key of `config/routes.js`: `henri destroy route "get /about"` |
+| `view <folder>`     | `app/views/pages/<folder>`                                        |
+| `worker <name>`     | `app/workers/<name>.js`                                           |
+| `test <name>`       | `test/<name>.test.js`                                             |
+| `crud <Name>`       | what `generate crud` wrote (model, controller, routes)            |
+| `scaffold <Name>`   | what `generate scaffold` wrote (model, controller, routes, pages) |
+
+Inside a git repository the files are deleted; elsewhere they are moved to `.backup/<timestamp>/` in the project.
+
+## `build`
+
+```bash
+henri build
+```
+
+Builds the production views without booting henri, so it needs no database: `next build` for the React renderer, the client and server Vite bundles for the Inertia renderer. The `template` renderer needs no build. It reads `config/production.json` (falling back to `default.json`) and sets `NODE_ENV=production` and `FORCE_BUILD`. Use it in a Docker build stage or in CI; `henri server --production` builds on first boot when no build exists.
+
+## `test`
+
+```bash
+henri test [files ...] [vitest options]
+```
+
+Runs the Vitest installed in the project (`vitest run`, or `vitest` in watch mode with `--watch`/`-w`) with `NODE_ENV=test` and exits with its code. Everything after `test` is passed to Vitest, except henri's own flags. Without `vitest` in the project it prints the install command (`pnpm add -D vitest @usehenri/testing`) and exits with `1`. See [Testing](/guides/testing/).
+
+## `clean`
+
+Lists the existing ones among `.tmp`, `.henri`, `logs`, `node_modules`, `app/views/.cache` and `app/views/.next`, asks which to delete, and recreates each selected directory empty.
+
+## `about`
+
+Prints the versions of henri, Node, pnpm, yarn and npm, whether the current directory is a henri project, the versions of the `@usehenri/*` packages, `next`, `react` and `react-dom` installed in it, and the names of its models, pages, controllers and helpers.
+
+## Global flags
+
+| Flag               | Effect                                                            |
+| ------------------ | ----------------------------------------------------------------- |
+| `--production`     | same as `NODE_ENV=production`                                     |
+| `--debug[=ns]`     | same as `DEBUG=*` or `DEBUG=<ns>`, e.g. `--debug=henri:*`         |
+| `--inspect[=port]` | start the Node.js inspector on `127.0.0.1` (port 9229 by default) |
+| `--wait`           | with `--inspect`, wait for a debugger to attach                   |
+| `--force-build`    | force a production rebuild of the views                           |
+| `--skip-workers`   | do not start `app/workers`                                        |
+| `--host=<ip>`      | bind the server to this address (same as `HENRI_HOST`)            |
+| `--version`, `-v`  | print the henri version                                           |
+| `--help`, `-h`     | print the help of a command                                       |

--- a/website/src/content/docs/reference/under-the-hood.md
+++ b/website/src/content/docs/reference/under-the-hood.md
@@ -1,34 +1,39 @@
 ---
 title: Under the hood
-description: The module system and boot sequence.
+description: The module system, the boot sequence, reloads and shutdown.
 sidebar:
-  order: 2
+  order: 3
 ---
-
-## Vision
-
-Bundle the best tools in a structured environment to provide a stable and fast-paced development experience.
 
 ## Modules
 
-henri is a set of modules booted in eight run levels. Modules on the same level start concurrently; the next level starts when they are all done.
+henri is a set of modules booted in run levels. Modules on the same level start concurrently; the next level starts when they are all done. A module that throws fails the boot: `henri.init()` rejects with an `Error` whose `cause` is the module's error, and the CLI prints it.
 
-| Level | Modules                                |
-| ----- | -------------------------------------- |
-| 0     | configuration, logger, module registry |
-| 1     | GraphQL, mail                          |
-| 2     | controllers, HTTP server (Express)     |
-| 3     | models, views                          |
-| 4     | users (sessions, passport, roles)      |
-| 5     | routes, workers                        |
-| 6     | last stage (your own modules)          |
-| 7     | tests                                  |
+| Level | Modules                                                                         |
+| ----- | ------------------------------------------------------------------------------- |
+| 0     | `config`: `config/<env>.json`, `.env`                                           |
+| 1     | `mail`, `graphql`                                                               |
+| 2     | `controllers`, `server` (the Express app is built, not listening yet)           |
+| 3     | `model` (stores and model globals), `view` (the engine's `init()`)              |
+| 4     | `user` (sessions, passport, CSRF, `req.permit()`)                               |
+| 5     | `router` (routes, the engine's `prepare()`, then the server listens), `workers` |
+| 6     | your own modules                                                                |
 
-Reloadable modules are torn down in reverse order and started again in order when a file changes, so a saved model reloads models, views, routes and workers but leaves the HTTP server alone.
+The logger (`henri.pen`) and the registry (`henri.modules`) exist before level 0. Level 7 is reserved for the legacy `tests` module: henri boots up to level 6, and that module only prints a pointer to `henri test` when `HENRI_TESTING` is set.
+
+## Reloads
+
+In development the server watches `app/controllers`, `app/helpers`, `app/models`, `app/workers`, `app/views/partials`, `config` and `package.json`. Changes are debounced, every changed file is syntax checked first (an error is printed and nothing reloads), then `henri.reload()` runs: the application's own files are evicted from the require cache (nothing under `node_modules`) and the reloadable modules run their `reload()` in level order: `config`, `graphql`, `controllers`, `model`, `view`, `router`, `workers`. `server`, `mail` and `user` are not reloadable. Reloads are serialized: a change during a reload queues exactly one more run.
+
+A model reload stops and restarts the stores; the session store follows the new adapter. The Handlebars engine drops its template cache; the React engine only announces that `config/next.js` or `config/webpack.js` changed (Next.js watches the pages itself); the Inertia engine lets Vite watch. `Ctrl+R` in the terminal triggers the same reload.
+
+## Shutdown
+
+`henri.stop()` stops the modules in reverse order, keeps going when one fails, and resolves with the array of errors (empty when everything stopped). `SIGINT` and `SIGTERM` call it with a 5 second timeout before the process is killed; a second signal exits at once. The exit code is `1` when a module failed to stop.
 
 ## Writing a module
 
-A module extends `BaseModule`, has a unique `name` and a `runlevel`, and implements `init()`. Reloadable modules add `reload()`; modules holding resources add `stop()`.
+A module extends `BaseModule`, has a unique `name` and a `runlevel`, and implements `init()` returning its name. Reloadable modules set `reloadable = true` and add `reload()`; modules holding resources add `stop()`; `consoleOnly = true` skips the module under `henri console`.
 
 ```js
 const BaseModule = require('@usehenri/core/src/base/module');
@@ -45,6 +50,7 @@ class Metrics extends BaseModule {
     this.henri.server.app.get('/_metrics', (req, res) =>
       res.json({ ok: true })
     );
+
     return this.name;
   }
 
@@ -56,8 +62,18 @@ class Metrics extends BaseModule {
 module.exports = Metrics;
 ```
 
+Modules are registered with `henri.modules.add(new Metrics())` before `henri.init()` runs, which means booting core yourself instead of through the CLI:
+
+```js
+const Henri = require('@usehenri/core/src/henri');
+const henri = new Henri();
+
+henri.modules.add(new Metrics());
+await henri.init();
+```
+
 The instance is exposed as `henri.<name>`, which is why names must be unique: registering two modules with the same name, or one whose name collides with an existing property of `henri`, stops the boot with a [duplicate module error](/e/dup_mods/).
 
 ## Contributing
 
-henri is a pnpm monorepo. Clone [usehenri/henri](https://github.com/usehenri/henri), run `pnpm install` at the root, `pnpm test` to run the suites and `pnpm lint` before sending a pull request. The disk adapter tests download a MongoDB binary on first run.
+henri is a pnpm monorepo. Clone [usehenri/henri](https://github.com/usehenri/henri), run `pnpm install` at the root, `pnpm test` to run the suites and `pnpm lint` before sending a pull request. The disk adapter tests download a MongoDB binary on first run. See `CONTRIBUTING.md` in the repository for the pull request checklist and how releases work.

--- a/website/src/content/docs/upgrading.md
+++ b/website/src/content/docs/upgrading.md
@@ -1,0 +1,80 @@
+---
+title: Upgrading
+description: From henri 0.37 to 1.x, what breaks and what to change.
+sidebar:
+  order: 3
+---
+
+henri 1.0 (2026) moved the framework to a current toolchain and 1.1 hardened it. Both break an application written for 0.37. This page lists the changes in the order you will meet them; the per-package details are in the [changelogs](https://github.com/usehenri/henri/releases).
+
+## Toolchain
+
+- Node.js 22 or newer. The `henri` binary refuses to start on an older version.
+- Express 5 (Express 4 in 0.37). Middlewares you register yourself must follow its rules: wildcard routes are written `/{*splat}`, `req.query` is a getter, rejected promises in handlers reach the error handler.
+- Next.js 16 with Turbopack and React 19. `next`, `react` and `react-dom` are peer dependencies: add them to the application (`henri new` does). The `inferno` and `preact` renderers are gone. The Vue renderer only loads with `"experimental": { "vue": true }` and has not been exercised since Nuxt 2.
+- Mongoose 9 and Sequelize 6 with current drivers. Mongoose queries take no callbacks: `Model.update()` and `Model.remove()` are gone, use `updateOne()`, `findByIdAndUpdate()`, `deleteOne()` and `findByIdAndDelete()`.
+- Tests run on Vitest, not Jest (see [Testing](/guides/testing/)).
+
+## Project layout
+
+- `config/default.json` is meant to be committed and the secret to live in `.env` as `HENRI_SECRET`, which henri reads on boot. A `secret` in the JSON still works.
+- The disk adapter stores its data under `<app>/.henri/data` instead of a temporary directory keyed on the project path. Data is not migrated; add `/.henri` to `.gitignore` (the scaffold does).
+- The React renderer needs `app/views/next.config.js` and `app/views/jsconfig.json`; the engine creates them on first boot when they are missing. `config/webpack.js` still works and switches the bundler to webpack; `config/next.js` extends the Next.js configuration under either bundler. Both are read once: edit, then restart.
+- Tests live in `test/**/*.test.js` with a `vitest.config.js` at the root (see below).
+
+## Server and HTTP
+
+- Development binds to `127.0.0.1`. Use `henri server --host=0.0.0.0`, `HENRI_HOST` or `config.host` to listen on the network; production still binds to `0.0.0.0`.
+- CORS is off unless `config.cors` is set.
+- Unmatched routes get a content-negotiated 404 and controller errors a logged 500 (message and stack in development only). `X-Powered-By` is gone. `/_routes` and `/_controllers` answer in development and only from the machine running the server.
+- `res.boom` is built in (express-boom is gone); the response shape is the same, see [Controllers](/guides/controllers/#resboom).
+- A misconfigured store, adapter, view or controller fails the boot instead of being logged and skipped. `henri.init()` rejects with an `Error` whose `cause` is the module error; `pen.fatal()` returns an `Error` for the caller to throw; `henri.stop()` resolves with the array of errors of the modules that failed to stop.
+- `SIGINT` and `SIGTERM` stop the server gracefully, with a 5 second timeout; a second signal exits at once.
+
+## Users, sessions and requests
+
+- Log out with `POST /logout`. `GET /logout` answers `405`.
+- `POST /login` answers `{ user }` to JSON clients and redirects browsers to `config.user.afterLogin`; failures are `401` (`400` when a field is missing) or a redirect to `<loginPath>?error=invalid`.
+- Views, `req._henri.user` and JSON answers receive the public user only: `{ id, email, roles }` plus the fields listed in `config.user.public`. `req.user` is still the model instance server side.
+- The `password` field is not selected by default: `User.findOne(...).select('+password')` on Mongoose, `User.scope('withPassword')` on SQL. `henri.user.findByEmail()` returns it, `findById()` does not.
+- `email` is trimmed, lowercased and unique. Existing rows are not rewritten; lookups lowercase their argument.
+- `roles` is dropped from mass-assigned creates and updates. Change roles with `user.setRoles(roles)`, `User.setRoles(id, roles)` or by passing `{ unsafe: true }` to the operation.
+- Double-submit CSRF protection: unsafe requests (`POST`, `PUT`, `PATCH`, `DELETE`) that carry the session cookie must send the `henri.csrf` cookie back as the `X-CSRF-Token` (or `X-XSRF-TOKEN`) header or a `_csrf` field, or they get a `403`. The React `fetch()` and `hydrate()` helpers, the Inertia `fetch()` helper and `Form` do it; a plain form needs the `_csrf` field; requests with a bearer token are exempt; `"csrf": false` disables it.
+- The session cookie is `httpOnly`, `SameSite=Lax`, `Secure` in production and lives 30 days (`config.user.sessionMaxAge`).
+- `req.logout()` takes a callback (passport 0.7). Prefer the built-in `POST /logout`.
+- Use `req.permit('title', 'body')` instead of `req.body` when creating or updating records.
+
+## Models
+
+- Models are written in the henri format (`{ type: 'string', required: true, default, enum, unique, index }`, see [Models](/guides/models/#the-schema-format)) and normalized per adapter. The SQL adapters throw on keys they do not know: Waterline-style `validations`, `isIn` or `defaultsTo` from old model files must become `enum` and `default`. The Mongoose adapter passes unknown keys through.
+- A store without `url` (or `host`) fails the boot instead of leaving a broken adapter. `host`, `port`, `database`, `username` and `password` are accepted instead of `url`.
+- Model files may export `associate(models)`, called once every model exists (before `sync()` on SQL). Adapters expose `ping()`, `transaction(fn)` and, on SQL, `query(sql, params)`.
+- On SQL, `roles` is a JSON column (TEXT with a JSON getter on MSSQL) and `email` is validated as an email.
+
+## Views
+
+- `fetch()` in `withHenri` uses the native `fetch` and resolves with the parsed body (it resolved the axios response before: `.data` is gone). Failed requests reject with a `RequestError` carrying `message`, `statusCode`, `error` and `data` from the boom body.
+- `withHenri` reads only `req._henri` on the server: query string values no longer become page props. `errors`, `graphql`, `csrf` and `localUrl` reach the page and `useHenri()`.
+- `hydrate()` keeps the current data when the answer is not a henri page and exposes the error as `useHenri().error`.
+- `pathFor()` and `getRoute()` replace whole parameter names (`:id` no longer rewrites `:identifier`).
+- Forms: sanitizers chain (`trim` then `escape`), the form stays disabled until the request settles, `Select` renders a real placeholder option, `Editor` is controlled by the form data and loads Quill in the browser only. `prop-types` and `shallowequal` are gone.
+- There is no `helpers/` import alias: any folder under `app/views` (`components/`, `styles/`, `assets/`) is importable by name, `app/helpers` is not.
+- Handlebars: `/artwork` resolves to `pages/artwork.{hbs,html,htm}` then `pages/artwork/index.*` and nothing else; a route without a page is a 404; the view options are data variables (`{{@user.email}}`).
+
+## GraphQL
+
+- `henri.graphql.run(query, variables, contextValue)` returns `{ data, errors }` and forwards `contextValue` to the resolvers (`res.render()` passes `{ req, res }`).
+- Apollo Server 5: the error classes on `henri.graphql` (`AuthenticationError`, `ForbiddenError`, `UserInputError`, ...) are `GraphQLError` subclasses with an `extensions.code`.
+
+## CLI
+
+- `henri test` spawns the application's Vitest with `NODE_ENV=test` and exits with its code. Add `vitest` and `@usehenri/testing` to the devDependencies and a `vitest.config.js` (see [Testing](/guides/testing/)); `@usehenri/testing` exports `setup`, `teardown`, `request`, `agent` and `henri`.
+- `henri build` builds the React views without booting the stores: it no longer needs a database.
+- Generators write plural, unscoped resources (`Post` gives `app/controllers/posts.js`, `resources posts` and `app/views/pages/posts/`), answer validation errors with a 422 and pick attributes with `req.permit()`. Existing files are skipped unless `--force` is given. `generate controller` adds a route per action, `generate worker` and `generate test` are new, and `henri routes` prints the routes table.
+- `utils.checkPackages()` never installs anything: it prints the install command and throws.
+
+## Packages
+
+- `@usehenri/mailer` and `@usehenri/websocket` are not published; the mailer lives in core (`henri.mail`).
+- `express-session` is a peer dependency of `@usehenri/sequelize` and `@usehenri/mongoose` (core depends on it, so applications need nothing).
+- `BaseModule` lost its unused `setup()`, `start()` and `info()` stubs. Custom store adapters must implement the [adapter contract](/reference/api/#store-adapters): `getSessionConnector()` is async and `findUserByEmail`, `findUserById`, `userId` and `toPlain` are required.


### PR DESCRIPTION
Documentation pass on the 1.1 behaviour, written against the code: new pages (upgrading from 0.37, users, testing, API reference), every guide updated (scaffold tree, configuration incl. .env, model format and adapter options, controllers with req.permit and res.boom, routes and role denial, React and Inertia views, mail, workers, CLI reference, module system), sidebar reorganized, CLAUDE.md and README updated. 18 pages build; 348 internal links checked, none broken.