### PR TITLE
Inertia template aligned with the release conventions

### DIFF
--- a/packages/cli/__tests__/new.spec.js
+++ b/packages/cli/__tests__/new.spec.js
@@ -318,21 +318,21 @@ describe('henri new --renderer inertia', () => {
     );
 
     for (const file of [
-      'app/models/Tasks.js',
+      'app/models/Task.js',
       'app/controllers/tasks.js',
       'app/views/pages/tasks/index.jsx',
       'app/views/vite.config.mjs',
+      'vitest.config.js',
     ]) {
       expect(exists(app, file)).toBe(true);
     }
 
     // Nothing from the react scaffold generator
     for (const file of [
-      'app/models/Task.js',
+      'app/models/Tasks.js',
       'app/views/pages/tasks/index.js',
       'app/views/pages/tasks/_form.js',
       'test/tasks.test.js',
-      'vitest.config.js',
     ]) {
       expect(exists(app, file)).toBe(false);
     }

--- a/packages/cli/template/inertia/.gitignore
+++ b/packages/cli/template/inertia/.gitignore
@@ -11,18 +11,19 @@
 # henri runtime (model globals for the linter)
 /.henri
 
-# configuration
-/config/*.json
+# configuration: config/default.json is committed, secrets live in .env
+/config/local.json
+.env
 
 # logs
 /logs/*.log
 
 # dbs and stuff
 /.tmp
+/.backup
 
 # misc
 .DS_Store
-.env
 npm-debug.log*
 pnpm-debug.log*
 yarn-debug.log*

--- a/packages/cli/template/inertia/app/controllers/tasks.js
+++ b/packages/cli/template/inertia/app/controllers/tasks.js
@@ -2,7 +2,7 @@
 // app/views/pages/<route>.jsx with `data` available through useHenri().
 // The Inertia client follows redirects, so a form submission ends on the
 // page the controller redirects to.
-const list = () => Tasks.find().sort({ createdAt: -1 }).lean();
+const list = () => Task.find().sort({ createdAt: -1 }).lean();
 
 module.exports = {
   index: async (req, res) => {
@@ -11,7 +11,7 @@ module.exports = {
 
   create: async (req, res) => {
     try {
-      await Tasks.create({
+      await Task.create({
         category: req.body.category,
         name: req.body.name,
       });
@@ -26,7 +26,7 @@ module.exports = {
   },
 
   destroy: async (req, res) => {
-    await Tasks.deleteOne({ _id: req.params.id });
+    await Task.deleteOne({ _id: req.params.id });
 
     res.redirect('/tasks');
   },

--- a/packages/cli/template/inertia/app/models/Task.js
+++ b/packages/cli/template/inertia/app/models/Task.js
@@ -1,4 +1,4 @@
-// Models are autoloaded from app/models and exposed globally (here: `Tasks`).
+// Models are autoloaded from app/models and exposed globally (here: `Task`).
 // The schema is handed to the store adapter (mongoose for disk/mongodb).
 module.exports = {
   options: {

--- a/packages/cli/template/inertia/gitignore
+++ b/packages/cli/template/inertia/gitignore
@@ -11,18 +11,19 @@
 # henri runtime (model globals for the linter)
 /.henri
 
-# configuration
-/config/*.json
+# configuration: config/default.json is committed, secrets live in .env
+/config/local.json
+.env
 
 # logs
 /logs/*.log
 
 # dbs and stuff
 /.tmp
+/.backup
 
 # misc
 .DS_Store
-.env
 npm-debug.log*
 pnpm-debug.log*
 yarn-debug.log*

--- a/packages/cli/template/inertia/package.json
+++ b/packages/cli/template/inertia/package.json
@@ -29,8 +29,10 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.5",
+    "@usehenri/testing": "^1.0.0",
     "eslint": "^9.39.5",
     "eslint-plugin-react": "^7.37.5",
-    "globals": "^17.12.0"
+    "globals": "^17.12.0",
+    "vitest": "^5.0.0"
   }
 }

--- a/packages/cli/template/inertia/vitest.config.js
+++ b/packages/cli/template/inertia/vitest.config.js
@@ -1,0 +1,14 @@
+// `henri test` runs vitest with this configuration. The setup file boots
+// henri (NODE_ENV=test) before each test file, so `henri`, the models and
+// request() from @usehenri/testing are available in your tests.
+const { defineConfig } = require('vitest/config');
+
+module.exports = defineConfig({
+  test: {
+    environment: 'node',
+    fileParallelism: false,
+    globals: true,
+    include: ['test/**/*.{spec,test}.js'],
+    setupFiles: ['@usehenri/testing/setup-file'],
+  },
+});


### PR DESCRIPTION
Follow-up from the Inertia teammate: the `--renderer inertia` template ships `app/models/Task.js` (singular, like the React template), the same gitignore entries, and a `vitest.config.js`, so `henri doctor` passes on a fresh Inertia app.