### PR TITLE
henri new --adapter, and three first-run fixes

### DIFF
--- a/.changeset/olive-donkeys-invite.md
+++ b/.changeset/olive-donkeys-invite.md
@@ -1,0 +1,12 @@
+---
+'@usehenri/cli': patch
+'henri': patch
+---
+
+Fix `henri new` picking the wrong package manager, and two Inertia scaffold problems.
+
+`henri new` probed `pnpm --version` then `yarn --version` and took the first that answered. A version manager shim (mise, asdf) answers non-zero outside a project it manages, so a pnpm machine got a yarn application with no `pnpm-workspace.yaml`, and the first `pnpm install` failed with `ERR_PNPM_IGNORED_BUILDS`. The manager is now, in order: `--pm pnpm|yarn|npm` (new flag on `new` and `init`), the `packageManager` field, the lockfile, `npm_config_user_agent` (the manager that ran the command), then the probe. The choice and where it came from are printed, and `pnpm-workspace.yaml` is written whatever the manager is, since npm and yarn ignore it.
+
+A fresh Inertia application now ships `test/tasks.test.js`, so `henri test` is green from the first minute instead of exiting `1` on "No test files found", and its `eslint.config.js` declares the model globals of `app/models`, the Vitest globals and `vitest.config.js` like the React one does.
+
+`henri doctor` no longer reports an installed ESM-only dependency as missing (`@inertiajs/react declared in package.json but not installed`): `resolvePackageJson` falls back to reading `node_modules/<name>/package.json` from disk when the package's `exports` map has no `require` and no `./package.json` condition.

--- a/.changeset/tricky-donuts-brake.md
+++ b/.changeset/tricky-donuts-brake.md
@@ -1,0 +1,9 @@
+---
+'@usehenri/cli': minor
+'@usehenri/mcp': minor
+'henri': minor
+---
+
+`henri new` and `henri init` take `--adapter disk|drizzle|mongoose|mysql|postgresql|mssql` (and `--dialect sqlite|postgres|mysql` with drizzle) to pick the store of the new application. `disk` stays the default, so nothing changes without the flag.
+
+The adapter drives the whole scaffold: the store block of `config/default.json`, a `config/test.json` on its own database, the dependencies and the driver (`better-sqlite3`, `pg` or `mysql2` for drizzle, allow-listed in `pnpm-workspace.yaml` when it needs a build), the README and AGENTS.md, and the sample `Task` resource. `henri generate scaffold|crud` now reads the adapter back from the configuration and writes a controller against the model API that store really has: Mongoose on `disk` and `mongoose`, Sequelize (`findAll`, `findByPk`, `row.update()`) on `mysql`, `postgresql` and `mssql`, the Rails-like Drizzle model (`query().offset().limit()`, `count`, `findByIdAndUpdate`) on `drizzle`. `henri doctor` knows the new combinations, including the driver a drizzle dialect needs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,8 +193,10 @@ the LICENSE and a README into every public package at publish time
   development boot create the tables that are missing and report the ones
   whose columns drifted (`Migrations#completeMySQLPlan`); a mysql schema
   change needs `henri db:generate` then `henri db:migrate`.
-- `henri generate scaffold|crud` write Mongoose-only controllers and React-only
-  pages.
+- `henri generate scaffold|crud` write React-only pages. The controllers follow
+  the adapter of the default store (`scripts/adapters.js` maps it to the
+  mongoose, sequelize or drizzle flavour), which `henri new --adapter <name>`
+  configures.
 - The idempotency and rate-limit stores are in memory unless the app plugs a
   shared store (`config.api.idempotency.store`, `config.rateLimit.store`).
 - The scaffolded app pins ESLint 9 because `eslint-plugin-react` does not

--- a/packages/cli/__tests__/adapters.spec.js
+++ b/packages/cli/__tests__/adapters.spec.js
@@ -496,4 +496,152 @@ describe('the generated controllers run on their adapter', () => {
 
     delete global.Task;
   });
+
+  describe('on a sequelize store', () => {
+    let sql;
+
+    /**
+     * A fake Sequelize model: findByPk on an integer key throws a
+     * SequelizeDatabaseError for a malformed id, instances update and
+     * destroy themselves, and errors carry an array of items
+     *
+     * @returns {object} The model
+     */
+    const sequelizeModel = () => {
+      const calls = {};
+      const invalid = () => {
+        const error = new Error('notNull Violation: Task.name cannot be null');
+
+        error.name = 'SequelizeValidationError';
+        error.errors = [{ message: 'Task.name cannot be null', path: 'name' }];
+
+        return error;
+      };
+      const row = (id, attrs) => ({
+        destroy: async () => {
+          calls.destroyed = id;
+        },
+        id,
+        update: async (data) => {
+          if (data.name === '') {
+            throw invalid();
+          }
+          calls.updated = data;
+
+          return { id, ...attrs, ...data };
+        },
+        ...attrs,
+      });
+
+      return {
+        calls,
+        model: {
+          count: async () => 1,
+          create: async (data) => {
+            calls.created = data;
+            if (!data.name) {
+              throw invalid();
+            }
+
+            return row(2, data);
+          },
+          findAll: async (options) => {
+            calls.findAll = options;
+
+            return [row(1, { name: 'one' })];
+          },
+          findByPk: async (id) => {
+            if (id === 'unknown') {
+              const error = new Error('invalid input syntax for type integer');
+
+              error.name = 'SequelizeDatabaseError';
+
+              throw error;
+            }
+
+            return String(id) === '1' ? row(1, { name: 'one' }) : null;
+          },
+        },
+      };
+    };
+
+    beforeAll(() => {
+      const scaffolded = scaffoldWith(dir, 'sqlrunner', [
+        '--adapter',
+        'postgresql',
+      ]);
+
+      sql = path.join(scaffolded.app, 'app/controllers/tasks.js');
+    });
+
+    test('index pages with limit and offset', async () => {
+      const fake = sequelizeModel();
+
+      global.Task = fake.model;
+
+      const controller = require(sql);
+      const res = fakeRes();
+
+      await controller.index(fakeReq(), res);
+
+      expect(fake.calls.findAll).toEqual({ limit: 25, offset: 0 });
+      expect(res.calls[0][0]).toBe('collection');
+      expect(res.calls[0][2]).toEqual({ page: 1, perPage: 25, total: 1 });
+
+      delete global.Task;
+    });
+
+    test('a malformed id is a 404, not a 500', async () => {
+      global.Task = sequelizeModel().model;
+
+      const controller = require(sql);
+      const res = fakeRes();
+
+      await controller.show(fakeReq({}, { id: 'unknown' }), res);
+
+      expect(res.calls).toEqual([['notFound', 404, 'Task unknown not found']]);
+
+      delete global.Task;
+    });
+
+    test('update loads the row then updates it, destroy destroys it', async () => {
+      const fake = sequelizeModel();
+
+      global.Task = fake.model;
+
+      const controller = require(sql);
+      const updated = fakeRes();
+      const gone = fakeRes();
+
+      await controller.update(fakeReq({ name: 'two' }, { id: '1' }), updated);
+      await controller.destroy(fakeReq({}, { id: '1' }), gone);
+
+      expect(fake.calls.updated).toEqual({ name: 'two' });
+      expect(updated.calls[0][0]).toBe('resource');
+      expect(fake.calls.destroyed).toBe(1);
+      expect(gone.calls).toEqual([['end', 204]]);
+
+      delete global.Task;
+    });
+
+    test('a validation error is a 422 with one message per field', async () => {
+      global.Task = sequelizeModel().model;
+
+      const controller = require(sql);
+      const res = fakeRes();
+
+      await controller.create(fakeReq({}), res);
+
+      expect(res.calls).toEqual([
+        [
+          'badData',
+          422,
+          'notNull Violation: Task.name cannot be null',
+          { errors: { name: 'Task.name cannot be null' } },
+        ],
+      ]);
+
+      delete global.Task;
+    });
+  });
 });

