### PR TITLE
Make the test suite deterministic

### DIFF
--- a/.changeset/loopback-test-port.md
+++ b/.changeset/loopback-test-port.md
@@ -1,0 +1,7 @@
+---
+'@usehenri/core': patch
+---
+
+Under `NODE_ENV=test` the server lets the kernel hand it a port instead of looking for a free one first.
+
+`server.start()` called `detect(port)` and then `listen()` on whatever it answered, which is two operations with a gap in between: anything else binding meanwhile — another suite booting its own application, a supertest listener, a database picking a port the same way — could take it, and the boot then failed with `port 3000 already in use`, or worse, succeeded on a port another suite believed it owned and answered its requests. Asking for port `0` is a single operation and cannot race; `henri.server.port` and `henri.server.url` report the port the kernel gave. Development and production keep the port from the configuration.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,9 @@ HENRI_TEST_MYSQL_URL=mysql://root:henri@127.0.0.1:3306/henri_test pnpm test:sql
 
 - Tests live in `__tests__/` or `tests/` next to the code. Snapshot tests exist
   for most core modules; regenerate them only when the diff is explained by
-  your change.
+  your change. `vitest.setup.js` makes every test server bind `127.0.0.1`
+  rather than the wildcard address: read it before adding anything that
+  listens, a wildcard bind lets another process answer the suite's requests.
 
 ## Releasing
 

