### PR TITLE
Bootstrap script for new npm packages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,9 +155,11 @@ changesets it opens or updates a "Version Packages" pull request; merging that
 PR runs the publish job, which publishes to npm with provenance and creates
 GitHub releases. Publishing uses npm trusted publishing (OIDC): every public
 package trusts this repository's `release.yml` running in the `npm` GitHub
-environment. There is no npm token to rotate; a new package needs its trusted
-publisher registered on npmjs.com before its first release, and must be added
-to the `fixed` group of `.changeset/config.json`. `scripts/prepublish.js` copies
+environment. There is no npm token to rotate. npm cannot create a package
+through OIDC, so a new package is bootstrapped once by a maintainer
+(`npm login`, then `node scripts/npm-bootstrap.mjs @usehenri/<name>` publishes
+an empty 0.0.0), gets its trusted publisher registered on npmjs.com, and must
+be added to the `fixed` group of `.changeset/config.json`. `scripts/prepublish.js` copies
 the LICENSE and a README into every public package at publish time
 (`packages/henri` gets the root README).
 

--- a/scripts/npm-bootstrap.mjs
+++ b/scripts/npm-bootstrap.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * Creates a package on npm so that trusted publishing can take over.
+ *
+ * npm cannot create a package through OIDC (the trusted publisher of a
+ * package is configured on npmjs.com, which needs the package to exist), so
+ * the first release of a new @usehenri package is bootstrapped by hand:
+ *
+ *   npm login                                   # once, as a maintainer
+ *   node scripts/npm-bootstrap.mjs @usehenri/foo   # publishes 0.0.0
+ *
+ * then register the trusted publisher of the package on npmjs.com
+ * (repository usehenri/henri, workflow release.yml, environment npm) and
+ * let the release workflow publish the real version. 0.0.0 is a placeholder
+ * with no code: `changeset publish` never picks it and a version range like
+ * ^1.1.0 never resolves to it.
+ *
+ *   --dry-run   print what would be published
+ */
+/* eslint-disable no-console */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const name = args.find((arg) => !arg.startsWith('--'));
+
+if (!name || !/^@usehenri\/[a-z0-9-]+$/.test(name)) {
+  console.error(
+    'usage: node scripts/npm-bootstrap.mjs [--dry-run] @usehenri/<name>'
+  );
+  process.exit(2);
+}
+
+const dir = mkdtempSync(join(tmpdir(), 'henri-npm-bootstrap-'));
+const manifest = {
+  description: `Placeholder creating ${name} on npm; the first real version is published by the henri release workflow`,
+  homepage: 'https://usehenri.io',
+  license: 'MIT',
+  name,
+  publishConfig: { access: 'public' },
+  repository: {
+    directory: `packages/${name.slice('@usehenri/'.length)}`,
+    type: 'git',
+    url: 'git+https://github.com/usehenri/henri.git',
+  },
+  version: '0.0.0',
+};
+
+writeFileSync(
+  join(dir, 'package.json'),
+  `${JSON.stringify(manifest, null, 2)}\n`
+);
+writeFileSync(
+  join(dir, 'README.md'),
+  `# ${name}\n\nPlaceholder release. Install a real version: see https://usehenri.io.\n`
+);
+
+console.log(
+  `${dryRun ? 'would publish' : 'publishing'} ${name}@0.0.0 from ${dir}`
+);
+
+execFileSync(
+  'npm',
+  ['publish', '--access', 'public', ...(dryRun ? ['--dry-run'] : [])],
+  { cwd: dir, stdio: 'inherit' }
+);


### PR DESCRIPTION
npm cannot create a package through OIDC (npm/cli#8544): the trusted publisher of a package is configured on npmjs.com, which needs the package to exist. `node scripts/npm-bootstrap.mjs @usehenri/<name>` publishes an empty 0.0.0 with a maintainer's login so the trusted publisher can be registered and the release workflow can publish the real version. CLAUDE.md documents the procedure. Needed for `@usehenri/inertia`, `@usehenri/mcp` and `@usehenri/drizzle` before 1.1.0.