### PR TITLE
Clear the CodeQL warnings left by the 1.1 merge

### DIFF
--- a/packages/inertia/engine/index.js
+++ b/packages/inertia/engine/index.js
@@ -70,12 +70,29 @@ const list = (value) =>
  * @returns {string} the component name
  */
 function componentName(route = '/') {
-  const name = String(route)
-    .replace(/\\/g, '/')
-    .replace(/^\/+/, '')
-    .replace(/\/+$/, '');
+  const name = trimSlashes(String(route).replace(/\\/g, '/'));
 
   return name === '' ? 'index' : name;
+}
+
+/**
+ * Removes the leading and trailing slashes of a path
+ *
+ * @param {string} value the path
+ * @returns {string} the path without its outer slashes
+ */
+function trimSlashes(value) {
+  let start = 0;
+  let end = value.length;
+
+  while (start < end && value[start] === '/') {
+    start += 1;
+  }
+  while (end > start && value[end - 1] === '/') {
+    end -= 1;
+  }
+
+  return value.slice(start, end);
 }
 
 /**

--- a/packages/inertia/src/resolve.mjs
+++ b/packages/inertia/src/resolve.mjs
@@ -18,9 +18,7 @@ export function resolvePage(
   name,
   { dir = './pages', extensions = ['jsx', 'tsx', 'js', 'ts'] } = {}
 ) {
-  const clean = String(name || 'index')
-    .replace(/^\/+/, '')
-    .replace(/\/+$/, '');
+  const clean = trimSlashes(String(name || 'index'));
   const candidates = [];
 
   for (const ext of extensions) {
@@ -42,4 +40,24 @@ export function resolvePage(
   const page = pages[key];
 
   return typeof page === 'function' ? page() : page;
+}
+
+/**
+ * Removes the leading and trailing slashes of a page name
+ *
+ * @param {string} value the name
+ * @returns {string} the name without its outer slashes
+ */
+function trimSlashes(value) {
+  let start = 0;
+  let end = value.length;
+
+  while (start < end && value[start] === '/') {
+    start += 1;
+  }
+  while (end > start && value[end - 1] === '/') {
+    end -= 1;
+  }
+
+  return value.slice(start, end);
 }

--- a/scripts/jest-to-vitest.mjs
+++ b/scripts/jest-to-vitest.mjs
@@ -238,7 +238,10 @@ function transform(source) {
   );
 
   if (usesVi && usesEsm && esmImport && !/\bvi\b/.test(esmImport[1])) {
-    output = output.replace(esmImport[0], esmImport[0].replace('{', '{ vi,'));
+    const brace = esmImport[0].indexOf('{');
+    const patched = `${esmImport[0].slice(0, brace + 1)} vi,${esmImport[0].slice(brace + 1)}`;
+
+    output = output.replace(esmImport[0], patched);
     changes.push('added vi to the existing vitest import');
   } else if (usesVi && usesEsm && !esmImport) {
     const statement = "import { vi } from 'vitest';\n";


### PR DESCRIPTION
Resolves the three code-scanning warnings still open on master after #297: the Inertia component name and page resolver trim slashes with a scan instead of anchored `/+` quantifiers (polynomial ReDoS), and the Jest to Vitest codemod splices `vi` into an existing vitest import instead of a first-occurrence `replace` (incomplete sanitization).