### PR TITLE
Ship the loopback test fix to every henri app

### DIFF
--- a/.changeset/testing-loopback.md
+++ b/.changeset/testing-loopback.md
@@ -1,0 +1,7 @@
+---
+'@usehenri/testing': patch
+---
+
+`@usehenri/testing/setup-file` now binds every server the suite starts to `127.0.0.1`.
+
+A server started with a port but no host takes the IPv6 wildcard in dual-stack mode, with address reuse enabled, so another process can hold the same port on the loopback address at the same time. On macOS and the BSDs the more specific socket then wins the IPv4 connection and a request is answered by the wrong server. The symptoms do not look like a port problem: a `404` on a route that exists, a missing middleware header, an empty body, a `socket hang up`, or a parse error when a database answers an HTTP client. This is what made henri's own suite fail about one run in ten. Applying it made 6000 requests answer correctly where 12 had gone to the wrong server. `@usehenri/testing/loopback` applies it on its own for a suite that boots henri another way.

--- a/packages/testing/__tests__/loopback.spec.js
+++ b/packages/testing/__tests__/loopback.spec.js
@@ -1,0 +1,57 @@
+const net = require('node:net');
+
+const bindTestServersToLoopback = require('../loopback');
+
+/**
+ * Listens and answers where the server ended up
+ *
+ * @param {...*} args what to hand to `listen()`
+ * @returns {Promise<object>} the address of the bound server
+ */
+const boundTo = (...args) =>
+  new Promise((resolve, reject) => {
+    const server = net.createServer();
+
+    server.on('error', reject);
+    server.listen(...args, () => {
+      const address = server.address();
+
+      server.close(() => resolve(address));
+    });
+  });
+
+describe('binding test servers to the loopback address', () => {
+  test('a listen without a host binds 127.0.0.1, not the wildcard', async () => {
+    const address = await boundTo(0);
+
+    // The wildcard would be '::' (dual stack), which another process can
+    // shadow by binding the more specific 127.0.0.1 on the same port
+    expect(address.address).toBe('127.0.0.1');
+    expect(address.family).toBe('IPv4');
+  });
+
+  test('the options form is treated the same way', async () => {
+    const address = await boundTo({ port: 0 });
+
+    expect(address.address).toBe('127.0.0.1');
+  });
+
+  test('a host asked for on purpose is left alone', async () => {
+    const address = await boundTo(0, '::1');
+
+    expect(address.address).toBe('::1');
+  });
+
+  test('the port is readable as soon as listen() returns', () => {
+    const server = net.createServer().listen(0);
+
+    // The http client reads it right away, so the dns lookup of the address
+    // literal must not defer the bind
+    expect(server.address().port).toBeGreaterThan(0);
+    server.close();
+  });
+
+  test('applying it twice is a no-op', () => {
+    expect(bindTestServersToLoopback()).toBe(false);
+  });
+});