--- a/packages/cli/__tests__/adapters.spec.js
+++ b/packages/cli/__tests__/adapters.spec.js
@@ -1,0 +1,499 @@
+const fs = require('fs');
+const path = require('path');
+
+const { version } = require('../package.json');
+const { cleanup, exists, henri, read, tmpdir } = require('./helpers');
+
+/**
+ * Scaffold an application on an adapter in a temporary directory
+ *
+ * @param {string} dir The parent directory
+ * @param {string} name The application folder
+ * @param {string[]} [flags=[]] Extra flags (--adapter, --dialect, ...)
+ * @returns {{app: string, result: object}} The path and the spawn result
+ */
+const scaffoldWith = (dir, name, flags = []) => {
+  const result = henri(['new', name, '--skip-install', '--no-git', ...flags], {
+    cwd: dir,
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`henri new failed: ${result.stdout}${result.stderr}`);
+  }
+
+  return { app: path.join(dir, name), result };
+};
+
+/**
+ * The store of config/default.json
+ *
+ * @param {string} app Application directory
+ * @param {string} [file='default'] The configuration file
+ * @returns {object} The default store
+ */
+const storeOf = (app, file = 'default') =>
+  JSON.parse(read(app, `config/${file}.json`)).stores.default;
+
+/**
+ * Every dependency of the application, dev included
+ *
+ * @param {string} app Application directory
+ * @returns {object} name -> range
+ */
+const depsOf = (app) => {
+  const pkg = JSON.parse(read(app, 'package.json'));
+
+  return { ...pkg.dependencies, ...pkg.devDependencies };
+};
+
+/**
+ * Run henri doctor on an application
+ *
+ * @param {string} app Application directory
+ * @returns {object} The report
+ */
+const doctor = (app) => {
+  const { stdout } = henri(['doctor', '--json'], { cwd: app });
+
+  return JSON.parse(stdout);
+};
+
+describe('henri new --adapter', () => {
+  let dir;
+
+  beforeAll(() => {
+    dir = tmpdir('henri-adapters-');
+  });
+
+  afterAll(() => {
+    cleanup(dir);
+  });
+
+  test('disk stays the default', () => {
+    const { app } = scaffoldWith(dir, 'plain');
+
+    expect(storeOf(app)).toEqual({ adapter: 'disk' });
+    expect(exists(app, 'config/test.json')).toBe(false);
+    expect(depsOf(app)['@usehenri/disk']).toBe(`^${version}`);
+    expect(depsOf(app)['@usehenri/drizzle']).toBeUndefined();
+  });
+
+  test('drizzle writes a sqlite store, its driver and a test database', () => {
+    const { app } = scaffoldWith(dir, 'dz', ['--adapter', 'drizzle']);
+
+    expect(storeOf(app)).toEqual({
+      adapter: 'drizzle',
+      dialect: 'sqlite',
+      url: 'file:.henri/app.db',
+    });
+    expect(storeOf(app, 'test')).toEqual({
+      adapter: 'drizzle',
+      dialect: 'sqlite',
+      url: ':memory:',
+    });
+
+    const deps = depsOf(app);
+
+    expect(deps['@usehenri/drizzle']).toBe(`^${version}`);
+    expect(deps['better-sqlite3']).toMatch(/^\^\d+\./);
+    expect(deps['@usehenri/disk']).toBeUndefined();
+    expect(doctor(app).summary.errors).toBe(0);
+  });
+
+  test('drizzle --dialect postgres and mysql pick the driver and the url', () => {
+    const postgres = scaffoldWith(dir, 'dzpg', [
+      '--adapter',
+      'drizzle',
+      '--dialect',
+      'postgres',
+    ]).app;
+
+    expect(storeOf(postgres)).toEqual({
+      adapter: 'drizzle',
+      dialect: 'postgres',
+      url: 'postgres://postgres@127.0.0.1:5432/dzpg',
+    });
+    expect(storeOf(postgres, 'test').url).toBe(
+      'postgres://postgres@127.0.0.1:5432/dzpg_test'
+    );
+    expect(depsOf(postgres).pg).toMatch(/^\^\d+\./);
+    expect(depsOf(postgres)['better-sqlite3']).toBeUndefined();
+
+    const mysql = scaffoldWith(dir, 'dzmy', [
+      '--adapter',
+      'drizzle',
+      '--dialect',
+      'mysql',
+    ]).app;
+
+    expect(storeOf(mysql).url).toBe('mysql://root@127.0.0.1:3306/dzmy');
+    expect(depsOf(mysql).mysql2).toMatch(/^\^\d+\./);
+    expect(doctor(mysql).summary.errors).toBe(0);
+  });
+
+  test.each([
+    ['mongoose', '@usehenri/mongoose', 'mongodb://127.0.0.1:27017/'],
+    ['mysql', '@usehenri/mysql', 'mysql://root@127.0.0.1:3306/'],
+    [
+      'postgresql',
+      '@usehenri/postgresql',
+      'postgres://postgres@127.0.0.1:5432/',
+    ],
+    ['mssql', '@usehenri/mssql', 'mssql://sa@127.0.0.1:1433/'],
+  ])(
+    '%s writes its store, its package and a test database',
+    (adapter, dependency, prefix) => {
+      const name = `app-${adapter}`;
+      const { app } = scaffoldWith(dir, name, ['--adapter', adapter]);
+
+      expect(storeOf(app)).toEqual({ adapter, url: `${prefix}${name}` });
+      expect(storeOf(app, 'test').url).toBe(`${prefix}${name}_test`);
+      expect(depsOf(app)[dependency]).toBe(`^${version}`);
+      expect(depsOf(app)['@usehenri/disk']).toBeUndefined();
+      expect(doctor(app).summary.errors).toBe(0);
+    }
+  );
+
+  test('rejects an unknown adapter and a misplaced dialect', () => {
+    const unknown = henri(
+      ['new', 'nope', '--skip-install', '--no-git', '--adapter', 'redis'],
+      { cwd: dir }
+    );
+
+    expect(unknown.status).toBe(2);
+    expect(unknown.stderr).toContain("Unknown adapter 'redis'");
+    expect(unknown.stderr).toContain('disk, drizzle, mongoose');
+    expect(fs.existsSync(path.join(dir, 'nope', 'package.json'))).toBe(false);
+
+    const dialect = henri(
+      [
+        'new',
+        'nope2',
+        '--skip-install',
+        '--no-git',
+        '--adapter',
+        'drizzle',
+        '--dialect',
+        'oracle',
+      ],
+      { cwd: dir }
+    );
+
+    expect(dialect.status).toBe(2);
+    expect(dialect.stderr).toContain("Unknown dialect 'oracle'");
+    expect(dialect.stderr).toContain('mysql, postgres, sqlite');
+
+    const misplaced = henri(
+      [
+        'new',
+        'nope3',
+        '--skip-install',
+        '--no-git',
+        '--adapter',
+        'mysql',
+        '--dialect',
+        'sqlite',
+      ],
+      { cwd: dir }
+    );
+
+    expect(misplaced.status).toBe(2);
+    expect(misplaced.stderr).toContain('--dialect only applies to');
+  });
+
+  test('henri init takes the same flags and allows the driver build for pnpm', () => {
+    const app = path.join(dir, 'initialized');
+
+    fs.mkdirSync(app);
+    fs.writeFileSync(
+      path.join(app, 'package.json'),
+      JSON.stringify({ packageManager: 'pnpm@11.25.0' })
+    );
+
+    const { status } = henri(
+      ['init', '--skip-install', '--no-git', '--adapter', 'drizzle'],
+      { cwd: app }
+    );
+
+    expect(status).toBe(0);
+    expect(storeOf(app).dialect).toBe('sqlite');
+
+    // The better-sqlite3 native addon compiles: pnpm 11 fails the install
+    // when the build script is not allow-listed
+    const workspace = read(app, 'pnpm-workspace.yaml');
+
+    expect(workspace).toMatch(/^ {2}better-sqlite3: true$/m);
+    expect(workspace.indexOf('better-sqlite3')).toBeLessThan(
+      workspace.indexOf('esbuild')
+    );
+  });
+});
+
+describe('the scaffolded resource follows the adapter', () => {
+  let dir;
+
+  beforeAll(() => {
+    dir = tmpdir('henri-adapter-code-');
+  });
+
+  afterAll(() => {
+    cleanup(dir);
+  });
+
+  test('drizzle: a relation for the page, no cast guard', () => {
+    const { app } = scaffoldWith(dir, 'dz', ['--adapter', 'drizzle']);
+    const controller = read(app, 'app/controllers/tasks.js');
+
+    expect(controller).toContain('Task.query().offset(skip).limit(limit)');
+    expect(controller).toContain('Task.count()');
+    expect(controller).toContain('Task.findByIdAndDelete(req.params.id)');
+    expect(controller).not.toContain('countDocuments');
+    expect(controller).not.toContain('CastError');
+    expect(read(app, 'app/controllers/main.js')).toContain('Task.find()');
+  });
+
+  test('sequelize: findAll, findByPk and instance updates', () => {
+    const { app } = scaffoldWith(dir, 'pg', ['--adapter', 'postgresql']);
+    const controller = read(app, 'app/controllers/tasks.js');
+
+    expect(controller).toContain('Task.findAll({ limit, offset: skip })');
+    expect(controller).toContain('Task.findByPk(id)');
+    expect(controller).toContain('task.update(req.permit(...FIELDS))');
+    expect(controller).toContain('task.destroy()');
+    expect(controller).not.toContain('findByIdAndUpdate');
+    // The template home page lists every task with the mongoose name
+    expect(read(app, 'app/controllers/main.js')).toContain('Task.findAll()');
+  });
+
+  test('mongoose: the scaffold is unchanged', () => {
+    const { app } = scaffoldWith(dir, 'mg', ['--adapter', 'mongoose']);
+    const controller = read(app, 'app/controllers/tasks.js');
+
+    expect(controller).toContain('Task.find().skip(skip).limit(limit)');
+    expect(controller).toContain('Task.countDocuments()');
+    expect(controller).toContain('CastError');
+  });
+
+  test('the generators read the adapter back from the configuration', () => {
+    const { app } = scaffoldWith(dir, 'gen', ['--adapter', 'drizzle']);
+    const { status } = henri(['g', 'crud', 'Note', 'body:text'], { cwd: app });
+
+    expect(status).toBe(0);
+    expect(read(app, 'app/controllers/notes.js')).toContain(
+      'Note.query().offset(skip).limit(limit)'
+    );
+  });
+
+  test('AGENTS.md and the README describe the store', () => {
+    const { app } = scaffoldWith(dir, 'docs', ['--adapter', 'drizzle']);
+    const agents = read(app, 'AGENTS.md');
+
+    expect(agents).toContain('store `drizzle`');
+    expect(agents).toContain('henri db:generate|migrate|push|status');
+    expect(agents).not.toContain('{{');
+    expect(agents.split('\n').length).toBeLessThan(150);
+
+    const readme = read(app, 'README.md');
+
+    expect(readme).toContain('henri db:status');
+    expect(readme).toContain('file:.henri/app.db');
+  });
+
+  test('the inertia sample is ported to the store too', () => {
+    const { app } = scaffoldWith(dir, 'inertia', [
+      '--renderer',
+      'inertia',
+      '--adapter',
+      'drizzle',
+    ]);
+    const controller = read(app, 'app/controllers/tasks.js');
+
+    expect(controller).toContain("Task.order('createdAt desc')");
+    expect(controller).toContain('Task.findByIdAndDelete(req.params.id)');
+    expect(controller).not.toContain('.lean()');
+    expect(controller).not.toContain('deleteOne');
+    expect(doctor(app).summary.errors).toBe(0);
+  });
+});
+
+describe('the generated controllers run on their adapter', () => {
+  let dir;
+  let app;
+
+  beforeAll(() => {
+    dir = tmpdir('henri-adapter-run-');
+    ({ app } = scaffoldWith(dir, 'runner', ['--adapter', 'drizzle']));
+  });
+
+  afterAll(() => {
+    cleanup(dir);
+  });
+
+  /**
+   * A fake response recording what the controller answered
+   *
+   * @returns {object} The response
+   */
+  const fakeRes = () => {
+    const res = { calls: [] };
+
+    res.json = (body) => res.calls.push(['json', body]) && res;
+    res.negotiate = (handlers) => handlers.json();
+    res.render = (route, opts) =>
+      res.calls.push(['render', route, opts]) && res;
+    res.redirect = (url) => res.calls.push(['redirect', url]) && res;
+    res.resource = (record, opts = {}) =>
+      res.calls.push(['resource', opts.status || 200, record]) && res;
+    res.collection = (records, meta) =>
+      res.calls.push(['collection', records, meta]) && res;
+    res.status = (code) => ({
+      end: () => res.calls.push(['end', code]) && res,
+    });
+    res.boom = {
+      badData: (message, data) =>
+        res.calls.push(['badData', 422, message, data]) && res,
+      notFound: (message) => res.calls.push(['notFound', 404, message]) && res,
+    };
+
+    return res;
+  };
+
+  /**
+   * A fake request with req.permit and req.pagination
+   *
+   * @param {object} [body={}] Request body
+   * @param {object} [params={}] Route params
+   * @returns {object} The request
+   */
+  const fakeReq = (body = {}, params = {}) => ({
+    body,
+    pagination: () => ({ limit: 25, page: 1, perPage: 25, skip: 0 }),
+    params,
+    permit: (...fields) =>
+      Object.fromEntries(
+        fields
+          .filter((field) => typeof body[field] !== 'undefined')
+          .map((field) => [field, body[field]])
+      ),
+  });
+
+  /**
+   * A fake drizzle model: a chainable relation, ids that are integers and
+   * a ValidationError with one entry per field
+   *
+   * @returns {object} The model
+   */
+  const drizzleModel = () => {
+    const rows = [{ id: 1, name: 'one' }];
+    const relation = {
+      limit: () => relation,
+      offset: () => relation,
+      then: (resolve, reject) => Promise.resolve(rows).then(resolve, reject),
+    };
+    const invalid = () => {
+      const error = new Error('Task validation failed: name: is required');
+
+      error.name = 'ValidationError';
+      error.errors = { name: { message: 'is required' } };
+
+      return error;
+    };
+
+    return {
+      count: async () => rows.length,
+      create: async (data) => {
+        if (!data.name) {
+          throw invalid();
+        }
+
+        return { id: 2, ...data };
+      },
+      findById: async (id) => (String(id) === '1' ? rows[0] : null),
+      findByIdAndDelete: async (id) => (String(id) === '1' ? rows[0] : null),
+      findByIdAndUpdate: async (id, data) => {
+        if (data.name === '') {
+          throw invalid();
+        }
+
+        return String(id) === '1' ? { id: 1, ...data } : null;
+      },
+      query: () => relation,
+    };
+  };
+
+  test('index pages with a relation and answers a HAL collection', async () => {
+    global.Task = drizzleModel();
+
+    const controller = require(path.join(app, 'app/controllers/tasks.js'));
+    const res = fakeRes();
+
+    await controller.index(fakeReq(), res);
+
+    expect(res.calls).toEqual([
+      [
+        'collection',
+        [{ id: 1, name: 'one' }],
+        { page: 1, perPage: 25, total: 1 },
+      ],
+    ]);
+
+    delete global.Task;
+  });
+
+  test('show answers 404 for an id the store does not know', async () => {
+    global.Task = drizzleModel();
+
+    const controller = require(path.join(app, 'app/controllers/tasks.js'));
+    const missing = fakeRes();
+
+    await controller.show(fakeReq({}, { id: 'unknown' }), missing);
+
+    expect(missing.calls).toEqual([
+      ['notFound', 404, 'Task unknown not found'],
+    ]);
+
+    delete global.Task;
+  });
+
+  test('create answers 201, or 422 with one message per field', async () => {
+    global.Task = drizzleModel();
+
+    const controller = require(path.join(app, 'app/controllers/tasks.js'));
+    const created = fakeRes();
+    const rejected = fakeRes();
+
+    await controller.create(
+      fakeReq({ name: 'two', roles: ['admin'] }),
+      created
+    );
+    await controller.create(fakeReq({}), rejected);
+
+    expect(created.calls).toEqual([['resource', 201, { id: 2, name: 'two' }]]);
+    expect(rejected.calls).toEqual([
+      [
+        'badData',
+        422,
+        'Task validation failed: name: is required',
+        { errors: { name: 'is required' } },
+      ],
+    ]);
+
+    delete global.Task;
+  });
+
+  test('destroy answers 204 and 404', async () => {
+    global.Task = drizzleModel();
+
+    const controller = require(path.join(app, 'app/controllers/tasks.js'));
+    const gone = fakeRes();
+    const missing = fakeRes();
+
+    await controller.destroy(fakeReq({}, { id: '1' }), gone);
+    await controller.destroy(fakeReq({}, { id: '9' }), missing);
+
+    expect(gone.calls).toEqual([['end', 204]]);
+    expect(missing.calls).toEqual([['notFound', 404, 'Task 9 not found']]);
+
+    delete global.Task;
+  });
+});

--- a/packages/cli/__tests__/new.spec.js
+++ b/packages/cli/__tests__/new.spec.js
@@ -48,10 +48,13 @@ describe('henri new', () => {
     expect(exists(app, 'app/models/Tasks.js')).toBe(false);
   });
 
