### PR TITLE
Lint the scaffolded db/seeds.js as server code

### DIFF
--- a/packages/cli/template/default/eslint.config.js
+++ b/packages/cli/template/default/eslint.config.js
@@ -51,6 +51,7 @@ module.exports = [
     files: [
       'app/**/*.js',
       'config/**/*.js',
+      'db/**/*.js',
       'test/**/*.js',
       'eslint.config.js',
       'vitest.config.js',

--- a/packages/cli/template/inertia/eslint.config.js
+++ b/packages/cli/template/inertia/eslint.config.js
@@ -48,6 +48,7 @@ module.exports = [
     files: [
       'app/**/*.js',
       'config/**/*.js',
+      'db/**/*.js',
       'test/**/*.js',
       'eslint.config.js',
       'vitest.config.js',


### PR DESCRIPTION
The scaffolded `db/seeds.js` added in #315 was not covered by any block of the generated `eslint.config.js`, so a fresh app failed its own `pnpm lint` with `'module' is not defined`. The Scaffold job caught it on #315, which merged anyway because that job is not a required check. `db/**/*.js` now sits with the other server-side CommonJS files in both templates. Verified by running `scripts/smoke.sh`, the same script CI runs: scaffold, install, lint, build, production boot and a 200.