--- a/packages/testing/loopback.js
+++ b/packages/testing/loopback.js
@@ -1,0 +1,132 @@
+const dns = require('node:dns');
+const net = require('node:net');
+
+/**
+ * Every test server binds the loopback address.
+ *
+ * `request()` and `agent()` start an http server with a port but no host for
+ * each request, then connect to `http://127.0.0.1:<port>`. Without a host,
+ * node binds the IPv6 wildcard (`[::]:port`, dual stack) and libuv sets
+ * `SO_REUSEADDR`, so another process may bind the *more specific*
+ * `127.0.0.1:port` at the same time -- and on macOS and the BSDs the more
+ * specific socket then wins the IPv4 connection. The request is answered by
+ * whatever else holds that port: another suite's application, a database the
+ * suite started on a port it picked the same way, or nothing at all any more.
+ *
+ * The symptoms are the confusing kind: 404s on routes that exist, missing
+ * middleware headers, empty bodies, status codes from a process outside the
+ * suite, `socket hang up`, and `Parse Error: Expected HTTP/, RTSP/ or ICE/`
+ * when the answer comes from a database speaking its own wire protocol.
+ *
+ * Naming the address makes the reservation exact: the kernel gives that
+ * address and port to one listener only. Only calls that name no host are
+ * changed, so a test binding an interface on purpose keeps it. Applying this
+ * twice is a no-op.
+ *
+ * `@usehenri/testing/setup-file` applies it. Apply it yourself when you boot
+ * henri another way:
+ *
+ *   // vitest.config.js
+ *   setupFiles: ['@usehenri/testing/loopback']
+ */
+const APPLIED = Symbol.for('@usehenri/testing.loopback');
+const LOOPBACK = '127.0.0.1';
+
+/**
+ * `listen(port, host)` resolves the host through `dns.lookup`, whose
+ * callback is deferred even for an address that needs no resolving. The
+ * handle is then bound a tick later and `server.address()` is still null when
+ * `listen()` returns, which the http client reads right away. Answering
+ * synchronously while our own `listen()` is running keeps the bind
+ * synchronous, as it is for a host-less `listen()`; every other lookup goes
+ * to node's.
+ */
+let binding = false;
+
+/**
+ * The arguments of a `listen()` call, with the loopback address added when
+ * the call names no host and no unix socket path
+ *
+ * @param {Array} args the arguments of `net.Server.prototype.listen`
+ * @returns {?Array} the arguments to use, or null to leave the call alone
+ */
+function onLoopback(args) {
+  const [first, second] = args;
+
+  // Port: `listen(port[, backlog][, callback])`
+  if (typeof first === 'number' && typeof second !== 'string') {
+    return [first, LOOPBACK, ...args.slice(1)];
+  }
+
+  // Options: `listen({ port, ... })`
+  if (
+    first &&
+    typeof first === 'object' &&
+    typeof first.port !== 'undefined' &&
+    typeof first.host === 'undefined' &&
+    typeof first.path === 'undefined'
+  ) {
+    return [Object.assign({}, first, { host: LOOPBACK }), ...args.slice(1)];
+  }
+
+  return null;
+}
+
+/**
+ * Binds every host-less `listen()` of this process to the loopback address
+ *
+ * @returns {boolean} false when it was already applied
+ */
+function bindTestServersToLoopback() {
+  if (net.Server.prototype.listen[APPLIED]) {
+    return false;
+  }
+
+  const { lookup } = dns;
+
+  dns.lookup = function lookupWhileBinding(hostname, options, callback) {
+    const done = typeof options === 'function' ? options : callback;
+    const family = net.isIP(hostname);
+
+    if (binding && family && typeof done === 'function') {
+      // `listen()` asks for every address (`{ all: true }`)
+      return options && options.all
+        ? done(null, [{ address: hostname, family }])
+        : done(null, hostname, family);
+    }
+
+    return lookup.apply(this, arguments);
+  };
+
+  // Node tags dns.lookup so util.promisify() resolves { address, family }
+  for (const symbol of Object.getOwnPropertySymbols(lookup)) {
+    dns.lookup[symbol] = lookup[symbol];
+  }
+
+  const { listen } = net.Server.prototype;
+
+  net.Server.prototype.listen = function listenOnLoopback(...args) {
+    const called = onLoopback(args);
+
+    if (!called) {
+      return listen.apply(this, args);
+    }
+
+    binding = true;
+
+    try {
+      return listen.apply(this, called);
+    } finally {
+      binding = false;
+    }
+  };
+
+  net.Server.prototype.listen[APPLIED] = true;
+
+  return true;
+}
+
+bindTestServersToLoopback();
+
+module.exports = bindTestServersToLoopback;
+module.exports.bindTestServersToLoopback = bindTestServersToLoopback;

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -16,15 +16,17 @@
   "main": "index.js",
   "exports": {
     ".": "./index.js",
-    "./setup-file": "./setup-file.mjs",
     "./global-setup": "./global-setup.mjs",
-    "./package.json": "./package.json"
+    "./loopback": "./loopback.js",
+    "./package.json": "./package.json",
+    "./setup-file": "./setup-file.mjs"
   },
   "files": [
-    "index.js",
-    "setup-file.mjs",
     "global-setup.mjs",
-    "README.md"
+    "index.js",
+    "loopback.js",
+    "README.md",
+    "setup-file.mjs"
   ],
   "engines": {
     "node": ">=22"

--- a/packages/testing/setup-file.mjs
+++ b/packages/testing/setup-file.mjs
@@ -12,7 +12,13 @@
 import { createRequire } from 'node:module';
 import { afterAll } from 'vitest';
 
-const { setup, teardown } = createRequire(import.meta.url)('./index.js');
+const require = createRequire(import.meta.url);
+
+// Bind every host-less listen() to 127.0.0.1 before anything starts a server:
+// without it a request can be answered by whatever else holds that port
+require('./loopback.js');
+
+const { setup, teardown } = require('./index.js');
 
 await setup();
 

--- a/website/src/content/docs/guides/testing.md
+++ b/website/src/content/docs/guides/testing.md
@@ -26,6 +26,8 @@ module.exports = defineConfig({
 });
 ```
 
+Booting through the setup file also binds every server the suite starts to `127.0.0.1`. Without that, a server started with a port but no host takes the IPv6 wildcard, another process can hold the same port on the loopback address, and a request is answered by whichever of the two the kernel prefers. The symptoms look like anything but a port problem: a `404` on a route that exists, a missing header, an empty body, a hung socket. Booting henri another way, apply it yourself with `setupFiles: ['@usehenri/testing/loopback']`.
+
 The setup file boots henri before each test file and stops it after, so `henri` and the models are globals in your tests exactly like in the application, and `request()` hits the in-process server. Each file gets a fresh boot: with the disk adapter that is an empty in-memory database. `fileParallelism: false` keeps one server and one database at a time; `globals: true` gives you `describe`, `test`, `expect` and `vi` without imports.
 
 Under `NODE_ENV=test`, henri loads `config/test.json` (falling back to `default.json`), lets the kernel assign it a port (`config.port` is ignored, so two suites never fight over one), skips the workers, keeps the disk adapter in memory, uses nodemailer's JSON transport and stays quiet in the console.


### PR DESCRIPTION
#324 made henri's own suite deterministic by binding every test server to the loopback address. Every henri application's suite has exactly the same exposure, because `@usehenri/testing` hands users the same HTTP client that starts a server with a port but no host for each request.

That server takes the IPv6 wildcard in dual-stack mode with address reuse enabled, so another process can hold the same port on the loopback address at the same time, and on macOS and the BSDs the more specific socket wins the IPv4 connection. The request is then answered by the wrong server, and the symptoms never look like a port problem: a 404 on a route that exists, a missing middleware header, an empty body, a hung socket, or a parse error when a database answers an HTTP client.

The setup file now applies the fix, so an app gets it by booting the way the docs already tell it to. A suite that boots henri another way can apply it alone through a new entry point. Applying it twice is a no-op, which matters because this repository already applies it in its own setup.

Five tests cover the behaviour rather than the patch: a host-less listen binds the loopback address in both call forms, a host asked for on purpose is left alone, the port is readable as soon as listen returns, and a second application changes nothing.

Verified through the real path as well: a scaffolded application installs, its own tests pass, and the entry point resolves from inside the app.