### PR TITLE
Only ask for sass when the app authors Sass

### DIFF
--- a/.changeset/drop-sass-from-the-scaffold.md
+++ b/.changeset/drop-sass-from-the-scaffold.md
@@ -1,0 +1,7 @@
+---
+'@usehenri/inertia': patch
+'@usehenri/react': patch
+'@usehenri/cli': patch
+---
+
+Both view engines warned at every boot that `sass` was missing, whether or not the application had any `.scss` to compile. Since the scaffold styles with Tailwind and writes no Sass, a new app carried the dependency only to silence that warning. The engines now look for an authored `.scss` under `app/views` first, skipping build output, and `henri new` no longer adds `sass`. An app that writes Sass keeps working and still gets the warning when the package is missing.

--- a/packages/cli/template/default/package.json
+++ b/packages/cli/template/default/package.json
@@ -24,7 +24,6 @@
     "next": "^16.3.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "sass": "^1.80.0",
     "tailwindcss": "^4.3.3"
   },
   "devDependencies": {

--- a/packages/cli/template/inertia/package.json
+++ b/packages/cli/template/inertia/package.json
@@ -25,7 +25,6 @@
     "@vitejs/plugin-react": "^6.1.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "sass": "^1.80.0",
     "tailwindcss": "^4.3.3",
     "vite": "^8.2.2"
   },

--- a/packages/inertia/engine/index.js
+++ b/packages/inertia/engine/index.js
@@ -384,10 +384,15 @@ class InertiaEngine {
       throw error;
     }
 
-    try {
-      this.resolve('sass');
-    } catch (error) {
-      pen.warn('view', "'sass' is not installed: .scss files will not compile");
+    if (hasStylesheets(this.dir)) {
+      try {
+        this.resolve('sass');
+      } catch (error) {
+        pen.warn(
+          'view',
+          "'sass' is not installed: the .scss files of this app will not compile"
+        );
+      }
     }
 
     if (!this.henri.isTest) {
@@ -976,5 +981,34 @@ InertiaEngine.componentName = componentName;
 InertiaEngine.findPackage = findPackage;
 InertiaEngine.partial = partial;
 InertiaEngine.DEFAULTS = DEFAULTS;
+
+/**
+ * Does the application still author any Sass?
+ *
+ * The scaffold styles with Tailwind and ships no `.scss`, so an app only
+ * needs the `sass` package when it wrote some itself. Build output is
+ * skipped: it holds the compiled css, never the sources.
+ *
+ * @param {string} dir the app/views directory
+ * @returns {boolean} true when a .scss file is authored under it
+ */
+function hasStylesheets(dir) {
+  const skipped = ['node_modules', 'dist', '.next', '.cache', '.turbo'];
+
+  try {
+    return fs
+      .readdirSync(dir, { recursive: true, withFileTypes: true })
+      .some(
+        (entry) =>
+          entry.isFile() &&
+          entry.name.endsWith('.scss') &&
+          !skipped.some((name) =>
+            entry.parentPath.includes(`${path.sep}${name}`)
+          )
+      );
+  } catch {
+    return false;
+  }
+}
 
 module.exports = InertiaEngine;

--- a/packages/react/engine/index.js
+++ b/packages/react/engine/index.js
@@ -306,10 +306,15 @@ class ReactEngine {
 
     await checkPackages(['next', 'react', 'react-dom']);
 
-    try {
-      this.resolve('sass');
-    } catch (error) {
-      pen.warn('view', "'sass' is not installed: .scss files will not compile");
+    if (hasStylesheets(this.dir)) {
+      try {
+        this.resolve('sass');
+      } catch (error) {
+        pen.warn(
+          'view',
+          "'sass' is not installed: the .scss files of this app will not compile"
+        );
+      }
     }
 
     if (!fs.existsSync(path.join(this.dir, 'pages'))) {
@@ -581,3 +586,32 @@ module.exports.createNextConfig = createNextConfig;
 module.exports.ensureNextConfig = ensureNextConfig;
 module.exports.pagePath = pagePath;
 module.exports.selectBundler = selectBundler;
+
+/**
+ * Does the application still author any Sass?
+ *
+ * The scaffold styles with Tailwind and ships no `.scss`, so an app only
+ * needs the `sass` package when it wrote some itself. Build output is
+ * skipped: it holds the compiled css, never the sources.
+ *
+ * @param {string} dir the app/views directory
+ * @returns {boolean} true when a .scss file is authored under it
+ */
+function hasStylesheets(dir) {
+  const skipped = ['node_modules', 'dist', '.next', '.cache', '.turbo'];
+
+  try {
+    return fs
+      .readdirSync(dir, { recursive: true, withFileTypes: true })
+      .some(
+        (entry) =>
+          entry.isFile() &&
+          entry.name.endsWith('.scss') &&
+          !skipped.some((name) =>
+            entry.parentPath.includes(`${path.sep}${name}`)
+          )
+      );
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Both view engines probed for `sass` at every boot and warned when it was missing, regardless of whether the application had any `.scss` to compile. Since #320 styles the scaffold with Tailwind and writes no Sass, every new app carried the dependency purely to silence that warning.

The engines now look for an authored `.scss` under `app/views` before probing, skipping build output, and the scaffold no longer adds `sass`. An app that does write Sass is unaffected and still gets the warning when the package is missing.

Verified by scaffolding an app with the smoke script: it installs without `sass`, boots in production with no warning in the log, serves 200, and its Tailwind stylesheet is still compiled and applied.