### PR TITLE
Stop the unstyled flash on load in development

### DIFF
--- a/.changeset/inertia-dev-stylesheet.md
+++ b/.changeset/inertia-dev-stylesheet.md
@@ -1,0 +1,7 @@
+---
+'@usehenri/inertia': patch
+---
+
+Development no longer paints an unstyled page before the styles arrive.
+
+Vite hands a stylesheet to the browser as a JavaScript module that injects it once the entry has run, so a server-rendered document had no stylesheet at all in its head and the browser painted the fully laid-out markup unstyled until the module executed. The engine now links the stylesheets the browser entry imports, asking the dev server for the compiled CSS itself, so the styles are there for the first paint. The module still runs and still owns hot updates. Production was never affected: the built stylesheets have always been linked from the manifest.

--- a/packages/inertia/__tests__/engine.test.js
+++ b/packages/inertia/__tests__/engine.test.js
@@ -75,6 +75,44 @@ describe('inertia engine', () => {
     });
   });
 
+  describe('stylesheets of the entry', () => {
+    test('reads the relative css imports of the browser entry', () => {
+      const { engine, henri } = ready();
+
+      dirs.push(henri.cwd());
+      fs.mkdirSync(path.join(engine.dir, 'styles'), { recursive: true });
+      fs.writeFileSync(
+        path.join(engine.dir, 'main.jsx'),
+        [
+          "import { createInertiaApp } from '@inertiajs/react';",
+          "import './styles/index.css';",
+          "import './styles/print.scss';",
+          // Not relative: vite resolves it, we cannot turn it into a url
+          "import 'some-package/dist/x.css';",
+          "import { resolvePage } from '@usehenri/inertia';",
+        ].join('\n')
+      );
+
+      expect(engine.entryStylesheets()).toEqual([
+        '/styles/index.css',
+        '/styles/print.scss',
+      ]);
+    });
+
+    test('is empty when the entry imports none, or cannot be read', () => {
+      const { engine, henri } = ready();
+
+      dirs.push(henri.cwd());
+      fs.mkdirSync(engine.dir, { recursive: true });
+      fs.writeFileSync(path.join(engine.dir, 'main.jsx'), 'const a = 1;\n');
+
+      expect(engine.entryStylesheets()).toEqual([]);
+
+      fs.rmSync(path.join(engine.dir, 'main.jsx'));
+      expect(engine.entryStylesheets()).toEqual([]);
+    });
+  });
+
   describe('page object', () => {
     test('has the Inertia shape and the henri props contract', () => {
       const { engine, henri } = ready();

--- a/packages/inertia/__tests__/shell.test.js
+++ b/packages/inertia/__tests__/shell.test.js
@@ -88,6 +88,17 @@ describe('inertia shell helpers', () => {
     );
   });
 
+  test('devTags() links the stylesheets before the entry runs', () => {
+    const tags = shell.devTags('main.jsx', ['/styles/index.css']);
+
+    // ?direct asks vite for the css itself: without it the dev server hands
+    // over a javascript module and the document paints unstyled first
+    expect(tags).toContain(
+      '<link rel="stylesheet" href="/styles/index.css?direct">'
+    );
+    expect(tags.indexOf('stylesheet')).toBeLessThan(tags.indexOf('<script'));
+  });
+
   test('hash() is stable', () => {
     expect(shell.hash('a')).toBe(shell.hash('a'));
     expect(shell.hash('a')).not.toBe(shell.hash('b'));

--- a/packages/inertia/engine/index.js
+++ b/packages/inertia/engine/index.js
@@ -322,6 +322,7 @@ class InertiaEngine {
 
     // Development: the vite dev server. Production: the static handler
     this.vite = null;
+    this.styles = [];
     this.serve = null;
     // (page) => Promise<{ head: string[], body: string }>, null without ssr
     this.ssr = null;
@@ -580,10 +581,52 @@ class InertiaEngine {
   }
 
   /**
-   * Read the html shell
+   * The stylesheets the browser entry imports, as urls under app/views
+   *
+   * In development Vite hands a stylesheet over as a javascript module that
+   * injects it once the entry has run, so a server rendered document paints
+   * unstyled until then. Linking them in the head fixes that. Only relative
+   * imports of the entry are read: a stylesheet imported by a component is
+   * still injected by its module, as before.
+   *
+   * @returns {Array<string>} urls, empty when the entry imports no stylesheet
+   * @memberof InertiaEngine
+   */
+  entryStylesheets() {
+    const file = path.join(this.dir, this.options.entry);
+    const relative =
+      /^\s*import\s+['"](\.[^'"]+\.(?:css|scss|sass|less))['"]/gm;
+    const found = [];
+
+    try {
+      const source = fs.readFileSync(file, 'utf8');
+
+      let match = relative.exec(source);
+
+      for (; match !== null; match = relative.exec(source)) {
+        const href = path.posix.normalize(
+          path.posix.join('/', path.posix.dirname(this.options.entry), match[1])
+        );
+
+        if (!found.includes(href)) {
+          found.push(href);
+        }
+      }
+    } catch (error) {
+      this.henri.pen.warn(
+        'view',
+        `unable to read ${this.options.entry} for its stylesheets`,
+        error.message
+      );
+    }
+
+    return found;
+  }
+
+  /**
+   * Reads the html template of the application
    *
    * @returns {string} the template
-   * @throws when app/views/index.html is missing
    * @memberof InertiaEngine
    */
   readTemplate() {
@@ -710,6 +753,7 @@ class InertiaEngine {
     }
 
     this.template = this.readTemplate();
+    this.styles = this.entryStylesheets();
 
     if (this.options.ssr !== false) {
       // Loaded on every render so hot updates of the pages apply
@@ -920,7 +964,7 @@ class InertiaEngine {
     }
 
     const assets = this.vite
-      ? shell.devTags(this.options.entry)
+      ? shell.devTags(this.options.entry, this.styles)
       : shell.assetTags(this.manifest, this.options.entry);
 
     return shell.inject(template, {

--- a/packages/inertia/engine/shell.js
+++ b/packages/inertia/engine/shell.js
@@ -75,8 +75,19 @@ function clientBody(id, page) {
  * @param {string} entry the entry file (relative to app/views)
  * @returns {string} html
  */
-function devTags(entry) {
-  return `<script type="module" src="/${entry}"></script>`;
+function devTags(entry, stylesheets = []) {
+  // Vite serves a stylesheet as a javascript module that injects it once the
+  // entry has run, so a server rendered document would paint unstyled first.
+  // `?direct` asks the dev server for the compiled css itself, which the
+  // browser can load from a <link> before it paints. The module still runs
+  // and still owns hot updates; the rules it injects are the same ones.
+  const links = stylesheets.map(
+    (href) => `<link rel="stylesheet" href="${escapeHtml(href)}?direct">`
+  );
+
+  return links
+    .concat(`<script type="module" src="/${entry}"></script>`)
+    .join('\n    ');
 }
 
 /**


### PR DESCRIPTION
Reported on the demo: the page flashes unstyled on load.

In development the document had no stylesheet in its head at all. Vite hands a stylesheet to the browser as a JavaScript module that injects it once the entry has run, so the browser received fully laid-out server-rendered markup with no styles and painted it that way until the module executed. Production was never affected, because the built stylesheets are linked from the manifest.

The engine now reads the stylesheets the browser entry imports and links them, asking the dev server for the compiled CSS itself rather than the JavaScript wrapper. The module still runs and still owns hot updates, and the rules it injects are the same ones. Only relative imports of the entry are read: a stylesheet imported by a component is still injected by its module, as before.

This affects every Inertia application in development, not just the demo.

Verified on the running demo: the head now carries the stylesheet link before the entry script, and the linked URL answers with the application's compiled CSS rather than JavaScript. Covered by tests on both halves, the tag builder and the import reader, including an entry that imports no stylesheet and one that cannot be read.