### PR TITLE
Run the SQL suites against live PostgreSQL and MySQL

### DIFF
--- a/.changeset/quiet-clocks-argue.md
+++ b/.changeset/quiet-clocks-argue.md
@@ -1,0 +1,9 @@
+---
+'@usehenri/drizzle': patch
+---
+
+Fix the adapter on live PostgreSQL and MySQL servers, now that the suites run against both.
+
+A unique violation answers a `ValidationError` again: drizzle-orm reports the failures of its asynchronous drivers wrapped in a `DrizzleQueryError`, so the dialects unwrap the cause before reading the constraint, and the MySQL constraint name is kept.
+
+A push on MySQL (`henri db:push` and the development boot) creates the tables that are missing instead of doing nothing: drizzle-kit answers the data loss of a MySQL push but never the DDL it would run. A table whose columns drifted from the model is reported — run `henri db:generate` then `henri db:migrate` for it — and the tables drizzle-kit suggests truncating are left alone.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,98 @@ jobs:
         env:
           NODE_ENV: test
 
+  # The SQL adapters run on sqlite in the jobs above; these two run the same
+  # suites against a real server, each store in a database of its own. They
+  # are separate jobs so one server (or one image) being unavailable does not
+  # touch the other, and `continue-on-error` keeps them out of the way of
+  # every pull request: nothing depends on them.
+  postgres:
+    name: Live PostgreSQL
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: henri
+          POSTGRES_PASSWORD: henri
+          POSTGRES_DB: henri_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U henri -d henri_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: jdx/mise-action@v4
+        with:
+          cache: true
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/pnpm/store
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-${{ runner.os }}-
+
+      - run: pnpm install --frozen-lockfile
+        env:
+          # The SQL suites never boot MongoDB
+          MONGOMS_DISABLE_POSTINSTALL: '1'
+
+      # Without the variable the suites would run on sqlite
+      - run: pnpm test:sql
+        env:
+          NODE_ENV: test
+          HENRI_TEST_POSTGRES_URL: postgres://henri:henri@127.0.0.1:5432/henri_test
+
+  mysql:
+    name: Live MySQL
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: henri
+          MYSQL_DATABASE: henri_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping -h 127.0.0.1 -uroot -phenri"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: jdx/mise-action@v4
+        with:
+          cache: true
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/pnpm/store
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-${{ runner.os }}-
+
+      - run: pnpm install --frozen-lockfile
+        env:
+          # The SQL suites never boot MongoDB
+          MONGOMS_DISABLE_POSTINSTALL: '1'
+
+      # Without the variable the suites would run on sqlite
+      - run: pnpm test:sql
+        env:
+          NODE_ENV: test
+          HENRI_TEST_MYSQL_URL: mysql://root:henri@127.0.0.1:3306/henri_test
+
   website:
     name: Website
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ mise install                          # node + pnpm from mise.toml
 pnpm install                          # whole workspace; builds @usehenri/react dist
 pnpm test                             # vitest 5, all packages (NODE_ENV=test)
 pnpm test packages/core               # one package (path filter); `pnpm test:cover` for coverage
+pnpm test:sql                         # the SQL adapters only (sqlite; see below for a live server)
 pnpm lint                             # eslint 10 flat config, zero warnings in CI
 pnpm format                           # prettier 3 (`pnpm format:check` in CI)
 pnpm build                            # rollup build of @usehenri/react
@@ -28,6 +29,20 @@ pnpm changeset                        # record a version bump for changed packag
 The first test run downloads a MongoDB binary (mongodb-memory-server) into
 `~/.cache/mongodb-binaries`. Set `MONGOMS_DISABLE_POSTINSTALL=1` when
 installing where that download is unwanted.
+
+The SQL suites (`@usehenri/sequelize`, its dialect packages and
+`@usehenri/drizzle`) run on sqlite by default, offline. Point
+`HENRI_TEST_POSTGRES_URL` or `HENRI_TEST_MYSQL_URL` at a server and the same
+suites run on it instead, each store in a `henri_test_*` database of its own
+(created and dropped by `packages/*/__tests__/targets.js`);
+`HENRI_TEST_SQL_DIALECT` picks one when both are set. The CI runs them that
+way in the `Live PostgreSQL` and `Live MySQL` jobs, on service containers:
+
+```bash
+docker run -d --name henri-pg -e POSTGRES_USER=henri -e POSTGRES_PASSWORD=henri \
+  -e POSTGRES_DB=henri_test -p 5432:5432 postgres:17
+HENRI_TEST_POSTGRES_URL=postgres://henri:henri@127.0.0.1:5432/henri_test pnpm test:sql
+```
 
 Applications built with henri run their own tests with `henri test`, which
 spawns the app's Vitest with `NODE_ENV=test`; `@usehenri/testing` boots the
@@ -169,9 +184,15 @@ the LICENSE and a README into every public package at publish time
   since 2020 and only loads with `experimental.vue: true`.
 - The Inertia engine is new in 1.1 and has had little use; its options may
   change.
-- The SQL adapters are tested against sqlite; live MySQL, PostgreSQL and MSSQL
-  connections are not covered, for the Drizzle adapter too. The Sequelize
+- The SQL adapters run their suites against sqlite by default and against a
+  live PostgreSQL or MySQL server with `HENRI_TEST_POSTGRES_URL` /
+  `HENRI_TEST_MYSQL_URL` (see above); MSSQL is only covered offline (its
+  generated DDL), and no adapter is exercised against MariaDB. The Sequelize
   adapters have no migrations (`sequelize.sync()`); Drizzle has them.
+- drizzle-kit does not alter a mysql table on a push: `henri db:push` and the
+  development boot create the tables that are missing and report the ones
+  whose columns drifted (`Migrations#completeMySQLPlan`); a mysql schema
+  change needs `henri db:generate` then `henri db:migrate`.
 - `henri generate scaffold|crud` write Mongoose-only controllers and React-only
   pages.
 - The idempotency and rate-limit stores are in memory unless the app plugs a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ mise install                          # node + pnpm from mise.toml
 pnpm install                          # whole workspace; builds @usehenri/react
 pnpm test                             # whole monorepo
 pnpm test packages/core               # one package
+pnpm test:sql                         # the SQL adapters (sqlite, or a live server)
 pnpm lint                             # eslint (flat config)
 pnpm format                           # prettier
 pnpm build                            # builds @usehenri/react
@@ -26,6 +27,25 @@ scripts/smoke.sh                      # scaffold an app from the workspace and b
 The first test run downloads a MongoDB binary for the disk adapter
 (`mongodb-memory-server`) into `~/.cache/mongodb-binaries`.
 
+### The SQL adapters on a live database
+
+`@usehenri/sequelize`, its dialect packages and `@usehenri/drizzle` run their
+suites on sqlite, so `pnpm test` needs no server and no network. Point
+`HENRI_TEST_POSTGRES_URL` or `HENRI_TEST_MYSQL_URL` at a server and the same
+suites run against it, each store in a `henri_test_*` database of its own,
+dropped when the file is done (`HENRI_TEST_SQL_DIALECT` picks one when both
+variables are set). The account needs the right to create databases:
+
+```bash
+docker run -d --name henri-pg -e POSTGRES_USER=henri -e POSTGRES_PASSWORD=henri \
+  -e POSTGRES_DB=henri_test -p 5432:5432 postgres:17
+docker run -d --name henri-mysql -e MYSQL_ROOT_PASSWORD=henri \
+  -e MYSQL_DATABASE=henri_test -p 3306:3306 mysql:8
+
+HENRI_TEST_POSTGRES_URL=postgres://henri:henri@127.0.0.1:5432/henri_test pnpm test:sql
+HENRI_TEST_MYSQL_URL=mysql://root:henri@127.0.0.1:3306/henri_test pnpm test:sql
+```
+
 ## Pull requests
 
 - Branch from `master`. `master` only takes pull requests whose `Node 22` and
@@ -33,7 +53,10 @@ The first test run downloads a MongoDB binary for the disk adapter
   rebased on it.
 - CI runs `prettier --check`, `eslint --max-warnings 0`, the test suite on
   Node 22 and 24, the website build and a scaffold smoke test
