### PR TITLE
Generated controllers use Model.paginate and the shared error normalizer

### DIFF
--- a/packages/cli/__tests__/adapters.spec.js
+++ b/packages/cli/__tests__/adapters.spec.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 
 const { hooksFor } = require('@usehenri/core/src/base/hooks');
+const { modelErrors } = require('@usehenri/core/src/base/model-errors');
 
 const { version } = require('../package.json');
 const { cleanup, exists, henri, read, tmpdir } = require('./helpers');
@@ -264,12 +265,10 @@ describe('the scaffolded resource follows the adapter', () => {
     cleanup(dir);
   });
 
-  test('drizzle: a relation for the page, no cast guard', () => {
+  test('drizzle: findById without a cast guard, instances destroy themselves', () => {
     const { app } = scaffoldWith(dir, 'dz', ['--adapter', 'drizzle']);
     const controller = read(app, 'app/controllers/tasks.js');
 
-    expect(controller).toContain('Task.query().offset(skip).limit(limit)');
-    expect(controller).toContain('Task.count()');
     // The before hook loads the record; findById() already answers null for
     // a malformed id, so there is no cast to guard
     expect(controller).toContain(
@@ -281,11 +280,10 @@ describe('the scaffolded resource follows the adapter', () => {
     expect(read(app, 'app/controllers/main.js')).toContain('Task.find()');
   });
 
-  test('sequelize: findAll, findByPk and instance updates', () => {
+  test('sequelize: findByPk and instance updates', () => {
     const { app } = scaffoldWith(dir, 'pg', ['--adapter', 'postgresql']);
     const controller = read(app, 'app/controllers/tasks.js');
 
-    expect(controller).toContain('Task.findAll({ limit, offset: skip })');
     expect(controller).toContain('Task.findByPk(id)');
     expect(controller).toContain('task.update(req.permit(...FIELDS))');
     expect(controller).toContain('task.destroy()');
@@ -294,23 +292,50 @@ describe('the scaffolded resource follows the adapter', () => {
     expect(read(app, 'app/controllers/main.js')).toContain('Task.findAll()');
   });
 
-  test('mongoose: the scaffold is unchanged', () => {
+  test('mongoose: the cast guard and the document methods', () => {
     const { app } = scaffoldWith(dir, 'mg', ['--adapter', 'mongoose']);
     const controller = read(app, 'app/controllers/tasks.js');
 
-    expect(controller).toContain('Task.find().skip(skip).limit(limit)');
-    expect(controller).toContain('Task.countDocuments()');
+    expect(controller).toContain('byId(Task.findById(req.params.id))');
+    expect(controller).toContain('req.task.set(req.permit(...FIELDS))');
+    expect(controller).toContain('req.task.deleteOne()');
     expect(controller).toContain('CastError');
+  });
+
+  test('the index and the 422 are the same code on the three flavours', () => {
+    const generator = require('../scripts/generate/controllers');
+    const resource = {
+      doc: 'Task',
+      keys: ['name'],
+      lower: 'task',
+      plural: 'tasks',
+    };
+    const written = ['drizzle', 'mongoose', 'sequelize'].map((api) =>
+      generator.resources({ ...resource, api })
+    );
+
+    for (const code of written) {
+      // Model.paginate() and henri.model.errors() answer the same shape on
+      // every adapter, so neither needs a flavour
+      expect(code).toContain(
+        'await Task.paginate(\n      req.pagination()\n    )'
+      );
+      expect(code).toContain('const errors = henri.model.errors(error);');
+      expect(code).not.toContain('countDocuments()');
+      expect(code).not.toContain('req.pagination();');
+    }
   });
 
   test('the generators read the adapter back from the configuration', () => {
     const { app } = scaffoldWith(dir, 'gen', ['--adapter', 'drizzle']);
     const { status } = henri(['g', 'crud', 'Note', 'body:text'], { cwd: app });
+    const controller = read(app, 'app/controllers/notes.js');
 
     expect(status).toBe(0);
-    expect(read(app, 'app/controllers/notes.js')).toContain(
-      'Note.query().offset(skip).limit(limit)'
+    expect(controller).toContain(
+      'req.note = await Note.findById(req.params.id)'
     );
+    expect(controller).not.toContain('CastError');
   });
 
   test('AGENTS.md and the README describe the store', () => {
@@ -320,7 +345,7 @@ describe('the scaffolded resource follows the adapter', () => {
     expect(agents).toContain('store `drizzle`');
     expect(agents).toContain('henri db:generate|migrate|push|status');
     expect(agents).not.toContain('{{');
-    // The longest combination (inertia + drizzle); see new.spec.js
+    // The budget of new.spec.js, on the store with the most to say
     expect(agents.split('\n').length).toBeLessThan(170);
 
     const readme = read(app, 'README.md');
@@ -353,10 +378,13 @@ describe('the generated controllers run on their adapter', () => {
   beforeAll(() => {
     dir = tmpdir('henri-adapter-run-');
     ({ app } = scaffoldWith(dir, 'runner', ['--adapter', 'drizzle']));
+    // Every flavour answers its 422 through henri.model.errors()
+    global.henri = { model: { errors: modelErrors } };
   });
 
   afterAll(() => {
     cleanup(dir);
+    delete global.henri;
   });
 
   /**
@@ -408,8 +436,8 @@ describe('the generated controllers run on their adapter', () => {
   });
 
   /**
-   * A fake drizzle model: a chainable relation, ids that are integers and
-   * a ValidationError with one entry per field
+   * A fake drizzle model: paginate() answers the shared page shape, ids are
+   * integers and an invalid write throws a ValidationError keyed by field
    *
    * @returns {object} The model
    */
@@ -440,11 +468,6 @@ describe('the generated controllers run on their adapter', () => {
       return instance;
     };
     const rows = [row({ id: 1, name: 'one' })];
-    const relation = {
-      limit: () => relation,
-      offset: () => relation,
-      then: (resolve, reject) => Promise.resolve(rows).then(resolve, reject),
-    };
     const invalid = () => {
       const error = new Error('Task validation failed: name: is required');
 
@@ -455,35 +478,48 @@ describe('the generated controllers run on their adapter', () => {
     };
 
     return {
-      count: async () => rows.length,
-      create: async (data) => {
-        if (!data.name) {
-          throw invalid();
-        }
+      calls,
+      model: {
+        create: async (data) => {
+          if (!data.name) {
+            throw invalid();
+          }
 
-        return { id: 2, ...data };
-      },
-      findById: async (id) => (String(id) === '1' ? rows[0] : null),
-      findByIdAndDelete: async (id) => (String(id) === '1' ? rows[0] : null),
-      findByIdAndUpdate: async (id, data) => {
-        if (data.name === '') {
-          throw invalid();
-        }
+          return { id: 2, ...data };
+        },
+        findById: async (id) => (String(id) === '1' ? rows[0] : null),
+        paginate: async (options) => {
+          calls.paginate = options;
 
-        return String(id) === '1' ? { id: 1, ...data } : null;
+          return {
+            page: options.page,
+            pages: 1,
+            perPage: options.perPage,
+            records: rows,
+            total: rows.length,
+          };
+        },
       },
-      query: () => relation,
     };
   };
 
-  test('index pages with a relation and answers a HAL collection', async () => {
-    global.Task = drizzleModel();
+  test('index pages with paginate() and answers a HAL collection', async () => {
+    const fake = drizzleModel();
+
+    global.Task = fake.model;
 
     const controller = require(path.join(app, 'app/controllers/tasks.js'));
     const res = fakeRes();
 
     await controller.index(fakeReq(), res);
 
+    // One call, handed what req.pagination() returned
+    expect(fake.calls.paginate).toEqual({
+      limit: 25,
+      page: 1,
+      perPage: 25,
+      skip: 0,
+    });
     expect(res.calls).toEqual([
       [
         'collection',
@@ -496,7 +532,7 @@ describe('the generated controllers run on their adapter', () => {
   });
 
   test('the before hook answers 404 for an id the store does not know', async () => {
-    global.Task = drizzleModel();
+    global.Task = drizzleModel().model;
 
     const controller = require(path.join(app, 'app/controllers/tasks.js'));
     const missing = fakeRes();
@@ -514,7 +550,7 @@ describe('the generated controllers run on their adapter', () => {
   });
 
   test('create answers 201, or 422 with one message per field', async () => {
-    global.Task = drizzleModel();
+    global.Task = drizzleModel().model;
 
     const controller = require(path.join(app, 'app/controllers/tasks.js'));
     const created = fakeRes();
@@ -540,7 +576,7 @@ describe('the generated controllers run on their adapter', () => {
   });
 
   test('destroy answers 204 and 404', async () => {
-    global.Task = drizzleModel();
+    global.Task = drizzleModel().model;
 
     const controller = require(path.join(app, 'app/controllers/tasks.js'));
     const gone = fakeRes();
@@ -561,7 +597,8 @@ describe('the generated controllers run on their adapter', () => {
     /**
      * A fake Sequelize model: findByPk on an integer key throws a
      * SequelizeDatabaseError for a malformed id, instances update and
-     * destroy themselves, and errors carry an array of items
+     * destroy themselves, and a validation error carries an array of items
+     * (the shape henri.model.errors() normalizes)
      *
      * @returns {object} The model
      */
@@ -594,7 +631,6 @@ describe('the generated controllers run on their adapter', () => {
       return {
         calls,
         model: {
-          count: async () => 1,
           create: async (data) => {
             calls.created = data;
             if (!data.name) {
@@ -602,11 +638,6 @@ describe('the generated controllers run on their adapter', () => {
             }
 
             return row(2, data);
-          },
-          findAll: async (options) => {
-            calls.findAll = options;
-
-            return [row(1, { name: 'one' })];
           },
           findByPk: async (id) => {
             if (id === 'unknown') {
@@ -618,6 +649,17 @@ describe('the generated controllers run on their adapter', () => {
             }
 
             return String(id) === '1' ? row(1, { name: 'one' }) : null;
+          },
+          paginate: async (options) => {
+            calls.paginate = options;
+
+            return {
+              page: options.page,
+              pages: 1,
+              perPage: options.perPage,
+              records: [row(1, { name: 'one' })],
+              total: 1,
+            };
           },
         },
       };
@@ -632,7 +674,7 @@ describe('the generated controllers run on their adapter', () => {
       sql = path.join(scaffolded.app, 'app/controllers/tasks.js');
     });
 
-    test('index pages with limit and offset', async () => {
+    test('index pages with the same paginate() call', async () => {
       const fake = sequelizeModel();
 
       global.Task = fake.model;
@@ -642,7 +684,12 @@ describe('the generated controllers run on their adapter', () => {
 
       await controller.index(fakeReq(), res);
 
-      expect(fake.calls.findAll).toEqual({ limit: 25, offset: 0 });
+      expect(fake.calls.paginate).toEqual({
+        limit: 25,
+        page: 1,
+        perPage: 25,
+        skip: 0,
+      });
       expect(res.calls[0][0]).toBe('collection');
       expect(res.calls[0][2]).toEqual({ page: 1, perPage: 25, total: 1 });
 

--- a/packages/cli/__tests__/generate.spec.js
+++ b/packages/cli/__tests__/generate.spec.js
@@ -3,6 +3,7 @@ const path = require('path');
 const { parse } = require('@babel/parser');
 
 const { hooksFor } = require('@usehenri/core/src/base/hooks');
+const { modelErrors } = require('@usehenri/core/src/base/model-errors');
 
 const { TYPES, parseAttributes } = require('../scripts/generate');
 const {
@@ -97,24 +98,6 @@ const fakeReq = (body = {}, params = {}) => ({
 });
 
 /**
- * A thenable mongoose-like query (find().skip().limit())
- *
- * @param {Array} rows The rows the query resolves to
- * @returns {object} The query
- */
-const fakeQuery = (rows) => {
-  const query = {
-    lean: () => query,
-    limit: () => query,
-    skip: () => query,
-    sort: () => query,
-    then: (resolve, reject) => Promise.resolve(rows).then(resolve, reject),
-  };
-
-  return query;
-};
-
-/**
  * A fake model with the mongoose methods the controllers use
  *
  * @returns {object} The model and the calls it received
@@ -170,10 +153,11 @@ const fakeModel = () => {
     return doc;
   };
 
+  const rows = [{ id: '1', title: 'one' }];
+
   return {
     calls,
     model: {
-      countDocuments: async () => 1,
       create: async (data) => {
         calls.create = data;
         if (!data.title && !data.name) {
@@ -182,13 +166,24 @@ const fakeModel = () => {
 
         return { id: '2', ...data };
       },
-      find: () => fakeQuery([{ id: '1', title: 'one' }]),
       findById: async (id) => {
         if (id === 'bad') {
           throw cast();
         }
 
         return id === '1' ? document({ id: '1', title: 'one' }) : null;
+      },
+      // The same shape on every adapter, whatever req.pagination() holds
+      paginate: async (options) => {
+        calls.paginate = options;
+
+        return {
+          page: options.page,
+          pages: 1,
+          perPage: options.perPage,
+          records: rows,
+          total: rows.length,
+        };
       },
     },
   };
@@ -250,10 +245,13 @@ describe('henri generate', () => {
 
   beforeAll(() => {
     ({ app, dir } = scaffold());
+    // The generated controllers answer a 422 through henri.model.errors()
+    global.henri = { model: { errors: modelErrors } };
   });
 
   afterAll(() => {
     cleanup(dir);
+    delete global.henri;
   });
 
   test('prints the usage without a generator', () => {
@@ -462,6 +460,14 @@ describe('henri generate', () => {
 
         await controller.index(fakeReq(), res);
 
+        // One Model.paginate(req.pagination()) call, not a find and a count
+        expect(fake.calls.paginate).toEqual({
+          limit: 25,
+          offset: 0,
+          page: 1,
+          perPage: 25,
+          skip: 0,
+        });
         expect(res.calls).toEqual([
           [
             'collection',

--- a/packages/cli/scripts/generate/controllers.js
+++ b/packages/cli/scripts/generate/controllers.js
@@ -18,6 +18,11 @@
  * for one document (201 + Location on create, 204 on destroy). Browsers get
  * the pages and redirects (scaffold only). `res.negotiate({ html, json })`
  * picks one from the Accept header.
+ *
+ * Two things do not need a flavour: `Model.paginate()` answers the same
+ * `{ records, page, perPage, total, pages }` on the three model APIs, and
+ * `henri.model.errors()` normalizes what any of them throws on an invalid
+ * write, so the index and the 422 are written once for all of them.
  */
 
 const DEFAULT_API = 'mongoose';
@@ -33,7 +38,7 @@ const apiOf = ({ api }) => (FLAVOURS[api] ? api : DEFAULT_API);
 /**
  * Pick the fragment of an api
  *
- * @param {string} part The fragment name (helpers, page, find, ...)
+ * @param {string} part The fragment name (helpers, load, create, ...)
  * @param {object} opts { doc, lower, plural, keys, api }
  * @returns {string} The source code
  */
@@ -55,19 +60,31 @@ const validationHelper = ({ doc }) => `
  * @returns {object} The response
  */
 const invalid = (res, error) => {
-  if (error.name !== 'ValidationError') {
+  // Same { field: message } whatever the store threw, null when the error
+  // is not a validation failure
+  const errors = henri.model.errors(error);
+
+  if (!errors) {
     throw error;
   }
 
-  const errors = Object.fromEntries(
-    Object.entries(error.errors || {}).map(([field, detail]) => [
-      field,
-      detail.message,
-    ])
-  );
-
   return res.boom.badData(error.message, { errors });
 };
+`;
+
+/**
+ * The paginated query of an index action: one call for the page and the
+ * counters `res.collection()` wants, on every adapter
+ *
+ * @param {object} opts { doc, plural }
+ * @returns {string} The source code
+ */
+const page = ({ doc, plural }) => `
+    // One query for the page and its counters: the page and the size come
+    // from ?page=2&per_page=50, bounded by config.api.maxPerPage
+    const { records: ${plural}, page, perPage, total } = await ${doc}.paginate(
+      req.pagination()
+    );
 `;
 
 /**
@@ -135,14 +152,6 @@ ${validationHelper(opts)}`,
       opts,
       `req.${opts.lower} = await byId(${opts.doc}.findById(req.params.id));`
     ),
-  page: ({ doc, plural }) => `
-    // Page and size from ?page=2&per_page=50, bounded by config.api.maxPerPage
-    const { page, perPage, skip, limit } = req.pagination();
-    const [${plural}, total] = await Promise.all([
-      ${doc}.find().skip(skip).limit(limit),
-      ${doc}.countDocuments(),
-    ]);
-`,
   update: ({ lower }) => `
     try {
       req.${lower}.set(req.permit(...FIELDS));
@@ -154,9 +163,8 @@ ${validationHelper(opts)}`,
 };
 
 // --- drizzle ----------------------------------------------------------------
-// The drizzle models answer to the Mongoose names too, but `find()` resolves
-// to an array instead of a chainable query and a malformed id is already
-// null, so the paginated query is a relation and there is no byId helper.
+// The drizzle models answer to the Mongoose names too, but a malformed id is
+// already null, so there is no byId helper to guard the cast.
 
 const drizzle = {
   create: mongoose.create,
@@ -170,14 +178,6 @@ const drizzle = {
       `// findById() answers null for a malformed id, no cast to guard
   req.${opts.lower} = await ${opts.doc}.findById(req.params.id);`
     ),
-  page: ({ doc, plural }) => `
-    // Page and size from ?page=2&per_page=50, bounded by config.api.maxPerPage
-    const { page, perPage, skip, limit } = req.pagination();
-    const [${plural}, total] = await Promise.all([
-      ${doc}.query().offset(skip).limit(limit),
-      ${doc}.count(),
-    ]);
-`,
   update: ({ lower }) => `
     try {
       await req.${lower}.update(req.permit(...FIELDS));
@@ -222,35 +222,9 @@ const byId = async (id) => {
   }
 };
 
-/**
- * Answer a failed validation with a 422 and one message per field
- *
- * @param {object} res Express response
- * @param {Error} error The error thrown by ${doc}
- * @returns {object} The response
- */
-const invalid = (res, error) => {
-  if (!String(error.name).startsWith('Sequelize')) {
-    throw error;
-  }
-
-  const errors = Object.fromEntries(
-    (error.errors || []).map((detail) => [detail.path, detail.message])
-  );
-
-  return res.boom.badData(error.message, { errors });
-};
-`,
+${validationHelper({ doc })}`,
   load: (opts) =>
     loadHelper(opts, `req.${opts.lower} = await byId(req.params.id);`),
-  page: ({ doc, plural }) => `
-    // Page and size from ?page=2&per_page=50, bounded by config.api.maxPerPage
-    const { page, perPage, skip, limit } = req.pagination();
-    const [${plural}, total] = await Promise.all([
-      ${doc}.findAll({ limit, offset: skip }),
-      ${doc}.count(),
-    ]);
-`,
   update: ({ lower }) => `
     try {
       await req.${lower}.update(req.permit(...FIELDS));
@@ -281,7 +255,7 @@ const before = ({ doc, actions }) => `
 
 const index = (opts) => `
   index: async (req, res) => {
-    ${of('page', opts)}
+    ${page(opts)}
     // app/views/pages/${opts.plural}/index.js is the /${opts.plural} page for next.js
     const html = () =>
       res.render('/${opts.plural}', {
@@ -297,7 +271,7 @@ const index = (opts) => `
 
 const indexJson = (opts) => `
   index: async (req, res) => {
-    ${of('page', opts)}
+    ${page(opts)}
     return res.collection(${opts.plural}, { page, perPage, total });
   },`;
 

--- a/packages/cli/template/default/AGENTS.md
+++ b/packages/cli/template/default/AGENTS.md
@@ -45,23 +45,17 @@ module.exports = {
     title: { type: 'string', required: true, unique: true, index: true },
     status: { type: 'string', enum: ['draft', 'live'], default: 'draft' },
   },
-  options: { timestamps: true },
+  options: {}, // timestamps: false opts out, paranoid: true soft deletes
   store: 'default', // a key of config.stores
   associate(models) {}, // optional, called once every model exists
 };
 ```
 
 Field keys: `type`, `required`, `default`, `enum`, `unique`, `index`; any other
-key is handed to the adapter as is. The global is the model of the `{{adapter}}`
-store, and what the generators write: {{#if mongoose}}Mongoose (`find().skip().limit()`,
-`countDocuments`, `findById`, `create`, `findByIdAndUpdate`, `findByIdAndDelete`),
-documents carry `_id`.{{/if}}{{#if drizzle}}the drizzle model (`where`, `order`, `include`,
-`query().offset().limit()`, `count`, `findById`, `create`, `findByIdAndUpdate`,
-`findByIdAndDelete`), rows carry `id`. Migrations live in `db/migrations`:
-`henri db:generate|migrate|push|status`, generate and commit one after a model change.{{/if}}{{#if sequelize}}Sequelize
-(`findAll`, `findByPk`, `count`, `create`, then `row.update()` and
-`row.destroy()`), rows carry `id`. There are no migrations: the boot runs
-`sequelize.sync()` and creates or extends the tables from the models.{{/if}}
+key is handed to the adapter as is. Every store adds `createdAt`/`updatedAt`,
+`Model.paginate({ page, perPage })` -> `{ records, page, perPage, total, pages }`,
+`henri.model.errors(error)` -> `{ field: message }` (`null` otherwise) and `db/seeds.js`, run by `henri db:seed`.
+The global is the model of the `{{adapter}}` store, and what the generators write: {{#if mongoose}}Mongoose (`find`, `findById`, `create`, then `doc.set()`, `doc.save()` and `doc.deleteOne()`), documents carry `_id`.{{/if}}{{#if drizzle}}the drizzle model (`where`, `order`, `include`, `findById`, `create`, then `row.update()` and `row.destroy()`), rows carry `id`. Migrations live in `db/migrations`: `henri db:generate|migrate|push|status`, generate and commit one after a model change.{{/if}}{{#if sequelize}}Sequelize (`findAll`, `findByPk`, `create`, then `row.update()` and `row.destroy()`), rows carry `id`. There are no migrations: the boot runs `sequelize.sync()` and creates or extends the tables from the models.{{/if}}
 
 ## Controllers
 
@@ -73,9 +67,9 @@ documents carry `_id`.{{/if}}{{#if drizzle}}the drizzle model (`where`, `order`,
   params (later wins). Never pass `req.body` to a model.
 - `res.negotiate({ html: () => res.render('/posts/show', { data: { post } }),
 json: () => res.resource(post) })`: the page for browsers, HAL for API
-  clients. `res.collection(posts, { page, perPage, total })` with
-  `req.pagination()` for an index, `{ status: 201 }` sets Location, 204 on
-  destroy. Mutations honour `Idempotency-Key`; rate limits apply outside dev.
+  clients. An index is one query, `Post.paginate(req.pagination())`, then
+  `res.collection(posts, { page, perPage, total })`; `{ status: 201 }` sets
+  Location, 204 on destroy. Mutations honour `Idempotency-Key`; rate limits apply outside dev.
 - `res.boom.notFound(message, data)`, `badData` (422), `badRequest`,
   `unauthorized`, `forbidden`, `conflict`, `tooManyRequests` answer JSON.
 - `req.flash('notice', 'Saved')` before a redirect: the next page rendered gets it in `flash.notice`, once (needs a user model, so a session).

--- a/website/src/content/docs/guides/api.md
+++ b/website/src/content/docs/guides/api.md
@@ -15,11 +15,12 @@ Every henri controller can answer JSON, and the answers follow the conventions a
 // app/controllers/tasks.js
 module.exports = {
   async index(req, res) {
-    const { page, perPage, skip, limit } = req.pagination();
-    const [tasks, total] = await Promise.all([
-      Task.find().skip(skip).limit(limit),
-      Task.countDocuments(),
-    ]);
+    const {
+      records: tasks,
+      page,
+      perPage,
+      total,
+    } = await Task.paginate(req.pagination());
 
     return res.negotiate({
       html: () => res.render('/tasks', { data: { tasks } }),

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -144,7 +144,7 @@ henri g worker cleanup
 henri g test highscores
 ```
 
-The scaffolded controllers are written for Mongoose (`findById`, `findByIdAndUpdate`, `findByIdAndDelete`), which the disk and mongoose adapters use; adapt them by hand for a SQL store. Their `index` uses [`Model.paginate(req.pagination())`](/guides/models/#pagination) and their 422 answers [`henri.model.errors(error)`](/guides/models/#validation-errors), both of which work on every adapter. The scaffolded pages target the React renderer.
+The scaffolded controllers follow the adapter of the default store: the Mongoose API on `disk` and `mongoose`, Sequelize on `mysql`, `postgresql` and `mssql`, the Drizzle model API on `drizzle` (see [Models](/guides/models/)). What they load a record with differs; their `index` is [`Model.paginate(req.pagination())`](/guides/models/#pagination) and their 422 is [`henri.model.errors(error)`](/guides/models/#validation-errors) on all three, because both answer the same shape on every adapter. The scaffolded pages target the React renderer.
 
 ## `destroy`
 


### PR DESCRIPTION
The last piece of the ergonomics tranche, held back while the controller generator was rewritten twice underneath it.

The generated index went from three calls to one: `Model.paginate(req.pagination())` answers the records and the counters the HAL collection helper wants. The 422 path goes through `henri.model.errors()`, so the three ORMs' different validation shapes become one answer.

Both turned out to be consolidations rather than per-adapter additions, so the generator lost a flavour-specific fragment in each case. What still differs per adapter is only what genuinely differs: how a record is loaded, updated and deleted.

Verified by generating all six outputs and reading them, then scaffolding real applications and driving them with a client: Mongoose against a real MongoDB, Drizzle against sqlite, and Sequelize against a real Sequelize model. All three answer the same paginated page and the same 422 shape, from three different underlying error messages. The paging links and the load hook's 404 were checked too.

The generated agent file was rewritten to match, compressed rather than given a bigger budget, and two stale doc passages were corrected: the API guide still showed the old three-call index, and the command line reference still claimed the generated controllers were Mongoose-only.

Suite green at 921 tests.