-  test('writes pnpm-workspace.yaml only for pnpm', () => {
-    expect(exists(app, 'pnpm-workspace.yaml')).toBe(
-      detectPackageManager(app) === 'pnpm'
-    );
+  test('always writes pnpm-workspace.yaml (npm and yarn ignore it)', () => {
+    expect(exists(app, 'pnpm-workspace.yaml')).toBe(true);
+    expect(read(app, 'pnpm-workspace.yaml')).toContain('allowBuilds:');
+  });
+
+  test('says which package manager it picked', () => {
+    expect(result.stdout).toContain(`- Using ${detectPackageManager(app)} (`);
   });
 
   test('initializes a git repository', () => {
@@ -211,6 +214,32 @@ describe('henri new options', () => {
     expect(fs.existsSync(path.join(dir, 'taken', 'package.json'))).toBe(false);
   });
 
+  test('--pm forces the package manager and says so', () => {
+    const { status, stdout } = henri(
+      ['new', 'forced', '--skip-install', '--no-git', '--pm', 'npm'],
+      { cwd: dir }
+    );
+    const app = path.join(dir, 'forced');
+
+    expect(status).toBe(0);
+    expect(stdout).toContain('- Using npm (--pm)');
+    expect(stdout).toContain('npm install && henri server');
+    expect(read(app, 'README.md')).toContain('npm install');
+    // The workspace file is inert for npm, and there for a later pnpm install
+    expect(exists(app, 'pnpm-workspace.yaml')).toBe(true);
+  });
+
+  test('rejects an unknown package manager', () => {
+    const { status, stderr } = henri(
+      ['new', 'bun', '--skip-install', '--no-git', '--pm', 'bun'],
+      { cwd: dir }
+    );
+
+    expect(status).toBe(2);
+    expect(stderr).toContain("Unknown package manager 'bun'");
+    expect(stderr).toContain('pnpm, yarn, npm');
+  });
+
   test('prints the usage without a folder', () => {
     const { status, stdout, stderr } = henri(['new'], { cwd: dir });
 
@@ -323,6 +352,8 @@ describe('henri new --renderer inertia', () => {
       'app/views/pages/tasks/index.jsx',
       'app/views/vite.config.mjs',
       'vitest.config.js',
+      // The template ships its own test, so `henri test` is green at once
+      'test/tasks.test.js',
     ]) {
       expect(exists(app, file)).toBe(true);
     }
@@ -332,10 +363,13 @@ describe('henri new --renderer inertia', () => {
       'app/models/Tasks.js',
       'app/views/pages/tasks/index.js',
       'app/views/pages/tasks/_form.js',
-      'test/tasks.test.js',
     ]) {
       expect(exists(app, file)).toBe(false);
     }
+
+    expect(read(app, 'test/tasks.test.js')).toContain(
+      "set('X-Inertia', 'true')"
+    );
 
     expect(routesOf(app)).toEqual({
       'delete /tasks/:id': 'tasks#destroy',

--- a/packages/cli/__tests__/utils.spec.js
+++ b/packages/cli/__tests__/utils.spec.js
@@ -1,3 +1,5 @@
+const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const utils = require('../scripts/utils.js');
@@ -39,6 +41,89 @@ describe('cli utilities', () => {
     expect(utils.readConfig(demo, 'test').env).toBe('test');
     expect(utils.readConfig(demo, 'nothing').env).toBe('default');
     expect(utils.readConfig(path.resolve(__dirname), 'test')).toEqual({});
+  });
+
+  describe('package manager detection', () => {
+    let dir;
+    let agent;
+
+    beforeEach(() => {
+      dir = fs.mkdtempSync(path.join(os.tmpdir(), 'henri-pm-'));
+      agent = process.env.npm_config_user_agent;
+    });
+
+    afterEach(() => {
+      fs.rmSync(dir, { force: true, recursive: true });
+      if (typeof agent === 'undefined') {
+        delete process.env.npm_config_user_agent;
+      } else {
+        process.env.npm_config_user_agent = agent;
+      }
+    });
+
+    test('--pm wins over everything and is validated', () => {
+      fs.writeFileSync(
+        path.join(dir, 'package.json'),
+        JSON.stringify({ packageManager: 'yarn@4.0.0' })
+      );
+
+      expect(utils.packageManagerChoice(dir, 'pnpm')).toEqual({
+        pm: 'pnpm',
+        source: '--pm',
+      });
+      expect(() => utils.detectPackageManager(dir, 'bun')).toThrow(
+        /Unknown package manager 'bun'/
+      );
+    });
+
+    test('reads the packageManager field, then the lockfile', () => {
+      fs.writeFileSync(
+        path.join(dir, 'package.json'),
+        JSON.stringify({ packageManager: 'pnpm@11.25.0' })
+      );
+      expect(utils.detectPackageManager(dir)).toBe('pnpm');
+
+      fs.writeFileSync(path.join(dir, 'package.json'), '{}');
+      fs.writeFileSync(path.join(dir, 'yarn.lock'), '');
+      expect(utils.packageManagerChoice(dir)).toEqual({
+        pm: 'yarn',
+        source: 'yarn.lock',
+      });
+    });
+
+    // The regression: outside a project a mise shim answers non-zero for
+    // `pnpm --version`, the probe fell through to yarn and a pnpm user got a
+    // yarn application. The manager that ran the command is asked first now.
+    test('prefers the manager that invoked the cli over the probe', () => {
+      process.env.npm_config_user_agent =
+        'pnpm/11.25.0 npm/? node/v24.0.0 darwin arm64';
+      expect(utils.packageManagerChoice(dir)).toEqual({
+        pm: 'pnpm',
+        source: 'npm_config_user_agent',
+      });
+
+      process.env.npm_config_user_agent = 'yarn/4.0.0 npm/? node/v24.0.0';
+      expect(utils.detectPackageManager(dir)).toBe('yarn');
+
+      process.env.npm_config_user_agent = 'bun/1.0.0';
+      expect(['pnpm', 'yarn', 'npm']).toContain(
+        utils.detectPackageManager(dir)
+      );
+    });
+  });
+
+  test('finds the package.json of an ESM only dependency', () => {
+    const inertia = path.resolve(__dirname, '../../inertia');
+
+    // @inertiajs/react has no `require` and no `./package.json` condition in
+    // its exports map: CommonJS resolution throws, the disk fallback answers
+    expect(utils.resolvePackageJson('@inertiajs/react', inertia).name).toBe(
+      '@inertiajs/react'
+    );
+    expect(utils.resolvePackageJson('@usehenri/cli', __dirname).name).toBe(
+      '@usehenri/cli'
+    );
+    expect(utils.resolvePackageJson('not-a-real-package', inertia)).toBe(null);
   });
 
   test('detects a git repository from a nested directory', () => {

--- a/packages/cli/scripts/adapters.js
+++ b/packages/cli/scripts/adapters.js
@@ -1,0 +1,308 @@
+const { CliError } = require('./errors');
+const { readConfig } = require('./utils');
+
+/**
+ * The store adapters of henri, what an application needs to use one, and
+ * the model API each one exposes.
+ *
+ * `api` is the flavour of the controllers `henri generate scaffold|crud`
+ * writes: `mongoose` (disk and mongoose stores), `sequelize` (mysql,
+ * postgresql, mssql, mariadb) or `drizzle`. It is read back from
+ * `config/default.json`, so a generator always writes code the configured
+ * store can run.
+ *
+ * `henri new --adapter <name>` scaffolds the ones with a `scaffold` entry:
+ * the store block of `config/default.json`, the packages to install and
+ * the pnpm build allowances the driver needs.
+ */
+
+/** The adapter `henri new` uses when `--adapter` is not given */
+const DEFAULT_ADAPTER = 'disk';
+
+/** The drizzle dialect `henri new --adapter drizzle` uses by default */
+const DEFAULT_DIALECT = 'sqlite';
+
+/**
+ * The model API of every adapter core can load. `mariadb` is a dialect of
+ * `@usehenri/mysql` and has no scaffold of its own.
+ */
+const APIS = {
+  disk: 'mongoose',
+  drizzle: 'drizzle',
+  mariadb: 'sequelize',
+  mongoose: 'mongoose',
+  mssql: 'sequelize',
+  mysql: 'sequelize',
+  postgresql: 'sequelize',
+};
+
+/** The henri package that provides each adapter */
+const PACKAGES = {
+  disk: '@usehenri/disk',
+  drizzle: '@usehenri/drizzle',
+  mariadb: '@usehenri/mysql',
+  mongoose: '@usehenri/mongoose',
+  mssql: '@usehenri/mssql',
+  mysql: '@usehenri/mysql',
+  postgresql: '@usehenri/postgresql',
+};
+
+/**
+ * The drizzle dialects: the driver the application installs (it is an
+ * optional peer dependency of `@usehenri/drizzle`), the dependency build
+ * scripts pnpm has to allow for it, and the url of a fresh application.
+ */
+const DIALECTS = {
+  mysql: {
+    builds: {},
+    driver: { mysql2: '^3.24.3' },
+    url: (name) => `mysql://root@127.0.0.1:3306/${name}`,
+  },
+  postgres: {
+    builds: {},
+    driver: { pg: '^8.23.0' },
+    url: (name) => `postgres://postgres@127.0.0.1:5432/${name}`,
+  },
+  sqlite: {
+    builds: { 'better-sqlite3': true },
+    driver: { 'better-sqlite3': '^13.0.3' },
+    // Sqlite keeps the test database in memory, like the disk adapter
+    testUrl: () => ':memory:',
+    url: () => 'file:.henri/app.db',
+  },
+};
+
+/**
+ * What `henri new --adapter <name>` writes. `store` builds the block of
+ * `config/default.json` (`test` gives the one of `config/test.json`, which
+ * is only written when it differs), `summary` shows up in the help.
+ */
+const SCAFFOLDS = {
+  disk: {
+    store: () => ({ adapter: 'disk' }),
+    summary: 'local MongoDB, nothing to install (default)',
+  },
+  drizzle: {
+    store: (name, dialect, test) => ({
+      adapter: 'drizzle',
+      dialect,
+      url: url(DIALECTS[dialect], name, test),
+    }),
+    summary: 'Drizzle ORM with migrations: sqlite (default), postgres, mysql',
+  },
+  mongoose: {
+    store: (name, dialect, test) => ({
+      adapter: 'mongoose',
+      url: `mongodb://127.0.0.1:27017/${database(name, test)}`,
+    }),
+    summary: 'MongoDB server (mongoose)',
+  },
+  mssql: {
+    store: (name, dialect, test) => ({
+      adapter: 'mssql',
+      url: `mssql://sa@127.0.0.1:1433/${database(name, test)}`,
+    }),
+    summary: 'Microsoft SQL Server (sequelize)',
+  },
+  mysql: {
+    store: (name, dialect, test) => ({
+      adapter: 'mysql',
+      url: `mysql://root@127.0.0.1:3306/${database(name, test)}`,
+    }),
+    summary: 'MySQL or MariaDB (sequelize)',
+  },
+  postgresql: {
+    store: (name, dialect, test) => ({
+      adapter: 'postgresql',
+      url: `postgres://postgres@127.0.0.1:5432/${database(name, test)}`,
+    }),
+    summary: 'PostgreSQL (sequelize)',
+  },
+};
+
+/**
+ * The database name of an application, `<name>_test` under NODE_ENV=test
+ *
+ * @param {string} name The application name
+ * @param {boolean} [test] The test database
+ * @returns {string} The database name
+ */
+const database = (name, test) => (test ? `${name}_test` : name);
+
+/**
+ * The url of a drizzle dialect for an application
+ *
+ * @param {object} dialect A DIALECTS entry
+ * @param {string} name The application name
+ * @param {boolean} [test] The test database
+ * @returns {string} The url
+ */
+const url = (dialect, name, test) =>
+  test && dialect.testUrl
+    ? dialect.testUrl()
+    : dialect.url(database(name, test));
+
+/** The adapters `henri new --adapter` accepts, sorted */
+const list = () => Object.keys(SCAFFOLDS).sort();
+
+/** The drizzle dialects `henri new --dialect` accepts, sorted */
+const dialects = () => Object.keys(DIALECTS).sort();
+
+/**
+ * The dialect of a drizzle store: the configured one, or the one its url
+ * points at, `sqlite` otherwise
+ *
+ * @param {object} [store={}] A store block of config/default.json
+ * @returns {string} sqlite, postgres or mysql
+ */
+const dialectOf = (store = {}) => {
+  const wanted = String((store && store.dialect) || '').toLowerCase();
+  const aliases = {
+    'better-sqlite3': 'sqlite',
+    mariadb: 'mysql',
+    mysql2: 'mysql',
+    pg: 'postgres',
+    postgresql: 'postgres',
+    sqlite3: 'sqlite',
+  };
+  const named = aliases[wanted] || wanted;
+
+  if (DIALECTS[named]) {
+    return named;
+  }
+
+  const target = String((store && store.url) || '').toLowerCase();
+
+  if (/^(postgres|postgresql|pg):/.test(target)) {
+    return 'postgres';
+  }
+
+  if (/^(mysql|mysql2|mariadb):/.test(target)) {
+    return 'mysql';
+  }
+
+  return DEFAULT_DIALECT;
+};
+
+/**
+ * The packages a configured store needs in the application package.json
+ *
+ * @param {object} [store] A store block of config/default.json
+ * @returns {Array<string>} Package names (empty for an unknown adapter)
+ */
+const packagesFor = (store) => {
+  const adapter = store && store.adapter;
+
+  if (!PACKAGES[adapter]) {
+    return [];
+  }
+
+  const needed = [PACKAGES[adapter]];
+
+  if (adapter === 'drizzle') {
+    needed.push(...Object.keys(DIALECTS[dialectOf(store)].driver));
+  }
+
+  return needed;
+};
+
+/**
+ * The model API of the default store of an application, so a generator
+ * writes controllers the store can run
+ *
+ * @param {string} [dir=process.cwd()] The application directory
+ * @returns {string} mongoose (the default), sequelize or drizzle
+ */
+const apiOf = (dir = process.cwd()) => {
+  let config = {};
+
+  try {
+    config = readConfig(dir, undefined);
+  } catch {
+    // An unreadable configuration: the mongoose flavour is the default
+  }
+
+  const stores = (config && config.stores) || {};
+  const store = stores.default || Object.values(stores)[0] || {};
+
+  return APIS[store.adapter] || 'mongoose';
+};
+
+/**
+ * Pick the adapter and its dialect from the CLI arguments
+ *
+ * @param {object} [args={}] CLI arguments (--adapter, --dialect)
+ * @returns {{adapter: string, dialect: string}} The selection
+ * @throws {CliError} USAGE on an unknown adapter or dialect
+ */
+const select = (args = {}) => {
+  const adapter = String(args.adapter || DEFAULT_ADAPTER).toLowerCase();
+  const wanted = args.dialect ? String(args.dialect).toLowerCase() : null;
+
+  if (!SCAFFOLDS[adapter]) {
+    throw new CliError('USAGE', `Unknown adapter '${adapter}'`, {
+      hint: `Valid values: ${list().join(', ')}`,
+    });
+  }
+
+  if (wanted && adapter !== 'drizzle') {
+    throw new CliError(
+      'USAGE',
+      `--dialect only applies to --adapter drizzle (got '${adapter}')`,
+      { hint: `henri new <folder> --adapter drizzle --dialect ${wanted}` }
+    );
+  }
+
+  if (wanted && !DIALECTS[wanted]) {
+    throw new CliError('USAGE', `Unknown dialect '${wanted}'`, {
+      hint: `Valid values: ${dialects().join(', ')}`,
+    });
+  }
+
+  return { adapter, dialect: wanted || DEFAULT_DIALECT };
+};
+
+/**
+ * Everything `henri init` needs to scaffold an application on an adapter
+ *
+ * @param {object} options Options
+ * @param {string} options.adapter The adapter name
+ * @param {string} [options.dialect] The drizzle dialect
+ * @param {string} options.name The application name (the database name)
+ * @returns {object} `{ adapter, api, builds, dialect, drivers, package,
+ *   store, test }`
+ */
+const describe = ({ adapter, dialect = DEFAULT_DIALECT, name }) => {
+  const scaffold = SCAFFOLDS[adapter];
+  const flavour = adapter === 'drizzle' ? dialect : null;
+  const store = scaffold.store(name, dialect, false);
+  const test = scaffold.store(name, dialect, true);
+
+  return {
+    adapter,
+    api: APIS[adapter],
+    builds: flavour ? DIALECTS[flavour].builds : {},
+    dialect: flavour,
+    drivers: flavour ? DIALECTS[flavour].driver : {},
+    package: PACKAGES[adapter],
+    store,
+    // Only useful when config/test.json says something new
+    test: JSON.stringify(test) === JSON.stringify(store) ? null : test,
+  };
+};
+
+module.exports = {
+  APIS,
+  DEFAULT_ADAPTER,
+  DEFAULT_DIALECT,
+  DIALECTS,
+  PACKAGES,
+  SCAFFOLDS,
+  apiOf,
+  describe,
+  dialectOf,
+  dialects,
+  list,
+  packagesFor,
+  select,
+};

--- a/packages/cli/scripts/agents.js
+++ b/packages/cli/scripts/agents.js
@@ -2,6 +2,8 @@ const fs = require('fs-extra');
 const path = require('path');
 const handlebars = require('handlebars');
 
+const { APIS, DEFAULT_ADAPTER } = require('./adapters');
+
 /**
  * The files that make an application readable by coding agents, all from
  * template/default: AGENTS.md (the conventions, with the application name
@@ -24,18 +26,29 @@ const RENDERERS = ['react', 'inertia'];
  * @param {object} options Options
  * @param {string} options.name The application name
  * @param {string} [options.renderer='react'] react or inertia
+ * @param {string} [options.adapter='disk'] The adapter of the default store
  * @returns {string} Markdown
  */
-const renderAgents = ({ name, renderer = 'react' }) => {
+const renderAgents = ({
+  adapter = DEFAULT_ADAPTER,
+  name,
+  renderer = 'react',
+}) => {
   const source = fs.readFileSync(path.join(TEMPLATE_DIR, 'AGENTS.md'), 'utf8');
   const template = handlebars.compile(source, { noEscape: true });
   const which = RENDERERS.includes(renderer) ? renderer : 'react';
+  const store = APIS[adapter] ? adapter : DEFAULT_ADAPTER;
+  const api = APIS[store];
 
   return template({
+    adapter: store,
+    drizzle: api === 'drizzle',
     inertia: which === 'inertia',
+    mongoose: api === 'mongoose',
     name,
     react: which === 'react',
     renderer: which,
+    sequelize: api === 'sequelize',
   })
     .replace(/[ \t]+$/gm, '')
     .replace(/\n{3,}/g, '\n\n');
@@ -48,10 +61,14 @@ const renderAgents = ({ name, renderer = 'react' }) => {
  * @param {object} options Options
  * @param {string} options.name The application name
  * @param {string} [options.renderer='react'] react or inertia
+ * @param {string} [options.adapter='disk'] The adapter of the default store
  * @param {boolean} [options.force=false] Overwrite existing files
  * @returns {{created: Array<string>, skipped: Array<string>}} What was written
  */
-const writeAgentFiles = (dir, { name, renderer = 'react', force = false }) => {
+const writeAgentFiles = (
+  dir,
+  { adapter = DEFAULT_ADAPTER, name, renderer = 'react', force = false }
+) => {
   const created = [];
   const skipped = [];
 
@@ -64,7 +81,7 @@ const writeAgentFiles = (dir, { name, renderer = 'react', force = false }) => {
     }
 
     const content = template
-      ? renderAgents({ name, renderer })
+      ? renderAgents({ adapter, name, renderer })
       : fs.readFileSync(path.join(TEMPLATE_DIR, source), 'utf8');
 
     fs.outputFileSync(location, content);

--- a/packages/cli/scripts/doctor.js
+++ b/packages/cli/scripts/doctor.js
@@ -1,6 +1,7 @@
 const fs = require('fs-extra');
 const path = require('path');
 
+const { APIS, packagesFor } = require('./adapters');
 const { CliError } = require('./errors');
 const { controllerOf, expand } = require('./routing');
 const {
@@ -20,19 +21,15 @@ const {
 
 const MINIMUM_NODE = 22;
 
-const ADAPTERS = [
-  'disk',
-  'mariadb',
-  'mongoose',
-  'mssql',
-  'mysql',
-  'postgresql',
-];
+/** The adapters core can load (scripts/adapters.js is the catalogue) */
+const ADAPTERS = Object.keys(APIS).sort();
 
-/** Packages the adapters and the renderers need in the app's package.json */
+/**
+ * Packages the renderers need in the app's package.json. What a store
+ * needs (its adapter package, and the driver of a drizzle dialect) comes
+ * from packagesFor().
+ */
 const NEEDS = {
-  disk: ['@usehenri/disk'],
-  drizzle: ['@usehenri/drizzle'],
   inertia: [
     '@usehenri/inertia',
     '@inertiajs/react',
@@ -40,11 +37,6 @@ const NEEDS = {
     'react-dom',
     'vite',
   ],
-  mariadb: ['@usehenri/mysql'],
-  mongoose: ['@usehenri/mongoose'],
-  mssql: ['@usehenri/mssql'],
-  mysql: ['@usehenri/mysql'],
-  postgresql: ['@usehenri/postgresql'],
   react: ['@usehenri/react', 'next', 'react', 'react-dom'],
 };
 
@@ -514,7 +506,7 @@ const check = (dir = process.cwd()) => {
   }
 
   for (const store of Object.values(config.stores || {})) {
-    for (const name of NEEDS[store && store.adapter] || []) {
+    for (const name of packagesFor(store)) {
       needed.add(name);
     }
   }

--- a/packages/cli/scripts/generate.js
+++ b/packages/cli/scripts/generate.js
@@ -3,6 +3,7 @@ const path = require('path');
 const util = require('util');
 const handlebars = require('handlebars');
 
+const { apiOf } = require('./adapters');
 const { CliError } = require('./errors');
 const { usage } = require('./help');
 const Report = require('./report');
@@ -337,7 +338,11 @@ const scaffold = async (name, attributes = [], opts = {}) => {
  * @return {Promise<void>} Resolves when done
  */
 const resources = async (name, attributes = [], opts = {}) => {
-  const resource = { ...names(name), keys: extractKeys(attributes) };
+  const resource = {
+    ...names(name),
+    api: apiOf(process.cwd()),
+    keys: extractKeys(attributes),
+  };
   const generator = require('./generate/controllers');
 
   await output(
@@ -360,7 +365,11 @@ const resources = async (name, attributes = [], opts = {}) => {
  * @return {Promise<void>} Resolves when done
  */
 const crud = async (name, attributes = [], opts = {}) => {
-  const resource = { ...names(name), keys: extractKeys(attributes) };
+  const resource = {
+    ...names(name),
+    api: apiOf(process.cwd()),
+    keys: extractKeys(attributes),
+  };
   const generator = require('./generate/controllers');
 
   await model(name, attributes, opts);

--- a/packages/cli/scripts/generate/controllers.js
+++ b/packages/cli/scripts/generate/controllers.js
@@ -3,8 +3,11 @@
  *
  * Every function receives the resource names: doc = 'Post' (model global),
  * lower = 'post' (data key of one document), plural = 'posts' (controller,
- * routes and pages) and keys = the attributes a request may set.
- * The output goes through prettier, so the indentation here does not matter.
+ * routes and pages), keys = the attributes a request may set and api = the
+ * model API of the store the resource lives in ('mongoose' for the disk and
+ * mongoose adapters, 'sequelize' for mysql, postgresql and mssql, 'drizzle'
+ * for the drizzle adapter; see scripts/adapters.js). The output goes through
+ * prettier, so the indentation here does not matter.
  *
  * JSON clients get HAL: `res.collection()` for the index, `res.resource()`
  * for one document (201 + Location on create, 204 on destroy). Browsers get
@@ -12,27 +15,33 @@
  * picks one from the Accept header.
  */
 
-const header = ({ doc, keys }) => `
-// Attributes a request may set (see req.permit)
-const FIELDS = ${JSON.stringify(keys)};
+const DEFAULT_API = 'mongoose';
 
 /**
- * Run a query by id, null when the id is malformed
+ * The api of a resource, `mongoose` when it is not one we know
  *
- * @param {Promise} query A mongoose query
- * @returns {Promise<object|null>} The document or null
+ * @param {object} opts { api }
+ * @returns {string} mongoose, sequelize or drizzle
  */
-const byId = async (query) => {
-  try {
-    return await query;
-  } catch (error) {
-    if (error.name === 'CastError') {
-      return null;
-    }
-    throw error;
-  }
-};
+const apiOf = ({ api }) => (FLAVOURS[api] ? api : DEFAULT_API);
 
+/**
+ * Pick the fragment of an api
+ *
+ * @param {string} part The fragment name (helpers, page, find, ...)
+ * @param {object} opts { doc, lower, plural, keys, api }
+ * @returns {string} The source code
+ */
+const of = (part, opts) => FLAVOURS[apiOf(opts)][part](opts);
+
+// --- the helpers every flavour shares --------------------------------------
+
+const fields = ({ keys }) => `
+// Attributes a request may set (see req.permit)
+const FIELDS = ${JSON.stringify(keys)};
+`;
+
+const validationHelper = ({ doc }) => `
 /**
  * Answer a failed validation with a 422 and one message per field
  *
@@ -54,54 +63,12 @@ const invalid = (res, error) => {
 
   return res.boom.badData(error.message, { errors });
 };
-
-module.exports = {`;
-
-const footer = () => `};`;
-
-/**
- * The paginated query of an index action
- *
- * @param {object} opts { doc, plural }
- * @returns {string} The source code
- */
-const page = ({ doc, plural }) => `
-    // Page and size from ?page=2&per_page=50, bounded by config.api.maxPerPage
-    const { page, perPage, skip, limit } = req.pagination();
-    const [${plural}, total] = await Promise.all([
-      ${doc}.find().skip(skip).limit(limit),
-      ${doc}.countDocuments(),
-    ]);
 `;
 
-const index = (opts) => `
-  index: async (req, res) => {
-    ${page(opts)}
-    // app/views/pages/${opts.plural}/index.js is the /${opts.plural} page for next.js
-    const html = () =>
-      res.render('/${opts.plural}', {
-        data: { ${[opts.plural, 'page', 'perPage', 'total'].sort().join(', ')} },
-      });
+// --- mongoose (disk, mongoose) ---------------------------------------------
 
-    // Browsers get the page, API clients a HAL collection
-    return res.negotiate({
-      html,
-      json: () => res.collection(${opts.plural}, { page, perPage, total }),
-    });
-  },`;
-
-const indexJson = (opts) => `
-  index: async (req, res) => {
-    ${page(opts)}
-    return res.collection(${opts.plural}, { page, perPage, total });
-  },`;
-
-const newC = ({ plural }) => `
-  new: async (req, res) => {
-    res.render('/${plural}/new');
-  },`;
-
-const createBody = ({ doc, lower }) => `
+const mongoose = {
+  create: ({ doc, lower }) => `
     let ${lower};
 
     try {
@@ -109,52 +76,48 @@ const createBody = ({ doc, lower }) => `
     } catch (error) {
       return invalid(res, error);
     }
-`;
+`,
+  destroy: ({ doc, lower }) => `
+    const ${lower} = await byId(${doc}.findByIdAndDelete(req.params.id));
 
-const create = (opts) => `
-  create: async (req, res) => {
-    ${createBody(opts)}
-    // 201 with a Location header pointing at the new ${opts.lower}
-    return res.negotiate({
-      html: () => res.redirect(\`/${opts.plural}/\${${opts.lower}.id}\`),
-      json: () => res.resource(${opts.lower}, { status: 201 }),
-    });
-  },`;
-
-const createJson = (opts) => `
-  create: async (req, res) => {
-    ${createBody(opts)}
-    // 201 with a Location header pointing at the new ${opts.lower}
-    return res.resource(${opts.lower}, { status: 201 });
-  },`;
-
-const findBody = ({ doc, lower }) => `
+    if (!${lower}) {
+      return res.boom.notFound(\`${doc} \${req.params.id} not found\`);
+    }
+`,
+  find: ({ doc, lower }) => `
     const ${lower} = await byId(${doc}.findById(req.params.id));
 
     if (!${lower}) {
       return res.boom.notFound(\`${doc} \${req.params.id} not found\`);
     }
-`;
-
-const show = (opts) => `
-  show: async (req, res) => {
-    ${findBody(opts)}
-    return res.negotiate({
-      html: () => res.render('/${opts.plural}/show', { data: { ${opts.lower} } }),
-      json: () => res.resource(${opts.lower}),
-    });
-  },`;
-
-const edit = (opts) => `
-  edit: async (req, res) => {
-    ${findBody(opts)}
-    return res.negotiate({
-      html: () => res.render('/${opts.plural}/edit', { data: { ${opts.lower} } }),
-      json: () => res.resource(${opts.lower}),
-    });
-  },`;
-
-const updateBody = ({ doc, lower }) => `
+`,
+  helpers: (opts) => `${fields(opts)}
+/**
+ * Run a query by id, null when the id is malformed
+ *
+ * @param {Promise} query A mongoose query
+ * @returns {Promise<object|null>} The document or null
+ */
+const byId = async (query) => {
+  try {
+    return await query;
+  } catch (error) {
+    if (error.name === 'CastError') {
+      return null;
+    }
+    throw error;
+  }
+};
+${validationHelper(opts)}`,
+  page: ({ doc, plural }) => `
+    // Page and size from ?page=2&per_page=50, bounded by config.api.maxPerPage
+    const { page, perPage, skip, limit } = req.pagination();
+    const [${plural}, total] = await Promise.all([
+      ${doc}.find().skip(skip).limit(limit),
+      ${doc}.countDocuments(),
+    ]);
+`,
+  update: ({ doc, lower }) => `
     let ${lower};
 
     try {
@@ -171,11 +134,222 @@ const updateBody = ({ doc, lower }) => `
     if (!${lower}) {
       return res.boom.notFound(\`${doc} \${req.params.id} not found\`);
     }
-`;
+`,
+};
+
+// --- drizzle ----------------------------------------------------------------
+// The drizzle models answer to the Mongoose names too, but `find()` resolves
+// to an array instead of a chainable query and a malformed id is already
+// null, so the paginated query is a relation and there is no byId helper.
+
+const drizzle = {
+  create: mongoose.create,
+  destroy: ({ doc, lower }) => `
+    const ${lower} = await ${doc}.findByIdAndDelete(req.params.id);
+
+    if (!${lower}) {
+      return res.boom.notFound(\`${doc} \${req.params.id} not found\`);
+    }
+`,
+  find: ({ doc, lower }) => `
+    // findById() answers null for a malformed id, no cast to guard
+    const ${lower} = await ${doc}.findById(req.params.id);
+
+    if (!${lower}) {
+      return res.boom.notFound(\`${doc} \${req.params.id} not found\`);
+    }
+`,
+  helpers: (opts) => `${fields(opts)}${validationHelper(opts)}`,
+  page: ({ doc, plural }) => `
+    // Page and size from ?page=2&per_page=50, bounded by config.api.maxPerPage
+    const { page, perPage, skip, limit } = req.pagination();
+    const [${plural}, total] = await Promise.all([
+      ${doc}.query().offset(skip).limit(limit),
+      ${doc}.count(),
+    ]);
+`,
+  update: ({ doc, lower }) => `
+    let ${lower};
+
+    try {
+      ${lower} = await ${doc}.findByIdAndUpdate(
+        req.params.id,
+        req.permit(...FIELDS)
+      );
+    } catch (error) {
+      return invalid(res, error);
+    }
+
+    if (!${lower}) {
+      return res.boom.notFound(\`${doc} \${req.params.id} not found\`);
+    }
+`,
+};
+
+// --- sequelize (mysql, postgresql, mssql) -----------------------------------
+// Sequelize has no findByIdAndUpdate/Delete: a row is loaded with findByPk
+// then updated or destroyed, and its errors carry an array of items.
+
+const sequelize = {
+  create: ({ doc, lower }) => `
+    let ${lower};
+
+    try {
+      ${lower} = await ${doc}.create(req.permit(...FIELDS));
+    } catch (error) {
+      return invalid(res, error);
+    }
+`,
+  destroy: ({ doc, lower }) => `
+    const ${lower} = await byId(req.params.id);
+
+    if (!${lower}) {
+      return res.boom.notFound(\`${doc} \${req.params.id} not found\`);
+    }
+
+    await ${lower}.destroy();
+`,
+  find: ({ doc, lower }) => `
+    const ${lower} = await byId(req.params.id);
+
+    if (!${lower}) {
+      return res.boom.notFound(\`${doc} \${req.params.id} not found\`);
+    }
+`,
+  helpers: ({ doc, keys }) => `${fields({ keys })}
+/**
+ * Load a row by primary key, null when the id is malformed
+ *
+ * @param {*} id The id from the route
+ * @returns {Promise<object|null>} The row or null
+ */
+const byId = async (id) => {
+  try {
+    return await ${doc}.findByPk(id);
+  } catch (error) {
+    if (error.name === 'SequelizeDatabaseError') {
+      return null;
+    }
+    throw error;
+  }
+};
+
+/**
+ * Answer a failed validation with a 422 and one message per field
+ *
+ * @param {object} res Express response
+ * @param {Error} error The error thrown by ${doc}
+ * @returns {object} The response
+ */
+const invalid = (res, error) => {
+  if (!String(error.name).startsWith('Sequelize')) {
+    throw error;
+  }
+
+  const errors = Object.fromEntries(
+    (error.errors || []).map((detail) => [detail.path, detail.message])
+  );
+
+  return res.boom.badData(error.message, { errors });
+};
+`,
+  page: ({ doc, plural }) => `
+    // Page and size from ?page=2&per_page=50, bounded by config.api.maxPerPage
+    const { page, perPage, skip, limit } = req.pagination();
+    const [${plural}, total] = await Promise.all([
+      ${doc}.findAll({ limit, offset: skip }),
+      ${doc}.count(),
+    ]);
+`,
+  update: ({ doc, lower }) => `
+    const ${lower} = await byId(req.params.id);
+
+    if (!${lower}) {
+      return res.boom.notFound(\`${doc} \${req.params.id} not found\`);
+    }
+
+    try {
+      await ${lower}.update(req.permit(...FIELDS));
+    } catch (error) {
+      return invalid(res, error);
+    }
+`,
+};
+
+const FLAVOURS = { drizzle, mongoose, sequelize };
+
+// --- the actions ------------------------------------------------------------
+
+const header = (opts) => `${of('helpers', opts)}
+module.exports = {`;
+
+const footer = () => `};`;
+
+const index = (opts) => `
+  index: async (req, res) => {
+    ${of('page', opts)}
+    // app/views/pages/${opts.plural}/index.js is the /${opts.plural} page for next.js
+    const html = () =>
+      res.render('/${opts.plural}', {
+        data: { ${[opts.plural, 'page', 'perPage', 'total'].sort().join(', ')} },
+      });
+
+    // Browsers get the page, API clients a HAL collection
+    return res.negotiate({
+      html,
+      json: () => res.collection(${opts.plural}, { page, perPage, total }),
+    });
+  },`;
+
+const indexJson = (opts) => `
+  index: async (req, res) => {
+    ${of('page', opts)}
+    return res.collection(${opts.plural}, { page, perPage, total });
+  },`;
+
+const newC = ({ plural }) => `
+  new: async (req, res) => {
+    res.render('/${plural}/new');
+  },`;
+
+const create = (opts) => `
+  create: async (req, res) => {
+    ${of('create', opts)}
+    // 201 with a Location header pointing at the new ${opts.lower}
+    return res.negotiate({
+      html: () => res.redirect(\`/${opts.plural}/\${${opts.lower}.id}\`),
+      json: () => res.resource(${opts.lower}, { status: 201 }),
+    });
+  },`;
+
+const createJson = (opts) => `
+  create: async (req, res) => {
+    ${of('create', opts)}
+    // 201 with a Location header pointing at the new ${opts.lower}
+    return res.resource(${opts.lower}, { status: 201 });
+  },`;
+
+const show = (opts) => `
+  show: async (req, res) => {
+    ${of('find', opts)}
+    return res.negotiate({
+      html: () => res.render('/${opts.plural}/show', { data: { ${opts.lower} } }),
+      json: () => res.resource(${opts.lower}),
+    });
+  },`;
+
+const edit = (opts) => `
+  edit: async (req, res) => {
+    ${of('find', opts)}
+    return res.negotiate({
+      html: () => res.render('/${opts.plural}/edit', { data: { ${opts.lower} } }),
+      json: () => res.resource(${opts.lower}),
+    });
+  },`;
 
 const update = (opts) => `
   update: async (req, res) => {
-    ${updateBody(opts)}
+    ${of('update', opts)}
     return res.negotiate({
       html: () => res.redirect(\`/${opts.plural}/\${${opts.lower}.id}\`),
       json: () => res.resource(${opts.lower}),
@@ -184,21 +358,13 @@ const update = (opts) => `
 
 const updateJson = (opts) => `
   update: async (req, res) => {
-    ${updateBody(opts)}
+    ${of('update', opts)}
     return res.resource(${opts.lower});
   },`;
 
-const destroyBody = ({ doc, lower }) => `
-    const ${lower} = await byId(${doc}.findByIdAndDelete(req.params.id));
-
-    if (!${lower}) {
-      return res.boom.notFound(\`${doc} \${req.params.id} not found\`);
-    }
-`;
-
 const destroy = (opts) => `
   destroy: async (req, res) => {
-    ${destroyBody(opts)}
+    ${of('destroy', opts)}
     return res.negotiate({
       html: () => res.redirect('/${opts.plural}'),
       json: () => res.status(204).end(),
@@ -207,14 +373,14 @@ const destroy = (opts) => `
 
 const destroyJson = (opts) => `
   destroy: async (req, res) => {
-    ${destroyBody(opts)}
+    ${of('destroy', opts)}
     return res.status(204).end();
   },`;
 
 /**
  * A controller with the seven resources actions and html/json answers
  *
- * @param {object} opts { doc, lower, plural, keys }
+ * @param {object} opts { doc, lower, plural, keys, api }
  * @returns {string} The source code
  */
 const resources = (opts) =>
@@ -233,7 +399,7 @@ const resources = (opts) =>
 /**
  * A json only controller with index, create, update and destroy
  *
- * @param {object} opts { doc, lower, plural, keys }
+ * @param {object} opts { doc, lower, plural, keys, api }
  * @returns {string} The source code
  */
 const crud = (opts) =>
@@ -246,4 +412,66 @@ const crud = (opts) =>
     footer(),
   ].join('\n');
 
-module.exports = { crud, resources };
+/**
+ * The sample tasks controller of the inertia template, ported to the model
+ * API of a store (the template ships the mongoose one)
+ *
+ * @param {object} opts { doc, lower, plural, api }
+ * @returns {string} The source code
+ */
+const inertia = (opts) => {
+  const { doc, plural } = opts;
+  const api = apiOf(opts);
+  const queries = {
+    drizzle: {
+      list: `${doc}.order('createdAt desc')`,
+      remove: `await ${doc}.findByIdAndDelete(req.params.id);`,
+    },
+    mongoose: {
+      list: `${doc}.find().sort({ createdAt: -1 }).lean()`,
+      remove: `await ${doc}.deleteOne({ _id: req.params.id });`,
+    },
+    sequelize: {
+      list: `${doc}.findAll({ order: [['createdAt', 'DESC']] })`,
+      remove: `await ${doc}.destroy({ where: { id: req.params.id } });`,
+    },
+  }[api];
+
+  return `
+// Controllers receive express requests. \`res.render(route, { data })\` renders
+// app/views/pages/<route>.jsx with \`data\` available through useHenri().
+// The Inertia client follows redirects, so a form submission ends on the
+// page the controller redirects to.
+const list = () => ${queries.list};
+
+module.exports = {
+  index: async (req, res) => {
+    res.render('/${plural}/index', { data: { ${plural}: await list() } });
+  },
+
+  create: async (req, res) => {
+    try {
+      await ${doc}.create({
+        category: req.body.category,
+        name: req.body.name,
+      });
+
+      return res.redirect('/${plural}');
+    } catch (error) {
+      // Rendering with errors: they show up in the <Form> render prop
+      res.inertia.errors({ name: error.message });
+
+      return res.render('/${plural}/index', { data: { ${plural}: await list() } });
+    }
+  },
+
+  destroy: async (req, res) => {
+    ${queries.remove}
+
+    res.redirect('/${plural}');
+  },
+};
+`;
+};
+
+module.exports = { crud, inertia, resources };

--- a/packages/cli/scripts/help.js
+++ b/packages/cli/scripts/help.js
@@ -349,11 +349,16 @@ const COMMANDS = [
         description: 'drizzle dialect: sqlite (default), postgres or mysql',
         flag: '--dialect <name>',
       },
+      {
+        description:
+          'install with pnpm, yarn or npm instead of the detected one',
+        flag: '--pm <name>',
+      },
     ],
     name: 'init',
     summary: 'add the henri structure to the current directory',
     usage: [
-      'henri init [--force | -f] [--skip-install] [--no-git] [--renderer <name>] [--adapter <name>] [--dialect <name>]',
+      'henri init [--force | -f] [--skip-install] [--no-git] [--renderer <name>] [--adapter <name>] [--dialect <name>] [--pm <name>]',
     ],
   },
   {
@@ -400,11 +405,16 @@ const COMMANDS = [
         description: 'drizzle dialect: sqlite (default), postgres or mysql',
         flag: '--dialect <name>',
       },
+      {
+        description:
+          'install with pnpm, yarn or npm instead of the detected one',
+        flag: '--pm <name>',
+      },
     ],
     name: 'new',
     summary: 'create a new application',
     usage: [
-      'henri new <folder> [--force | -f] [--skip-install] [--no-git] [--renderer <name>] [--adapter <name>] [--dialect <name>]',
+      'henri new <folder> [--force | -f] [--skip-install] [--no-git] [--renderer <name>] [--adapter <name>] [--dialect <name>] [--pm <name>]',
     ],
   },
   {

--- a/packages/cli/scripts/help.js
+++ b/packages/cli/scripts/help.js
@@ -340,11 +340,20 @@ const COMMANDS = [
         description: 'react (default) or inertia',
         flag: '--renderer <name>',
       },
+      {
+        description:
+          'store adapter: disk (default), drizzle, mongoose, mysql, postgresql, mssql',
+        flag: '--adapter <name>',
+      },
+      {
+        description: 'drizzle dialect: sqlite (default), postgres or mysql',
+        flag: '--dialect <name>',
+      },
     ],
     name: 'init',
     summary: 'add the henri structure to the current directory',
     usage: [
-      'henri init [--force | -f] [--skip-install] [--no-git] [--renderer <name>]',
+      'henri init [--force | -f] [--skip-install] [--no-git] [--renderer <name>] [--adapter <name>] [--dialect <name>]',
     ],
   },
   {
@@ -364,7 +373,8 @@ const COMMANDS = [
     description: [
       'Creates a new henri application in <folder>, with a sample Task',
       'resource, a README, AGENTS.md (the conventions for coding agents),',
-      'CLAUDE.md and .mcp.json.',
+      'CLAUDE.md and .mcp.json. The sample resource is written against the',
+      'model API of the selected --adapter.',
     ],
     flags: [
       {
@@ -381,11 +391,20 @@ const COMMANDS = [
         description: 'react (default) or inertia',
         flag: '--renderer <name>',
       },
+      {
+        description:
+          'store adapter: disk (default), drizzle, mongoose, mysql, postgresql, mssql',
+        flag: '--adapter <name>',
+      },
+      {
+        description: 'drizzle dialect: sqlite (default), postgres or mysql',
+        flag: '--dialect <name>',
+      },
     ],
     name: 'new',
     summary: 'create a new application',
     usage: [
-      'henri new <folder> [--force | -f] [--skip-install] [--no-git] [--renderer <name>]',
+      'henri new <folder> [--force | -f] [--skip-install] [--no-git] [--renderer <name>] [--adapter <name>] [--dialect <name>]',
     ],
   },
   {

--- a/packages/cli/scripts/init.js
+++ b/packages/cli/scripts/init.js
@@ -2,6 +2,7 @@ const spawn = require('cross-spawn');
 const fs = require('fs-extra');
 const path = require('path');
 
+const adapters = require('./adapters');
 const { writeAgentFiles } = require('./agents');
 const { CliError } = require('./errors');
 const { detectPackageManager, format, insideGit, version } = require('./utils');
@@ -55,6 +56,27 @@ const templateDir = () =>
   path.resolve(__dirname, '../template', RENDERERS[renderer]);
 // --- end renderer selection -------------------------------------------------
 
+// --- store selection --------------------------------------------------------
+// `henri new <app> --adapter drizzle --dialect postgres` writes the store of
+// that adapter in config/default.json, depends on its package and driver and
+// generates the sample resource against its model API. The default stays the
+// zero-config `disk` adapter (see scripts/adapters.js).
+let adapter = adapters.DEFAULT_ADAPTER;
+let dialect = adapters.DEFAULT_DIALECT;
+
+/**
+ * Pick the store adapter (and its dialect) from the CLI arguments
+ *
+ * @param {object} args CLI arguments
+ * @returns {string} the adapter
+ */
+const selectAdapter = (args) => {
+  ({ adapter, dialect } = adapters.select(args));
+
+  return adapter;
+};
+// --- end store selection ----------------------------------------------------
+
 /**
  * Initialize a new install in the current directory
  *
@@ -70,6 +92,9 @@ const main = async (args, name) => {
   const projectName = slug(name) || slug(path.basename(cwd)) || 'henri-app';
 
   selectRenderer(args);
+  selectAdapter(args);
+
+  const store = adapters.describe({ adapter, dialect, name: projectName });
 
   console.log('');
 
@@ -84,8 +109,10 @@ const main = async (args, name) => {
   const pm = detectPackageManager(cwd);
 
   copyTemplate(pm);
-  buildPackage(projectName);
-  generateConfig();
+  buildPackage(projectName, store);
+  generateConfig(store);
+  allowBuilds(store);
+  await portSample(store);
 
   // The react template gets its Task sample from the scaffold generator;
   // the other templates ship their own sample pages.
@@ -93,7 +120,7 @@ const main = async (args, name) => {
     await sampleResource(force);
   }
 
-  createReadme(projectName, pm);
+  createReadme(projectName, pm, store);
   createAgentFiles(projectName, force);
   initGit(skipGit);
 
@@ -107,7 +134,7 @@ const main = async (args, name) => {
     You can start coding right away with:
 
     # cd ${name || '.'}${skipInstall ? ` && ${pm} install` : ''} && henri server
-
+${storeNotice(store)}
     Coding agents: AGENTS.md holds the conventions of the app (CLAUDE.md
     points to it) and .mcp.json starts the henri MCP server (henri mcp).
     Check the app anytime with: henri doctor
@@ -130,6 +157,7 @@ const createAgentFiles = (name, force) => {
   );
 
   const { skipped } = writeAgentFiles(process.cwd(), {
+    adapter,
     force,
     name,
     renderer,
@@ -141,14 +169,26 @@ const createAgentFiles = (name, force) => {
 };
 
 /**
+ * Sorts the keys of a dependency map
+ *
+ * @param {object} [deps={}] Dependencies
+ * @returns {object} The same entries, sorted by name
+ */
+const sorted = (deps = {}) =>
+  Object.fromEntries(
+    Object.entries(deps).sort(([left], [right]) => left.localeCompare(right))
+  );
+
+/**
  * Creates or completes the package.json file.
  * Runs after the template copy so template dependencies are merged with
  * anything that already existed in the folder.
  *
  * @param {string} name Project name
+ * @param {object} store The selected store (see scripts/adapters.js)
  * @returns {void}
  */
-const buildPackage = (name) => {
+const buildPackage = (name, store) => {
   const cwd = process.cwd();
   let existing = {};
 
@@ -172,17 +212,25 @@ const buildPackage = (name) => {
       ])
     );
 
+  // The templates depend on the default adapter: swap it for the selected
+  // one and add the driver it needs (drizzle keeps its drivers optional).
+  const dependencies = withCliVersion(templatePkg.dependencies);
+
+  delete dependencies[adapters.PACKAGES[adapters.DEFAULT_ADAPTER]];
+  dependencies[store.package] = `^${version}`;
+  Object.assign(dependencies, store.drivers);
+
   const pkg = {
     ...templatePkg,
     ...existing,
-    dependencies: {
-      ...withCliVersion(templatePkg.dependencies),
+    dependencies: sorted({
+      ...dependencies,
       ...(existing.dependencies || {}),
-    },
-    devDependencies: {
+    }),
+    devDependencies: sorted({
       ...withCliVersion(templatePkg.devDependencies),
       ...(existing.devDependencies || {}),
-    },
+    }),
     henri: version,
     name: existing.name || name,
     scripts: {
@@ -200,9 +248,10 @@ const buildPackage = (name) => {
  *
  * @param {string} name Project name
  * @param {string} pm Package manager
+ * @param {object} store The selected store (see scripts/adapters.js)
  * @returns {void}
  */
-const createReadme = (name, pm) => {
+const createReadme = (name, pm, store) => {
   const cwd = process.cwd();
 
   console.log(' - Adding new readme file...');
@@ -211,7 +260,7 @@ const createReadme = (name, pm) => {
     fs.renameSync(path.join(cwd, 'README.md'), path.join(cwd, 'README.old.md'));
   }
 
-  fs.writeFileSync(path.join(cwd, 'README.md'), readme(name, pm));
+  fs.writeFileSync(path.join(cwd, 'README.md'), readme(name, pm, store));
 };
 
 /**
@@ -219,9 +268,10 @@ const createReadme = (name, pm) => {
  *
  * @param {string} name Project name
  * @param {string} pm Package manager
+ * @param {object} store The selected store (see scripts/adapters.js)
  * @returns {string} Markdown
  */
-const readme = (name, pm) => {
+const readme = (name, pm, store) => {
   const react = renderer === 'react';
   const sample = react
     ? `The home page lists the sample \`Task\` resource; add tasks at \`/tasks\`.
@@ -241,6 +291,24 @@ henri destroy model Post      # undo a generator`;
   const pages = react
     ? 'React pages rendered by next.js                  '
     : 'Inertia (React) pages, built by vite            ';
+  const migrations =
+    store.adapter === 'drizzle'
+      ? `
+The \`drizzle\` store has migrations (drizzle-kit, \`db/migrations\`):
+
+\`\`\`bash
+henri db:status                        # applied and pending migrations
+henri db:generate --name=add-priority  # write a migration from the models
+henri db:migrate                       # apply the pending migrations
+henri db:push                          # match the database to the models
+\`\`\`
+`
+      : '';
+  const database = store.store.url
+    ? `The default store is \`${store.adapter}\`${store.dialect ? ` (\`${store.dialect}\`)` : ''} at
+\`${store.store.url}\`${store.test ? `, and \`${store.test.url}\` under \`NODE_ENV=test\`` : ''}. Change it in \`config/default.json\`.`
+    : `The default store is \`${store.adapter}\`: a local MongoDB started with the
+application, no server to install. Change it in \`config/default.json\`.`;
 
   return `# ${name}
 
@@ -265,9 +333,10 @@ henri routes                  # the routes table from config/routes.js
 ${generators}
 henri test                    # run test/**/*.test.js
 henri build                   # build the production views
+henri doctor                  # check the app against the henri conventions
 ${pm} run lint                # eslint
 \`\`\`
-
+${migrations}
 ## Layout
 
 | Path                   | Role                                             |
@@ -284,11 +353,13 @@ ${pm} run lint                # eslint
 
 ## Configuration
 
-\`config/default.json\` is committed. \`config/<NODE_ENV>.json\` overrides it for
-an environment (\`config/local.json\` is ignored by git). Secrets do not belong
+\`config/default.json\` is committed. \`config/<NODE_ENV>.json\` replaces it as a
+whole for an environment (\`config/local.json\` is ignored by git). Secrets do not belong
 in these files: the session and token secret is \`HENRI_SECRET\` in \`.env\`,
 which is not committed. Add a \`User\` model to get password hashing, sessions
 and roles.
+
+${database}
 
 See the [documentation](https://usehenri.io) for models, routes, views,
 GraphQL, mail and workers.
@@ -334,23 +405,26 @@ const copyTemplate = (pm) => {
 };
 
 /**
- * Generate the configuration: config/default.json (committed, no secret)
- * and .env (ignored) with the secret
+ * Generate the configuration: config/default.json (committed, no secret),
+ * config/test.json when the store needs a database of its own, and .env
+ * (ignored) with the secret
  *
+ * @param {object} store The selected store (see scripts/adapters.js)
  * @returns {void}
  */
-const generateConfig = () => {
+const generateConfig = (store) => {
   const cwd = process.cwd();
+  const files = store.test
+    ? 'config/default.json, config/test.json'
+    : 'config/default.json';
 
-  console.log(' - Generating config/default.json and .env...');
+  console.log(` - Generating ${files} and .env...`);
 
   const configuration = {
     baseRole: 'guest',
     renderer,
     stores: {
-      default: {
-        adapter: 'disk',
-      },
+      default: store.store,
     },
     user: 'user',
   };
@@ -358,6 +432,16 @@ const generateConfig = () => {
   fs.writeJsonSync(path.join(cwd, 'config', 'default.json'), configuration, {
     spaces: 2,
   });
+
+  // The config/<NODE_ENV>.json file replaces default.json as a whole, so
+  // `henri test` gets the same configuration on its own database.
+  if (store.test) {
+    fs.writeJsonSync(
+      path.join(cwd, 'config', 'test.json'),
+      { ...configuration, stores: { default: store.test } },
+      { spaces: 2 }
+    );
+  }
 
   const secret = require('crypto').randomBytes(64).toString('hex');
 
@@ -368,6 +452,115 @@ const generateConfig = () => {
 HENRI_SECRET=${secret}
 `
   );
+};
+
+/**
+ * Adds the dependency build scripts the driver of the store needs to
+ * pnpm-workspace.yaml (better-sqlite3 compiles a native addon). Nothing to
+ * do when the file was not written (yarn, npm).
+ *
+ * @param {object} store The selected store (see scripts/adapters.js)
+ * @returns {void}
+ */
+const allowBuilds = (store) => {
+  const file = path.join(process.cwd(), 'pnpm-workspace.yaml');
+  const entries = Object.entries(store.builds);
+
+  if (entries.length === 0 || !fs.existsSync(file)) {
+    return;
+  }
+
+  const lines = fs.readFileSync(file, 'utf8').split('\n');
+  const start = lines.findIndex((line) => line.trim() === 'allowBuilds:');
+
+  if (start < 0) {
+    return;
+  }
+
+  for (const [name, allowed] of entries) {
+    if (lines.some((line) => line.trim().startsWith(`${name}:`))) {
+      continue;
+    }
+
+    let at = start + 1;
+
+    while (
+      at < lines.length &&
+      lines[at].startsWith('  ') &&
+      lines[at].trim() < name
+    ) {
+      at += 1;
+    }
+
+    lines.splice(at, 0, `  ${name}: ${allowed}`);
+  }
+
+  console.log(
+    ` - Allowing the ${Object.keys(store.builds).join(', ')} build in pnpm-workspace.yaml...`
+  );
+  fs.writeFileSync(file, lines.join('\n'));
+};
+
+/**
+ * Ports the sample controllers the templates ship (written for the mongoose
+ * API) to the model API of the selected store. The react template gets its
+ * sample from the scaffold generator, which is adapter aware on its own.
+ *
+ * @param {object} store The selected store (see scripts/adapters.js)
+ * @returns {Promise<void>} Resolves when written
+ */
+const portSample = async (store) => {
+  if (store.api === 'mongoose') {
+    return;
+  }
+
+  const cwd = process.cwd();
+  const controllers = require('./generate/controllers');
+  const home = path.join(cwd, 'app', 'controllers', 'main.js');
+
+  console.log(
+    ` - Porting the sample controllers to the ${store.adapter} store...`
+  );
+
+  if (store.api === 'sequelize' && fs.existsSync(home)) {
+    fs.writeFileSync(
+      home,
+      fs.readFileSync(home, 'utf8').replace('Task.find()', 'Task.findAll()')
+    );
+  }
+
+  if (renderer === 'inertia') {
+    fs.writeFileSync(
+      path.join(cwd, 'app', 'controllers', 'tasks.js'),
+      await format(
+        controllers.inertia({
+          api: store.api,
+          doc: 'Task',
+          lower: 'task',
+          plural: 'tasks',
+        })
+      )
+    );
+  }
+};
+
+/**
+ * What to do before `henri server` when the store needs a database server
+ *
+ * @param {object} store The selected store (see scripts/adapters.js)
+ * @returns {string} A paragraph for the closing message, or an empty string
+ */
+const storeNotice = (store) => {
+  const url = store.store.url || '';
+
+  if (store.adapter === 'disk' || url === '' || url.startsWith('file:')) {
+    return '';
+  }
+
+  return `
+    The "${store.adapter}" store expects a database at ${url}
+    (config/default.json${store.test ? ', config/test.json for henri test' : ''}). Create it, then start the server.
+${store.adapter === 'drizzle' ? '    Migrations: henri db:generate, henri db:migrate, henri db:status.\n' : ''}`;
 };
 
 /**

--- a/packages/cli/scripts/init.js
+++ b/packages/cli/scripts/init.js
@@ -5,7 +5,7 @@ const path = require('path');
 const adapters = require('./adapters');
 const { writeAgentFiles } = require('./agents');
 const { CliError } = require('./errors');
-const { detectPackageManager, format, insideGit, version } = require('./utils');
+const { format, insideGit, packageManagerChoice, version } = require('./utils');
 
 /**
  * Template files written by writeAgentFiles (with the placeholders filled)
@@ -106,9 +106,11 @@ const main = async (args, name) => {
     );
   }
 
-  const pm = detectPackageManager(cwd);
+  const { pm, source } = packageManagerChoice(cwd, args.pm);
 
-  copyTemplate(pm);
+  console.log(` - Using ${pm} (${source})`);
+
+  copyTemplate();
   buildPackage(projectName, store);
   generateConfig(store);
   allowBuilds(store);
@@ -369,10 +371,9 @@ GraphQL, mail and workers.
 /**
  * Copies the template from @usehenri/cli/template
  *
- * @param {string} pm Package manager (pnpm-workspace.yaml is pnpm only)
  * @returns {void}
  */
-const copyTemplate = (pm) => {
+const copyTemplate = () => {
   const cwd = process.cwd();
 
   console.log(' - Copying new directory structure...');
@@ -388,15 +389,14 @@ const copyTemplate = (pm) => {
     );
   }
 
+  // The pnpm-workspace.yaml file is written whatever the package manager:
+  // npm and yarn ignore it, and its absence is what breaks a pnpm install
+  // (ERR_PNPM_IGNORED_BUILDS on the dependencies that need a build script).
   fs.copySync(templatePath, cwd, {
     filter: (src) => {
       const base = path.basename(src);
 
-      if (base === '.gitignore' || AGENT_FILES.includes(base)) {
-        return false;
-      }
-
-      return base !== 'pnpm-workspace.yaml' || pm === 'pnpm';
+      return base !== '.gitignore' && !AGENT_FILES.includes(base);
     },
   });
   fs.moveSync(path.resolve(cwd, 'gitignore'), path.resolve(cwd, '.gitignore'), {
@@ -456,14 +456,14 @@ HENRI_SECRET=${secret}
 
 /**
  * Adds the dependency build scripts the driver of the store needs to
- * pnpm-workspace.yaml (better-sqlite3 compiles a native addon). Nothing to
- * do when the file was not written (yarn, npm).
+ * pnpm-workspace.yaml (better-sqlite3 compiles a native addon).
  *
  * @param {object} store The selected store (see scripts/adapters.js)
  * @returns {void}
  */
 const allowBuilds = (store) => {
   const file = path.join(process.cwd(), 'pnpm-workspace.yaml');
+
   const entries = Object.entries(store.builds);
 
   if (entries.length === 0 || !fs.existsSync(file)) {
@@ -545,22 +545,31 @@ const portSample = async (store) => {
 };
 
 /**
- * What to do before `henri server` when the store needs a database server
+ * What to know about the store before the first `henri server`: where the
+ * database is expected, and how to migrate it when it has migrations
  *
  * @param {object} store The selected store (see scripts/adapters.js)
  * @returns {string} A paragraph for the closing message, or an empty string
  */
 const storeNotice = (store) => {
   const url = store.store.url || '';
-
-  if (store.adapter === 'disk' || url === '' || url.startsWith('file:')) {
-    return '';
-  }
-
-  return `
+  const server =
+    store.adapter !== 'disk' && url !== '' && !url.startsWith('file:')
+      ? `
     The "${store.adapter}" store expects a database at ${url}
     (config/default.json${store.test ? ', config/test.json for henri test' : ''}). Create it, then start the server.
-${store.adapter === 'drizzle' ? '    Migrations: henri db:generate, henri db:migrate, henri db:status.\n' : ''}`;
+`
+      : '';
+  const migrations =
+    store.adapter === 'drizzle'
+      ? `
+    Development pushes the schema on boot. For production, write the first
+    migration and apply it: henri db:generate --name=init && henri db:migrate
+    (henri db:status lists them, henri db:push skips the migration files).
+`
+      : '';
+
+  return `${server}${migrations}`;
 };
 
 /**

--- a/packages/cli/scripts/utils.js
+++ b/packages/cli/scripts/utils.js
@@ -14,37 +14,94 @@ const cwd = process.cwd();
  */
 const check = (file) => fs.existsSync(path.join(process.cwd(), file));
 
+/** The package managers henri knows how to install with */
+const PACKAGE_MANAGERS = ['pnpm', 'yarn', 'npm'];
+
+/** The lockfile each one leaves in a project */
+const LOCKFILES = {
+  'package-lock.json': 'npm',
+  'pnpm-lock.yaml': 'pnpm',
+  'yarn.lock': 'yarn',
+};
+
 /**
- * Detects which package manager is available, preferring pnpm, then yarn, then npm.
- * Honors the packageManager field of the current project when present.
+ * Which package manager to install with, and why
+ *
+ * In order: an explicit choice (`--pm`), the `packageManager` field of the
+ * project, its lockfile, the manager that invoked this process
+ * (`npm_config_user_agent`, set by `pnpm dlx`, `npx`, `yarn dlx` and every
+ * `<pm> run`), then a probe of the binaries. The probe is last because a
+ * version manager shim can answer non-zero outside its own project (mise
+ * exits 1 with "No version is set for shim: pnpm"), which used to hand a
+ * pnpm user a yarn application with no pnpm-workspace.yaml.
  *
  * @param {string} [dir=process.cwd()] Project directory
- * @returns {('pnpm'|'yarn'|'npm')} The package manager binary name
+ * @param {string} [preferred] An explicit choice (--pm)
+ * @returns {{pm: ('pnpm'|'yarn'|'npm'), source: string}} The manager and
+ *   where the answer came from
+ * @throws {CliError} USAGE when `preferred` is not a known manager
  */
-const detectPackageManager = (dir = process.cwd()) => {
+const packageManagerChoice = (dir = process.cwd(), preferred = undefined) => {
+  if (typeof preferred !== 'undefined' && preferred !== null) {
+    const wanted = String(preferred).toLowerCase();
+
+    if (!PACKAGE_MANAGERS.includes(wanted)) {
+      const { CliError } = require('./errors');
+
+      throw new CliError('USAGE', `Unknown package manager '${preferred}'`, {
+        hint: `Valid values: ${PACKAGE_MANAGERS.join(', ')}`,
+      });
+    }
+
+    return { pm: wanted, source: '--pm' };
+  }
+
   try {
-    const pkg = require(path.resolve(dir, 'package.json'));
+    const pkg = fs.readJsonSync(path.resolve(dir, 'package.json'));
     const declared =
       typeof pkg.packageManager === 'string' &&
       pkg.packageManager.split('@')[0];
 
-    if (declared && ['pnpm', 'yarn', 'npm'].includes(declared)) {
-      return declared;
+    if (declared && PACKAGE_MANAGERS.includes(declared)) {
+      return { pm: declared, source: 'the packageManager field' };
     }
   } catch {
     // No package.json yet; fall through to detection
+  }
+
+  for (const [lockfile, name] of Object.entries(LOCKFILES)) {
+    if (fs.existsSync(path.resolve(dir, lockfile))) {
+      return { pm: name, source: lockfile };
+    }
+  }
+
+  const [agent] = String(process.env.npm_config_user_agent || '').split('/');
+
+  if (PACKAGE_MANAGERS.includes(agent)) {
+    return { pm: agent, source: 'npm_config_user_agent' };
   }
 
   for (const candidate of ['pnpm', 'yarn']) {
     const result = spawn.sync(candidate, ['--version'], { stdio: 'ignore' });
 
     if (!result.error && result.status === 0) {
-      return candidate;
+      return { pm: candidate, source: `${candidate} --version` };
     }
   }
 
-  return 'npm';
+  return { pm: 'npm', source: 'the default' };
 };
+
+/**
+ * Which package manager to install with (see packageManagerChoice)
+ *
+ * @param {string} [dir=process.cwd()] Project directory
+ * @param {string} [preferred] An explicit choice (--pm)
+ * @returns {('pnpm'|'yarn'|'npm')} The package manager binary name
+ * @throws {CliError} USAGE when `preferred` is not a known manager
+ */
+const detectPackageManager = (dir = process.cwd(), preferred = undefined) =>
+  packageManagerChoice(dir, preferred).pm;
 
 /**
  * Resolve a module the way `require()` would from a project directory
@@ -59,6 +116,12 @@ const resolveFrom = (name, dir = process.cwd()) =>
 
 /**
  * Resolve the package.json of a package installed in a project
+ *
+ * Three ways, because CommonJS resolution alone is not enough any more: an
+ * ESM-only package whose `exports` map has no `./package.json` and no
+ * `require` condition (`@inertiajs/react`) throws
+ * ERR_PACKAGE_PATH_NOT_EXPORTED on both attempts even though it is
+ * installed, so the last resort reads node_modules from disk.
  *
  * @param {string} name Package name (ex: @usehenri/core)
  * @param {string} [dir=process.cwd()] Project directory to resolve from
@@ -87,10 +150,34 @@ const resolvePackageJson = (name, dir = process.cwd()) => {
       current = path.dirname(current);
     }
   } catch {
-    // Not installed
+    // ESM only, or not installed at all: look on disk
   }
 
-  return null;
+  let current = path.resolve(dir);
+
+  for (;;) {
+    const candidate = path.join(
+      current,
+      'node_modules',
+      ...name.split('/'),
+      'package.json'
+    );
+
+    try {
+      if (fs.existsSync(candidate)) {
+        return fs.readJsonSync(candidate);
+      }
+    } catch {
+      // Unreadable: keep walking up
+    }
+
+    const parent = path.dirname(current);
+
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
 };
 
 /**
@@ -300,6 +387,7 @@ const names = (name) => {
 };
 
 module.exports = {
+  PACKAGE_MANAGERS,
   abort,
   capitalize,
   check,
@@ -311,6 +399,7 @@ module.exports = {
   insideGit,
   isProject,
   names,
+  packageManagerChoice,
   pluralize,
   readConfig,
   readRoutes,

--- a/packages/cli/template/default/AGENTS.md
+++ b/packages/cli/template/default/AGENTS.md
@@ -1,8 +1,8 @@
 # {{name}}: conventions for coding agents
 
 A [henri](https://usehenri.io) application: Rails-like MVC for Node.js, CommonJS
-on the server, renderer `{{renderer}}`. Follow these rules instead of guessing;
-`henri doctor` checks most of them, the `henri` MCP server answers the rest.
+on the server, renderer `{{renderer}}`, store `{{adapter}}`. Follow these rules instead of
+guessing; `henri doctor` checks most of them, the `henri` MCP server answers the rest.
 
 ## Layout and naming
 
@@ -51,12 +51,16 @@ module.exports = {
 ```
 
 Field keys: `type`, `required`, `default`, `enum`, `unique`, `index`; any other
-key is handed to the adapter as is (Mongoose options on `disk` and `mongoose`
-stores, Sequelize attribute options on `mysql`, `postgresql`, `mssql`). The
-global is the ORM model: Mongoose (`find`, `findById`, `create`,
-`findByIdAndUpdate`, `findByIdAndDelete`) on `disk`/`mongoose`, Sequelize
-(`findAll`, `findByPk`) on SQL stores, its own Rails-like model on `drizzle`
-stores (`henri db:generate|migrate|push|status` migrations). Scaffold: Mongoose.
+key is handed to the adapter as is. The global is the model of the `{{adapter}}`
+store, and what the generators write: {{#if mongoose}}Mongoose (`find().skip().limit()`,
+`countDocuments`, `findById`, `create`, `findByIdAndUpdate`, `findByIdAndDelete`),
+documents carry `_id`.{{/if}}{{#if drizzle}}the drizzle model (`where`, `order`, `include`,
+`query().offset().limit()`, `count`, `findById`, `create`, `findByIdAndUpdate`,
+`findByIdAndDelete`), rows carry `id`. Migrations live in `db/migrations`:
+`henri db:generate|migrate|push|status`, generate and commit one after a model change.{{/if}}{{#if sequelize}}Sequelize
+(`findAll`, `findByPk`, `count`, `create`, then `row.update()` and
+`row.destroy()`), rows carry `id`. There are no migrations: the boot runs
+`sequelize.sync()` and creates or extends the tables from the models.{{/if}}
 
 ## Controllers
 

--- a/packages/cli/template/default/pnpm-workspace.yaml
+++ b/packages/cli/template/default/pnpm-workspace.yaml
@@ -1,7 +1,8 @@
 # pnpm 10+ only runs dependency build scripts that are allow-listed, and pnpm 11
 # fails the install when it meets one that is not listed. Allow the ones an
 # henri app needs (sass file watching, local MongoDB binary) and warn about the
-# rest instead of failing.
+# rest instead of failing. npm and yarn ignore this file, so henri new always
+# writes it: a pnpm install later works without an ERR_PNPM_IGNORED_BUILDS.
 strictDepBuilds: false
 allowBuilds:
   '@apollo/protobufjs': false

--- a/packages/cli/template/inertia/app/views/pages/tasks/index.jsx
+++ b/packages/cli/template/inertia/app/views/pages/tasks/index.jsx
@@ -30,10 +30,13 @@ export default function TasksIndex() {
 
       <ul>
         {tasks.map((task) => (
-          <li key={task._id}>
+          <li key={String(task._id ?? task.id)}>
             {task.name} ({task.category}){' '}
             <Form
-              action={pathFor('destroy_tasks_path', String(task._id))}
+              action={pathFor(
+                'destroy_tasks_path',
+                String(task._id ?? task.id)
+              )}
               method="delete"
             >
               <button type="submit">remove</button>

--- a/packages/cli/template/inertia/eslint.config.js
+++ b/packages/cli/template/inertia/eslint.config.js
@@ -4,16 +4,29 @@ const js = require('@eslint/js');
 const react = require('eslint-plugin-react');
 const globals = require('globals');
 
-// henri writes the global model ids (User, Task, ...) to .henri/globals.json
-// on boot so the linter knows about them.
-let modelGlobals = {};
+// Models are globals (User, Task, ...). Their names come from the files in
+// app/models, plus whatever henri recorded in .henri/globals.json on boot.
+const modelGlobals = {};
 
 try {
-  modelGlobals = JSON.parse(
-    fs.readFileSync(path.join(__dirname, '.henri', 'globals.json'), 'utf8')
+  for (const file of fs.readdirSync(path.join(__dirname, 'app', 'models'))) {
+    if (file.endsWith('.js')) {
+      modelGlobals[path.basename(file, '.js')] = true;
+    }
+  }
+} catch {
+  // No app/models directory yet
+}
+
+try {
+  Object.assign(
+    modelGlobals,
+    JSON.parse(
+      fs.readFileSync(path.join(__dirname, '.henri', 'globals.json'), 'utf8')
+    )
   );
 } catch {
-  // No models loaded yet, nothing to declare
+  // Nothing recorded yet
 }
 
 const henriGlobals = Object.fromEntries(
@@ -37,6 +50,7 @@ module.exports = [
       'config/**/*.js',
       'test/**/*.js',
       'eslint.config.js',
+      'vitest.config.js',
     ],
     ignores: ['app/views/**'],
     languageOptions: {
@@ -46,6 +60,15 @@ module.exports = [
         ...globals.node,
         ...henriGlobals,
         henri: 'readonly',
+      },
+    },
+  },
+  {
+    // Tests run by `henri test` (vitest globals: describe, test, expect, vi)
+    files: ['test/**/*.js'],
+    languageOptions: {
+      globals: {
+        ...(globals.vitest || globals.jest),
       },
     },
   },

--- a/packages/cli/template/inertia/pnpm-workspace.yaml
+++ b/packages/cli/template/inertia/pnpm-workspace.yaml
@@ -1,7 +1,8 @@
 # pnpm 10+ only runs dependency build scripts that are allow-listed, and pnpm 11
 # fails the install when it meets one that is not listed. Allow the ones an
 # henri app needs (sass file watching, local MongoDB binary) and warn about the
-# rest instead of failing.
+# rest instead of failing. npm and yarn ignore this file, so henri new always
+# writes it: a pnpm install later works without an ERR_PNPM_IGNORED_BUILDS.
 strictDepBuilds: false
 allowBuilds:
   '@apollo/protobufjs': false

--- a/packages/cli/template/inertia/test/tasks.test.js
+++ b/packages/cli/template/inertia/test/tasks.test.js
@@ -1,0 +1,77 @@
+// Runs with `henri test`: setup() boots henri under NODE_ENV=test and
+// request() is a supertest agent bound to the running server.
+//
+// A request carrying `X-Inertia: true` gets the page object Inertia's client
+// consumes, `{ component, props: { data, errors, csrf, user, paths }, url,
+// version }`, instead of the HTML document a browser gets. The client is
+// loaded with an asset version and sends it back on every visit: a GET whose
+// `X-Inertia-Version` does not match answers `409` so the browser reloads,
+// which is why the version is read once below.
+const { request, setup } = require('@usehenri/testing');
+
+let version = '';
+
+/**
+ * The Inertia page object of a path
+ *
+ * @param {string} path The path to request
+ * @returns {object} The supertest request
+ */
+const page = (path) =>
+  request()
+    .get(path)
+    .set('X-Inertia', 'true')
+    .set('X-Inertia-Version', version);
+
+describe('tasks', () => {
+  beforeAll(async () => {
+    await setup();
+
+    const probe = await request().get('/tasks').set('X-Inertia', 'true');
+
+    version = probe.headers['x-inertia-version'] || '';
+  });
+
+  test('GET /tasks renders the tasks page with its data', async () => {
+    const response = await page('/tasks');
+
+    expect(response.status).toBe(200);
+    expect(response.body.component).toBe('tasks/index');
+    expect(response.body.props.data.tasks).toEqual(expect.any(Array));
+    expect(response.body.props.errors).toEqual({});
+  });
+
+  test('GET / answers a document to a browser', async () => {
+    const response = await request().get('/');
+
+    expect(response.status).toBe(200);
+    expect(response.headers['content-type']).toContain('text/html');
+  });
+
+  test('POST /tasks creates a task and redirects to the list', async () => {
+    const before = (await page('/tasks')).body.props.data.tasks.length;
+    const response = await request()
+      .post('/tasks')
+      .set('X-Inertia', 'true')
+      .send({ category: 'high', name: 'Write a test' });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.location).toBe('/tasks');
+
+    const tasks = (await page('/tasks')).body.props.data.tasks;
+
+    expect(tasks).toHaveLength(before + 1);
+    expect(tasks.map((task) => task.name)).toContain('Write a test');
+  });
+
+  test('POST /tasks without a name renders the page with an error', async () => {
+    const response = await request()
+      .post('/tasks')
+      .set('X-Inertia', 'true')
+      .send({ category: 'high' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.component).toBe('tasks/index');
+    expect(response.body.props.errors.name).toEqual(expect.any(String));
+  });
+});

--- a/packages/mcp/src/app.js
+++ b/packages/mcp/src/app.js
@@ -260,9 +260,9 @@ class App {
   }
 
   /**
-   * The application name and renderer
+   * The application name, renderer and default store adapter
    *
-   * @returns {{name: string, renderer: string}} Identity
+   * @returns {{name: string, renderer: string, adapter: string}} Identity
    */
   identity() {
     let name = path.basename(this.cwd);
@@ -277,7 +277,11 @@ class App {
 
     const config = this.cli.utils.readConfig(this.cwd, undefined);
 
+    const stores = (config && config.stores) || {};
+    const store = stores.default || Object.values(stores)[0] || {};
+
     return {
+      adapter: String(store.adapter || 'disk').toLowerCase(),
       name,
       renderer: String(config.renderer || 'react').toLowerCase(),
     };

--- a/website/src/content/docs/getting-started.md
+++ b/website/src/content/docs/getting-started.md
@@ -31,7 +31,7 @@ cd my-app
 henri server
 ```
 
-`henri new` copies the application skeleton, writes the configuration, scaffolds a sample `Task` resource, writes a README, runs `git init` (unless the folder is already inside a repository) and installs the dependencies. `--skip-install` and `--no-git` skip those two steps; `--renderer inertia` picks the [Inertia](/guides/views/#inertia) view engine instead of React. The result:
+`henri new` copies the application skeleton, writes the configuration, scaffolds a sample `Task` resource, writes a README, runs `git init` (unless the folder is already inside a repository) and installs the dependencies. `--skip-install` and `--no-git` skip those two steps; `--renderer inertia` picks the [Inertia](/guides/views/#inertia) view engine instead of React, and `--adapter drizzle|mongoose|mysql|postgresql|mssql` the [store](/guides/models/#adapters) instead of the default `disk` one. The result:
 
 ```text
 ├── .env                      <- HENRI_SECRET, ignored by git
@@ -70,6 +70,19 @@ henri server
 If you have a Ruby on Rails background, this should look familiar. The sample resource is a regular scaffold (`henri generate scaffold Task name:string! category:string done:boolean` writes the same files); `henri destroy scaffold Task` removes it.
 
 `config/default.json` is committed and holds no secret: the session secret is generated into `.env` as `HENRI_SECRET`, which henri reads on boot. The default store is the [disk adapter](/guides/models/#disk), a local MongoDB persisted under `.henri/data` (ignored by git too), so there is nothing to install to run the application.
+
+### Another database
+
+`--adapter` picks the store of the new application. The sample resource, the dependencies and `config/default.json` follow it, and a `config/test.json` is written so `henri test` runs on its own database.
+
+```bash
+henri new my-app --adapter drizzle                     # sqlite, file:.henri/app.db
+henri new my-app --adapter drizzle --dialect postgres  # or mysql
+henri new my-app --adapter postgresql                  # sequelize
+henri new my-app --adapter mongoose                    # a MongoDB server
+```
+
+`drizzle` is the [Drizzle ORM adapter](/guides/models/#drizzle): sqlite by default, so a new application still boots with no database to install, and it is the only one with migrations (`henri db:generate`, `db:migrate`, `db:push`, `db:status`). The other adapters expect a server running at the url written in `config/default.json`.
 
 ## Start coding
 

--- a/website/src/content/docs/getting-started.md
+++ b/website/src/content/docs/getting-started.md
@@ -8,7 +8,7 @@ sidebar:
 ## Requirements
 
 - Node.js 22 or newer
-- A package manager: pnpm, npm or yarn. `henri new` uses the one it finds (the `packageManager` field of an existing `package.json`, then pnpm, yarn, npm).
+- A package manager: pnpm, npm or yarn. `henri new` uses the one it finds (the `packageManager` field of an existing `package.json`, its lockfile, then the manager that ran the command, then a probe) and prints its choice; `--pm pnpm|yarn|npm` forces it.
 
 :::note
 henri was revived in 2026 on a modern toolchain (Node 22+, Express 5, Next.js 16, React 19, Mongoose 9, Sequelize 6). Releases published before 1.0 still target Node 10 to 14. If you have an application written for henri 0.37, read [Upgrading](/upgrading/).
@@ -60,7 +60,7 @@ henri server
 │   └── routes.js             <- 'get /': 'main#home', 'resources tasks': 'tasks'
 ├── eslint.config.js
 ├── package.json
-├── pnpm-workspace.yaml       <- written for pnpm only
+├── pnpm-workspace.yaml       <- allowBuilds for pnpm; npm and yarn ignore it
 ├── README.md
 ├── test
 │   └── tasks.test.js         <- run with `henri test`

--- a/website/src/content/docs/guides/models.md
+++ b/website/src/content/docs/guides/models.md
@@ -104,9 +104,16 @@ await Task.create(req.permit('name', 'category'));
 await Task.findAll({ where: { done: false } });
 await Task.findByPk(id);
 await Task.create(req.permit('name', 'category'));
+
+// Drizzle (drizzle), which also answers to the two sets of names above
+await Task.where({ done: false }).order('createdAt desc');
+await Task.findById(id);
+await Task.create(req.permit('name', 'category'));
 ```
 
 Use [`req.permit()`](/guides/controllers/#reqpermitfields) rather than `req.body` when you create or update records.
+
+`henri generate scaffold|crud` reads the adapter of the default store from `config/default.json` and writes the controller against that API, so the sample resource of `henri new --adapter <name>` runs on the store it configured.
 
 ## The user model
 
@@ -132,7 +139,7 @@ Server side, `henri.user.findByEmail(email)` (lowercases its argument and return
 
 ## Adapters
 
-Each adapter is a package to install in the application; the name in `stores.<name>.adapter` selects it. All of them implement the same contract, documented in the [API reference](/reference/api/#store-adapters), and expose a few helpers on the store object, `henri.model.stores.<name>`:
+Each adapter is a package to install in the application; the name in `stores.<name>.adapter` selects it. `henri new <folder> --adapter disk|drizzle|mongoose|mysql|postgresql|mssql` (`--dialect sqlite|postgres|mysql` with `drizzle`) writes the store block, the dependencies and the driver of a new application; `disk` is the default. All of them implement the same contract, documented in the [API reference](/reference/api/#store-adapters), and expose a few helpers on the store object, `henri.model.stores.<name>`:
 
 ```js
 await henri.model.stores.default.ping(); // true when the database answers
@@ -231,11 +238,13 @@ pnpm add @usehenri/mssql
 
 ### Drizzle
 
-An SQL adapter on [Drizzle ORM](https://orm.drizzle.team/) with migrations, for sqlite, PostgreSQL and MySQL. It is the adapter henri intends to make the SQL default; the Sequelize-based ones stay supported. Install it with the driver of your dialect:
+An SQL adapter on [Drizzle ORM](https://orm.drizzle.team/) with migrations, for sqlite, PostgreSQL and MySQL. It is the adapter henri intends to make the SQL default; the Sequelize-based ones stay supported. `henri new my-app --adapter drizzle` scaffolds an application on it (sqlite by default, `--dialect postgres` or `--dialect mysql` for the others), or install it in an existing one with the driver of your dialect:
 
 ```bash
 pnpm add @usehenri/drizzle better-sqlite3   # or pg, or mysql2
 ```
+
+`better-sqlite3` compiles a native addon, so a pnpm application also needs `better-sqlite3: true` under `allowBuilds` in `pnpm-workspace.yaml` (`henri new` writes it).
 
 ```json
 {

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -31,8 +31,8 @@ henri <command> [options]
 ## `new` and `init`
 
 ```bash
-henri new <folder> [--force | -f] [--skip-install] [--no-git] [--renderer react|inertia] [--adapter <name>] [--dialect <name>]
-henri init [--force | -f] [--skip-install] [--no-git] [--renderer react|inertia] [--adapter <name>] [--dialect <name>]
+henri new <folder> [--force | -f] [--skip-install] [--no-git] [--renderer react|inertia] [--adapter <name>] [--dialect <name>] [--pm pnpm|yarn|npm]
+henri init [--force | -f] [--skip-install] [--no-git] [--renderer react|inertia] [--adapter <name>] [--dialect <name>] [--pm pnpm|yarn|npm]
 ```
 
 `new` creates the folder and runs `init` in it; it refuses a non-empty folder without `--force`, and `init` refuses a directory that already has an `app` folder. The project is named after the folder. Both:
@@ -42,7 +42,17 @@ henri init [--force | -f] [--skip-install] [--no-git] [--renderer react|inertia]
 3. with the React renderer, scaffold the sample `Task` resource (model, controller, `resources tasks` route, pages and `test/tasks.test.js`) against the model API of the adapter;
 4. write a README (an existing one is renamed `README.old.md`);
 5. run `git init` unless `--no-git` is given, the folder is already inside a repository, or git is missing;
-6. install the dependencies with the detected package manager (the `packageManager` field, then pnpm, yarn, npm) unless `--skip-install` is given. `pnpm-workspace.yaml`, which allows the build scripts pnpm needs, is only written for pnpm.
+6. install the dependencies with the package manager of `--pm`, or the detected one, unless `--skip-install` is given.
+
+### `--pm`
+
+`pnpm`, `yarn` or `npm`. Without it, the manager is, in order: the `packageManager` field of an existing `package.json`, its lockfile, `npm_config_user_agent` (the manager that ran the command, set by `pnpm dlx`, `npx`, `yarn dlx` and every `<pm> run`), then a probe of `pnpm --version` and `yarn --version`, `npm` otherwise. The command prints the manager it picked and why, so a wrong guess is visible:
+
+```text
+ - Using pnpm (npm_config_user_agent)
+```
+
+The probe comes last on purpose: a version manager shim (mise, asdf) answers non-zero for `pnpm --version` outside a project it manages, which used to make `henri new` fall back to yarn on a pnpm machine. `pnpm-workspace.yaml`, which allow-lists the dependency build scripts pnpm 11 refuses to run silently, is written whatever the manager is: npm and yarn ignore the file.
 
 ### `--adapter`
 

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -31,18 +31,35 @@ henri <command> [options]
 ## `new` and `init`
 
 ```bash
-henri new <folder> [--force | -f] [--skip-install] [--no-git] [--renderer react|inertia]
-henri init [--force | -f] [--skip-install] [--no-git] [--renderer react|inertia]
+henri new <folder> [--force | -f] [--skip-install] [--no-git] [--renderer react|inertia] [--adapter <name>] [--dialect <name>]
+henri init [--force | -f] [--skip-install] [--no-git] [--renderer react|inertia] [--adapter <name>] [--dialect <name>]
 ```
 
 `new` creates the folder and runs `init` in it; it refuses a non-empty folder without `--force`, and `init` refuses a directory that already has an `app` folder. The project is named after the folder. Both:
 
 1. copy the template of the renderer (`react` by default, `-r` is short for `--renderer`) and merge an existing `package.json` into the generated one (dependencies, scripts and name are kept);
-2. write `config/default.json` (`baseRole`, `renderer`, a `disk` default store, `user: "user"`) and `.env` with a random `HENRI_SECRET`;
-3. with the React renderer, scaffold the sample `Task` resource (model, controller, `resources tasks` route, pages and `test/tasks.test.js`);
+2. write `config/default.json` (`baseRole`, `renderer`, the store of `--adapter`, `user: "user"`), `config/test.json` when that store needs a database of its own, and `.env` with a random `HENRI_SECRET`;
+3. with the React renderer, scaffold the sample `Task` resource (model, controller, `resources tasks` route, pages and `test/tasks.test.js`) against the model API of the adapter;
 4. write a README (an existing one is renamed `README.old.md`);
 5. run `git init` unless `--no-git` is given, the folder is already inside a repository, or git is missing;
 6. install the dependencies with the detected package manager (the `packageManager` field, then pnpm, yarn, npm) unless `--skip-install` is given. `pnpm-workspace.yaml`, which allows the build scripts pnpm needs, is only written for pnpm.
+
+### `--adapter`
+
+| Value        | Store written in `config/default.json`                                       | Dependencies added                    |
+| ------------ | ---------------------------------------------------------------------------- | ------------------------------------- |
+| `disk`       | `{ "adapter": "disk" }` (default): a local MongoDB, nothing to install       | `@usehenri/disk`                      |
+| `drizzle`    | `{ "adapter": "drizzle", "dialect": "sqlite", "url": "file:.henri/app.db" }` | `@usehenri/drizzle`, `better-sqlite3` |
+| `mongoose`   | `mongodb://127.0.0.1:27017/<app>`                                            | `@usehenri/mongoose`                  |
+| `mysql`      | `mysql://root@127.0.0.1:3306/<app>`                                          | `@usehenri/mysql`                     |
+| `postgresql` | `postgres://postgres@127.0.0.1:5432/<app>`                                   | `@usehenri/postgresql`                |
+| `mssql`      | `mssql://sa@127.0.0.1:1433/<app>`                                            | `@usehenri/mssql`                     |
+
+Every adapter but `disk` also gets a `config/test.json` on its own database (`<app>_test`, or `:memory:` for drizzle on sqlite), because `config/<NODE_ENV>.json` replaces `config/default.json` as a whole. The generated controllers use the model API of the adapter: Mongoose on `disk` and `mongoose`, Sequelize on `mysql`, `postgresql` and `mssql`, the [Drizzle](/guides/models/#drizzle) model on `drizzle`. `henri generate scaffold|crud` reads the adapter back from the configuration, so later generators match too.
+
+### `--dialect`
+
+Only with `--adapter drizzle`: `sqlite` (the default, `better-sqlite3`, `file:.henri/app.db`), `postgres` (`pg`) or `mysql` (`mysql2`). A drizzle application has migrations, so the README it gets mentions `henri db:generate`, `henri db:migrate`, `henri db:push` and `henri db:status` (see [`db`](#db)). Any other value, or `--dialect` without `--adapter drizzle`, exits with `2`.
 
 See [Getting started](/getting-started/) for the resulting tree.
 


### PR DESCRIPTION
`henri new` and `henri init` take `--adapter disk|drizzle|mongoose|mysql|postgresql|mssql`, with `--dialect sqlite|postgres|mysql` for Drizzle. `disk` stays the default, so existing behaviour is unchanged.

A new catalogue in the CLI is the single source for each adapter: its model API, the packages a store needs, the store block written into the config, and the pnpm build allowance a driver requires. The scaffolder, doctor, the agent file writer and the generators all read it instead of hard-coding the disk adapter. Every adapter except disk also gets a test config on its own database, since a per-environment config replaces the default one wholesale.

The generated controllers now follow the adapter of the default store: the Mongoose flavour is byte-identical to before, and there are Sequelize and Drizzle flavours with the right query, update and error handling. A malformed id is a 404 rather than a 500 on Sequelize.

**Three first-run bugs found during the Inertia browser pass, fixed here.**

- The package manager was picked by probing, so on a machine using mise the pnpm shim exits non-zero outside a project, yarn classic won, and the pnpm workspace file was never written. The first `pnpm install` then failed. Selection is now explicit `--pm`, then the manifest field, then the lockfile, then the invoking manager, then probing, and the choice is printed. The workspace file is written whatever the manager is, since npm and yarn ignore it and its absence is the actual failure.
- A fresh Inertia app had no tests, so `henri test` exited 1. The template now ships a test for the sample resource. Its lint config was also missing the model and test globals, so `pnpm lint` failed on a fresh Inertia app.
- `henri doctor` reported the Inertia client as missing on every Inertia app. It resolved packages through CommonJS and that client is ESM-only, so the check always threw. It now falls back to reading the manifest from disk.

Verified by scaffolding real apps from packed tarballs and running doctor, lint, test, build and a production boot with curl: React with Drizzle on sqlite through the full migration and CRUD cycle including HAL links and a 422, React with disk unchanged, and Inertia on both. Live MongoDB, MySQL, PostgreSQL and MSSQL servers were not available, so those adapters are covered at the scaffold level plus the generated Sequelize controller against a fake model.

One thing to know: a Drizzle app must run `henri db:generate` and `henri db:migrate` before a production boot, because the adapter only pushes the schema outside production. That is said in the closing message of `henri new`, the generated README and the agent file.