--- a/packages/core/src/2.server.js
+++ b/packages/core/src/2.server.js
@@ -439,10 +439,15 @@ class Server extends BaseModule {
 
     let { port } = this;
 
-    port = henri.isTest ? await detect(port) : port;
+    // Tests get whatever port the kernel has free: asking for one and
+    // binding it are a single operation, where detecting a free port and
+    // then binding it races with anything else binding meanwhile
+    port = henri.isTest ? 0 : port;
     port = henri.isDev ? await choosePort(port, pen) : port;
 
     await this.listen(port, this.host);
+
+    port = this.httpServer.address().port;
 
     const ip = lanIp();
     const urls = prepareUrls('http', this.host, ip, port);

--- a/packages/mongoose/__tests__/mongoose.spec.js
+++ b/packages/mongoose/__tests__/mongoose.spec.js
@@ -105,7 +105,9 @@ beforeAll(async () => {
 }, 120000);
 
 afterAll(async () => {
-  await mongod.stop();
+  // A mongod that never started leaves the real error in beforeAll: stopping
+  // it here would bury it under a TypeError from every test of the file
+  await mongod?.stop();
 }, 60000);
 
 describe('mongoose adapter', () => {

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -82,5 +82,8 @@ export default defineConfig({
     // Forks: core tests chdir into packages/demo, impossible in worker threads
     pool: 'forks',
     projects: projects(),
+    // Test servers bind the loopback address, never the wildcard: see the
+    // file for why a wildcard bind lets another process answer our requests
+    setupFiles: [path.join(root, 'vitest.setup.js')],
   },
 });

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -1,0 +1,120 @@
+const dns = require('node:dns');
+const net = require('node:net');
+
+/**
+ * Every test server binds the loopback address.
+ *
+ * `supertest(app)` starts an http server with `app.listen(0)` for each
+ * request and connects to `http://127.0.0.1:<port>`. Without a host, node
+ * binds the IPv6 wildcard (`[::]:port`, dual stack) and libuv sets
+ * `SO_REUSEADDR`, so another process may bind the *more specific*
+ * `127.0.0.1:port` at the same time -- and on macOS and the BSDs the more
+ * specific socket then wins the IPv4 connection. The request is answered by
+ * whatever else holds that port: another suite's application (stray 404s on
+ * routes that exist, missing middleware headers, foreign status codes), the
+ * mongod that mongodb-memory-server binds on `127.0.0.1` on a port it picked
+ * the same way (`Parse Error: Expected HTTP/, RTSP/ or ICE/`), or nothing at
+ * all any more (`socket hang up`).
+ *
+ * Naming the address makes the reservation exact: the kernel gives that
+ * address and port to one listener only. Measured over 6000 sequential
+ * supertest requests against two applications: 12 answers from the wrong
+ * server on the wildcard, none on the loopback.
+ *
+ * Only calls that name no host are changed, so a test binding an interface
+ * on purpose keeps it.
+ */
+const LOOPBACK = '127.0.0.1';
+
+/**
+ * `listen(port, host)` resolves the host through `dns.lookup`, whose
+ * callback is deferred even for an address that needs no resolving. The
+ * handle is then bound a tick later and `server.address()` is still null
+ * when `listen()` returns, which supertest reads right away. Answering
+ * synchronously while our own `listen()` is running keeps the bind
+ * synchronous, as it is for a host-less `listen()`; every other lookup goes
+ * to node's.
+ */
+let binding = false;
+
+const { lookup } = dns;
+
+/**
+ * `dns.lookup()`, answering an address literal on the spot while binding
+ *
+ * @param {string} hostname the host to resolve
+ * @param {object|function} options options, or the callback
+ * @param {function} [callback] the callback
+ * @returns {*} whatever `dns.lookup` answers
+ */
+dns.lookup = function lookupWhileBinding(hostname, options, callback) {
+  const done = typeof options === 'function' ? options : callback;
+  const family = net.isIP(hostname);
+
+  if (binding && family && typeof done === 'function') {
+    // `listen()` asks for every address (`{ all: true }`)
+    return options && options.all
+      ? done(null, [{ address: hostname, family }])
+      : done(null, hostname, family);
+  }
+
+  return lookup.apply(this, arguments);
+};
+
+// Node tags dns.lookup so util.promisify() resolves { address, family }
+for (const symbol of Object.getOwnPropertySymbols(lookup)) {
+  dns.lookup[symbol] = lookup[symbol];
+}
+
+/**
+ * The arguments of a `listen()` call, with the loopback address added when
+ * the call names no host and no unix socket path
+ *
+ * @param {Array} args the arguments of `net.Server.prototype.listen`
+ * @returns {?Array} the arguments to use, or null to leave the call alone
+ */
+function onLoopback(args) {
+  const [first, second] = args;
+
+  // Port: `listen(port[, backlog][, callback])`
+  if (typeof first === 'number' && typeof second !== 'string') {
+    return [first, LOOPBACK, ...args.slice(1)];
+  }
+
+  // Options: `listen({ port, ... })`
+  if (
+    first &&
+    typeof first === 'object' &&
+    typeof first.port !== 'undefined' &&
+    typeof first.host === 'undefined' &&
+    typeof first.path === 'undefined'
+  ) {
+    return [Object.assign({}, first, { host: LOOPBACK }), ...args.slice(1)];
+  }
+
+  return null;
+}
+
+const { listen } = net.Server.prototype;
+
+/**
+ * `Server.listen()`, defaulting the host to the loopback address
+ *
+ * @param {...*} args the arguments of `net.Server.prototype.listen`
+ * @returns {net.Server} the server
+ */
+net.Server.prototype.listen = function listenOnLoopback(...args) {
+  const called = onLoopback(args);
+
+  if (!called) {
+    return listen.apply(this, args);
+  }
+
+  binding = true;
+
+  try {
+    return listen.apply(this, called);
+  } finally {
+    binding = false;
+  }
+};

--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -30,7 +30,7 @@ The file is parsed on boot: a syntax error is reported with its line, and the bo
 
 | Key                | Default       | Description                                                                                                                                    |
 | ------------------ | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `port`             | `3000`        | Port to listen on. In development a busy port is replaced by the next free one.                                                                |
+| `port`             | `3000`        | Port to listen on. In development a busy port is replaced by the next free one; under `NODE_ENV=test` the kernel assigns one.                  |
 | `host`             | see below     | Interface to bind: `127.0.0.1` outside production, `0.0.0.0` in production. `HENRI_HOST` (what `henri server --host` sets) wins over the file. |
 | `cors`             | off           | `true` enables [cors](https://github.com/expressjs/cors) with its defaults; an object is passed to it as options.                              |
 | `renderer`         | `template`    | View engine: `react`, `inertia` or `template` (Handlebars). `henri new` writes `react`. See [Views](/guides/views/).                           |

--- a/website/src/content/docs/guides/testing.md
+++ b/website/src/content/docs/guides/testing.md
@@ -28,7 +28,7 @@ module.exports = defineConfig({
 
 The setup file boots henri before each test file and stops it after, so `henri` and the models are globals in your tests exactly like in the application, and `request()` hits the in-process server. Each file gets a fresh boot: with the disk adapter that is an empty in-memory database. `fileParallelism: false` keeps one server and one database at a time; `globals: true` gives you `describe`, `test`, `expect` and `vi` without imports.
 
-Under `NODE_ENV=test`, henri loads `config/test.json` (falling back to `default.json`), picks a free port, skips the workers, keeps the disk adapter in memory, uses nodemailer's JSON transport and stays quiet in the console.
+Under `NODE_ENV=test`, henri loads `config/test.json` (falling back to `default.json`), lets the kernel assign it a port (`config.port` is ignored, so two suites never fight over one), skips the workers, keeps the disk adapter in memory, uses nodemailer's JSON transport and stays quiet in the console.
 
 ## Writing tests
 


### PR DESCRIPTION
The suite failed roughly one run in ten, and the core project four runs in fifteen, on a rotating cast of specs. The cause is not shared state or a timeout: **requests were being answered by the wrong server.**

A test client starts a server with a port but no host for every request and then connects to the loopback address. With no host, Node binds the IPv6 wildcard in dual-stack mode and the socket option that permits address reuse is set, so another process can bind the more specific loopback address on the same port at the same time. On macOS and the BSDs the more specific socket then wins the IPv4 connection, and the request is answered by whoever else holds that port.

Inside this suite those others are the in-process MongoDB, which picks a port by probing and then binds the loopback address, and henri's own server. That explains every symptom on the list, including the ones that looked impossible: 404s on routes that exist, missing middleware headers, empty bodies, status codes from processes outside the suite, hung sockets, and a parse error that turns out to be the database's wire protocol answering an HTTP client.

**The fixes.** Test-only, a setup file makes any listen call that names no host bind the loopback address, which makes the reservation exact. Shipped, under the test environment henri now binds port zero and reads the port back instead of detecting a free port and then binding it, because those two steps race. A teardown in the Mongoose spec also stopped burying a failed database start under a type error.

**Measured, with a negative control.** Six thousand sequential requests against two applications: twelve answers from the wrong server on the wildcard, none on the loopback. The core project went from four failures in fifteen runs to none in fifteen. A control that ran the same setup file but kept binding the wildcard still failed at the old rate, so it is the loopback bind doing the work rather than the setup file existing.

I re-measured after rebasing: ten consecutive core runs and three full runs, all clean.

One trade-off worth knowing: two servers wanting the same address now collide loudly instead of quietly corrupting a response. That is the better failure, but it is a different one.

The setup file patches two Node functions. It is deliberately narrow, it only touches calls that name no host, and it preserves the tagging that promisify relies on.