-  (`scripts/smoke.sh`). Run `pnpm lint` and `pnpm test` before pushing.
+  (`scripts/smoke.sh`). Run `pnpm lint` and `pnpm test` before pushing. The
+  `Live PostgreSQL` and `Live MySQL` jobs run the SQL suites against service
+  containers; they never block a pull request, so read them when you touch an
+  SQL adapter.
 - Commits follow [Conventional Commits](https://www.conventionalcommits.org)
   (`feat(core): ...`, `fix(react): ...`, `chore(ci): ...`). The husky hooks run
   lint-staged and commitlint on every commit.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:watch": "vitest",
     "test:cover": "vitest run --coverage",
     "test:ci": "vitest run --coverage",
+    "test:sql": "vitest run --project sequelize --project mysql --project postgresql --project mssql --project drizzle",
     "changeset": "changeset",
     "changeset:version": "changeset version",
     "changeset:publish": "pnpm sync-readme && pnpm build && changeset publish"

--- a/packages/drizzle/__tests__/dialect.spec.js
+++ b/packages/drizzle/__tests__/dialect.spec.js
@@ -1,0 +1,205 @@
+const dialects = require('../dialects');
+const { ValidationError } = require('../validation');
+const { build, target } = require('./helpers');
+
+// The columns the schema types are compiled to, per dialect. sqlite has
+// four storage classes, postgres and mysql keep the henri types apart.
+const COLUMNS = {
+  mysql: {
+    active: 'tinyint(1)',
+    amount: 'double',
+    id: 'int',
+    key: 'varchar(36)',
+    // The values are part of the column type
+    level: "enum('low','high')",
+    notes: 'text',
+    ratio: 'float',
+    settings: 'json',
+    title: 'varchar(255)',
+    total: 'int',
+    when: 'datetime(3)',
+  },
+  postgres: {
+    active: 'boolean',
+    amount: 'double precision',
+    id: 'integer',
+    key: 'uuid',
+    // A type of its own, named after the table and the column
+    level: 'things_level',
+    notes: 'text',
+    ratio: 'real',
+    settings: 'jsonb',
+    title: 'character varying(255)',
+    total: 'integer',
+    when: 'timestamp with time zone',
+  },
+  sqlite: {
+    active: 'integer',
+    amount: 'real',
+    id: 'integer',
+    key: 'text',
+    // No enum on sqlite: the values are only checked by the model
+    level: 'text',
+    notes: 'text',
+    ratio: 'real',
+    settings: 'text',
+    title: 'text',
+    total: 'integer',
+    when: 'integer',
+  },
+};
+
+// One row per column, `{ name, type }`, on every dialect
+const INTROSPECT = {
+  mysql: `SELECT column_name AS name, column_type AS type
+          FROM information_schema.columns
+          WHERE table_schema = DATABASE() AND table_name = 'things'`,
+  postgres: `SELECT attname AS name, format_type(atttypid, atttypmod) AS type
+             FROM pg_attribute
+             WHERE attrelid = 'things'::regclass AND attnum > 0`,
+  sqlite: `SELECT name, type FROM pragma_table_info('things')`,
+};
+
+const thingModel = {
+  globalId: 'Thing',
+  identity: 'thing',
+  options: { timestamps: false },
+  schema: {
+    active: 'boolean',
+    amount: 'number',
+    key: 'uuid',
+    level: { enum: ['low', 'high'], type: 'string' },
+    notes: 'text',
+    ratio: 'float',
+    settings: 'json',
+    title: { type: 'string', unique: true },
+    total: 'integer',
+    when: 'date',
+  },
+};
+
+describe('driver errors', () => {
+  const wrap = (error) =>
+    Object.assign(new Error('Failed query: insert into ...'), { cause: error });
+
+  test('unwraps the driver error drizzle reports the failure with', () => {
+    const driver = Object.assign(new Error('duplicate'), { code: '23505' });
+
+    expect(dialects.driverError(wrap(driver))).toBe(driver);
+    expect(dialects.driverError(driver)).toBe(driver);
+    expect(dialects.driverError(new Error('plain')).code).toBeUndefined();
+  });
+
+  test('flags a postgres unique violation, wrapped or not', () => {
+    const { translate } = dialects.get('postgres');
+    const driver = Object.assign(new Error('duplicate key'), {
+      code: '23505',
+      detail: 'Key (email)=(a@b.co) already exists.',
+    });
+
+    expect(translate(driver).henri).toEqual({
+      columns: ['email'],
+      key: undefined,
+      kind: 'unique',
+    });
+    expect(translate(wrap(driver)).henri.columns).toEqual(['email']);
+    expect(translate(new Error('other')).henri).toBeUndefined();
+  });
+
+  test('flags a mysql unique violation by constraint name', () => {
+    const { translate } = dialects.get('mysql');
+    const driver = Object.assign(
+      new Error("Duplicate entry 'a@b.co' for key 'users.users_email_unique'"),
+      { code: 'ER_DUP_ENTRY' }
+    );
+
+    expect(translate(wrap(driver)).henri).toEqual({
+      columns: [],
+      key: 'users_email_unique',
+      kind: 'unique',
+    });
+  });
+
+  test('flags a sqlite unique violation by column', () => {
+    const { translate } = dialects.get('sqlite');
+    const driver = Object.assign(
+      new Error('UNIQUE constraint failed: users.email'),
+      { code: 'SQLITE_CONSTRAINT_UNIQUE' }
+    );
+
+    expect(translate(driver).henri).toEqual({
+      columns: ['email'],
+      key: undefined,
+      kind: 'unique',
+    });
+  });
+});
+
+describe(`schema on ${target.name}`, () => {
+  let adapter;
+  let Thing;
+
+  beforeAll(async () => {
+    ({ adapter } = build());
+    Thing = adapter.addModel(thingModel, 'user');
+    await adapter.start();
+  });
+
+  afterAll(async () => {
+    await adapter.stop();
+  });
+
+  test('maps the henri types to the columns of the dialect', async () => {
+    const rows = await adapter.query(INTROSPECT[target.name]);
+    const columns = Object.fromEntries(
+      rows.map((row) => [row.name, String(row.type).toLowerCase()])
+    );
+
+    expect(columns).toEqual(COLUMNS[target.name]);
+  });
+
+  test('stores and reads every type back', async () => {
+    const when = new Date('2026-02-03T04:05:06.000Z');
+    const key = '5f4dcc3b-5aa7-4b8d-a4e2-4f4dcc3b5aa7';
+    const thing = await Thing.create({
+      active: true,
+      amount: 12.5,
+      key,
+      level: 'high',
+      notes: 'a long note',
+      ratio: 0.5,
+      settings: { deep: { list: [1, 2] } },
+      title: 'first',
+      total: 42,
+      when,
+    });
+    const stored = await Thing.findById(thing.id);
+
+    expect(stored.active).toBe(true);
+    expect(stored.amount).toBe(12.5);
+    expect(stored.key).toBe(key);
+    expect(stored.level).toBe('high');
+    expect(stored.notes).toBe('a long note');
+    expect(stored.ratio).toBe(0.5);
+    expect(stored.settings).toEqual({ deep: { list: [1, 2] } });
+    expect(stored.total).toBe(42);
+    expect(stored.when.getTime()).toBe(when.getTime());
+  });
+
+  test('refuses a value outside the enum', async () => {
+    await expect(Thing.create({ level: 'nope', title: 'x' })).rejects.toThrow(
+      /must be one of low, high/
+    );
+  });
+
+  test('turns a unique violation into a validation error', async () => {
+    await Thing.create({ title: 'unique' });
+
+    const failed = await Thing.create({ title: 'unique' }).catch(
+      (error) => error
+    );
+
+    expect(failed).toBeInstanceOf(ValidationError);
+    expect(failed.errors.title.message).toBe('must be unique');
+  });
+});

--- a/packages/drizzle/__tests__/migrations.spec.js
+++ b/packages/drizzle/__tests__/migrations.spec.js
@@ -3,29 +3,55 @@ const path = require('path');
 const {
   Drizzle,
   fakeHenri,
+  target,
   taskModel,
   tmpdir,
   userModel,
 } = require('./helpers');
 
+// What drizzle-kit writes for the same schema change on each dialect
+const EXPECTED = {
+  mysql: {
+    added: 'ALTER TABLE `tasks` ADD `priority` int DEFAULT 1;',
+    create: 'CREATE TABLE `tasks`',
+    dropped: /DROP COLUMN `extra`/,
+  },
+  postgres: {
+    added: 'ALTER TABLE "tasks" ADD COLUMN "priority" integer DEFAULT 1;',
+    create: 'CREATE TABLE "tasks"',
+    dropped: /DROP COLUMN "extra"/,
+  },
+  sqlite: {
+    added: 'ALTER TABLE `tasks` ADD `priority` integer DEFAULT 1;',
+    create: 'CREATE TABLE `tasks`',
+    // A sqlite column is dropped by rebuilding the table
+    dropped: /DROP COLUMN `extra`|__new_tasks/,
+  },
+};
+
+const expected = EXPECTED[target.name];
+
 /**
- * An adapter on a sqlite file with its migrations folder in the same dir
+ * An adapter on the target database, with its migrations folder in a
+ * directory: two adapters built for the same `file` share one database (one
+ * sqlite file), the way an application restarts on its data
  *
  * @param {string} dir The directory
  * @param {object} [config={}] Extra store configuration
- * @param {string} [file='app.db'] The database file
+ * @param {string} [file='app.db'] The database of the store
  * @returns {object} The adapter
  */
 const adapterIn = (dir, config = {}, file = 'app.db') =>
-  new Drizzle(
-    'default',
-    {
-      dialect: 'sqlite',
-      migrationsFolder: path.join(dir, 'db/migrations'),
-      url: `file:${path.join(dir, file)}`,
-      ...config,
-    },
-    fakeHenri({ baseRole: 'member' })
+  target.prepare(
+    new Drizzle(
+      'default',
+      {
+        migrationsFolder: path.join(dir, 'db/migrations'),
+        ...target.store(path.join(dir, file)),
+        ...config,
+      },
+      fakeHenri({ baseRole: 'member' })
+    )
   );
 
 describe('migrations', () => {
@@ -75,10 +101,10 @@ describe('migrations', () => {
       )
     );
 
-    expect(sql).toContain('CREATE TABLE `tasks`');
+    expect(sql).toContain(expected.create);
     expect(sql).toContain('--> statement-breakpoint');
     expect(journal).toMatchObject({
-      dialect: 'sqlite',
+      dialect: target.dialect.kit.dialect,
       entries: [
         {
           breakpoints: true,
@@ -89,11 +115,12 @@ describe('migrations', () => {
       ],
       version: '7',
     });
-    expect(Object.keys(snapshot.tables).sort()).toEqual([
-      'henri_sessions',
-      'tasks',
-      'users',
-    ]);
+    // Postgres snapshots are keyed by schema and table
+    expect(
+      Object.keys(snapshot.tables)
+        .map((key) => key.replace(/^public\./, ''))
+        .sort()
+    ).toEqual(['henri_sessions', 'tasks', 'users']);
     expect(snapshot.prevId).toBe('00000000-0000-0000-0000-000000000000');
 
     // The database was pushed to this schema: nothing pending
@@ -141,9 +168,7 @@ describe('migrations', () => {
 
     expect(added.tag).toBe('0001_add_priority');
     expect(added.recorded).toEqual([]);
-    expect(fs.readFileSync(added.file, 'utf8')).toBe(
-      'ALTER TABLE `tasks` ADD `priority` integer DEFAULT 1;'
-    );
+    expect(fs.readFileSync(added.file, 'utf8')).toBe(expected.added);
     expect(await second.migrations.status()).toMatchObject({
       applied: [],
       pending: ['0000_init', '0001_add_priority'],
@@ -153,9 +178,9 @@ describe('migrations', () => {
       applied: ['0000_init', '0001_add_priority'],
       pending: [],
     });
-    expect(await second.listTables()).toEqual(
-      expect.arrayContaining(['__drizzle_migrations', 'tasks'])
-    );
+    expect(await second.listTables()).toContain('tasks');
+    // The migrations table lives in the `drizzle` schema on postgres
+    expect(await second.migrations.applied()).toHaveLength(2);
     expect((await Task.create({ name: 'migrated' })).priority).toBe(1);
     expect(await second.migrations.migrate()).toEqual({
       applied: [],
@@ -171,8 +196,15 @@ describe('migrations', () => {
     await second.stop();
   });
 
-  test('push refuses to lose data unless forced, and to guess renames without a terminal', async () => {
-    const wide = adapterIn(dir);
+  /**
+   * A database with a task table holding an `extra` column and one row, and
+   * a second store on it whose model dropped that column
+   *
+   * @param {string} directory The directory of the database
+   * @returns {Promise<object>} The second store and its Task model
+   */
+  const narrowed = async (directory) => {
+    const wide = adapterIn(directory);
     const Wide = wide.addModel(
       { ...taskModel, schema: { ...taskModel.schema, extra: 'string' } },
       'user'
@@ -183,31 +215,79 @@ describe('migrations', () => {
     await Wide.create({ extra: 'kept?', name: 'row' });
     await wide.stop();
 
-    const narrow = adapterIn(dir);
+    const narrow = adapterIn(directory);
     const Task = narrow.addModel(taskModel, 'user');
 
     await narrow.start();
-    expect(
-      narrow.henri.calls.some(
-        (call) => call[0] === 'warn' && /lose data/.test(call[2])
-      )
-    ).toBe(true);
 
-    const plan = await narrow.migrations.plan();
+    return { Task, narrow };
+  };
 
-    expect(plan.hasDataLoss).toBe(true);
-    expect(plan.statements.join('\n')).toMatch(
-      /DROP COLUMN `extra`|__new_tasks/
-    );
-    expect((await narrow.migrations.push()).applied).toBe(false);
-    expect((await narrow.migrations.push({ force: true })).applied).toBe(true);
-    expect((await narrow.migrations.plan()).statements).toEqual([]);
-    expect(await Task.count()).toBe(1);
-    expect((await Task.first()).extra).toBeUndefined();
+  test.runIf(target.name !== 'mysql')(
+    'push refuses to lose data unless it is forced',
+    async () => {
+      const { Task, narrow } = await narrowed(dir);
+
+      expect(
+        narrow.henri.calls.some(
+          (call) => call[0] === 'warn' && /lose data/.test(call[2])
+        )
+      ).toBe(true);
+
+      const plan = await narrow.migrations.plan();
+
+      expect(plan.hasDataLoss).toBe(true);
+      expect(plan.statements.join('\n')).toMatch(expected.dropped);
+      expect((await narrow.migrations.push()).applied).toBe(false);
+      expect((await narrow.migrations.push({ force: true })).applied).toBe(
+        true
+      );
+      expect((await narrow.migrations.plan()).statements).toEqual([]);
+      expect(await Task.count()).toBe(1);
+      expect((await Task.first()).extra).toBeUndefined();
+      await narrow.stop();
+    }
+  );
+
+  test.runIf(target.name === 'mysql')(
+    'push leaves a mysql table alone and reports the drift',
+    async () => {
+      const { Task, narrow } = await narrowed(dir);
+
+      // Drizzle-kit does not alter a mysql table on a push: the column is
+      // kept, the drift is reported, and the rows are never truncated
+      expect(
+        narrow.henri.calls.some(
+          (call) => call[0] === 'warn' && /does not alter mysql/.test(call[2])
+        )
+      ).toBe(true);
+
+      const plan = await narrow.migrations.plan();
+
+      expect(plan.hasDataLoss).toBe(true);
+      expect(plan.statements).toEqual([]);
+      expect(plan.drifted).toEqual(['tasks']);
+      expect((await narrow.migrations.push()).applied).toBe(true);
+      expect(await Task.count()).toBe(1);
+      expect(
+        (
+          await narrow.query(
+            "SELECT column_name AS name FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'tasks' AND column_name = 'extra'"
+          )
+        ).length
+      ).toBe(1);
+      await narrow.stop();
+    }
+  );
+
+  test('push refuses to guess a rename without a terminal', async () => {
+    const first = adapterIn(dir);
+
+    first.addModel(taskModel, 'user');
+    await first.start();
+    await first.stop();
 
     // A new table with a removed one: drizzle-kit would ask
-    await narrow.stop();
-
     const renamed = adapterIn(dir);
 
     renamed.addModel(

--- a/packages/drizzle/__tests__/model.spec.js
+++ b/packages/drizzle/__tests__/model.spec.js
@@ -1,7 +1,23 @@
+const { driverError } = require('../dialects');
 const { ValidationError } = require('../validation');
-const { build, taskModel } = require('./helpers');
+const { build, target, taskModel } = require('./helpers');
 
-describe('model API (sqlite in memory)', () => {
+// The driver error code of a foreign key violation
+const FOREIGN_KEY = {
+  mysql: 'ER_NO_REFERENCED_ROW_2',
+  postgres: '23503',
+  sqlite: 'SQLITE_CONSTRAINT_FOREIGNKEY',
+};
+
+/**
+ * The parameter placeholder of the target (`?`, or `$1` on postgres)
+ *
+ * @param {number} index The parameter position, from 1
+ * @returns {string} The placeholder
+ */
+const placeholder = (index) => target.dialect.placeholder(index);
+
+describe(`model API (${target.name})`, () => {
   let adapter;
   let Task;
   let Post;
@@ -499,9 +515,13 @@ describe('model API (sqlite in memory)', () => {
     });
 
     test('rejects a foreign key to a missing row', async () => {
-      await expect(
-        Post.create({ authorId: 999, title: 'orphan' })
-      ).rejects.toThrow(/FOREIGN KEY constraint failed/);
+      const failed = await Post.create({
+        authorId: 999,
+        title: 'orphan',
+      }).catch((error) => error);
+
+      expect(failed).toBeInstanceOf(Error);
+      expect(driverError(failed).code).toBe(FOREIGN_KEY[target.name]);
     });
   });
 
@@ -520,7 +540,8 @@ describe('model API (sqlite in memory)', () => {
       expect(await Task.count()).toBe(0);
 
       const result = await adapter.transaction(async (tx) => {
-        expect(tx).toBe(adapter.rawDatabase());
+        // The synchronous driver runs BEGIN/COMMIT on the database itself
+        expect(tx === adapter.rawDatabase()).toBe(target.dialect.synchronous);
         await Task.create({ name: 'kept' });
 
         return 'done';
@@ -534,16 +555,19 @@ describe('model API (sqlite in memory)', () => {
       await Task.create({ name: 'raw' });
 
       await expect(adapter.ping()).resolves.toBe(true);
-      await expect(
-        adapter.query('SELECT COUNT(*) AS total FROM tasks WHERE name = ?', [
-          'raw',
-        ])
-      ).resolves.toEqual([{ total: 1 }]);
-      await expect(
-        adapter.query('UPDATE tasks SET name = ?', ['renamed'])
-      ).resolves.toMatchObject({
-        changes: 1,
-      });
+
+      const rows = await adapter.query(
+        `SELECT COUNT(*) AS total FROM tasks WHERE name = ${placeholder(1)}`,
+        ['raw']
+      );
+
+      // Postgres counts in a bigint, which the driver reads as a string
+      expect(Number(rows[0].total)).toBe(1);
+
+      await adapter.query(`UPDATE tasks SET name = ${placeholder(1)}`, [
+        'renamed',
+      ]);
+      expect((await Task.first()).name).toBe('renamed');
     });
   });
 });

--- a/packages/drizzle/__tests__/session.spec.js
+++ b/packages/drizzle/__tests__/session.spec.js
@@ -1,5 +1,19 @@
 const session = require('express-session');
-const { build, sessions, taskModel, userModel } = require('./helpers');
+const { build, sessions, target, taskModel, userModel } = require('./helpers');
+
+// `?` on sqlite and mysql, `$1` on postgres
+const EXPIRES = `SELECT expires_at FROM henri_sessions WHERE sid = ${target.dialect.placeholder(1)}`;
+
+/**
+ * The expiry stored for a session, as a timestamp (an integer of
+ * milliseconds on sqlite, a date on postgres and mysql)
+ *
+ * @param {object} adapter The store
+ * @param {string} sid A session id
+ * @returns {Promise<number>} The expiry
+ */
+const expiresAt = async (adapter, sid) =>
+  new Date((await adapter.query(EXPIRES, [sid]))[0].expires_at).getTime();
 
 describe('session store', () => {
   let adapter;
@@ -78,21 +92,11 @@ describe('session store', () => {
   test('touch extends the expiry', async () => {
     await api.set('touched', { cookie: { maxAge: 1000 } });
 
-    const before = (
-      await adapter.query(
-        'SELECT expires_at FROM henri_sessions WHERE sid = ?',
-        ['touched']
-      )
-    )[0].expires_at;
+    const before = await expiresAt(adapter, 'touched');
 
     await api.touch('touched', { cookie: { maxAge: 100000 } });
 
-    const after = (
-      await adapter.query(
-        'SELECT expires_at FROM henri_sessions WHERE sid = ?',
-        ['touched']
-      )
-    )[0].expires_at;
+    const after = await expiresAt(adapter, 'touched');
 
     expect(after).toBeGreaterThan(before);
   });

--- a/packages/drizzle/__tests__/targets.js
+++ b/packages/drizzle/__tests__/targets.js
@@ -1,0 +1,243 @@
+const dialects = require('../dialects');
+
+/**
+ * The database the adapter suites run on.
+ *
+ * Nothing set: an in-memory sqlite database, as before, so `pnpm test`
+ * stays fast and offline. With `HENRI_TEST_POSTGRES_URL` or
+ * `HENRI_TEST_MYSQL_URL` in the environment the same suites run against
+ * that server instead; `HENRI_TEST_SQL_DIALECT` picks one when both are
+ * set (postgres wins otherwise).
+ *
+ * The url in the environment is only used to connect and to create
+ * databases: every store gets its own `henri_test_*` database so the test
+ * files, which vitest runs in parallel, never share a table. They are
+ * dropped when the file is done (`cleanup()`, called by the helpers).
+ */
+
+const ENV = {
+  mysql: 'HENRI_TEST_MYSQL_URL',
+  postgres: 'HENRI_TEST_POSTGRES_URL',
+};
+
+// One prefix per process, so parallel workers never pick the same name
+const RUN = `${process.pid.toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+
+/**
+ * The dialect asked for in the environment
+ *
+ * @returns {string} sqlite, postgres or mysql
+ */
+const selected = () => {
+  const wanted = dialects.get(process.env.HENRI_TEST_SQL_DIALECT);
+  const names = wanted ? [wanted.name] : ['postgres', 'mysql'];
+
+  return names.find((name) => process.env[ENV[name]]) || 'sqlite';
+};
+
+const name = selected();
+const baseUrl = process.env[ENV[name]] || null;
+const dialect = dialects.get(name);
+const created = new Set();
+const databases = new Map();
+
+let sequence = 0;
+let admin = null;
+
+/**
+ * The url of the environment, pointed at another database
+ *
+ * @param {string} database A database name
+ * @returns {string} A connection url
+ */
+const urlFor = (database) => {
+  const url = new URL(baseUrl);
+
+  url.pathname = `/${database}`;
+
+  return url.toString();
+};
+
+/**
+ * The database name of a store, memoized by key so two stores built with
+ * the same key (the sqlite file of the suites) share one database
+ *
+ * @param {string} [key] A stable key, or nothing for a brand new database
+ * @returns {string} A database name
+ */
+const databaseFor = (key) => {
+  if (typeof key === 'undefined') {
+    sequence += 1;
+
+    return `henri_test_${RUN}_${sequence}`;
+  }
+
+  if (!databases.has(key)) {
+    sequence += 1;
+    databases.set(key, `henri_test_${RUN}_${sequence}`);
+  }
+
+  return databases.get(key);
+};
+
+/**
+ * The connection to the server itself, opened once per test file
+ *
+ * @returns {Promise<object>} A driver client
+ */
+const adminClient = async () => {
+  if (!admin) {
+    admin = await dialect.connect({ url: baseUrl });
+  }
+
+  return admin;
+};
+
+/**
+ * Creates the database of a store when it is missing
+ *
+ * @param {string} database A database name
+ * @returns {Promise<void>} Resolves when it exists
+ */
+const createDatabase = async (database) => {
+  const client = await adminClient();
+
+  if (name === 'postgres') {
+    const rows = await dialect.query(
+      client,
+      'SELECT 1 FROM pg_database WHERE datname = $1',
+      [database]
+    );
+
+    if (rows.length === 0) {
+      await dialect.query(client, `CREATE DATABASE "${database}"`);
+    }
+  } else {
+    await dialect.query(
+      client,
+      `CREATE DATABASE IF NOT EXISTS \`${database}\``
+    );
+  }
+
+  created.add(database);
+};
+
+/**
+ * Drops a database once the driver let go of it
+ *
+ * Postgres refuses to drop a database another connection still holds, and
+ * a pool that was just closed can take a moment to disappear: the drop is
+ * retried, then given up on (a leftover database is not a test failure,
+ * and the servers of the CI are thrown away).
+ *
+ * @param {string} database A database name
+ * @returns {Promise<void>} Resolves when done
+ */
+const dropDatabase = async (database) => {
+  const client = await adminClient();
+  const statement =
+    name === 'postgres'
+      ? `DROP DATABASE IF EXISTS "${database}"`
+      : `DROP DATABASE IF EXISTS \`${database}\``;
+
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    try {
+      await dialect.query(client, statement);
+
+      return;
+    } catch (error) {
+      await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
+    }
+  }
+};
+
+/**
+ * The database name of a connection url
+ *
+ * @param {string} url A connection url
+ * @returns {?string} The database, or null
+ */
+const databaseOf = (url) => {
+  try {
+    return new URL(url).pathname.replace(/^\//, '') || null;
+  } catch (error) {
+    return null;
+  }
+};
+
+const target = {
+  /**
+   * Drops the databases this file created and closes the connection
+   *
+   * @returns {Promise<void>} Resolves when done
+   */
+  cleanup: async () => {
+    if (!baseUrl) {
+      return;
+    }
+
+    for (const database of created) {
+      await dropDatabase(database);
+    }
+
+    created.clear();
+
+    if (admin) {
+      const client = admin;
+
+      admin = null;
+      await dialect.close(client);
+    }
+  },
+
+  dialect,
+  live: Boolean(baseUrl),
+  name,
+
+  /**
+   * Creates the database of a store before its first start
+   *
+   * @param {object} adapter A store adapter
+   * @returns {object} The adapter
+   */
+  prepare: (adapter) => {
+    // Nothing to prepare on sqlite, nor for a store the suite pointed
+    // somewhere else itself
+    const database = baseUrl && databaseOf(adapter.config.url);
+
+    if (!database || !database.startsWith(`henri_test_${RUN}`)) {
+      return adapter;
+    }
+
+    const start = adapter.start.bind(adapter);
+
+    adapter.start = async () => {
+      await createDatabase(database);
+
+      return start();
+    };
+
+    return adapter;
+  },
+
+  /**
+   * The store configuration of a database on the target
+   *
+   * @param {string} [key] A stable key: the same key gives the same
+   *   database (and the same sqlite file), so a suite can stop a store and
+   *   open another one on it
+   * @returns {object} A store configuration
+   */
+  store: (key) => {
+    if (!baseUrl) {
+      return {
+        dialect: 'sqlite',
+        url: typeof key === 'undefined' ? ':memory:' : `file:${key}`,
+      };
+    }
+
+    return { dialect: name, url: urlFor(databaseFor(key)) };
+  },
+};
+
+module.exports = target;

--- a/packages/drizzle/dialects.js
+++ b/packages/drizzle/dialects.js
@@ -94,6 +94,24 @@ const credentials = (config) => {
 };
 
 /**
+ * The driver error behind a wrapper: drizzle-orm reports the failures of
+ * the asynchronous drivers as a `DrizzleQueryError` carrying the driver
+ * error as its `cause`
+ *
+ * @param {Error} error The error thrown by drizzle
+ * @returns {Error} The first error of the chain with a `code`
+ */
+const driverError = (error) => {
+  let current = error;
+
+  while (current && !current.code && current.cause) {
+    current = current.cause;
+  }
+
+  return current || error;
+};
+
+/**
  * Unique constraint violations are turned into validation errors by the
  * model layer; each dialect extracts the column names from its driver error
  *
@@ -102,7 +120,9 @@ const credentials = (config) => {
  * @returns {object} The error, flagged
  */
 const uniqueViolation = (error, details) =>
-  Object.assign(error, { henri: { columns: details.columns, kind: 'unique' } });
+  Object.assign(error, {
+    henri: { columns: details.columns, key: details.key, kind: 'unique' },
+  });
 
 const sqlite = {
   /**
@@ -258,9 +278,11 @@ const sqlite = {
    * @returns {Error} The error
    */
   translate: (error) => {
-    if (error && error.code === 'SQLITE_CONSTRAINT_UNIQUE') {
+    const driver = driverError(error);
+
+    if (driver && driver.code === 'SQLITE_CONSTRAINT_UNIQUE') {
       const prefix = 'UNIQUE constraint failed: ';
-      const message = String(error.message || '');
+      const message = String(driver.message || '');
       const start = message.indexOf(prefix);
       const columns =
         start >= 0
@@ -396,8 +418,10 @@ const postgres = {
   synchronous: false,
 
   translate: (error) => {
-    if (error && error.code === '23505') {
-      const detail = String(error.detail || '');
+    const driver = driverError(error);
+
+    if (driver && driver.code === '23505') {
+      const detail = String(driver.detail || '');
       const start = detail.indexOf('Key (');
       const end = start >= 0 ? detail.indexOf(')=', start) : -1;
       const columns =
@@ -530,8 +554,10 @@ const mysql = {
   synchronous: false,
 
   translate: (error) => {
-    if (error && error.code === 'ER_DUP_ENTRY') {
-      const message = String(error.message || '');
+    const driver = driverError(error);
+
+    if (driver && driver.code === 'ER_DUP_ENTRY') {
+      const message = String(driver.message || '');
       const marker = "for key '";
       const start = message.indexOf(marker);
       const end = start >= 0 ? message.indexOf("'", start + marker.length) : -1;
@@ -620,4 +646,4 @@ const fromUrl = (url) => {
   return get(scheme);
 };
 
-module.exports = { DIALECTS, fromUrl, get, sqliteFile };
+module.exports = { DIALECTS, driverError, fromUrl, get, sqliteFile };

--- a/packages/drizzle/drizzle
+++ b/packages/drizzle/drizzle
@@ -1,1 +1,0 @@
-/Users/felixp/code/henri/packages/drizzle

--- a/packages/drizzle/index.js
+++ b/packages/drizzle/index.js
@@ -812,13 +812,24 @@ class Drizzle {
         result.warnings.forEach((warning) =>
           pen.warn(this.adapterName, warning)
         );
-      } else if (result.statements.length > 0) {
+
+        return;
+      }
+
+      if (result.statements.length > 0) {
         pen.info(
           this.adapterName,
           `schema pushed: ${result.statements.length} statement(s) in ${this.timings.push}ms`
         );
       } else {
         debug('schema up to date (%dms)', this.timings.push);
+      }
+
+      // A mysql push cannot alter a table (see Migrations#plan)
+      if (result.drifted.length > 0) {
+        result.warnings.forEach((warning) =>
+          pen.warn(this.adapterName, warning)
+        );
       }
 
       return;

--- a/packages/drizzle/migrations.js
+++ b/packages/drizzle/migrations.js
@@ -340,7 +340,7 @@ class Migrations {
    *
    * @param {object} [options={}] `force` applies destructive statements,
    *   `interactive` lets drizzle-kit prompt on renames
-   * @returns {Promise<{ applied: boolean, statements: Array<string>, warnings: Array<string>, hasDataLoss: boolean }>} What happened
+   * @returns {Promise<{ applied: boolean, statements: Array<string>, warnings: Array<string>, hasDataLoss: boolean, drifted: Array<string> }>} What happened
    * @memberof Migrations
    */
   async push({ force = false, interactive = false } = {}) {
@@ -348,6 +348,7 @@ class Migrations {
     const plan = await this.plan({ interactive });
     const result = {
       applied: false,
+      drifted: plan.drifted || [],
       hasDataLoss: plan.hasDataLoss,
       statements: plan.statements,
       warnings: plan.warnings,
@@ -406,12 +407,99 @@ class Migrations {
         ? [imports, db, adapter.databaseName()]
         : [imports, db];
     const plan = await quiet(() => kit[adapter.dialect.kit.push](...args));
-
-    return {
+    const result = {
       hasDataLoss: Boolean(plan.hasDataLoss),
       statements: plan.statementsToExecute || [],
       warnings: plan.warnings || [],
     };
+
+    return adapter.dialect.name === 'mysql'
+      ? this.completeMySQLPlan(result, { added, existing, imports })
+      : result;
+  }
+
+  /**
+   * Completes a mysql push plan
+   *
+   * drizzle-kit answers the data loss of a mysql push but not the DDL it
+   * would run: `statementsToExecute` only ever holds the tables it suggests
+   * truncating, where postgres and sqlite hold the whole migration. Those
+   * truncates are dropped (a boot never empties a table), the tables that
+   * do not exist yet are created from the schema, and a table whose columns
+   * no longer match is reported instead of being altered silently.
+   *
+   * @param {object} plan The plan of drizzle-kit
+   * @param {object} context `added` tables, `existing` tables, `imports`
+   * @returns {Promise<object>} The completed plan
+   * @memberof Migrations
+   */
+  async completeMySQLPlan(plan, { added, existing, imports }) {
+    const { adapter } = this;
+    const keys = Object.keys(adapter.tables);
+    const missing = keys.filter((key) =>
+      added.includes(adapter.tableNameOfKey(key))
+    );
+    const statements = [];
+
+    if (missing.length > 0) {
+      statements.push(
+        ...(await this.ddl(
+          Object.fromEntries(missing.map((key) => [key, imports[key]]))
+        ))
+      );
+    }
+
+    const drifted = await this.driftedTables(
+      keys.filter((key) => existing.includes(adapter.tableNameOfKey(key)))
+    );
+    const warnings = [...plan.warnings];
+
+    if (drifted.length > 0) {
+      warnings.push(
+        `${drifted.join(', ')}: the columns of the database and of the schema differ; drizzle-kit does not alter mysql tables on a push, run "henri db:generate" then "henri db:migrate"`
+      );
+    }
+
+    return { ...plan, drifted, statements, warnings };
+  }
+
+  /**
+   * The tables whose columns differ from the compiled schema (mysql)
+   *
+   * @param {Array<string>} keys The schema keys of the tables to compare
+   * @returns {Promise<Array<string>>} The table names that drifted
+   * @memberof Migrations
+   */
+  async driftedTables(keys) {
+    const { adapter } = this;
+
+    if (keys.length === 0) {
+      return [];
+    }
+
+    const rows = await adapter.query(
+      'SELECT table_name AS table_name, column_name AS column_name FROM information_schema.columns WHERE table_schema = DATABASE()'
+    );
+    const columns = {};
+
+    for (const row of rows) {
+      const table = row.table_name || row.TABLE_NAME;
+
+      columns[table] = columns[table] || new Set();
+      columns[table].add(row.column_name || row.COLUMN_NAME);
+    }
+
+    return keys
+      .map((key) => adapter.tableNameOfKey(key))
+      .filter((table, index) => {
+        const wanted = Object.values(adapter.tables[keys[index]].columns);
+        const present = columns[table] || new Set();
+
+        return (
+          wanted.length !== present.size ||
+          wanted.some((column) => !present.has(column))
+        );
+      });
   }
 
   /**

--- a/packages/mysql/__tests__/mysql.spec.js
+++ b/packages/mysql/__tests__/mysql.spec.js
@@ -1,4 +1,7 @@
 const Sql = require('@usehenri/sequelize');
+// The target of the shared suite: sqlite unless HENRI_TEST_MYSQL_URL
+// points at a server, in which case this suite runs on it too
+const target = require('@usehenri/sequelize/__tests__/targets');
 const MySQL = require('../index');
 
 /**
@@ -198,5 +201,96 @@ describe('mysql database adapter', () => {
     expect(
       User.build({ email: 'a@b.io', password: 'x', roles: null }).roles
     ).toEqual([]);
+  });
+});
+
+describe.runIf(target.live && target.name === 'mysql')('mysql server', () => {
+  let store;
+  let Task;
+  let User;
+
+  beforeAll(async () => {
+    store = target.prepare(
+      new MySQL('default', target.store(), fakeHenri({ baseRole: 'member' }))
+    );
+    Task = store.addModel(taskModel, 'user');
+    User = store.addModel(
+      { globalId: 'User', identity: 'user', schema: { name: 'string' } },
+      'user'
+    );
+    await store.start();
+  });
+
+  afterAll(async () => {
+    await store.stop();
+    await target.cleanup();
+  });
+
+  test('connects and syncs the henri model format', async () => {
+    expect(store.adapterName).toBe('mysql');
+    await expect(store.ping()).resolves.toBe(true);
+
+    const columns = await store.query(
+      `SELECT column_name AS name, column_type AS type, is_nullable AS nullable
+       FROM information_schema.columns
+       WHERE table_schema = DATABASE() AND table_name = :table`,
+      { table: 'Tasks' },
+      { type: Sql.Sequelize.QueryTypes.SELECT }
+    );
+    const byName = Object.fromEntries(
+      columns.map((column) => [column.name, column])
+    );
+
+    expect(byName.id.type).toMatch(/^int/);
+    expect(byName.name).toMatchObject({
+      nullable: 'NO',
+      type: 'varchar(255)',
+    });
+    expect(byName.done.type).toBe('tinyint(1)');
+    expect(byName.createdAt.type).toBe('datetime');
+    // The enum is part of the column type, unlike the postgres enum type
+    expect(byName.category.type).toBe("enum('urgent','high','medium','low')");
+    await expect(Task.create({ category: 'nope', name: 'x' })).rejects.toThrow(
+      /Data truncated for column 'category'|CHECK constraint/
+    );
+  });
+
+  test('stores the user model and refuses a duplicate email', async () => {
+    const user = await User.create({
+      email: ' Grace@UseHenri.io ',
+      name: 'Grace',
+      password: 'compiler-1952',
+    });
+
+    expect(user.email).toBe('grace@usehenri.io');
+    expect(user.password).toBe('hashed:compiler-1952');
+    expect(user.roles).toEqual(['member']);
+
+    await expect(
+      User.create({ email: 'GRACE@usehenri.io', password: 'other' })
+    ).rejects.toThrow(/SequelizeUniqueConstraintError|Validation error/);
+
+    const [[row]] = await store.query(
+      'SELECT roles FROM `Users` WHERE email = ?',
+      ['grace@usehenri.io']
+    );
+
+    // A json column comes back parsed on mysql, and has no literal default
+    expect(row.roles).toEqual(['member']);
+    expect((await store.findUserByEmail('grace@usehenri.io')).password).toBe(
+      'hashed:compiler-1952'
+    );
+  });
+
+  test('rolls a transaction back', async () => {
+    await expect(
+      store.transaction(async (transaction) => {
+        await Task.create({ name: 'rolled back' }, { transaction });
+        expect(await Task.count({ transaction })).toBe(1);
+
+        throw new Error('boom');
+      })
+    ).rejects.toThrow('boom');
+    expect(await Task.count()).toBe(0);
   });
 });

--- a/packages/postgresql/__tests__/postgresql.spec.js
+++ b/packages/postgresql/__tests__/postgresql.spec.js
@@ -1,4 +1,7 @@
 const Sql = require('@usehenri/sequelize');
+// The target of the shared suite: sqlite unless HENRI_TEST_POSTGRES_URL
+// points at a server, in which case this suite runs on it too
+const target = require('@usehenri/sequelize/__tests__/targets');
 const Postgresql = require('../index');
 
 /**
@@ -189,3 +192,118 @@ describe('postgresql database adapter', () => {
     ]);
   });
 });
+
+describe.runIf(target.live && target.name === 'postgres')(
+  'postgresql server',
+  () => {
+    let store;
+    let Task;
+    let User;
+
+    beforeAll(async () => {
+      store = target.prepare(
+        new Postgresql(
+          'default',
+          target.store(),
+          fakeHenri({ baseRole: 'member' })
+        )
+      );
+      Task = store.addModel(taskModel, 'user');
+      User = store.addModel(
+        { globalId: 'User', identity: 'user', schema: { name: 'string' } },
+        'user'
+      );
+      await store.start();
+    });
+
+    afterAll(async () => {
+      await store.stop();
+      await target.cleanup();
+    });
+
+    test('connects and syncs the henri model format', async () => {
+      expect(store.adapterName).toBe('postgresql');
+      await expect(store.ping()).resolves.toBe(true);
+
+      const columns = await store.query(
+        `SELECT column_name AS name, data_type AS type, udt_name AS udt,
+                is_nullable AS nullable
+         FROM information_schema.columns
+         WHERE table_schema = 'public' AND table_name = :table`,
+        { table: 'Tasks' },
+        { type: Sql.Sequelize.QueryTypes.SELECT }
+      );
+      const byName = Object.fromEntries(
+        columns.map((column) => [column.name, column])
+      );
+
+      expect(byName.id.type).toBe('integer');
+      expect(byName.name).toMatchObject({
+        nullable: 'NO',
+        type: 'character varying',
+      });
+      expect(byName.done.type).toBe('boolean');
+      expect(byName.createdAt.type).toBe('timestamp with time zone');
+      // The enum is a type of its own, unlike the mysql column type
+      expect(byName.category).toMatchObject({
+        type: 'USER-DEFINED',
+        udt: 'enum_Tasks_category',
+      });
+
+      const labels = await store.query(
+        `SELECT unnest(enum_range(NULL::"enum_Tasks_category"))::text AS label`,
+        [],
+        { type: Sql.Sequelize.QueryTypes.SELECT }
+      );
+
+      expect(labels.map((row) => row.label)).toEqual([
+        'urgent',
+        'high',
+        'medium',
+        'low',
+      ]);
+      await expect(
+        Task.create({ category: 'nope', name: 'x' })
+      ).rejects.toThrow(/invalid input value for enum/);
+    });
+
+    test('stores the user model and refuses a duplicate email', async () => {
+      const user = await User.create({
+        email: ' Grace@UseHenri.io ',
+        name: 'Grace',
+        password: 'compiler-1952',
+      });
+
+      expect(user.email).toBe('grace@usehenri.io');
+      expect(user.password).toBe('hashed:compiler-1952');
+      expect(user.roles).toEqual(['member']);
+
+      await expect(
+        User.create({ email: 'GRACE@usehenri.io', password: 'other' })
+      ).rejects.toThrow(/SequelizeUniqueConstraintError|Validation error/);
+
+      const [[row]] = await store.query(
+        'SELECT roles FROM "Users" WHERE email = ?',
+        ['grace@usehenri.io']
+      );
+
+      // A json column comes back parsed on postgres
+      expect(row.roles).toEqual(['member']);
+      expect((await store.findUserByEmail('grace@usehenri.io')).password).toBe(
+        'hashed:compiler-1952'
+      );
+    });
+
+    test('rolls a transaction back', async () => {
+      await expect(
+        store.transaction(async (transaction) => {
+          await Task.create({ name: 'rolled back' }, { transaction });
+          expect(await Task.count({ transaction })).toBe(1);
+
+          throw new Error('boom');
+        })
+      ).rejects.toThrow('boom');
+      expect(await Task.count()).toBe(0);
+    });
+  }
+);

--- a/packages/sequelize/__tests__/helpers.js
+++ b/packages/sequelize/__tests__/helpers.js
@@ -1,7 +1,4 @@
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
-const Drizzle = require('../index');
+const Sql = require('../index');
 const target = require('./targets');
 
 // Every store the suites open lives on the target (sqlite in memory, or
@@ -22,11 +19,7 @@ const fakeHenri = (settings = {}) => {
   const pen = {};
 
   ['error', 'fatal', 'info', 'warn'].forEach((level) => {
-    pen[level] = (...args) => {
-      calls.push([level, ...args]);
-
-      return level === 'fatal' ? new Error(args[1]) : undefined;
-    };
+    pen[level] = (...args) => calls.push([level, ...args]);
   });
 
   return {
@@ -36,8 +29,6 @@ const fakeHenri = (settings = {}) => {
       get: (key) => settings[key],
       has: (key) => typeof settings[key] !== 'undefined',
     },
-    cwd: () => process.cwd(),
-    isProduction: false,
     pen,
     user: {
       encrypt: async (password) => `hashed:${password}`,
@@ -52,15 +43,14 @@ const fakeHenri = (settings = {}) => {
  * @param {object} [settings={}] configuration values
  * @param {object} [config={}] extra store configuration
  * @param {string} [key] A stable key: two stores built with the same key
- *   share one database (one sqlite file), the way an application restarts
- *   on the same data
- * @returns {{ adapter: Drizzle, henri: object }} adapter and its fake henri
+ *   share one database (one sqlite file)
+ * @returns {{ adapter: Sql, henri: object }} adapter and its fake henri
  */
 const build = (settings = {}, config = {}, key) => {
   const henri = fakeHenri(settings);
   // A suite pointing the store somewhere itself (a sqlite file) keeps it
-  const store = config.url ? {} : target.store(key);
-  const adapter = new Drizzle('default', { ...store, ...config }, henri);
+  const store = config.storage ? {} : target.store(key);
+  const adapter = new Sql('default', { ...store, ...config }, henri);
 
   return { adapter: target.prepare(adapter), henri };
 };
@@ -93,43 +83,29 @@ const userModel = {
  * Promisified express-session store calls
  *
  * @param {object} store A session store
- * @returns {object} set, get, destroy, touch, all, length and clear
+ * @returns {object} set, get and destroy returning promises
  */
-const sessions = (store) => {
-  const call = (method, ...args) =>
+const sessions = (store) => ({
+  destroy: (sid) =>
     new Promise((resolve, reject) =>
-      store[method](...args, (error, result) =>
-        error ? reject(error) : resolve(result)
-      )
-    );
-
-  return {
-    all: () => call('all'),
-    clear: () => call('clear'),
-    destroy: (sid) => call('destroy', sid),
-    get: (sid) => call('get', sid),
-    length: () => call('length'),
-    set: (sid, data) => call('set', sid, data),
-    touch: (sid, data) => call('touch', sid, data),
-  };
-};
-
-/**
- * A temporary directory, removed by the caller
- *
- * @param {string} [prefix='henri-drizzle-'] Directory prefix
- * @returns {string} The directory
- */
-const tmpdir = (prefix = 'henri-drizzle-') =>
-  fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+      store.destroy(sid, (error) => (error ? reject(error) : resolve()))
+    ),
+  get: (sid) =>
+    new Promise((resolve, reject) =>
+      store.get(sid, (error, data) => (error ? reject(error) : resolve(data)))
+    ),
+  set: (sid, data) =>
+    new Promise((resolve, reject) =>
+      store.set(sid, data, (error) => (error ? reject(error) : resolve()))
+    ),
+});
 
 module.exports = {
-  Drizzle,
+  Sql,
   build,
   fakeHenri,
   sessions,
   target,
   taskModel,
-  tmpdir,
   userModel,
 };

--- a/packages/sequelize/__tests__/sequelize.spec.js
+++ b/packages/sequelize/__tests__/sequelize.spec.js
@@ -1,107 +1,45 @@
 const session = require('express-session');
 const Sql = require('../index');
 const { redact } = require('../utils');
+const {
+  build,
+  fakeHenri,
+  sessions,
+  target,
+  taskModel,
+  userModel,
+} = require('./helpers');
 
 const { DataTypes, QueryTypes } = Sql.Sequelize;
 
-/**
- * Builds a minimal henri stand-in for the adapter
- *
- * @param {object} [settings={}] configuration values
- * @returns {object} fake henri
- */
-const fakeHenri = (settings = {}) => {
-  const calls = [];
-  const pen = {};
+// Raw queries need the identifiers quoted the way the target does
+const tasks = target.quote('Tasks');
+const users = target.quote('Users');
 
-  ['error', 'fatal', 'info', 'warn'].forEach((level) => {
-    pen[level] = (...args) => calls.push([level, ...args]);
-  });
-
-  return {
-    _user: null,
-    calls,
-    config: {
-      get: (key) => settings[key],
-      has: (key) => typeof settings[key] !== 'undefined',
-    },
-    pen,
-    user: {
-      encrypt: async (password) => `hashed:${password}`,
-    },
-  };
+// How a bad enum value is refused: sqlite validates it in the model, the
+// dialects with a native ENUM column let the server refuse the value
+const ENUM_ERROR = {
+  mysql: /Data truncated for column 'category'|CHECK constraint/,
+  postgres: /invalid input value for enum/,
+  sqlite: /isIn/,
 };
 
 /**
- * Builds an adapter backed by an in-memory sqlite database
+ * A JSON column, read back (a string on sqlite, parsed elsewhere)
  *
- * @param {object} [settings={}] configuration values
- * @param {object} [config={}] extra store configuration
- * @returns {{ adapter: Sql, henri: object }} adapter and its fake henri
+ * @param {*} value The value the driver answered
+ * @returns {*} The parsed value
  */
-const build = (settings = {}, config = {}) => {
-  const henri = fakeHenri(settings);
-  const adapter = new Sql(
-    'default',
-    { dialect: 'sqlite', storage: ':memory:', ...config },
-    henri
-  );
-
-  return { adapter, henri };
-};
-
-// The model scaffolded by `henri new`, in the henri format
-const taskModel = {
-  globalId: 'Task',
-  identity: 'task',
-  options: { timestamps: true },
-  schema: {
-    category: {
-      default: 'low',
-      enum: ['urgent', 'high', 'medium', 'low'],
-      type: 'string',
-    },
-    done: { default: false, type: 'boolean' },
-    name: { required: true, type: 'string' },
-  },
-  store: 'default',
-};
-
-const userModel = {
-  globalId: 'User',
-  identity: 'user',
-  options: { timestamps: true },
-  schema: { name: { type: 'string' } },
-};
-
-/**
- * Promisified express-session store calls
- *
- * @param {object} store A session store
- * @returns {object} set, get and destroy returning promises
- */
-const sessions = (store) => ({
-  destroy: (sid) =>
-    new Promise((resolve, reject) =>
-      store.destroy(sid, (error) => (error ? reject(error) : resolve()))
-    ),
-  get: (sid) =>
-    new Promise((resolve, reject) =>
-      store.get(sid, (error, data) => (error ? reject(error) : resolve(data)))
-    ),
-  set: (sid, data) =>
-    new Promise((resolve, reject) =>
-      store.set(sid, data, (error) => (error ? reject(error) : resolve()))
-    ),
-});
+const asJson = (value) =>
+  typeof value === 'string' ? JSON.parse(value) : value;
 
 describe('sequelize adapter', () => {
   describe('constructor', () => {
     test('builds the connector from the configuration', () => {
       const { adapter } = build({}, { pool: { max: 3 } });
 
-      expect(adapter.adapterName).toBe('sqlite');
-      expect(adapter.connector.getDialect()).toBe('sqlite');
+      expect(adapter.adapterName).toBe(target.name);
+      expect(adapter.connector.getDialect()).toBe(target.name);
       expect(adapter.connector.options.pool.max).toBe(3);
       expect(adapter.connector.options.adapter).toBeUndefined();
       expect(adapter.connector.options.session).toBeUndefined();
@@ -213,20 +151,25 @@ describe('sequelize adapter', () => {
         'write docs',
       ]);
       await expect(Task.create({})).rejects.toThrow(/notNull Violation/);
+      // The dialects with a native ENUM check the value themselves
       await expect(
         Task.create({ category: 'nope', name: 'x' })
-      ).rejects.toThrow(/isIn/);
+      ).rejects.toThrow(ENUM_ERROR[target.name]);
     });
 
     test('exposes ping, query and transaction', async () => {
       await expect(adapter.ping()).resolves.toBe(true);
+
+      const [counted, metadata] = await adapter.query(
+        `SELECT COUNT(*) AS total FROM ${tasks} WHERE name = ?`,
+        ['write docs']
+      );
+
+      // Postgres counts in a bigint, which the driver reads as a string
+      expect(Number(counted[0].total)).toBe(1);
+      expect(metadata).toBeDefined();
       await expect(
-        adapter.query('SELECT COUNT(*) AS total FROM Tasks WHERE name = ?', [
-          'write docs',
-        ])
-      ).resolves.toEqual([[{ total: 1 }], expect.anything()]);
-      await expect(
-        adapter.query('SELECT name FROM Tasks', [], {
+        adapter.query(`SELECT name FROM ${tasks}`, [], {
           type: QueryTypes.SELECT,
         })
       ).resolves.toEqual([{ name: 'write docs' }]);
@@ -301,7 +244,7 @@ describe('sequelize adapter', () => {
       expect(henri._user).toBe(User);
       expect(henri.calls).toContainEqual([
         'info',
-        'sqlite',
+        target.name,
         'basic user role',
         ['member'],
       ]);
@@ -496,11 +439,11 @@ describe('sequelize adapter', () => {
       expect(User.rawAttributes.roles.type).toBeInstanceOf(DataTypes.JSON);
 
       const [[row]] = await adapter.query(
-        'SELECT roles FROM Users WHERE email = ?',
+        `SELECT roles FROM ${users} WHERE email = ?`,
         ['felix@usehenri.io']
       );
 
-      expect(JSON.parse(row.roles)).toEqual(['member']);
+      expect(asJson(row.roles)).toEqual(['member']);
     });
   });
 
@@ -523,7 +466,7 @@ describe('sequelize adapter', () => {
       await expect(user.hasRole('admin')).resolves.toBe(false);
       expect(henri.calls).toContainEqual([
         'warn',
-        'sqlite',
+        target.name,
         'no basic user role. are you sure?',
       ]);
 
@@ -635,7 +578,10 @@ describe('sequelize adapter', () => {
     test('start rejects when the connection fails', async () => {
       const adapter = new Sql(
         'broken',
-        { dialect: 'sqlite', storage: '/nonexistent/dir/db.sqlite' },
+        // A database nobody created on the server, an impossible file on sqlite
+        target.live
+          ? target.store('never-created')
+          : { dialect: 'sqlite', storage: '/nonexistent/dir/db.sqlite' },
         fakeHenri()
       );
 

--- a/packages/sequelize/__tests__/targets.js
+++ b/packages/sequelize/__tests__/targets.js
@@ -1,0 +1,258 @@
+const { Sequelize } = require('sequelize');
+
+/**
+ * The database the adapter suites run on.
+ *
+ * Nothing set: an in-memory sqlite database, as before, so `pnpm test`
+ * stays fast and offline. With `HENRI_TEST_POSTGRES_URL` or
+ * `HENRI_TEST_MYSQL_URL` in the environment the same suites run against
+ * that server instead; `HENRI_TEST_SQL_DIALECT` picks one when both are
+ * set (postgres wins otherwise).
+ *
+ * The url in the environment is only used to connect and to create
+ * databases: every store gets its own `henri_test_*` database so the test
+ * files, which vitest runs in parallel, never share a table. They are
+ * dropped when the file is done (`cleanup()`, called by the helpers).
+ *
+ * The dialect packages (`@usehenri/mysql`, `@usehenri/postgresql`) read it
+ * through `@usehenri/sequelize/__tests__/targets`.
+ */
+
+const ENV = {
+  mysql: 'HENRI_TEST_MYSQL_URL',
+  postgres: 'HENRI_TEST_POSTGRES_URL',
+};
+
+const ALIASES = {
+  mariadb: 'mysql',
+  mysql: 'mysql',
+  pg: 'postgres',
+  postgres: 'postgres',
+  postgresql: 'postgres',
+};
+
+// One prefix per process, so parallel workers never pick the same name
+const RUN = `${process.pid.toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+
+/**
+ * The dialect asked for in the environment
+ *
+ * @returns {string} sqlite, postgres or mysql
+ */
+const selected = () => {
+  const wanted = ALIASES[String(process.env.HENRI_TEST_SQL_DIALECT || '')];
+  const names = wanted ? [wanted] : ['postgres', 'mysql'];
+
+  return names.find((entry) => process.env[ENV[entry]]) || 'sqlite';
+};
+
+const name = selected();
+const baseUrl = process.env[ENV[name]] || null;
+const created = new Set();
+const databases = new Map();
+
+let sequence = 0;
+let admin = null;
+
+/**
+ * The url of the environment, pointed at another database
+ *
+ * @param {string} database A database name
+ * @returns {string} A connection url
+ */
+const urlFor = (database) => {
+  const url = new URL(baseUrl);
+
+  url.pathname = `/${database}`;
+
+  return url.toString();
+};
+
+/**
+ * The database name of a store, memoized by key so two stores built with
+ * the same key share one database
+ *
+ * @param {string} [key] A stable key, or nothing for a brand new database
+ * @returns {string} A database name
+ */
+const databaseFor = (key) => {
+  if (typeof key === 'undefined') {
+    sequence += 1;
+
+    return `henri_test_${RUN}_${sequence}`;
+  }
+
+  if (!databases.has(key)) {
+    sequence += 1;
+    databases.set(key, `henri_test_${RUN}_${sequence}`);
+  }
+
+  return databases.get(key);
+};
+
+/**
+ * The connection to the server itself, opened once per test file
+ *
+ * @returns {object} A Sequelize instance
+ */
+const adminClient = () => {
+  if (!admin) {
+    admin = new Sequelize(baseUrl, { logging: false });
+  }
+
+  return admin;
+};
+
+/**
+ * Creates the database of a store when it is missing
+ *
+ * @param {string} database A database name
+ * @returns {Promise<void>} Resolves when it exists
+ */
+const createDatabase = async (database) => {
+  const client = adminClient();
+
+  if (name === 'postgres') {
+    const [rows] = await client.query(
+      `SELECT 1 FROM pg_database WHERE datname = '${database}'`
+    );
+
+    if (rows.length === 0) {
+      await client.query(`CREATE DATABASE "${database}"`);
+    }
+  } else {
+    await client.query(`CREATE DATABASE IF NOT EXISTS \`${database}\``);
+  }
+
+  created.add(database);
+};
+
+/**
+ * Drops a database once the driver let go of it
+ *
+ * Postgres refuses to drop a database another connection still holds, and
+ * a pool that was just closed can take a moment to disappear: the drop is
+ * retried, then given up on (a leftover database is not a test failure,
+ * and the servers of the CI are thrown away).
+ *
+ * @param {string} database A database name
+ * @returns {Promise<void>} Resolves when done
+ */
+const dropDatabase = async (database) => {
+  const client = adminClient();
+  const statement =
+    name === 'postgres'
+      ? `DROP DATABASE IF EXISTS "${database}"`
+      : `DROP DATABASE IF EXISTS \`${database}\``;
+
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    try {
+      await client.query(statement);
+
+      return;
+    } catch (error) {
+      await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
+    }
+  }
+};
+
+/**
+ * The database name of a connection url
+ *
+ * @param {string} url A connection url
+ * @returns {?string} The database, or null
+ */
+const databaseOf = (url) => {
+  try {
+    return new URL(url).pathname.replace(/^\//, '') || null;
+  } catch (error) {
+    return null;
+  }
+};
+
+const target = {
+  // The name the adapter logs with (the dialect packages set their own)
+  adapterName: name === 'postgres' ? 'postgres' : name,
+
+  /**
+   * Drops the databases this file created and closes the connection
+   *
+   * @returns {Promise<void>} Resolves when done
+   */
+  cleanup: async () => {
+    if (!baseUrl) {
+      return;
+    }
+
+    for (const database of created) {
+      await dropDatabase(database);
+    }
+
+    created.clear();
+
+    if (admin) {
+      const client = admin;
+
+      admin = null;
+      await client.close();
+    }
+  },
+
+  // The dialect keeps a native ENUM column type
+  enums: name !== 'sqlite',
+  live: Boolean(baseUrl),
+  name,
+
+  /**
+   * Creates the database of a store before its first start
+   *
+   * @param {object} adapter A store adapter
+   * @returns {object} The adapter
+   */
+  prepare: (adapter) => {
+    const database = baseUrl && databaseOf(adapter.config.url);
+
+    if (!database || !database.startsWith(`henri_test_${RUN}`)) {
+      return adapter;
+    }
+
+    const start = adapter.start.bind(adapter);
+
+    adapter.start = async () => {
+      await createDatabase(database);
+
+      return start();
+    };
+
+    return adapter;
+  },
+
+  /**
+   * Quotes an identifier for a raw query
+   *
+   * @param {string} identifier A table or column name
+   * @returns {string} The quoted identifier
+   */
+  quote: (identifier) =>
+    name === 'mysql' ? `\`${identifier}\`` : `"${identifier}"`,
+
+  /**
+   * The store configuration of a database on the target
+   *
+   * @param {string} [key] A stable key: the same key gives the same
+   *   database (and the same sqlite file)
+   * @returns {object} A store configuration
+   */
+  store: (key) => {
+    if (!baseUrl) {
+      return {
+        dialect: 'sqlite',
+        storage: typeof key === 'undefined' ? ':memory:' : key,
+      };
+    }
+
+    return { dialect: name, url: urlFor(databaseFor(key)) };
+  },
+};
+
+module.exports = target;

--- a/packages/sequelize/package.json
+++ b/packages/sequelize/package.json
@@ -45,6 +45,9 @@
   },
   "devDependencies": {
     "express-session": "^1.19.0",
+    "mysql2": "^3.24.3",
+    "pg": "^8.23.0",
+    "pg-hstore": "^2.3.4",
     "sqlite3": "^6.0.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -392,6 +392,15 @@ importers:
       express-session:
         specifier: ^1.19.0
         version: 1.19.0(supports-color@8.1.1)
+      mysql2:
+        specifier: ^3.24.3
+        version: 3.24.3(@types/node@26.4.1)
+      pg:
+        specifier: ^8.23.0
+        version: 8.23.0
+      pg-hstore:
+        specifier: ^2.3.4
+        version: 2.3.4
       sqlite3:
         specifier: ^6.0.1
         version: 6.0.1

--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -55,17 +55,17 @@ The file is parsed on boot: a syntax error is reported with its line, and the bo
 
 Each entry of `stores` names an adapter and how to reach its database. The adapter package (`@usehenri/<adapter>`) must be installed in the application.
 
-| Key                                                | Adapters      | Description                                                                                                                     |
-| -------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `adapter`                                          | all           | `disk`, `mongoose`, `mysql`, `mariadb`, `postgresql`, `mssql` or `drizzle`.                                                     |
-| `url`                                              | mongoose, SQL | Connection string. Required unless `host` is given (`mariadb://` is accepted by the mysql adapter).                             |
-| `host`, `port`, `database`, `username`, `password` | mongoose, SQL | Alternative to `url`. On mongoose, `host` may also be a full `mongodb://` url.                                                  |
-| `opts`                                             | mongoose      | Options passed to `mongoose.connect()`; henri sets `connectTimeoutMS` and `serverSelectionTimeoutMS` to 10 seconds.             |
-| `session`                                          | mongoose, SQL | Options of the session store (connect-mongo, whose collection is `henriSessions`, or connect-session-sequelize).                |
-| `path`, `dbName`                                   | disk          | Data directory, relative to the application (`.henri/data`), and database name (`henri`).                                       |
-| `logging`, `pool`, `dialectOptions`, ...           | SQL           | Every other key is forwarded to Sequelize. `logging` defaults to the `henri:sequelize` debug namespace.                         |
-| `dialect`                                          | drizzle       | `sqlite`, `postgres` or `mysql`; the app installs the driver (`better-sqlite3`, `pg` or `mysql2`).                              |
-| `sync`, `migrate`                                  | drizzle       | `sync: false` stops the development boot from pushing the schema; `migrate: true` applies `db/migrations` on a production boot. |
+| Key                                                | Adapters      | Description                                                                                                                                                                                                              |
+| -------------------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `adapter`                                          | all           | `disk`, `mongoose`, `mysql`, `mariadb`, `postgresql`, `mssql` or `drizzle`.                                                                                                                                              |
+| `url`                                              | mongoose, SQL | Connection string. Required unless `host` is given (`mariadb://` is accepted by the mysql adapter).                                                                                                                      |
+| `host`, `port`, `database`, `username`, `password` | mongoose, SQL | Alternative to `url`. On mongoose, `host` may also be a full `mongodb://` url.                                                                                                                                           |
+| `opts`                                             | mongoose      | Options passed to `mongoose.connect()`; henri sets `connectTimeoutMS` and `serverSelectionTimeoutMS` to 10 seconds.                                                                                                      |
+| `session`                                          | mongoose, SQL | Options of the session store (connect-mongo, whose collection is `henriSessions`, or connect-session-sequelize).                                                                                                         |
+| `path`, `dbName`                                   | disk          | Data directory, relative to the application (`.henri/data`), and database name (`henri`).                                                                                                                                |
+| `logging`, `pool`, `dialectOptions`, ...           | SQL           | Every other key is forwarded to Sequelize. `logging` defaults to the `henri:sequelize` debug namespace.                                                                                                                  |
+| `dialect`                                          | drizzle       | `sqlite`, `postgres` or `mysql`; the app installs the driver (`better-sqlite3`, `pg` or `mysql2`).                                                                                                                       |
+| `sync`, `migrate`                                  | drizzle       | `sync: false` stops the development boot from pushing the schema; `migrate: true` applies `db/migrations` on a production boot. On mysql a push only creates the missing tables (see [Models](/guides/models/#drizzle)). |
 
 See [Models](/guides/models/#adapters) for each adapter.
 

--- a/website/src/content/docs/guides/models.md
+++ b/website/src/content/docs/guides/models.md
@@ -279,6 +279,8 @@ henri db:push                            # makes the database match the models, 
 
 In development the boot pushes the schema unless the store sets `"sync": false`; in production the boot applies the pending migrations when the store sets `"migrate": true` and warns about them otherwise. `henri db:push` refuses statements that lose data unless `--force` is passed; every command accepts `--store=<name>` and `--json`.
 
+On MySQL a push only creates the tables that do not exist yet: drizzle-kit does not alter a MySQL table on a push, so a table whose columns no longer match the model is reported (`the columns of the database and of the schema differ`) and left alone rather than altered or truncated. Change a MySQL schema with `henri db:generate` and `henri db:migrate`, which work on every dialect. sqlite and PostgreSQL push the whole diff.
+
 ### SQL adapters
 
 The three SQL packages are thin dialects over `@usehenri/sequelize`. `host`, `port`, `database`, `username` and `password` are accepted instead of `url`; a store with none of them fails the boot. Every other key of the store (`pool`, `dialectOptions`, `logging`, ...) is forwarded to Sequelize. `logging` defaults to the `henri:sequelize` debug namespace (`henri server --debug=henri:sequelize` prints the queries) and credentials are redacted from that output.


### PR DESCRIPTION
Closes the "SQL adapters are only tested against sqlite" gap for PostgreSQL and MySQL, on both the Sequelize and the Drizzle adapter.

**How it runs.** The existing suites pick sqlite unless `HENRI_TEST_POSTGRES_URL` or `HENRI_TEST_MYSQL_URL` is set, so `pnpm test` stays offline and fast for contributors. Each store gets its own `henri_test_*` database, created before first use and dropped at the end of the file, so vitest keeps running files in parallel. Assertions that only held on sqlite became per-dialect tables: raw-query placeholders, enum refusals, `COUNT` returning a string on Postgres, the drizzle-kit statements, foreign key and transaction shapes. A new dialect spec reads the physical column types back out of each server.

**Two real bugs the live runs found.**

- Unique violations were never translated on Postgres or MySQL. Drizzle wraps async driver errors, so the error inspected had no `code` and a duplicate email surfaced as a raw driver error instead of a `ValidationError`. The cause is now unwrapped and the MySQL key is kept.
- A MySQL push created nothing at all. The drizzle-kit MySQL push never returns the DDL to run, so `henri db:push` and every development boot on MySQL silently applied no schema, and a forced push would have truncated tables. The plan now drops the truncates, creates the missing tables and reports drifted columns. Generating and applying migrations was unaffected.

**Also removed** a symlink committed inside `packages/drizzle` in #305, pointing at an absolute path on one machine. It never shipped (it is not in the package `files`), but where the path existed vitest collected every Drizzle spec twice, which is why the suite reported 61 files and now reports 55, and why two copies of the auth spec raced on the same fixture app.

**CI.** Two jobs, `postgres:17` and `mysql:8`, with health checks and `continue-on-error`, separate from the Node 22/24 matrix so a database outage cannot block a pull request.

Verified against real containers: the SQL suites pass on sqlite, Postgres and MySQL, with no test database left behind. Whole suite green at 763 tests across 55 files. MSSQL and MariaDB remain offline-only and the known-gaps entry says so.