### PR TITLE
Keep the development JSX runtime out of the published bundle

### DIFF
--- a/.changeset/jsx-runtime-production.md
+++ b/.changeset/jsx-runtime-production.md
@@ -1,0 +1,5 @@
+---
+'@usehenri/react': patch
+---
+
+The published bundle no longer carries the development JSX runtime. `@babel/preset-react` 8 turns `development` on by default, which emitted `jsxDEV()` calls into the build, and a production `next build` of an application using the package then failed with `jsxDevRuntime.jsxDEV is not a function` while prerendering. The preset is now configured explicitly.

--- a/packages/react/rollup.config.mjs
+++ b/packages/react/rollup.config.mjs
@@ -23,7 +23,10 @@ export default {
       configFile: false,
       presets: [
         ['@babel/preset-env', { targets: { node: '22' } }],
-        ['@babel/preset-react', { runtime: 'automatic' }],
+        // `development` defaults to true from preset-react 8, which emits
+        // jsxDEV() into the published bundle and breaks a production next
+        // build of the app consuming it
+        ['@babel/preset-react', { development: false, runtime: 'automatic' }],
       ],
     }),
   ],


### PR DESCRIPTION
My mistake in #328: I took the Babel React preset to 8 after checking the build and the package's own tests, but not the scaffold smoke test. Version 8 turns its `development` option on by default, so the published bundle carried `jsxDEV()` calls, and a production build of any application using the package failed while prerendering with `jsxDevRuntime.jsxDEV is not a function`. That broke `henri build` on master for about an hour.

The preset is now configured explicitly, which keeps the major rather than pinning back. Confirmed by counting the calls in the built bundle: several before, none after. Then verified the way it should have been the first time, with the full scaffold smoke test: a fresh application installs, lints, builds, boots in production, serves 200 and has its stylesheet applied.