### PR TITLE
Do not assume row order in the soft delete tests

### DIFF
--- a/packages/drizzle/__tests__/paranoid.spec.js
+++ b/packages/drizzle/__tests__/paranoid.spec.js
@@ -108,7 +108,9 @@ describe('timestamps, soft deletes and paginate (sqlite in memory)', () => {
       await gone.restore();
 
       expect(gone.deletedAt).toBeNull();
-      expect(await Task.pluck('name')).toEqual([kept.name, gone.name]);
+      expect((await Task.pluck('name')).sort()).toEqual(
+        [kept.name, gone.name].sort()
+      );
     });
 
     test('mass destroy and restore work on a condition', async () => {
@@ -117,7 +119,8 @@ describe('timestamps, soft deletes and paginate (sqlite in memory)', () => {
       expect(await Task.destroy({ name: ['one', 'two'] })).toBe(2);
       expect(await Task.pluck('name')).toEqual(['three']);
       expect(await Task.restore({ name: 'one' })).toBe(1);
-      expect(await Task.pluck('name')).toEqual(['one', 'three']);
+      // No ORDER BY: postgres is free to hand the rows back in any order
+      expect((await Task.pluck('name')).sort()).toEqual(['one', 'three']);
     });
 
     test('force deletes for real, soft deleted rows included', async () => {


### PR DESCRIPTION
Two assertions in the soft delete spec added by #315 compared plucked rows to a literal array without an `ORDER BY`. sqlite happened to return insertion order, PostgreSQL does not, so the Live PostgreSQL job failed on #315 with `expected [ 'three', 'one' ] to deeply equal [ 'one', 'three' ]`. Both assertions now sort before comparing, which is what they meant to check. Verified against a real `postgres:17` container: the SQL suites pass, 156 tests.