### PR TITLE
Docker compose for the local databases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,9 @@ pnpm format                           # prettier 3 (`pnpm format:check` in CI)
 pnpm build                            # rollup build of @usehenri/react
 pnpm --filter @usehenri/website dev   # docs site (Astro + Starlight); `build` and `preview` too
 scripts/smoke.sh                      # scaffold an app from the packed workspace and boot it
+pnpm db:up                            # postgres, mysql and mongo for local dev (compose.yaml)
+pnpm test:sql:live                    # the SQL suites against the live postgres, then mysql
+pnpm db:down                          # stop them (`db:reset` also deletes the data)
 pnpm changeset                        # record a version bump for changed packages
 ```
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,72 @@
+# Databases for local development, mirroring the service containers the
+# `Live PostgreSQL` and `Live MySQL` jobs of .github/workflows/ci.yml use, so
+# that a local run and CI exercise the same servers and versions.
+#
+#   pnpm db:up             start them and wait until they answer
+#   pnpm test:sql:live     the SQL suites against postgres, then against mysql
+#   pnpm test:sql:postgres one of the two on its own
+#   pnpm db:down           stop them, keeping the data
+#   pnpm db:reset          stop them and delete the data
+#
+# Nothing else in the repository needs Docker: `pnpm test` runs on sqlite and
+# an in-process MongoDB, offline. The host ports can be moved when something
+# else already listens on them:
+#
+#   HENRI_POSTGRES_PORT=55432 HENRI_MYSQL_PORT=53306 pnpm db:up
+
+name: henri
+
+services:
+  postgres:
+    image: postgres:17
+    environment:
+      POSTGRES_USER: henri
+      POSTGRES_PASSWORD: henri
+      POSTGRES_DB: henri_test
+    ports:
+      - '${HENRI_POSTGRES_PORT:-5432}:5432'
+    volumes:
+      - postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U henri -d henri_test']
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  mysql:
+    image: mysql:8
+    environment:
+      MYSQL_ROOT_PASSWORD: henri
+      MYSQL_DATABASE: henri_test
+    ports:
+      - '${HENRI_MYSQL_PORT:-3306}:3306'
+    volumes:
+      - mysql:/var/lib/mysql
+    healthcheck:
+      test: ['CMD-SHELL', 'mysqladmin ping -h 127.0.0.1 -uroot -phenri']
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  # The adapter henri apps use for MongoDB. The test suite does not need it
+  # (@usehenri/disk starts an in-process server), but an app configured with
+  # `"adapter": "mongoose"` can point at this one.
+  # Pinned to 7: mongo:8 refuses to start on Linux kernels 6.19 and newer,
+  # which is what recent Docker Desktop VMs run (MongoDB SERVER-121912).
+  mongo:
+    image: mongo:7
+    ports:
+      - '${HENRI_MONGO_PORT:-27017}:27017'
+    volumes:
+      - mongo:/data/db
+    healthcheck:
+      test:
+        ['CMD-SHELL', 'mongosh --quiet --eval "db.adminCommand({ ping: 1 })"']
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+volumes:
+  postgres:
+  mysql:
+  mongo:

--- a/package.json
+++ b/package.json
@@ -19,9 +19,15 @@
     "test:cover": "vitest run --coverage",
     "test:ci": "vitest run --coverage",
     "test:sql": "vitest run --project sequelize --project mysql --project postgresql --project mssql --project drizzle",
+    "test:sql:mysql": "HENRI_TEST_SQL_DIALECT=mysql HENRI_TEST_MYSQL_URL=mysql://root:henri@127.0.0.1:${HENRI_MYSQL_PORT:-3306}/henri_test vitest run --project sequelize --project mysql --project postgresql --project mssql --project drizzle",
+    "test:sql:postgres": "HENRI_TEST_SQL_DIALECT=postgres HENRI_TEST_POSTGRES_URL=postgres://henri:henri@127.0.0.1:${HENRI_POSTGRES_PORT:-5432}/henri_test vitest run --project sequelize --project mysql --project postgresql --project mssql --project drizzle",
+    "test:sql:live": "pnpm test:sql:postgres && pnpm test:sql:mysql",
     "changeset": "changeset",
     "changeset:version": "changeset version",
-    "changeset:publish": "pnpm sync-readme && pnpm build && changeset publish"
+    "changeset:publish": "pnpm sync-readme && pnpm build && changeset publish",
+    "db:up": "docker compose up --detach --wait",
+    "db:down": "docker compose down",
+    "db:reset": "docker compose down --volumes"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^1.0.0",


### PR DESCRIPTION
Running the SQL suites against a real server meant hand-rolling `docker run` commands. A `compose.yaml` at the root now provides PostgreSQL, MySQL and MongoDB, mirroring the image versions, credentials and health checks the `Live PostgreSQL` and `Live MySQL` jobs use, so a local run and CI exercise the same servers.

```bash
pnpm db:up             # start them and wait until they answer
pnpm test:sql:live     # the SQL suites against postgres, then against mysql
pnpm db:down           # stop them, keeping the data (db:reset drops it)
```

Nothing else needs Docker: `pnpm test` still runs on sqlite and an in-process MongoDB, offline.

Two details worth knowing.

`test:sql:live` runs the two dialects one after the other rather than setting both connection strings at once. The suites pick the first configured dialect they find, so setting both would have silently tested only PostgreSQL.

MongoDB is pinned to 7 because 8 refuses to start on Linux kernels 6.19 and newer, which is what recent Docker Desktop virtual machines run. The comment in the file links the upstream issue. The suite does not need it, since the disk adapter starts its own in-process server; it is there for an app configured with the Mongoose adapter.

Host ports are overridable for machines already running one of these servers. Verified end to end: the stack comes up healthy, both dialects pass at 156 tests each, and the stack tears down cleanly.