### PR TITLE
Strip tags until stable in the derived mail text

### DIFF
--- a/.changeset/mail-text-strip.md
+++ b/.changeset/mail-text-strip.md
@@ -1,0 +1,5 @@
+---
+'@usehenri/core': patch
+---
+
+The derived plain text part of a mail no longer keeps a fragment of a malformed tag. Stripping tags in one pass turns `<scr<script>ipt>` into `<script`, and an unterminated opener matches no tag pattern at all, so a crafted or simply broken document left something element shaped in the text a reader sees. Tags are now removed until the string stops changing, and a leftover opener is dropped. A less-than sign that is not a tag is untouched.

--- a/packages/core/src/__tests__/mailers.spec.js
+++ b/packages/core/src/__tests__/mailers.spec.js
@@ -242,6 +242,22 @@ describe('mailers', () => {
   });
 
   describe('htmlToText', () => {
+    test('leaves nothing element shaped behind, however malformed', () => {
+      // One strip pass turns `<scr<script>ipt>` into `<script`, and the
+      // leftover opener has no closing bracket for a tag pattern to match
+      expect(htmlToText('<p>Hello <scr<script>ipt>alert(1)</script></p>')).toBe(
+        'Hello scr'
+      );
+      expect(htmlToText('<p>a<!--<!-- nested -->b</p>')).toBe('ab');
+      expect(htmlToText('<p>x</p>')).not.toContain('<');
+    });
+
+    test('keeps a less-than sign that is not a tag', () => {
+      expect(htmlToText('<p>5 &lt; 6 and 7 &gt; 6</p>')).toBe(
+        '5 < 6 and 7 > 6'
+      );
+    });
+
     test('drops what never belongs in the text part', () => {
       expect(
         htmlToText('<style>b{color:red}</style><script>x()</script><p>Hi</p>')

--- a/packages/core/src/base/mail-text.js
+++ b/packages/core/src/base/mail-text.js
@@ -81,6 +81,30 @@ function decode(value) {
 }
 
 /**
+ * Removes every occurrence of a pattern, and keeps removing until the string
+ * stops changing.
+ *
+ * One pass is not enough: `<scr<script>ipt>` becomes `<script` once the inner
+ * tag is taken out, so a single replace leaves a fragment in the text part.
+ * Every pass strictly shortens the string, so this terminates.
+ *
+ * @param {string} value the string to clean
+ * @param {RegExp} pattern what to remove, with the global flag
+ * @returns {string} the string, with nothing left to remove
+ */
+function removeAll(value, pattern) {
+  let text = value;
+  let previous = null;
+
+  while (previous !== text) {
+    previous = text;
+    text = text.replace(pattern, '');
+  }
+
+  return text;
+}
+
+/**
  * The text of an anchor, with its target when it adds something
  * `<a href="https://x">Open</a>` becomes `Open (https://x)`, and an anchor
  * whose text already is the url is left alone.
@@ -91,7 +115,7 @@ function decode(value) {
  */
 function anchor(href, inner) {
   const target = decode(String(href || '')).trim();
-  const label = decode(inner.replace(/<[^>]*>/g, '')).trim();
+  const label = decode(removeAll(inner, /<[^>]*>/g)).trim();
 
   if (!target || target.startsWith('#') || target === label) {
     return inner;
@@ -120,7 +144,7 @@ function htmlToText(html) {
     );
   }
 
-  text = text.replace(/<!--[\s\S]*?-->/g, '');
+  text = removeAll(text, /<!--[\s\S]*?-->/g);
   // Anchors keep their target before the tags go away
   text = text.replace(
     /<a\b[^>]*\bhref\s*=\s*("([^"]*)"|'([^']*)'|([^\s>]+))[^>]*>([\s\S]*?)<\/a\s*>/gi,
@@ -145,7 +169,11 @@ function htmlToText(html) {
     text = text.replace(new RegExp(`</${tag}\\s*>`, 'gi'), '\n\n');
   }
 
-  text = text.replace(/<[^>]*>/g, '');
+  text = removeAll(text, /<[^>]*>/g);
+  // A malformed document can leave an unterminated opener behind, and
+  // `<scr` is not a tag any pattern above will match. Drop the bracket so
+  // nothing element shaped survives into the text part.
+  text = text.replace(/<(?=[/!?a-z])/gi, '');
   text = decode(text);
 
   return text


### PR DESCRIPTION
Three CodeQL warnings on #337, all in the code that derives the plain text part of a mail from the rich one.

Stripping tags in a single pass is incomplete: `<scr<script>ipt>` becomes `<script` once the inner tag is removed. And an opener with no closing bracket, which is what a malformed document leaves behind, matches no tag pattern at all.

The security impact is small, because the output is a text/plain mail part and a mail client does not render it as markup, but the reader would see the fragment, so it is a correctness bug either way. Tags are now removed until the string stops changing, which terminates because every pass shortens it, and a leftover tag-like opener is dropped so nothing element shaped survives. A less-than sign that is not a tag is left alone, and so are lists, links and blocks.

Covered by tests for the nested payload, a nested comment, and a genuine less-than sign.