### PR TITLE
Type definitions for the API an application touches

### DIFF
--- a/.changeset/type-declarations.md
+++ b/.changeset/type-declarations.md
@@ -1,0 +1,39 @@
+---
+'@usehenri/core': minor
+'@usehenri/cli': minor
+'@usehenri/inertia': minor
+'@usehenri/react': minor
+'@usehenri/testing': minor
+---
+
+Type declarations for the API an application touches.
+
+Every published package now ships hand-written `.d.ts` files, pointed at by
+`types` and included in `files`. henri stays JavaScript: there is no build step,
+no `.ts` file in an application and nothing to install.
+
+- **`@usehenri/core`** declares the `henri` global (`config`, `pen`, `model`,
+  `user`, `router`, `server`, `mail`, `graphql`, `validator`, `addMiddleware`,
+  ...), the request and response additions (`req.permit()`, `req.pagination()`,
+  `req.flash()`, `req.id`, `req.apiVersion`, `req._henri`, `res.render()`,
+  `res.hbs()`, `res.boom.*`, `res.resource()`, `res.collection()`,
+  `res.negotiate()`), and the shape of the three files an application writes:
+  `Controller`, `RoutesFile`, `ModelFile`, plus `Configuration` for
+  `config/default.json`. The routes keys are checked as far as a type can check
+  them, so `'gett /tasks'` and `only: ['list']` are type errors.
+- **`@usehenri/react`** declares `withHenri`, `useHenri`, `request`,
+  `RequestError` and the form components with their props;
+  **`@usehenri/inertia`** `useHenri`, `Form`, `pathFor`, `getRoute`, `request`,
+  `resolvePage` and `henriViteConfig()` (`Link`, `Head`, `router`, `usePage` and
+  `useForm` re-export Inertia's own types); **`@usehenri/testing`** `setup`,
+  `teardown`, `request`, `agent` and `henri`. Neither view package depends on
+  `@types/react`.
+- **`henri new` writes a `jsconfig.json`** with `types: ["@usehenri/core"]`, so
+  an editor knows the `henri` global and completes everything above with no
+  setup. The generators write the one JSDoc line that binds a file to its shape
+  (`/** @type {import('@usehenri/core').Controller} */`), on controllers, model
+  files and `config/routes.js`.
+
+The models themselves stay untyped: `Task` is a Mongoose, Sequelize or Drizzle
+model whose fields come from your schema, and henri does not pretend to know
+it. See the new [Types](https://usehenri.io/reference/types/) page.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,9 @@ jobs:
 
       - run: pnpm lint --max-warnings 0
 
+      # The hand-written .d.ts files: packaging, then tsc over types/
+      - run: pnpm test:types
+
       - run: pnpm test:ci
         env:
           NODE_ENV: test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ pnpm install                          # whole workspace; builds @usehenri/react 
 pnpm test                             # vitest 5, all packages (rebuilds @usehenri/react first)
 pnpm test packages/core               # one package (path filter); `pnpm test:cover` for coverage
 pnpm test:sql                         # the SQL adapters only (sqlite; see below for a live server)
+pnpm test:types                       # the hand-written .d.ts: packaging, then tsc over types/
 pnpm lint                             # eslint 10 flat config, zero warnings in CI
 pnpm format                           # prettier 3 (`pnpm format:check` in CI)
 pnpm build                            # rollup build of @usehenri/react
@@ -181,7 +182,16 @@ request-id,redact,headers,pagination,timeout,health}.js`: `res.resource()` and
 
 - CommonJS everywhere except `packages/react/src` (ESM + JSX compiled by rollup
   to `dist/lib`), `packages/inertia/src` and `vite.mjs` (ESM consumed by Vite)
-  and `website` (Astro). No TypeScript.
+  and `website` (Astro). No TypeScript: the source is JavaScript and the type
+  declarations are hand-written `.d.ts` files, one per package
+  (`packages/core/index.d.ts`, `packages/react/{index,forms,engine}.d.ts`,
+  `packages/inertia/{src/index.d.mts,vite.d.mts,engine/index.d.ts}`,
+  `packages/testing/*.d.ts`), pointed at by `types` and shipped in `files`.
+  `pnpm test:types` (`scripts/check-types.mjs`) checks that every declaration
+  is published and runs `tsc --noEmit` over the fixtures in `types/`, whose
+  `@ts-expect-error` lines make the wrong calls part of the test. Changing a
+  signature means changing its `.d.ts` and, usually, `types/*.test-d.ts`.
+  eslint ignores `.d.ts`; prettier formats them.
 - pnpm links strictly: every module a package `require()`s must be in that
   package's `package.json`. Internal dependencies use `workspace:^`.
 - Apps that use the React renderer must depend on `next`, `react` and `react-dom`

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,6 +40,11 @@ module.exports = [
   {
     ignores: [
       '**/node_modules/**',
+      // Type declarations: hand-written TypeScript, checked by
+      // `pnpm test:types` (tsc) and formatted by prettier, not linted here
+      '**/*.d.ts',
+      '**/*.d.mts',
+      '**/*.d.cts',
       '.claude/**',
       '.tmp/**',
       '**/dist/**',
@@ -191,6 +196,16 @@ module.exports = [
       '**/types.js',
     ],
     rules: {
+      'sort-keys': 'off',
+    },
+  },
+  {
+    // The type-test fixture is a henri application in miniature: type-checked
+    // by `pnpm test:types`, never run. Its key order mirrors a routes file and
+    // a controller, where the order is load-bearing rather than alphabetical.
+    files: ['types/**/*.js'],
+    rules: {
+      'no-unused-vars': 'off',
       'sort-keys': 'off',
     },
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "changeset:publish": "pnpm sync-readme && pnpm build && changeset publish",
     "db:up": "docker compose up --detach --wait",
     "db:down": "docker compose down",
-    "db:reset": "docker compose down --volumes"
+    "db:reset": "docker compose down --volumes",
+    "test:types": "node scripts/check-types.mjs"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^1.0.1",
@@ -36,6 +37,12 @@
     "@commitlint/cli": "^21.2.2",
     "@commitlint/config-conventional": "^21.2.2",
     "@eslint/js": "^10.0.1",
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.7",
+    "@usehenri/core": "workspace:*",
+    "@usehenri/inertia": "workspace:*",
+    "@usehenri/react": "workspace:*",
+    "@usehenri/testing": "workspace:*",
     "@vitest/coverage-v8": "^5.0.0",
     "@vitest/eslint-plugin": "^1.6.27",
     "eslint": "^10.10.0",
@@ -44,6 +51,7 @@
     "lint-staged": "^17.4.1",
     "prettier": "^3.9.6",
     "supertest": "^7.2.2",
+    "typescript": "^7.0.2",
     "vitest": "^5.0.0"
   },
   "lint-staged": {

--- a/packages/cli/scripts/destroy.js
+++ b/packages/cli/scripts/destroy.js
@@ -251,7 +251,12 @@ const editRoutes = async (matches, ctx, label) => {
 
   fs.outputFileSync(
     location,
-    await format(`module.exports = ${util.inspect(actual, { depth: 6 })};`)
+    await format(
+      `/** @type {import('@usehenri/core').RoutesFile} */\nmodule.exports = ${util.inspect(
+        actual,
+        { depth: 6 }
+      )};`
+    )
   );
 };
 

--- a/packages/cli/scripts/generate.js
+++ b/packages/cli/scripts/generate.js
@@ -145,6 +145,8 @@ const model = async (name, attributes = [], opts = {}) => {
 // Types: ${TYPES.join(', ')}.
 // Keys: type, required, default, enum, unique, index (anything else is
 // handed to the adapter as is).
+
+/** @type {import('@usehenri/core').ModelFile} */
 module.exports = {
   options: { timestamps: true },
   schema: ${util.inspect(schema, { depth: 6 })},
@@ -502,7 +504,12 @@ const addRoutes = async (entries, opts = {}) => {
 
   fs.outputFileSync(
     location,
-    await format(`module.exports = ${util.inspect(actual, { depth: 6 })};`)
+    await format(
+      `/** @type {import('@usehenri/core').RoutesFile} */\nmodule.exports = ${util.inspect(
+        actual,
+        { depth: 6 }
+      )};`
+    )
   );
 
   for (const key of Object.keys(entries)) {

--- a/packages/cli/scripts/generate/controllers.js
+++ b/packages/cli/scripts/generate/controllers.js
@@ -239,6 +239,7 @@ const FLAVOURS = { drizzle, mongoose, sequelize };
 // --- the actions ------------------------------------------------------------
 
 const header = (opts) => `${of('helpers', opts)}${of('load', opts)}
+/** @type {import('@usehenri/core').Controller} */
 module.exports = {`;
 
 const footer = () => `};`;

--- a/packages/cli/scripts/init.js
+++ b/packages/cli/scripts/init.js
@@ -608,6 +608,8 @@ const sampleResource = async (force) => {
 // Types: string, text, number, integer, float, boolean, date, json, uuid.
 // Keys: type, required, default, enum, unique (anything else is handed to
 // the adapter as is).
+
+/** @type {import('@usehenri/core').ModelFile} */
 module.exports = {
   options: { timestamps: true },
   schema: {

--- a/packages/cli/template/default/AGENTS.md
+++ b/packages/cli/template/default/AGENTS.md
@@ -2,7 +2,9 @@
 
 A [henri](https://usehenri.io) application: Rails-like MVC for Node.js, CommonJS
 on the server, renderer `{{renderer}}`, store `{{adapter}}`. Follow these rules instead of
-guessing; `henri doctor` checks most of them, the `henri` MCP server answers the rest.
+guessing; `henri doctor` checks most of them, the `henri` MCP server answers the rest. Types
+ship with every package and `jsconfig.json` points at them, so keep the `/** @type ... */` line
+the generators write above `module.exports` (`req`, `res` and `henri` complete; models are `any`).
 
 ## Layout and naming
 
@@ -40,6 +42,7 @@ is given; `--json` prints the files written or removed. Generators rewrite
 ## Models
 
 ```js
+/** @type {import('@usehenri/core').ModelFile} */
 module.exports = {
   schema: {
     title: { type: 'string', required: true, unique: true, index: true },
@@ -80,6 +83,7 @@ json: () => res.resource(post) })`: the page for browsers, HAL for API
 ## Routes
 
 ```js
+/** @type {import('@usehenri/core').RoutesFile} */
 module.exports = {
   root: 'main#home', // GET /, like 'get /': 'main#home'
   'resources posts': { only: ['index', 'show'], member: ['post archive'] },

--- a/packages/cli/template/default/app/controllers/main.js
+++ b/packages/cli/template/default/app/controllers/main.js
@@ -1,5 +1,8 @@
 // Controllers are plain objects of `(req, res)` functions, wired by
 // config/routes.js. Models are globals: `Task` comes from app/models/Task.js.
+// The annotation is what gives `req` and `res` completion in an editor.
+
+/** @type {import('@usehenri/core').Controller} */
 module.exports = {
   home: async (req, res) => {
     res.render('/', { data: { tasks: await Task.find() } });

--- a/packages/cli/template/default/config/routes.js
+++ b/packages/cli/template/default/config/routes.js
@@ -1,3 +1,4 @@
+/** @type {import('@usehenri/core').RoutesFile} */
 module.exports = {
   'get /': 'main#home',
 };

--- a/packages/cli/template/default/jsconfig.json
+++ b/packages/cli/template/default/jsconfig.json
@@ -1,0 +1,13 @@
+{
+  "//": "Editors read this: `types` loads henri's declarations, so `henri`, `req`, `res`, the routes file and the model files get completion and inline documentation with nothing to install. Turn `checkJs` on to have the annotations checked too; declare the model globals you use (`declare const Task: any`) in a .d.ts of your own when you do.",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": false,
+    "module": "node16",
+    "moduleResolution": "node16",
+    "skipLibCheck": true,
+    "target": "es2023",
+    "types": ["@usehenri/core"]
+  },
+  "exclude": ["node_modules", "app/views", ".henri"]
+}

--- a/packages/cli/template/inertia/app/controllers/main.js
+++ b/packages/cli/template/inertia/app/controllers/main.js
@@ -1,3 +1,4 @@
+/** @type {import('@usehenri/core').Controller} */
 module.exports = {
   home: (req, res) => {
     res.render('/');

--- a/packages/cli/template/inertia/app/controllers/tasks.js
+++ b/packages/cli/template/inertia/app/controllers/tasks.js
@@ -4,6 +4,7 @@
 // page the controller redirects to.
 const list = () => Task.find().sort({ createdAt: -1 }).lean();
 
+/** @type {import('@usehenri/core').Controller} */
 module.exports = {
   index: async (req, res) => {
     res.render('/tasks/index', { data: { tasks: await list() } });

--- a/packages/cli/template/inertia/app/models/Task.js
+++ b/packages/cli/template/inertia/app/models/Task.js
@@ -1,5 +1,7 @@
 // Models are autoloaded from app/models and exposed globally (here: `Task`).
 // The schema is handed to the store adapter (mongoose for disk/mongodb).
+
+/** @type {import('@usehenri/core').ModelFile} */
 module.exports = {
   options: {
     timestamps: true,

--- a/packages/cli/template/inertia/app/views/jsconfig.json
+++ b/packages/cli/template/inertia/app/views/jsconfig.json
@@ -1,0 +1,18 @@
+{
+  "//": "The pages: ESM and JSX, bundled by Vite. `components/nav` and the other aliases of vite.config.mjs resolve through `paths`.",
+  "compilerOptions": {
+    "allowJs": true,
+    "jsx": "react-jsx",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "target": "es2023",
+    "paths": {
+      "assets/*": ["./assets/*"],
+      "components/*": ["./components/*"],
+      "helpers/*": ["./helpers/*"],
+      "styles/*": ["./styles/*"]
+    }
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/cli/template/inertia/config/routes.js
+++ b/packages/cli/template/inertia/config/routes.js
@@ -1,3 +1,4 @@
+/** @type {import('@usehenri/core').RoutesFile} */
 module.exports = {
   'get /': 'main#home',
   'get /tasks': 'tasks#index',

--- a/packages/cli/template/inertia/jsconfig.json
+++ b/packages/cli/template/inertia/jsconfig.json
@@ -1,0 +1,13 @@
+{
+  "//": "Editors read this: `types` loads henri's declarations, so `henri`, `req`, `res`, the routes file and the model files get completion and inline documentation with nothing to install. Turn `checkJs` on to have the annotations checked too; declare the model globals you use (`declare const Task: any`) in a .d.ts of your own when you do.",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": false,
+    "module": "node16",
+    "moduleResolution": "node16",
+    "skipLibCheck": true,
+    "target": "es2023",
+    "types": ["@usehenri/core"]
+  },
+  "exclude": ["node_modules", "app/views", ".henri"]
+}

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -1,0 +1,1009 @@
+// Type definitions for @usehenri/core
+//
+// Hand-written, and deliberately so: henri is CommonJS JavaScript and stays
+// that way. These declarations describe the API an application touches -- the
+// `henri` global, the request and response helpers, the controller, model and
+// routes files, and the configuration. They are checked by `pnpm test:types`
+// (see `types/` at the root of the repository).
+//
+// Nothing here changes what the framework does at runtime; a JavaScript
+// application picks them up through `jsconfig.json` (`"types":
+// ["@usehenri/core"]`, which `henri new` writes) and annotates a file with
+// JSDoc where a plain object needs a shape:
+//
+//     /** @type {import('@usehenri/core').Controller} */
+//     module.exports = { index: async (req, res) => ({ tasks: await Task.find() }) };
+
+import type {
+  NextFunction,
+  Request as ExpressRequest,
+  Response as ExpressResponse,
+  Router as ExpressRouter,
+  Express,
+} from 'express';
+import type { Server as HttpServer } from 'node:http';
+
+/**
+ * Boots the application in the current working directory and resolves with
+ * the running instance. This is what `henri server` and `@usehenri/testing`
+ * call; an application rarely calls it itself.
+ */
+declare function start(): Promise<start.Henri>;
+
+declare namespace start {
+  // ---------------------------------------------------------------------------
+  // Configuration (config/default.json, config/<NODE_ENV>.json)
+  // ---------------------------------------------------------------------------
+
+  /** The adapters `stores.<name>.adapter` accepts. */
+  type AdapterName =
+    | 'disk'
+    | 'drizzle'
+    | 'mariadb'
+    | 'mongoose'
+    | 'mssql'
+    | 'mysql'
+    | 'postgresql';
+
+  /**
+   * One entry of `config.stores`. The keys an adapter does not know are
+   * forwarded to the driver (Sequelize takes `logging`, `pool`,
+   * `dialectOptions`, ...), which is what the index signature stands for.
+   */
+  interface StoreConfig {
+    adapter: AdapterName;
+    /** Connection string (mongoose and SQL); required unless `host` is given. */
+    url?: string;
+    host?: string;
+    port?: number;
+    database?: string;
+    username?: string;
+    password?: string;
+    /** mongoose: options passed to `mongoose.connect()`. */
+    opts?: Record<string, unknown>;
+    /** mongoose and SQL: options of the session store. */
+    session?: Record<string, unknown>;
+    /** disk: data directory, relative to the application (`.henri/data`). */
+    path?: string;
+    /** disk: database name (`henri`). */
+    dbName?: string;
+    /** drizzle: the dialect, whose driver the application installs. */
+    dialect?: 'mysql' | 'postgres' | 'sqlite';
+    /** drizzle: `false` stops the development boot from pushing the schema. */
+    sync?: boolean;
+    /** drizzle: apply `db/migrations` on a production boot. */
+    migrate?: boolean;
+    [key: string]: unknown;
+  }
+
+  /** `config.user` when it is an object rather than the model name. */
+  interface UserConfig {
+    /** Name of the user model (`user`). */
+    model?: string;
+    /** Fields, besides `id`, `email` and `roles`, that may leave the server. */
+    public?: string[];
+    /** Where browsers are sent when a route denies them (`/login`). */
+    loginPath?: string;
+    /** Where they land after a form login (`/`). */
+    afterLogin?: string;
+    /** Session lifetime in milliseconds (30 days). */
+    sessionMaxAge?: number;
+  }
+
+  /** The normalized `config.user`, as `henri.user.settings`. */
+  interface UserSettings extends Required<UserConfig> {}
+
+  /** `config.api`: the JSON API. */
+  interface ApiConfig {
+    /** Default page size of `req.pagination()` (`25`). */
+    perPage?: number;
+    /** Largest page size a client may ask for (`100`). */
+    maxPerPage?: number;
+    /** Refuse (500) a JSON answer without `_links` on a resource route. */
+    strict?: boolean;
+    /** `Idempotency-Key` replays; `false` disables the feature. */
+    idempotency?:
+      | false
+      | {
+          /** How long answers are kept (`86400000`). */
+          ttl?: number;
+          /** Module exporting a shared `{ get, set, delete }` store. */
+          store?: string | null;
+        };
+  }
+
+  /** `config.rateLimit`: `false` disables every limit. */
+  interface RateLimitConfig {
+    /** The window of the global limit (`60000`). */
+    windowMs?: number;
+    /** Requests per window and per user or ip (`600`). */
+    max?: number;
+    /** Alias of `max`, the name express-rate-limit 8 uses. */
+    limit?: number;
+    /** The limit on `POST` to the login and register-style paths. */
+    auth?:
+      | false
+      | {
+          windowMs?: number;
+          max?: number;
+          /** Overrides the list of guarded paths. */
+          paths?: string[];
+        };
+    /** Module exporting an express-rate-limit store, or a factory. */
+    store?: string | null;
+  }
+
+  /** `config.inertia`: the options of the Inertia renderer. */
+  interface InertiaConfig {
+    /** Server render the pages (`true`). */
+    ssr?: boolean;
+    /** Id of the root element (`app`). */
+    id?: string;
+    /** Client entry, relative to `app/views` (`main.jsx`). */
+    entry?: string;
+    /** Server entry, relative to `app/views` (`ssr.jsx`). */
+    ssrEntry?: string;
+    /** Html shell, relative to `app/views` (`index.html`). */
+    template?: string;
+  }
+
+  /**
+   * The shape of `config/default.json` and of every `config/<NODE_ENV>.json`.
+   * Annotate a configuration file read from JavaScript, or use it to keep a
+   * hand-written config object honest.
+   */
+  interface Configuration {
+    /** Port to listen on (`3000`). */
+    port?: number;
+    /** Interface to bind; `HENRI_HOST` wins over the file. */
+    host?: string;
+    /** `true` for the cors defaults, an object for its options. */
+    cors?: boolean | Record<string, unknown>;
+    /** View engine (`template`). */
+    renderer?: 'inertia' | 'react' | 'template' | 'vue';
+    inertia?: InertiaConfig;
+    /** Opt-in to the unmaintained renderers. */
+    experimental?: { vue?: boolean };
+    stores?: Record<string, StoreConfig>;
+    /** Session and token secret; usually provided by `HENRI_SECRET`. */
+    secret?: string;
+    /** Name of the user model, or its settings. */
+    user?: string | UserConfig;
+    /** Role, or roles, given to every new user. */
+    baseRole?: string | string[];
+    /** Express `trust proxy` (`true`). */
+    trustProxy?: boolean | number | string;
+    /** `false` disables the CSRF protection. */
+    csrf?: boolean;
+    /** Path of the GraphQL endpoint (`/_henri/gql`). */
+    graphql?: string;
+    /** Nodemailer transport options, or `"test"` for an Ethereal account. */
+    mail?: 'test' | Record<string, unknown>;
+    api?: ApiConfig;
+    rateLimit?: boolean | RateLimitConfig;
+    /** Options merged over henri's helmet defaults; `false` disables it. */
+    helmet?: false | Record<string, unknown>;
+    /** Parameter names masked in the logs. */
+    filterParameters?: string[];
+    /** Maximum size of a JSON or form body (`"1mb"`). */
+    bodyLimit?: string | number;
+    /** Milliseconds before a running request is answered 503. */
+    requestTimeout?: number | false;
+    [key: string]: unknown;
+  }
+
+  /** `henri.api.settings`: the configuration above, normalized. */
+  interface ApiSettings {
+    bodyLimit: string | number;
+    filterParameters: string[];
+    idempotency: false | { store: string | null; ttl: number };
+    pagination: { maxPerPage: number; perPage: number };
+    rateLimit:
+      | false
+      | {
+          auth:
+            | false
+            | {
+                loginPath: string;
+                max: number;
+                paths?: string[];
+                windowMs: number;
+              };
+          max: number;
+          store: string | null;
+          windowMs: number;
+        };
+    requestTimeout: number | false;
+    strict: boolean;
+  }
+
+  // ---------------------------------------------------------------------------
+  // config/routes.js
+  // ---------------------------------------------------------------------------
+
+  /** The http verbs a route key may use. */
+  type Verb =
+    | 'checkout'
+    | 'copy'
+    | 'delete'
+    | 'get'
+    | 'head'
+    | 'lock'
+    | 'm-search'
+    | 'merge'
+    | 'mkactivity'
+    | 'mkcol'
+    | 'move'
+    | 'notify'
+    | 'options'
+    | 'patch'
+    | 'post'
+    | 'purge'
+    | 'put'
+    | 'report'
+    | 'search'
+    | 'subscribe'
+    | 'trace'
+    | 'unlock'
+    | 'unsubscribe';
+
+  /** The seven actions `resources` expands to. */
+  type ResourceAction =
+    'create' | 'destroy' | 'edit' | 'index' | 'new' | 'show' | 'update';
+
+  /** Options every route accepts; they end up on the route object. */
+  interface RouteOptions {
+    /** `controller#action`. */
+    controller?: string;
+    /** Roles allowed to reach the route; anything else gets a 401 or a 403. */
+    roles?: string | string[];
+    /** Answer 406 to clients asking for another api version. */
+    version?: string;
+    /** A rate limit of its own for this route. */
+    rateLimit?: { windowMs?: number; max?: number };
+    /** `false` opts a mutating route out of `Idempotency-Key`. */
+    idempotent?: boolean;
+    [key: string]: unknown;
+  }
+
+  /**
+   * The `member` and `collection` routes of a resource: an array of segments
+   * (`['archive']`, a GET), or `'<verb> <segment>': '<action>'`.
+   */
+  type ResourceExtras =
+    | string[]
+    | Record<string, string | null | (RouteOptions & { action?: string })>;
+
+  /** Options of a `resources` or `crud` entry. */
+  interface ResourceOptions extends RouteOptions {
+    /** Only these actions. */
+    only?: ResourceAction | ResourceAction[];
+    /** Every action but these (`omit` is an alias). */
+    except?: ResourceAction | ResourceAction[];
+    omit?: ResourceAction | ResourceAction[];
+    /** Routes on one record: `/tasks/:id/<segment>`. */
+    member?: ResourceExtras;
+    /** Routes on the collection: `/tasks/<segment>`. */
+    collection?: ResourceExtras;
+    /** Resources nested under this one, below `/tasks/:task_id`. */
+    nested?: RoutesFile;
+    /** The parameter nested resources use (`task_id`). */
+    param?: string;
+    /** A prefix inserted before the resource name. */
+    scope?: string;
+  }
+
+  /**
+   * `config/routes.js`.
+   *
+   * The keys are checked as far as a type can check them: `root`, a path
+   * (`/about`), `<verb> <path>`, `resources <name>`, `crud <name>` and
+   * `namespace <name>`. Their order is load-bearing -- henri registers the
+   * routes in file order -- so keep `get /tasks/mine` above `get /tasks/:id`.
+   */
+  type RoutesFile = {
+    [key in `namespace ${string}`]?: RoutesFile;
+  } & {
+    [key in `crud ${string}` | `resources ${string}`]?:
+      string | ResourceOptions;
+  } & {
+    [key in 'root' | `${Verb} ${string}` | `/${string}`]?:
+      string | RouteOptions;
+  };
+
+  /** One expanded route, as `henri.router.routes` holds them. */
+  interface Route extends RouteOptions {
+    verb: Verb;
+    route: string;
+    controller: string;
+    /** Name of the path helper, always `<action>_<controller>_path`. */
+    path: string;
+    /** True for the routes `resources` and `crud` expanded. */
+    resource?: boolean;
+  }
+
+  /** One entry of the `paths` a view receives. */
+  interface PathHelper {
+    route: string;
+    method: string;
+    roles?: string | string[] | null;
+  }
+
+  /** The path helpers a user may follow, keyed `<action>_<controller>_path`. */
+  type Paths = Record<string, PathHelper>;
+
+  // ---------------------------------------------------------------------------
+  // Request and response
+  // ---------------------------------------------------------------------------
+
+  /** The page `req.pagination()` describes. */
+  interface Pagination {
+    page: number;
+    perPage: number;
+    /** `(page - 1) * perPage`, for Mongoose. */
+    skip: number;
+    /** The same number, for Sequelize. */
+    offset: number;
+    /** `perPage`, for both. */
+    limit: number;
+  }
+
+  /** Flash messages by type, as the views receive them. */
+  type FlashBag = Record<string, unknown[]>;
+
+  /**
+   * `req.flash()`: queue a message, or read and clear what is queued.
+   * Messages live in the session, so this is a no-op without a user model.
+   */
+  interface Flash {
+    /** Reads and clears everything. */
+    (): FlashBag;
+    /** Reads and clears one type. */
+    (type: string): unknown[];
+    /** Queues a message (arrays are flattened). */
+    (type: string, message: unknown): unknown[];
+  }
+
+  /** The current user as it may leave the server. */
+  interface PublicUser {
+    id: string;
+    email: string;
+    roles: string[];
+    /** Plus the fields listed in `config.user.public`. */
+    [field: string]: unknown;
+  }
+
+  /**
+   * What `req._henri` carries and what a view engine receives: set on every
+   * request, then completed by `res.render()` with `data`, `errors` and
+   * `graphql`.
+   */
+  interface ViewOptions {
+    csrf: string | null;
+    flash: FlashBag;
+    localUrl: string;
+    paths: Paths;
+    query: Record<string, unknown>;
+    user: PublicUser | null;
+    /** What the action passed to `res.render({ data })`. */
+    data?: Record<string, unknown>;
+    /** The GraphQL errors, when the page was rendered from a query. */
+    errors?: readonly unknown[] | null;
+    graphql?: { endpoint: string | false; query: string | false };
+  }
+
+  /** The second argument of `res.render()` and `res.hbs()`. */
+  interface RenderOptions {
+    /** What the page receives as `data`. */
+    data?: Record<string, unknown>;
+    /** A GraphQL query run for the page; its result becomes `data`. */
+    graphql?: string;
+  }
+
+  /** Options of `res.resource()`. */
+  interface ResourceOptions {
+    /** Controller name; defaults to the one of the current route. */
+    type?: string;
+    /** Extra links, as `{ rel: href }` or as HAL links. */
+    links?: Record<string, string | { href: string; method?: string }>;
+    /** `201` also sets `Location`. */
+    status?: number;
+  }
+
+  /** Options of `res.collection()`. */
+  interface CollectionOptions extends ResourceOptions {
+    page?: number;
+    perPage?: number;
+    /** Total number of records; without it there is no `last` link. */
+    total?: number;
+  }
+
+  /**
+   * `res.boom.<name>(message, data)`: a JSON error
+   * `{ statusCode, error, message, data }`.
+   */
+  interface Boom {
+    /** 400 */
+    badRequest(message?: string, data?: unknown): ExpressResponse;
+    /** 401 */
+    unauthorized(message?: string, data?: unknown): ExpressResponse;
+    /** 403 */
+    forbidden(message?: string, data?: unknown): ExpressResponse;
+    /** 404 */
+    notFound(message?: string, data?: unknown): ExpressResponse;
+    /** 405 */
+    methodNotAllowed(message?: string, data?: unknown): ExpressResponse;
+    /** 409 */
+    conflict(message?: string, data?: unknown): ExpressResponse;
+    /** 422 */
+    badData(message?: string, data?: unknown): ExpressResponse;
+    /** 429 */
+    tooManyRequests(message?: string, data?: unknown): ExpressResponse;
+    /** 500 */
+    internal(message?: string, data?: unknown): ExpressResponse;
+    /** 501 */
+    notImplemented(message?: string, data?: unknown): ExpressResponse;
+    /** 502 */
+    badGateway(message?: string, data?: unknown): ExpressResponse;
+    /** 503 */
+    serverUnavailable(message?: string, data?: unknown): ExpressResponse;
+  }
+
+  /**
+   * The request henri hands a controller: an Express request plus what the
+   * framework adds.
+   *
+   * `user`, `session`, `isAuthenticated()`, `logIn()` and `logout()` come from
+   * passport and express-session, which core owns; they are declared here so
+   * that an application needs no `@types/passport` of its own. A project that
+   * installs those typings should annotate with Express's own `Request`
+   * instead of this one.
+   */
+  interface Request extends ExpressRequest {
+    /** `X-Request-Id`, accepted from the client or generated. */
+    id: string;
+    /** `'v1'` when the client asked for `application/vnd.henri.v1+json`. */
+    apiVersion: string | null;
+    /** The CSRF token of the request, with a user model. */
+    csrfToken?: string;
+    /** What the view engine reads. */
+    _henri: ViewOptions;
+    /**
+     * The listed fields from the query string, body and path parameters
+     * (later sources win); missing fields are omitted.
+     */
+    permit(...fields: Array<string | string[]>): Record<string, unknown>;
+    /** `{ page, perPage, skip, limit, offset }`, bounded by `config.api`. */
+    pagination(overrides?: {
+      perPage?: number;
+      maxPerPage?: number;
+    }): Pagination;
+    flash: Flash;
+    /**
+     * The logged-in user: a model instance, whose shape only the application
+     * knows. Cast it, or declare your own model type.
+     */
+    user?: any;
+    session?: any;
+    isAuthenticated?(): boolean;
+    isUnauthenticated?(): boolean;
+    logIn?(user: any, done: (error: unknown) => void): void;
+    logOut?(done: (error: unknown) => void): void;
+    logout?(done: (error: unknown) => void): void;
+    /** With the Inertia renderer. */
+    inertia?: { request: boolean; errors: Record<string, string> | null };
+  }
+
+  /**
+   * The response henri hands a controller. `render` is henri's, not Express's:
+   * it takes a route and `{ data }` or `{ graphql }`, and answers JSON when the
+   * client asks for it.
+   */
+  interface Response extends Omit<ExpressResponse, 'render'> {
+    /**
+     * Renders a page with `{ data }` or `{ graphql }`, or answers the view
+     * options as JSON when the client asks for it.
+     *
+     * It resolves once the engine has been handed the request, not once the
+     * page is written, and the value it resolves with is the response itself
+     * (Express's content negotiation returns it) -- there is nothing useful
+     * to read from it.
+     */
+    render(route: string, options?: RenderOptions): Promise<ExpressResponse>;
+    /** The same, through Handlebars whatever the renderer. */
+    hbs(route: string, options?: RenderOptions): Promise<ExpressResponse>;
+    boom: Boom;
+    /** One HAL resource: the record plus `_links`. A list is refused. */
+    resource<T extends object>(
+      record: T extends readonly unknown[] ? never : T,
+      options?: ResourceOptions
+    ): ExpressResponse;
+    /** A HAL collection: `_embedded`, `_links` and the paging headers. */
+    collection(
+      records: readonly object[],
+      options?: CollectionOptions
+    ): ExpressResponse;
+    /**
+     * Runs `html` for browsers and `json` for API clients. The handler is not
+     * awaited: what comes back is the response, not what the handler returned.
+     */
+    negotiate(handlers: {
+      html?: () => unknown;
+      json?: () => unknown;
+    }): ExpressResponse;
+    /** With the Inertia renderer. */
+    inertia?: {
+      errors(errors: Record<string, string>): ExpressResponse;
+      location(url: string): ExpressResponse | void;
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // app/controllers/*.js
+  // ---------------------------------------------------------------------------
+
+  /**
+   * A controller action. Returning without answering renders
+   * `/<controller>/<action>` with what was returned as `data`.
+   */
+  type Action = (req: Request, res: Response) => unknown;
+
+  /**
+   * A `before` hook. Take `next` and call it, or leave it out and return a
+   * promise; a hook that answers ends the request.
+   */
+  type Hook = (req: Request, res: Response, next: NextFunction) => unknown;
+
+  /** A hook with the rails selectors. */
+  interface HookSelector {
+    run: Hook | Hook[];
+    only?: string | string[];
+    except?: string | string[];
+  }
+
+  /**
+   * The `before` block: keyed by action (`all`, `'show,edit'`), or a list of
+   * hooks and selectors.
+   */
+  type BeforeBlock = Record<string, Hook | Hook[]> | Array<Hook | HookSelector>;
+
+  /**
+   * A controller file. Every exported function is an action (`tasks#index`);
+   * `before` is the only reserved key.
+   *
+   *     /** @type {import('@usehenri/core').Controller} *\/
+   *     module.exports = {
+   *       before: { 'show,edit': loadTask },
+   *       index: async (req, res) => ({ tasks: await Task.find() }),
+   *     };
+   */
+  interface Controller {
+    before?: BeforeBlock;
+    [action: string]: Action | BeforeBlock | undefined;
+  }
+
+  // ---------------------------------------------------------------------------
+  // app/models/*.js
+  // ---------------------------------------------------------------------------
+
+  /** The field types every adapter understands. */
+  type FieldType =
+    | 'boolean'
+    | 'date'
+    | 'float'
+    | 'integer'
+    | 'json'
+    | 'number'
+    | 'string'
+    | 'text'
+    | 'uuid';
+
+  /**
+   * One field of a model schema.
+   *
+   * The keys below are the ones every adapter honours. Each also accepts its
+   * own: Mongoose passes anything it does not know straight to the path
+   * (`ref`, `select`, `lowercase`, `validate`, ...), while Sequelize and
+   * Drizzle throw at boot on a key they do not know -- which is why this is an
+   * open interface rather than an exact one.
+   */
+  interface FieldDefinition {
+    type: FieldTypeValue;
+    /** `NOT NULL`, or `required` on Mongoose. */
+    required?: boolean;
+    /** A value, or a function returning one. */
+    default?: unknown;
+    /** Allowed values (an ENUM on mysql and postgres, a validation elsewhere). */
+    enum?: unknown[];
+    unique?: boolean;
+    index?: boolean;
+    [key: string]: unknown;
+  }
+
+  /**
+   * Anything the `type` of a field accepts.
+   *
+   * Only the names henri normalizes are listed. An adapter's own types are
+   * passed as values rather than as names -- a Sequelize `DataTypes.DECIMAL`,
+   * a Mongoose sub-schema, `[String]` -- which is what the last three members
+   * stand for. Sequelize also resolves an uppercase `DataTypes` name
+   * (`'DECIMAL'`); that spelling is deliberately not typed, because Mongoose
+   * would take the same string for something else.
+   */
+  type FieldTypeValue =
+    | FieldType
+    /** Mongoose: `{ type: 'ObjectId', ref: 'User' }`. */
+    | 'ObjectId'
+    /** A constructor (`String`, `Number`, `Date`) or a Sequelize DataType. */
+    | Function
+    /** A list (`[String]`, `['string']`) or a nested schema. */
+    | readonly unknown[]
+    | object;
+
+  /**
+   * One entry of a schema: a type name, a definition, or -- on Mongoose -- a
+   * nested schema.
+   */
+  type SchemaValue =
+    | FieldType
+    | 'ObjectId'
+    | Function
+    | readonly unknown[]
+    | FieldDefinition
+    | Schema;
+
+  /** A schema: field name to type name or definition. */
+  type Schema = { [field: string]: SchemaValue };
+
+  /**
+   * `model.options`. `timestamps` and `paranoid` are henri's; every other key
+   * goes to the ORM (`tableName`, `indexes`, `defaultScope`, ... on Sequelize,
+   * anything `new mongoose.Schema()` takes on Mongoose).
+   */
+  interface ModelOptions {
+    /** `createdAt` and `updatedAt` (`true`). */
+    timestamps?: boolean;
+    /** Soft deletes: `deletedAt` instead of a real delete. */
+    paranoid?: boolean;
+    [key: string]: unknown;
+  }
+
+  /**
+   * A model file. Core adds `identity` (the lowercased file name) and
+   * `globalId` (the file name) before handing it to the adapter, and exposes
+   * the ORM model as `global[globalId]`.
+   */
+  interface ModelFile {
+    schema: Schema;
+    /** The store of `config.stores` this model lives in (`default`). */
+    store?: string;
+    /** Collection or table name; defaults to the file name, pluralized. */
+    name?: string;
+    options?: ModelOptions;
+    graphql?: { types?: string; resolvers?: Record<string, unknown> };
+    /** Called once every model exists, with the models by global id. */
+    associate?(models: Record<string, unknown>): void;
+  }
+
+  /** What `Model.paginate({ page, perPage })` answers, on every adapter. */
+  interface Page<T = any> {
+    records: T[];
+    page: number;
+    perPage: number;
+    /** Number of records matching the query. */
+    total: number;
+    /** Number of pages. */
+    pages: number;
+  }
+
+  /**
+   * The store adapters, as `henri.model.stores` holds them.
+   *
+   * The ORM models themselves are not typed here: their shape is the ORM's
+   * (a Mongoose `Model`, a Sequelize `ModelStatic`, a Drizzle model class),
+   * and henri only adds `paginate()` and, on Mongoose with
+   * `options.paranoid`, the soft-delete statics. Type a model in your own
+   * application if you want more than `any` from the globals.
+   */
+  interface StoreAdapter {
+    /** The kind of adapter (`mysql`, `disk`, ...). */
+    adapterName: string;
+    /** The store name (`default`). */
+    name: string;
+    addModel(model: ModelFile, userModelName?: string): any;
+    getModels(): Record<string, any>;
+    start(): Promise<unknown>;
+    stop(): Promise<unknown>;
+    getSessionConnector(session: unknown): Promise<unknown>;
+    findUserByEmail(email: string): Promise<any>;
+    findUserById(id: string): Promise<any>;
+    userId(user: unknown): string;
+    toPlain(user: unknown): Record<string, unknown>;
+    ping(): Promise<boolean>;
+    transaction<T>(fn: (transaction: any) => Promise<T>): Promise<T>;
+    /** SQL adapters only: a raw query with `?` or `:name` replacements. */
+    query?(
+      sql: string,
+      params?: unknown[] | Record<string, unknown>,
+      options?: Record<string, unknown>
+    ): Promise<any>;
+  }
+
+  // ---------------------------------------------------------------------------
+  // View engines
+  // ---------------------------------------------------------------------------
+
+  /** What a view engine implements; `new Engine(henri)`. */
+  interface ViewEngine {
+    /** Level 3: check the dependencies and the layout. */
+    init(): Promise<unknown>;
+    /** Level 5, before the server listens: build, or start the dev server. */
+    prepare(): Promise<unknown>;
+    /** The catch-all serving the pages no route claimed, and the assets. */
+    fallback(router: ExpressRouter): void;
+    render(
+      req: Request,
+      res: Response,
+      route: string,
+      opts?: ViewOptions
+    ): Promise<unknown>;
+    reload?(): Promise<unknown>;
+    close?(): Promise<unknown>;
+  }
+
+  // ---------------------------------------------------------------------------
+  // The modules of the henri instance
+  // ---------------------------------------------------------------------------
+
+  /**
+   * `henri.config`. The type of a value is only known to the application:
+   * pass it (`henri.config.get<string>('secret')`).
+   */
+  interface ConfigModule {
+    name: 'config';
+    /** The loaded (and frozen) configuration. */
+    config: Configuration | null;
+    /** Throws when the key is missing. Keys use dots: `stores.default.url`. */
+    get<T = any>(key: string): T;
+    /** With `safe`, answers `false` instead of throwing. */
+    get<T = any>(key: string, safe: boolean): T | false;
+    has(key: string): boolean;
+  }
+
+  /** `henri.pen`, the logger. Every line is prefixed with the module name. */
+  interface Pen {
+    error(name: string, ...args: unknown[]): void;
+    warn(name: string, ...args: unknown[]): void;
+    info(name: string, ...args: unknown[]): void;
+    verbose(name: string, ...args: unknown[]): void;
+    debug(name: string, ...args: unknown[]): void;
+    silly(name: string, ...args: unknown[]): void;
+    /**
+     * Prints the error with its stack and returns an Error to throw:
+     * `throw henri.pen.fatal('view', 'unknown renderer')`.
+     */
+    fatal(
+      name?: string,
+      summary?: string | Error,
+      full?: string | null,
+      obj?: object | null
+    ): Error;
+    /** Prints blank lines. */
+    line(times?: number): void;
+    /** A desktop notification, in development. */
+    notify(title?: string | null, message?: string | null): void;
+  }
+
+  /** `henri.user`. */
+  interface UserModule {
+    name: 'user';
+    /** The normalized `config.user`. */
+    settings: UserSettings | null;
+    /** The passport instance holding the `local` and `jwt` strategies. */
+    passport: any;
+    /** Hashes a password; rejects strings shorter than 6 characters. */
+    encrypt(password: string, rounds?: number): Promise<string>;
+    /** Resolves `true`; rejects with an error on a mismatch, never `false`. */
+    compare(password: string, hash: string): Promise<true>;
+    findByEmail(email: string): Promise<any>;
+    findById(id: string): Promise<any>;
+    /** `{ id, email, roles }` plus `config.user.public`. */
+    publicUser(user: unknown): PublicUser | null;
+  }
+
+  /** `henri.router`. */
+  interface RouterModule {
+    name: 'router';
+    /** The expanded table, keyed `<verb> <path>`. */
+    routes: Record<string, Route>;
+    /** The Express router the routes are mounted on. */
+    handler: ExpressRouter;
+    /** The path helpers this user may follow. */
+    pathForRoles(user: unknown): Paths;
+  }
+
+  /** `henri.controllers`. */
+  interface ControllersModule {
+    name: 'controllers';
+    /** One action, by `name#action`. */
+    get(key: string): Action | undefined;
+    /** The `before` hooks of an action, as middlewares. */
+    hooks(key: string): Array<(...args: any[]) => unknown>;
+    all(): Record<string, unknown>;
+    size(): number;
+  }
+
+  /** `henri.server`. */
+  interface ServerModule {
+    name: 'server';
+    /** The Express application. */
+    app: Express | null;
+    express: unknown;
+    httpServer: HttpServer | null;
+    /** Where the server answers (`http://127.0.0.1:3000`). */
+    url: string;
+    host: string | null;
+    port: number;
+  }
+
+  /** `henri.model`. */
+  interface ModelModule {
+    name: 'model';
+    /** The adapter instances, by store name. */
+    stores: Record<string, StoreAdapter>;
+    /** The names of the model globals. */
+    ids: string[];
+    getStore(name: string): StoreAdapter;
+    /**
+     * Normalizes what any adapter throws on an invalid write into
+     * `{ field: message }`, and answers `null` when the error is not a
+     * validation failure (rethrow it then).
+     */
+    errors(error: unknown): Record<string, string> | null;
+  }
+
+  /** `henri.view`. */
+  interface ViewModule {
+    name: 'view';
+    engine: ViewEngine | null;
+    renderer: string;
+    /** The Handlebars engine, always available (`res.hbs()`). */
+    hbs: any;
+  }
+
+  /** `henri.mail`. */
+  interface MailModule {
+    name: 'mail';
+    /** Sends a message through the configured transport. */
+    send(message: Record<string, unknown>): Promise<any>;
+    /** The nodemailer transport. */
+    transporter: any;
+    /** The nodemailer module. */
+    nodemailer: any;
+  }
+
+  /** `henri.graphql`. */
+  interface GraphqlModule {
+    name: 'graphql';
+    /** Path of the endpoint (`/_henri/gql`). */
+    endpoint: string;
+    /** Whether a schema was found and the endpoint mounted. */
+    active: boolean;
+    /**
+     * Runs a query against the merged schema. Answers the string
+     * `'No graphql schema found.'` when there is no schema.
+     */
+    run(
+      query?: string,
+      variables?: Record<string, unknown>,
+      contextValue?: Record<string, unknown>
+    ): Promise<{ data: unknown; errors?: readonly unknown[] } | string>;
+    GraphQLError: unknown;
+    ApolloError: unknown;
+    SyntaxError: unknown;
+    ValidationError: unknown;
+    AuthenticationError: unknown;
+    ForbiddenError: unknown;
+    UserInputError: unknown;
+    toApolloError(error: Error, code?: string): Error;
+  }
+
+  /** `henri.workers`. */
+  interface WorkersModule {
+    name: 'workers';
+    /** The loaded workers, by file. */
+    workers: Record<string, unknown>;
+    files: string[];
+  }
+
+  /** `henri.api`: the JSON API settings and the stores it uses. */
+  interface ApiNamespace {
+    settings: ApiSettings;
+    /** Resource routes already reported for answering JSON without `_links`. */
+    warned: Set<string>;
+    idempotencyStore: unknown;
+    rateLimitStore(name: string): unknown;
+    limiters: unknown[];
+    stop(): void;
+  }
+
+  /** `henri.utils`. */
+  interface Utils {
+    resolveFrom(name: string, dir?: string): string;
+    resolvePackageJson(name: string, dir?: string): string;
+    /** Throws with the install command when a package is missing. */
+    checkPackages(names: string[]): boolean;
+    detectPackageManager(dir?: string): string;
+    installCommand(names: string[]): string;
+    loadModules(dir: string): Promise<unknown[]>;
+    syntax(file: string): unknown;
+    isLoopback(address: string): boolean;
+    [key: string]: unknown;
+  }
+
+  /**
+   * The running application: `global.henri` in an app, and what
+   * `require('@usehenri/core')()` resolves with.
+   */
+  interface Henri {
+    config: ConfigModule;
+    pen: Pen;
+    mail: MailModule;
+    graphql: GraphqlModule;
+    controllers: ControllersModule;
+    server: ServerModule;
+    model: ModelModule;
+    view: ViewModule;
+    user: UserModule;
+    router: RouterModule;
+    workers: WorkersModule;
+    api: ApiNamespace;
+    /** The passport instance (also `henri.user.passport`). */
+    passport: any;
+    /** `.permit(...fields)` and `.all()`, the helper behind `req.permit()`. */
+    params(req: Request | ExpressRequest): {
+      all(): Record<string, unknown>;
+      permit(...fields: Array<string | string[]>): Record<string, unknown>;
+    };
+    /** validator.js. Install `@types/validator` for its own declarations. */
+    validator: any;
+    utils: Utils;
+    /** A tagged template returning the query string, so editors format it. */
+    gql(ast: TemplateStringsArray | string): string;
+
+    env: string | undefined;
+    isProduction: boolean;
+    isDev: boolean;
+    isTest: boolean;
+    isTesting: boolean;
+    /** The core version. */
+    release: string;
+    runlevel: number;
+    status: Map<string, unknown>;
+    /** Use the configured mail transport under `NODE_ENV=test`. */
+    forceMail?: boolean;
+
+    cwd(): string;
+    init(): Promise<boolean>;
+    reload(): Promise<boolean>;
+    /** Resolves with the errors of the modules that failed to stop. */
+    stop(): Promise<Error[]>;
+    /**
+     * Registers a middleware run before the routes are mounted. Call it
+     * before the router starts (a `db/seeds.js`-style boot file, or a module).
+     */
+    addMiddleware(name: string, fn: (router: ExpressRouter) => void): boolean;
+    modules: { add(module: unknown): unknown; [key: string]: unknown };
+  }
+}
+
+declare global {
+  /**
+   * The running application. henri sets it on boot (`@usehenri/testing` does
+   * it under `NODE_ENV=test`), so every file of an application can use it
+   * without requiring anything.
+   */
+  var henri: start.Henri;
+}
+
+export = start;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,9 +23,11 @@
     "url": "https://github.com/usehenri/henri/issues"
   },
   "main": "src/index.js",
+  "types": "index.d.ts",
   "files": [
     "src",
     "!src/__tests__",
+    "index.d.ts",
     "CHANGELOG.md",
     "LICENSE",
     "README.md"
@@ -42,6 +44,7 @@
     "@as-integrations/express5": "^1.1.2",
     "@graphql-tools/merge": "^9.2.3",
     "@graphql-tools/schema": "^10.1.0",
+    "@types/express": "^5.0.6",
     "bcryptjs": "^3.0.3",
     "chalk": "^4.1.2",
     "chokidar": "^4.0.3",
@@ -66,7 +69,7 @@
     "validator": "^13.15.35"
   },
   "devDependencies": {
-    "@types/validator": "^13.15.0"
+    "@types/validator": "^13.15.10"
   },
   "engines": {
     "node": ">=22"

--- a/packages/inertia/engine/index.d.ts
+++ b/packages/inertia/engine/index.d.ts
@@ -1,0 +1,65 @@
+// Type definitions for @usehenri/inertia/engine
+//
+// The engine is what core loads for `"renderer": "inertia"`, and what
+// `henri build` calls. An application rarely touches it.
+
+/** The view engine core instantiates with `new InertiaEngine(henri)`. */
+declare class InertiaEngine {
+  constructor(henri: unknown);
+  init(): Promise<true>;
+  prepare(): Promise<unknown>;
+  fallback(router: unknown): void;
+  render(
+    req: unknown,
+    res: unknown,
+    route: string,
+    opts?: Record<string, unknown>
+  ): Promise<void>;
+  build(): Promise<InertiaEngine.BuildResult>;
+  close(): Promise<true>;
+}
+
+declare namespace InertiaEngine {
+  /** What `build()` reports. */
+  interface BuildResult {
+    /** Path of the client manifest. */
+    client: string;
+    /** How long the build took, in milliseconds. */
+    duration: number;
+    /** Path of the server bundle, or null without ssr. */
+    ssr: string | null;
+  }
+
+  /** The defaults of `config.inertia`. */
+  interface Options {
+    /** Client entry, relative to `app/views` (`main.jsx`). */
+    entry: string;
+    /** Id of the root element (`app`). */
+    id: string;
+    /** Server render the pages (`true`). */
+    ssr: boolean;
+    /** Server entry, relative to `app/views` (`ssr.jsx`). */
+    ssrEntry: string;
+    /** Html shell, relative to `app/views` (`index.html`). */
+    template: string;
+  }
+
+  interface BuildOptions {
+    /** The application directory (`process.cwd()`). */
+    cwd?: string;
+    /** Only `config.inertia` is read, and it must be a plain object. */
+    config?: { inertia?: Partial<Options> };
+    /** Passed to Vite. */
+    logLevel?: 'error' | 'info' | 'silent' | 'warn';
+  }
+
+  /** Builds the client (and the ssr bundle) without booting henri. */
+  function build(options?: BuildOptions): Promise<BuildResult>;
+
+  /** The component a route renders (`/tasks/` -> `tasks`). */
+  function componentName(route?: string): string;
+
+  const DEFAULTS: Options;
+}
+
+export = InertiaEngine;

--- a/packages/inertia/package.json
+++ b/packages/inertia/package.json
@@ -14,10 +14,20 @@
     "url": "https://github.com/usehenri/henri/issues"
   },
   "main": "./src/index.mjs",
+  "types": "./src/index.d.mts",
   "exports": {
-    ".": "./src/index.mjs",
-    "./engine": "./engine/index.js",
-    "./vite": "./vite.mjs",
+    ".": {
+      "types": "./src/index.d.mts",
+      "default": "./src/index.mjs"
+    },
+    "./engine": {
+      "types": "./engine/index.d.ts",
+      "default": "./engine/index.js"
+    },
+    "./vite": {
+      "types": "./vite.d.mts",
+      "default": "./vite.mjs"
+    },
     "./package.json": "./package.json"
   },
   "engines": {
@@ -26,6 +36,7 @@
   "files": [
     "engine",
     "src",
+    "vite.d.mts",
     "vite.mjs"
   ],
   "dependencies": {

--- a/packages/inertia/src/index.d.mts
+++ b/packages/inertia/src/index.d.mts
@@ -1,0 +1,173 @@
+// Type definitions for @usehenri/inertia
+//
+// `Head`, `Link`, `router`, `usePage` and `useForm` are re-exported from
+// @inertiajs/react unchanged, so their own declarations are re-exported too
+// rather than restated here. Only henri's additions are declared.
+
+export { Head, Link, router, usePage, useForm } from '@inertiajs/react';
+
+/** A path helper of the current user, keyed `<action>_<controller>_path`. */
+export interface PathHelper {
+  route: string;
+  method: string;
+}
+
+/** The path helpers a page received, filtered by the roles of the user. */
+export type Paths = Record<string, PathHelper>;
+
+/** The current user, as it may leave the server. */
+export interface PublicUser {
+  id: string;
+  email: string;
+  roles: string[];
+  [field: string]: unknown;
+}
+
+/**
+ * What `useHenri()` answers.
+ *
+ * Not the same shape as `@usehenri/react`'s: the Inertia page carries `query`,
+ * `errors` defaults to `{}` rather than to null, and there is no `error` --
+ * a failed request throws instead.
+ */
+export interface HenriView {
+  /** The CSRF token of the request; `<Form>` sends it for you. */
+  csrf: string | null;
+  /** What the controller passed to `res.render({ data })`. */
+  data: Record<string, any>;
+  /** Validation errors of the last write (`res.inertia.errors()`). */
+  errors: Record<string, any>;
+  /** Flash messages by type. */
+  flash: Record<string, unknown[]>;
+  graphql: any | null;
+  /** Where the server answers, for absolute links. */
+  localUrl: string;
+  paths: Paths;
+  /** The query string of the request. */
+  query: Record<string, any>;
+  user: PublicUser | null;
+  /** A JSON request against the application, with the CSRF token attached. */
+  fetch(
+    target: string | { method?: string; route: string },
+    payload?: any
+  ): Promise<any>;
+  /** Reloads the `data` prop through the Inertia router. */
+  hydrate(options?: Record<string, unknown>): any;
+  /**
+   * A path helper.
+   *
+   * - without `params`: the `{ method, route }` entry, unfilled
+   * - with a string: the route with `:id` replaced, as a string
+   * - with an object: `{ method, route }` with the named parameters replaced
+   * - `undefined` when the route is unknown to this user
+   */
+  pathFor(
+    path?: string | null,
+    params?: string | Record<string, unknown> | null
+  ): PathHelper | string | undefined;
+  /** The route of a helper (`'route-not-found'` when it is unknown). */
+  getRoute(route?: string | null, id?: string | null): string;
+}
+
+/** The view options of the page being rendered. */
+export declare function useHenri(): HenriView;
+
+/** The same, from the props of a page rendered outside a hook. */
+export declare function henriProps(props?: Record<string, any>): HenriView;
+
+/** The defaults `henriProps()` fills in. */
+export declare const EMPTY: Readonly<{
+  csrf: null;
+  data: Record<string, never>;
+  errors: Record<string, never>;
+  flash: Record<string, never>;
+  graphql: null;
+  localUrl: '';
+  paths: Record<string, never>;
+  query: Record<string, never>;
+  user: null;
+}>;
+
+/** A path helper, curried over the `paths` of a page. */
+export declare function pathFor(
+  paths?: Paths,
+  path?: string | null,
+  params?: string | Record<string, unknown> | null
+): PathHelper | string | undefined;
+
+/** The route of a helper (`'route-not-found'` when it is unknown). */
+export declare function getRoute(
+  paths?: Paths,
+  route?: string | null,
+  id?: string | null
+): string;
+
+/** Options of `request()`. */
+export interface RequestOptions {
+  /** Wins over `target.method` (`get`). */
+  method?: string;
+  /** The query string on a GET, a JSON body otherwise. */
+  data?: any;
+  /** Sent as `X-CSRF-Token`. */
+  csrf?: string | null;
+  headers?: Record<string, string>;
+}
+
+/**
+ * A JSON request against the application. Answers the parsed body, and throws
+ * an `Error` carrying `status` and `response` (the parsed body) on anything
+ * but a 2xx -- there is no error class here, unlike in `@usehenri/react`.
+ */
+export declare function request(
+  target: string | { method?: string; route: string },
+  options?: RequestOptions
+): Promise<any>;
+
+/** Where a form submits: a path, or a path helper from `pathFor()`. */
+export type FormAction =
+  string | { method?: string; route?: string; url?: string };
+
+/** `{ method, url }`, the shape Inertia's own `<Form>` takes. */
+export declare function normalizeAction(
+  action: FormAction,
+  method?: string
+): { method: string; url: string };
+
+export interface FormProps {
+  /** Where to submit; a `pathFor()` result works as it is. */
+  action?: FormAction;
+  /** Wins over `action.method` (`post`). */
+  method?: string;
+  /**
+   * The token for the hidden `_csrf` field. Left out, the token of the page is
+   * used; `false` leaves the field out entirely.
+   */
+  csrf?: string | false;
+  children?: any;
+  [prop: string]: any;
+}
+
+/**
+ * Inertia's `<Form>` with henri's CSRF field and path helpers: everything else
+ * is forwarded, so its render prop and its options work unchanged.
+ */
+export declare function Form(props: FormProps): any;
+
+/** Options of `resolvePage()`. */
+export interface ResolvePageOptions {
+  /** Where the pages live in the glob (`'./pages'`). */
+  dir?: string;
+  /** Tried in order (`['jsx', 'tsx', 'js', 'ts']`). */
+  extensions?: string[];
+}
+
+/**
+ * Resolves the component of a page name against an `import.meta.glob()` map,
+ * trying `<dir>/<name>.<ext>` then `<dir>/<name>/index.<ext>`. This is what an
+ * application's `main.jsx` passes to `createInertiaApp({ resolve })`.
+ */
+export declare function resolvePage(
+  pages: Record<string, (() => Promise<any>) | any>,
+  name: string,
+  options?: ResolvePageOptions
+): Promise<any> | any;

--- a/packages/inertia/vite.d.mts
+++ b/packages/inertia/vite.d.mts
@@ -1,0 +1,31 @@
+// Type definitions for @usehenri/inertia/vite
+
+import type { UserConfig } from 'vite';
+
+/** The directories aliased inside `app/views` (`components/nav`). */
+export declare const ALIASES: string[];
+
+export interface HenriViteOptions {
+  /** The views directory (`<cwd>/app/views`). */
+  views?: string;
+  /** The client entry, relative to `views` (`main.jsx`). */
+  entry?: string;
+  /** Options for `@vitejs/plugin-react`. */
+  react?: Record<string, unknown>;
+}
+
+/**
+ * The Vite configuration of a henri application: the views as the root, the
+ * `components/`, `styles/`, `assets/` and `helpers/` aliases, the manifest the
+ * engine reads, and the sass load paths.
+ *
+ *     import { henriViteConfig } from '@usehenri/inertia/vite';
+ *
+ *     export default henriViteConfig({ entry: 'main.jsx' });
+ */
+export declare function henriViteConfig(options?: HenriViteOptions): UserConfig;
+
+/** `henriViteConfig()` with the defaults, already evaluated. */
+declare const config: UserConfig;
+
+export default config;

--- a/packages/react/engine.d.ts
+++ b/packages/react/engine.d.ts
@@ -1,0 +1,81 @@
+// Type definitions for @usehenri/react/engine
+//
+// The engine is what core loads for `"renderer": "react"`, and what
+// `henri build` calls. An application rarely touches it; `app/views/
+// next.config.js` and a deployment script do.
+
+/** The view engine core instantiates with `new ReactEngine(henri)`. */
+declare class ReactEngine {
+  constructor(henri: unknown, deps?: { next?: Function; spawn?: Function });
+  init(): Promise<true>;
+  prepare(): Promise<true>;
+  fallback(router: unknown): void;
+  render(
+    req: unknown,
+    res: unknown,
+    route: string,
+    opts?: Record<string, unknown>
+  ): Promise<void>;
+  build(): Promise<ReactEngine.BuildResult | null>;
+  reload(): Promise<true>;
+  close(): Promise<true>;
+}
+
+declare namespace ReactEngine {
+  /** What `build()` reports. */
+  export interface BuildResult {
+    /** The next.js build id, when one was written. */
+    buildId: string | null;
+    bundler: string;
+    /** The directory that was built (`<cwd>/app/views`). */
+    dir: string;
+    distDir: string;
+  }
+
+  export interface BuildOptions {
+    /** The application directory (`process.cwd()`). */
+    cwd?: string;
+    /**
+     * The configuration: a plain object, or henri's config module. Only
+     * `renderer` is read -- `build()` answers `null` for another one.
+     */
+    config?:
+      | Record<string, unknown>
+      | { has(key: string): boolean; get(key: string): unknown }
+      | null;
+    /** Where the lines go; defaults to the console. */
+    pen?: {
+      error(name: string, ...args: unknown[]): void;
+      info(name: string, ...args: unknown[]): void;
+      warn(name: string, ...args: unknown[]): void;
+    };
+    bundler?: 'turbopack' | 'webpack';
+    distDir?: string | null;
+  }
+
+  /**
+   * Builds the pages for production without booting henri. `henri build`
+   * calls this; a deployment can call it directly.
+   */
+  export function build(options?: BuildOptions): Promise<BuildResult | null>;
+
+  /**
+   * The next.js configuration of an application: the sass load paths, plus
+   * the `config/webpack.js` and `config/next.js` hooks. This is what
+   * `app/views/next.config.js` re-exports.
+   */
+  export function createNextConfig(cwd?: string): Record<string, any>;
+
+  /** Creates `next.config.js` and `jsconfig.json` when they are missing. */
+  export function ensureNextConfig(dir: string, pen: unknown): string[];
+
+  /** The page a route renders (`/tasks/index` -> `/tasks`). */
+  export function pagePath(route?: string): string;
+
+  /** `webpack` when `config/webpack.js` has a hook, `turbopack` otherwise. */
+  export function selectBundler(cwd: string): 'turbopack' | 'webpack';
+
+  export { ReactEngine };
+}
+
+export = ReactEngine;

--- a/packages/react/forms.d.ts
+++ b/packages/react/forms.d.ts
@@ -1,0 +1,195 @@
+// Type definitions for @usehenri/react/forms
+//
+// The components are `(props) => any` on purpose: the package does not depend
+// on `@types/react`, and a function returning `any` is still a valid JSX
+// element type, so props are checked either way.
+
+/**
+ * A validator.js rule name mapped to its options: `true` to run it with none,
+ * anything else is passed as the second argument
+ * (`{ isLength: { min: 3 }, isEmail: true }`).
+ */
+export type Rules = Record<string, unknown>;
+
+/** What `useForm()` answers: the state of the surrounding `<Form>`. */
+export interface FormState {
+  /** Always true inside a `<Form>`; the fields warn when it is not. */
+  _henriForm: boolean;
+  /** The values, keyed by field name (dotted names nest). */
+  data: Record<string, any>;
+  /** True while a submit is in flight. */
+  disabled: boolean;
+  /** The form-level error: the message, `true` without one, or null. */
+  error: string | true | null;
+  /** The failing rule (or the server message) per field. */
+  errors: Record<string, string | null>;
+  /** True once a field changed. */
+  modified: boolean;
+  /** Registers a sanitizer for a field; the returned function removes it. */
+  addSanitizer(fieldName: string, rules?: Rules): () => void;
+  /** Resets the values to what `data` was. */
+  clear(): void;
+  handleChange(
+    event: {
+      target: {
+        name: string;
+        value?: any;
+        type?: string;
+        checked?: boolean;
+      };
+    },
+    validation?: Rules
+  ): void;
+  handleSubmit(event?: { preventDefault?: () => void }): Promise<any> | void;
+}
+
+/** The context `Form` provides. Prefer `useForm()`. */
+export declare const FormContext: any;
+
+/** The state of the surrounding `<Form>`. */
+export declare function useForm(): FormState;
+
+/** Where a form submits: a path, or a path helper from `pathFor()`. */
+export type FormAction = string | { method?: string; route?: string };
+
+export interface FormProps {
+  /** Where to submit. Cannot be combined with `handleSubmit`. */
+  action?: FormAction | null;
+  /** Wins over `action.method` (`post`). */
+  method?: string | null;
+  /** The initial values; changing it resets the form. */
+  data?: Record<string, any> | null;
+  /** An error to show, from outside the form. */
+  error?: any;
+  /** Submit yourself: `(action, sanitizedData, clear) => any`. */
+  handleSubmit?:
+    | ((
+        action: FormAction | null,
+        data: Record<string, any>,
+        clear: () => void
+      ) => any)
+    | null;
+  /** Called with the sanitized payload and the answer. */
+  onSuccess?: ((data: Record<string, any>, result: any) => void) | null;
+  onError?: ((message: string, error: unknown) => void) | null;
+  /** The message used when the server sends none. */
+  onFail?: string;
+  /** Logs the payload and the result. */
+  debug?: boolean;
+  className?: string;
+  /** Rendered as the `id` of the `<form>`. */
+  name?: string;
+  children?: any;
+}
+
+/**
+ * A form bound to the page's `fetch`: it submits as JSON, puts the server's
+ * validation errors on the fields and re-hydrates the page on success.
+ */
+export declare function Form(props: FormProps): any;
+
+/** What every field shares. */
+export interface FieldProps {
+  /** The key in the form data (dotted names nest). */
+  name: string;
+  /** validator.js rules run on change. */
+  validation?: Rules;
+  /** validator.js rules applied to the value before it is submitted. */
+  sanitation?: Rules;
+  /** A message per failing rule name. */
+  errorMsg?: Record<string, string>;
+  baseClassName?: string;
+  errorClassName?: string;
+  required?: boolean;
+  [prop: string]: any;
+}
+
+export interface InputProps extends FieldProps {
+  /** Default `'form-control'`. */
+  className?: string;
+  /** Default `'text'`; `'checkbox'` binds `checked` instead of `value`. */
+  type?: string;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+export declare function Input(props: InputProps): any;
+
+export interface SelectProps extends FieldProps {
+  /** Strings, numbers, or objects read through `displayProp` and `id`. */
+  choices?: Array<string | number | Record<string, any>>;
+  /** The key holding the label of an object choice (`'name'`). */
+  displayProp?: string;
+  /** Renders a leading empty option. */
+  placeholder?: string | null;
+  className?: string;
+  disabled?: boolean;
+}
+
+export declare function Select(props: SelectProps): any;
+
+export interface RadioProps extends FieldProps {
+  /** The value this button sets; it is also the `id`. */
+  name: string;
+  /** The field the buttons of a group share. */
+  group: string;
+  label?: string;
+  children?: any;
+  className?: string;
+  disabled?: boolean;
+}
+
+export declare function Radio(props: RadioProps): any;
+
+export interface EditorProps extends FieldProps {
+  /** Quill theme (`'snow'`). */
+  theme?: string;
+  placeholder?: string;
+}
+
+/** A rich text field (Quill), loaded on the client only. */
+export declare function Editor(props: EditorProps): any;
+
+export interface ButtonProps {
+  /** Wins over `children`. */
+  label?: string;
+  /** Default `'submit'`. */
+  type?: string;
+  className?: string;
+  children?: any;
+  [prop: string]: any;
+}
+
+/** A submit button, disabled while the form is submitting. */
+export declare function Button(props: ButtonProps): any;
+
+export interface FormErrorProps {
+  /** Shown instead of the message. */
+  children?: any;
+  className?: string;
+}
+
+/** The form-level error; renders nothing when there is none. */
+export declare function FormError(props: FormErrorProps): any;
+
+/**
+ * Runs one validator.js rule. Answers what the rule answers: a boolean for a
+ * check, the new value for a sanitizer.
+ */
+export declare function Validation(
+  rule: string,
+  opts: unknown,
+  value: unknown
+): boolean | string | any;
+
+/** Applies the registered sanitizers to a copy of the data. */
+export declare function sanitize(
+  data: Record<string, any>,
+  sanitizers?: Record<string, Rules>
+): Record<string, any>;
+
+/** The message to show for a failing rule. */
+export declare function messageFor(
+  errorMsg: Record<string, string>,
+  failure: unknown
+): string;

--- a/packages/react/index.d.ts
+++ b/packages/react/index.d.ts
@@ -1,0 +1,138 @@
+// Type definitions for @usehenri/react
+//
+// Hand-written. The components are declared as `(props) => any` rather than as
+// `React.FC`: `@usehenri/react` does not depend on `@types/react`, so a
+// JavaScript application installs nothing extra, and a project that does have
+// `@types/react` still gets its props checked in JSX.
+
+/** A path helper of the current user, keyed `<action>_<controller>_path`. */
+export interface PathHelper {
+  route: string;
+  method: string;
+}
+
+/** The path helpers a page received, filtered by the roles of the user. */
+export type Paths = Record<string, PathHelper>;
+
+/** The current user, as it may leave the server. */
+export interface PublicUser {
+  id: string;
+  email: string;
+  roles: string[];
+  [field: string]: unknown;
+}
+
+/** What a failed `hydrate()` or `fetch()` left behind. */
+export interface HenriError {
+  message: string;
+  status: number | null;
+}
+
+/** What `useHenri()` answers, and what a page receives as props. */
+export interface HenriView {
+  /** The CSRF token of the request, to send back on a write. */
+  csrf: string | null;
+  /** What the controller passed to `res.render({ data })`. */
+  data: Record<string, any>;
+  /** The last hydrate or fetch error, when there was one. */
+  error: Error | HenriError | null;
+  /** The GraphQL errors, when the page was rendered from a query. */
+  errors: Record<string, any> | null;
+  /** Flash messages by type; reading them on the server consumed them. */
+  flash: Record<string, unknown[]>;
+  graphql: any | null;
+  /** Where the server answers, for absolute links. */
+  localUrl: string;
+  paths: Paths;
+  user: PublicUser | null;
+  /** Re-fetches the current page as JSON and refreshes `data`. */
+  hydrate(): Promise<any | null>;
+  /** A JSON request against the application. */
+  fetch(
+    target?: string | { route?: string; method?: string },
+    body?: any
+  ): Promise<any>;
+  /**
+   * A path helper.
+   *
+   * - without `params`: the `{ method, route }` entry, unfilled
+   * - with a string: the route with `:id` filled, as a string
+   * - with an object: `{ method, route }` with every named parameter filled
+   * - `undefined` when the route is unknown to this user
+   */
+  pathFor(
+    path?: string | null,
+    params?: string | Record<string, unknown> | null
+  ): PathHelper | string | undefined;
+  /** The route of a helper (`'route-not-found'` when it is unknown). */
+  getRoute(route?: string | null, id?: string | null): string;
+}
+
+/**
+ * The props `withHenri` adds to a page, on top of whatever the page declares
+ * itself. `router` comes from next's `withRouter`.
+ */
+export type HenriProps = HenriView & { router: any };
+
+/**
+ * Wraps a next.js page: reads the view options henri put on the request (or
+ * fetches them as JSON on a client navigation) and passes them down, both as
+ * props and through `useHenri()`.
+ *
+ *     import withHenri from '@usehenri/react';
+ *
+ *     const Tasks = ({ data, pathFor }) => ...;
+ *
+ *     export default withHenri(Tasks);
+ */
+declare function withHenri<P extends object>(
+  ComposedComponent: (props: P & HenriProps) => any
+): (props: Partial<P>) => any;
+
+export default withHenri;
+
+/** The context `withHenri` provides; `useHenri()` is the way to read it. */
+export declare const HenriContext: any;
+
+/** The view options of the page being rendered. */
+export declare function useHenri(): HenriView;
+
+/** Options of `request()`. */
+export interface RequestOptions {
+  /** The path, or a path helper. */
+  route?: string | { route?: string; method?: string };
+  /** Defaults to `get`. */
+  method?: string;
+  /** Sent as JSON on anything but a GET. */
+  body?: any;
+  /** Sent as `X-CSRF-Token`. */
+  csrf?: string | null;
+  headers?: Record<string, string>;
+}
+
+/**
+ * A JSON request against the application. Answers the parsed body (`null` on a
+ * 204) and throws a `RequestError` on anything but a 2xx.
+ */
+export declare function request(options?: RequestOptions): Promise<any>;
+
+/**
+ * What `request()` throws. henri's error bodies
+ * (`{ statusCode, error, message, data }`) are unpacked onto it.
+ */
+export declare class RequestError extends Error {
+  constructor(response: Response, body: any);
+  name: 'RequestError';
+  /** The http status. */
+  status: number;
+  /** The `statusCode` of the body, or the http status. */
+  statusCode: number;
+  /** The `error` of the body (`'Not Found'`), or null. */
+  error: string | null;
+  /** The `data` of the body (validation errors, ...), or null. */
+  data: any | null;
+  /** The parsed body. */
+  body: any;
+  /** The raw fetch response. */
+  response: Response;
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -22,12 +22,17 @@
     "url": "https://github.com/usehenri/henri/issues"
   },
   "main": "index.js",
+  "types": "index.d.ts",
   "files": [
     "dist",
     "engine",
+    "engine.d.ts",
     "engine.js",
+    "forms.d.ts",
     "forms.js",
+    "index.d.ts",
     "index.js",
+    "withHenri.d.ts",
     "withHenri.js",
     "CHANGELOG.md",
     "LICENSE",

--- a/packages/react/withHenri.d.ts
+++ b/packages/react/withHenri.d.ts
@@ -1,0 +1,3 @@
+// `@usehenri/react/withHenri` is the package root under another name.
+export * from './index';
+export { default } from './index';

--- a/packages/testing/global-setup.d.mts
+++ b/packages/testing/global-setup.d.mts
@@ -1,0 +1,8 @@
+// `globalSetup: ['@usehenri/testing/global-setup']`: boots henri once in
+// Vitest's main process and publishes its url through `HENRI_TEST_URL`, so the
+// workers reach it over http but get no `henri` global.
+
+/** Boots the application and returns Vitest's teardown callback. */
+declare function globalSetup(): Promise<() => Promise<boolean>>;
+
+export default globalSetup;

--- a/packages/testing/index.d.ts
+++ b/packages/testing/index.d.ts
@@ -1,0 +1,44 @@
+// Type definitions for @usehenri/testing
+//
+// Hand-written; see packages/core/index.d.ts for the rest of the API.
+
+import type Supertest from 'supertest';
+import type { Henri } from '@usehenri/core';
+
+/** Options of `setup()`. */
+export interface SetupOptions {
+  /** Start the application's workers too (`false`). */
+  workers?: boolean;
+}
+
+/**
+ * Boots the application under `NODE_ENV=test` and resolves with the instance,
+ * setting `global.henri` and the model globals. Idempotent: a second call
+ * while one boot is in flight resolves with the same instance.
+ *
+ *     beforeAll(() => setup());
+ *     afterAll(() => teardown());
+ */
+export function setup(options?: SetupOptions): Promise<Henri>;
+
+/** Stops the instance. Resolves `false` when there was nothing running. */
+export function teardown(): Promise<boolean>;
+
+/**
+ * A supertest agent bound to the running server, one request at a time.
+ *
+ *     await request().get('/tasks').expect(200);
+ */
+export function request(instance?: Henri): Supertest.Agent;
+
+/** The same, keeping the cookies between requests (a logged-in session). */
+export function agent(instance?: Henri): Supertest.Agent;
+
+/** The supertest module, so a test needs no dependency of its own. */
+export const supertest: typeof Supertest;
+
+/**
+ * The running instance: the one `setup()` booted, or `global.henri`.
+ * `undefined` before the first boot.
+ */
+export const henri: Henri | undefined;

--- a/packages/testing/loopback.d.ts
+++ b/packages/testing/loopback.d.ts
@@ -1,0 +1,12 @@
+/**
+ * Binds every test server to the loopback address rather than the wildcard, so
+ * that no other process on the machine can answer a test's requests. Importing
+ * the module applies it; calling it again answers `false`.
+ */
+declare function bindTestServersToLoopback(): boolean;
+
+declare namespace bindTestServersToLoopback {
+  const bindTestServersToLoopback: () => boolean;
+}
+
+export = bindTestServersToLoopback;

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -14,24 +14,42 @@
     "url": "https://github.com/usehenri/henri/issues"
   },
   "main": "index.js",
+  "types": "index.d.ts",
   "exports": {
-    ".": "./index.js",
-    "./global-setup": "./global-setup.mjs",
-    "./loopback": "./loopback.js",
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    },
+    "./global-setup": {
+      "types": "./global-setup.d.mts",
+      "default": "./global-setup.mjs"
+    },
+    "./loopback": {
+      "types": "./loopback.d.ts",
+      "default": "./loopback.js"
+    },
     "./package.json": "./package.json",
-    "./setup-file": "./setup-file.mjs"
+    "./setup-file": {
+      "types": "./setup-file.d.mts",
+      "default": "./setup-file.mjs"
+    }
   },
   "files": [
+    "global-setup.d.mts",
     "global-setup.mjs",
+    "index.d.ts",
     "index.js",
+    "loopback.d.ts",
     "loopback.js",
     "README.md",
+    "setup-file.d.mts",
     "setup-file.mjs"
   ],
   "engines": {
     "node": ">=22"
   },
   "dependencies": {
+    "@types/supertest": "^7.2.1",
     "supertest": "^7.2.2"
   },
   "peerDependencies": {

--- a/packages/testing/setup-file.d.mts
+++ b/packages/testing/setup-file.d.mts
@@ -1,0 +1,4 @@
+// `setupFiles: ['@usehenri/testing/setup-file']`: boots henri in the test
+// worker before every test file and stops it afterwards, so `henri`, the model
+// globals and `request()` are available. It exports nothing.
+export {};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,19 +20,37 @@ importers:
         version: 3.0.2
       '@commitlint/cli':
         specifier: ^21.2.2
-        version: 21.2.2(@types/node@26.4.1)(conventional-commits-parser@7.1.2)(typescript@6.0.3)
+        version: 21.2.2(@types/node@26.4.1)(conventional-commits-parser@7.1.2)(typescript@7.0.2)
       '@commitlint/config-conventional':
         specifier: ^21.2.2
         version: 21.2.2
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))
+      '@types/react':
+        specifier: ^19.2.18
+        version: 19.2.18
+      '@types/react-dom':
+        specifier: ^19.2.7
+        version: 19.2.7(@types/react@19.2.18)
+      '@usehenri/core':
+        specifier: workspace:*
+        version: link:packages/core
+      '@usehenri/inertia':
+        specifier: workspace:*
+        version: link:packages/inertia
+      '@usehenri/react':
+        specifier: workspace:*
+        version: link:packages/react
+      '@usehenri/testing':
+        specifier: workspace:*
+        version: link:packages/testing
       '@vitest/coverage-v8':
         specifier: ^5.0.0
         version: 5.0.0(vitest@5.0.0)
       '@vitest/eslint-plugin':
         specifier: ^1.6.27
-        version: 1.6.27(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)(vitest@5.0.0)
+        version: 1.6.27(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@7.0.2)(vitest@5.0.0)
       eslint:
         specifier: ^10.10.0
         version: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
@@ -51,6 +69,9 @@ importers:
       supertest:
         specifier: ^7.2.2
         version: 7.2.2(supports-color@8.1.1)
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^5.0.0
         version: 5.0.0(@types/node@26.4.1)(@vitest/coverage-v8@5.0.0)(jsdom@28.1.0(@noble/hashes@1.8.0)(supports-color@8.1.1))(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.104.0)(tsx@4.23.13)(yaml@2.9.0))
@@ -103,6 +124,9 @@ importers:
       '@graphql-tools/schema':
         specifier: ^10.1.0
         version: 10.1.0(graphql@16.14.2)
+      '@types/express':
+        specifier: ^5.0.6
+        version: 5.0.6
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
@@ -171,7 +195,7 @@ importers:
         version: 13.15.35
     devDependencies:
       '@types/validator':
-        specifier: ^13.15.0
+        specifier: ^13.15.10
         version: 13.15.10
 
   packages/demo:
@@ -407,6 +431,9 @@ importers:
 
   packages/testing:
     dependencies:
+      '@types/supertest':
+        specifier: ^7.2.1
+        version: 7.2.1
       supertest:
         specifier: ^7.2.2
         version: 7.2.2(supports-color@8.1.1)
@@ -3224,8 +3251,17 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/cookiejar@2.1.5':
+    resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
 
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
@@ -3245,8 +3281,17 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/express-serve-static-core@5.1.3':
+    resolution: {integrity: sha512-dPfW8NFiOF4wOHc7+N/QSxlY9cfSsenewGbAz8C8U/MULPd/YZ27LvJUIlzaXie7e6Ove9YunJGgC9tbHD2cKw==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
   '@types/hast@3.0.5':
     resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
   '@types/js-yaml@4.0.9':
     resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
@@ -3263,6 +3308,9 @@ packages:
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
+  '@types/methods@1.1.4':
+    resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
+
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
@@ -3275,11 +3323,37 @@ packages:
   '@types/node@26.4.1':
     resolution: {integrity: sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==}
 
+  '@types/qs@6.15.1':
+    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/react-dom@19.2.7':
+    resolution: {integrity: sha512-I8bPpDLcHBv1qiIiXDCy71Rt8eQDKJP0sMSWJphDdAcdqiJ1sGpZamavoEIRZmYzjia9LuEb2HlYdDpmoENpvQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.18':
+    resolution: {integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==}
+
   '@types/readable-stream@4.0.24':
     resolution: {integrity: sha512-NRvUNC/JFGPJvqdAfEve8oginbM6V08u5NzLWpG8MwA2kTPOLnqk+wpwuPT+mp3aUsxyuT6m2gnrPuHYCruzEg==}
 
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
+  '@types/superagent@8.1.11':
+    resolution: {integrity: sha512-KA7srSW/HENDtOw9DOqaFLgWuMqN9WgjEw62lh9dpvRaZDkhdOkazASd7X7i2eMUYLHa1U37ZttnePsH5zTDHw==}
+
+  '@types/supertest@7.2.1':
+    resolution: {integrity: sha512-4CbBvoYVLHL7+yhbYrZET0vsvuyXTC05aRe7dNQkwMzm56auceoy6Yu3K50uZmwfHna1os3CMSgM/3QVkUtPTw==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -4090,6 +4164,9 @@ packages:
   cssstyle@6.2.0:
     resolution: {integrity: sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==}
     engines: {node: '>=20'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -6556,11 +6633,6 @@ packages:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
 
-  typescript@6.0.3:
-    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@7.0.2:
     resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
     engines: {node: '>=16.20.0'}
@@ -8333,12 +8405,12 @@ snapshots:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@commitlint/cli@21.2.2(@types/node@26.4.1)(conventional-commits-parser@7.1.2)(typescript@6.0.3)':
+  '@commitlint/cli@21.2.2(@types/node@26.4.1)(conventional-commits-parser@7.1.2)(typescript@7.0.2)':
     dependencies:
       '@commitlint/config-conventional': 21.2.2
       '@commitlint/format': 21.2.2
       '@commitlint/lint': 21.2.2
-      '@commitlint/load': 21.2.2(@types/node@26.4.1)(typescript@6.0.3)
+      '@commitlint/load': 21.2.2(@types/node@26.4.1)(typescript@7.0.2)
       '@commitlint/read': 21.2.1(conventional-commits-parser@7.1.2)
       '@commitlint/types': 21.2.0
       tinyexec: 1.3.1
@@ -8383,14 +8455,14 @@ snapshots:
       '@commitlint/rules': 21.2.2
       '@commitlint/types': 21.2.0
 
-  '@commitlint/load@21.2.2(@types/node@26.4.1)(typescript@6.0.3)':
+  '@commitlint/load@21.2.2(@types/node@26.4.1)(typescript@7.0.2)':
     dependencies:
       '@commitlint/config-validator': 21.2.0
       '@commitlint/execute-rule': 21.0.1
       '@commitlint/resolve-extends': 21.2.2
       '@commitlint/types': 21.2.0
-      cosmiconfig: 9.0.2(typescript@6.0.3)
-      cosmiconfig-typescript-loader: 6.3.0(@types/node@26.4.1)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3)
+      cosmiconfig: 9.0.2(typescript@7.0.2)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@26.4.1)(cosmiconfig@9.0.2(typescript@7.0.2))(typescript@7.0.2)
       es-toolkit: 1.52.0
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
@@ -9611,10 +9683,21 @@ snapshots:
       '@babel/types': 7.29.8
     optional: true
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 26.4.1
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 26.4.1
+
+  '@types/cookiejar@2.1.5': {}
 
   '@types/cors@2.8.19':
     dependencies:
@@ -9634,9 +9717,24 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/express-serve-static-core@5.1.3':
+    dependencies:
+      '@types/node': 26.4.1
+      '@types/qs': 6.15.1
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.3
+      '@types/serve-static': 2.2.0
+
   '@types/hast@3.0.5':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/http-errors@2.0.5': {}
 
   '@types/js-yaml@4.0.9': {}
 
@@ -9649,6 +9747,8 @@ snapshots:
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/methods@1.1.4': {}
 
   '@types/ms@2.1.0': {}
 
@@ -9664,6 +9764,18 @@ snapshots:
     dependencies:
       undici-types: 8.3.0
 
+  '@types/qs@6.15.1': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/react-dom@19.2.7(@types/react@19.2.18)':
+    dependencies:
+      '@types/react': 19.2.18
+
+  '@types/react@19.2.18':
+    dependencies:
+      csstype: 3.2.3
+
   '@types/readable-stream@4.0.24':
     dependencies:
       '@types/node': 26.4.1
@@ -9671,6 +9783,27 @@ snapshots:
   '@types/sax@1.2.7':
     dependencies:
       '@types/node': 26.4.1
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 26.4.1
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 26.4.1
+
+  '@types/superagent@8.1.11':
+    dependencies:
+      '@types/cookiejar': 2.1.5
+      '@types/methods': 1.1.4
+      '@types/node': 26.4.1
+      form-data: 4.0.6
+
+  '@types/supertest@7.2.1':
+    dependencies:
+      '@types/methods': 1.1.4
+      '@types/superagent': 8.1.11
 
   '@types/unist@2.0.11': {}
 
@@ -9688,12 +9821,12 @@ snapshots:
     dependencies:
       '@types/node': 26.4.1
 
-  '@typescript-eslint/project-service@8.69.0(supports-color@8.1.1)(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.69.0(supports-color@8.1.1)(typescript@7.0.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.69.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.69.0(typescript@7.0.2)
       '@typescript-eslint/types': 8.69.0
       debug: 4.4.3(supports-color@8.1.1)
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -9702,35 +9835,35 @@ snapshots:
       '@typescript-eslint/types': 8.69.0
       '@typescript-eslint/visitor-keys': 8.69.0
 
-  '@typescript-eslint/tsconfig-utils@8.69.0(typescript@6.0.3)':
+  '@typescript-eslint/tsconfig-utils@8.69.0(typescript@7.0.2)':
     dependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   '@typescript-eslint/types@8.69.0': {}
 
-  '@typescript-eslint/typescript-estree@8.69.0(supports-color@8.1.1)(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.69.0(supports-color@8.1.1)(typescript@7.0.2)':
     dependencies:
-      '@typescript-eslint/project-service': 8.69.0(supports-color@8.1.1)(typescript@6.0.3)
-      '@typescript-eslint/tsconfig-utils': 8.69.0(typescript@6.0.3)
+      '@typescript-eslint/project-service': 8.69.0(supports-color@8.1.1)(typescript@7.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.69.0(typescript@7.0.2)
       '@typescript-eslint/types': 8.69.0
       '@typescript-eslint/visitor-keys': 8.69.0
       debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.6
       semver: 7.8.5
       tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.5.0(typescript@7.0.2)
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@7.0.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.10.1(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))
       '@typescript-eslint/scope-manager': 8.69.0
       '@typescript-eslint/types': 8.69.0
-      '@typescript-eslint/typescript-estree': 8.69.0(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.69.0(supports-color@8.1.1)(typescript@7.0.2)
       eslint: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -9826,13 +9959,13 @@ snapshots:
       tinyrainbow: 3.1.1
       vitest: 5.0.0(@types/node@26.4.1)(@vitest/coverage-v8@5.0.0)(jsdom@28.1.0(@noble/hashes@1.8.0)(supports-color@8.1.1))(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.104.0)(tsx@4.23.13)(yaml@2.9.0))
 
-  '@vitest/eslint-plugin@1.6.27(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)(vitest@5.0.0)':
+  '@vitest/eslint-plugin@1.6.27(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@7.0.2)(vitest@5.0.0)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.69.0
-      '@typescript-eslint/utils': 8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.69.0(eslint@10.10.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@7.0.2)
       eslint: 10.10.0(jiti@2.7.0)(supports-color@8.1.1)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
       vitest: 5.0.0(@types/node@26.4.1)(@vitest/coverage-v8@5.0.0)(jsdom@28.1.0(@noble/hashes@1.8.0)(supports-color@8.1.1))(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.104.0)(tsx@4.23.13)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
@@ -10420,21 +10553,21 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@6.3.0(@types/node@26.4.1)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3):
+  cosmiconfig-typescript-loader@6.3.0(@types/node@26.4.1)(cosmiconfig@9.0.2(typescript@7.0.2))(typescript@7.0.2):
     dependencies:
       '@types/node': 26.4.1
-      cosmiconfig: 9.0.2(typescript@6.0.3)
+      cosmiconfig: 9.0.2(typescript@7.0.2)
       jiti: 2.6.1
-      typescript: 6.0.3
+      typescript: 7.0.2
 
-  cosmiconfig@9.0.2(typescript@6.0.3):
+  cosmiconfig@9.0.2(typescript@7.0.2):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.3.2
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   cross-inspect@1.0.1:
     dependencies:
@@ -10484,6 +10617,8 @@ snapshots:
       '@csstools/css-syntax-patches-for-csstree': 1.1.12(css-tree@3.2.1)
       css-tree: 3.2.1
       lru-cache: 11.5.2
+
+  csstype@3.2.3: {}
 
   data-urls@7.0.0(@noble/hashes@1.8.0):
     dependencies:
@@ -13175,9 +13310,9 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-api-utils@2.5.0(typescript@6.0.3):
+  ts-api-utils@2.5.0(typescript@7.0.2):
     dependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   tslib@2.8.1: {}
 
@@ -13207,8 +13342,6 @@ snapshots:
       es-errors: 1.3.0
       is-typed-array: 1.1.15
 
-  typescript@6.0.3: {}
-
   typescript@7.0.2:
     optionalDependencies:
       '@typescript/typescript-aix-ppc64': 7.0.2
@@ -13231,7 +13364,6 @@ snapshots:
       '@typescript/typescript-sunos-x64': 7.0.2
       '@typescript/typescript-win32-arm64': 7.0.2
       '@typescript/typescript-win32-x64': 7.0.2
-    optional: true
 
   ufo@1.6.4: {}
 

--- a/scripts/check-types.mjs
+++ b/scripts/check-types.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+// `pnpm test:types`: the type test (website/src/content/docs/reference/types.md
+// documents what the declarations cover).
+//
+// Two things are checked, in this order:
+//
+//  1. packaging -- every declaration a package points at exists and is listed
+//     in `files`, so that `npm publish` ships it;
+//  2. the declarations themselves -- `tsc --noEmit` over `types/`, whose
+//     fixtures call the API the right way and, on the lines marked
+//     `@ts-expect-error`, the wrong way. tsc reports an unused
+//     `@ts-expect-error`, so a declaration that stops catching a mistake fails
+//     the run just like a declaration that rejects correct code.
+//
+// `tsc --noEmit` was picked over tsd or expect-type because it needs no
+// dependency besides typescript, checks the JavaScript-with-JSDoc an
+// application actually writes (`types/app.js`, `checkJs`), and gets the
+// negative cases from `@ts-expect-error` for free.
+
+/* eslint-disable no-console */
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Packages expected to ship declarations. */
+const PACKAGES = ['core', 'inertia', 'react', 'testing'];
+
+const problems = [];
+
+/**
+ * Every declaration file a package.json points at, as package-relative paths
+ *
+ * @param {object} pkg the parsed package.json
+ * @returns {string[]} the paths
+ */
+const declarationsOf = (pkg) => {
+  const found = new Set();
+  const walk = (value) => {
+    if (typeof value === 'string') {
+      if (/\.d\.[cm]?ts$/.test(value)) {
+        found.add(value.replace(/^\.\//, ''));
+      }
+
+      return;
+    }
+
+    if (value && typeof value === 'object') {
+      Object.values(value).forEach(walk);
+    }
+  };
+
+  walk(pkg.types);
+  walk(pkg.exports);
+
+  return [...found];
+};
+
+/**
+ * Every declaration file in a package, as package-relative paths
+ *
+ * A subpath like `@usehenri/react/forms` resolves through the file system
+ * rather than through `exports`, so its declarations are only found by
+ * looking; unshipped, they would be missing for everyone but this repository.
+ *
+ * @param {string} dir the package directory
+ * @param {string} [prefix=''] the path so far, when recursing
+ * @returns {string[]} the paths
+ */
+const declarationsIn = (dir, prefix = '') =>
+  fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.name !== 'node_modules' && entry.name !== 'dist')
+    .flatMap((entry) => {
+      const file = prefix ? `${prefix}/${entry.name}` : entry.name;
+
+      if (entry.isDirectory()) {
+        return declarationsIn(path.join(dir, entry.name), file);
+      }
+
+      return /\.d\.[cm]?ts$/.test(entry.name) ? [file] : [];
+    });
+
+/**
+ * Is `file` shipped, given a `files` list? A directory entry covers what is
+ * under it, the way npm reads it.
+ *
+ * @param {string} file a package-relative path
+ * @param {string[]} files the `files` list
+ * @returns {boolean} shipped or not
+ */
+const isShipped = (file, files) =>
+  files.some((entry) => {
+    const clean = entry.replace(/^\.\//, '').replace(/\/$/, '');
+
+    return (
+      !clean.startsWith('!') && (clean === file || file.startsWith(`${clean}/`))
+    );
+  });
+
+for (const name of PACKAGES) {
+  const dir = path.join(root, 'packages', name);
+  const pkg = JSON.parse(
+    fs.readFileSync(path.join(dir, 'package.json'), 'utf8')
+  );
+  const declared = declarationsOf(pkg);
+
+  if (declared.length === 0) {
+    problems.push(`${pkg.name}: no types field and no types condition`);
+    continue;
+  }
+
+  for (const file of new Set([...declared, ...declarationsIn(dir)])) {
+    if (!fs.existsSync(path.join(dir, file))) {
+      problems.push(`${pkg.name}: ${file} is declared but missing`);
+    } else if (!isShipped(file, pkg.files || [])) {
+      problems.push(
+        `${pkg.name}: ${file} is not in "files", npm would skip it`
+      );
+    }
+  }
+}
+
+if (problems.length > 0) {
+  console.error('Packaging of the type declarations:');
+  problems.forEach((problem) => console.error(`  - ${problem}`));
+  process.exit(1);
+}
+
+console.log(`Declarations shipped by ${PACKAGES.length} packages: ok`);
+
+const tsc = spawnSync(
+  process.execPath,
+  [
+    path.join(root, 'node_modules', 'typescript', 'bin', 'tsc'),
+    '--noEmit',
+    '-p',
+    path.join(root, 'types', 'tsconfig.json'),
+  ],
+  { cwd: root, stdio: 'inherit' }
+);
+
+if (tsc.error) {
+  throw tsc.error;
+}
+
+if (tsc.status !== 0) {
+  process.exit(tsc.status ?? 1);
+}
+
+console.log('Type test: ok');

--- a/types/app.js
+++ b/types/app.js
@@ -1,0 +1,88 @@
+// What a henri application actually writes: CommonJS, no TypeScript, the
+// shapes named through JSDoc. `checkJs` is on for this project, so tsc checks
+// this file the way an editor checks it in a scaffolded application.
+//
+// If this file stops compiling, the annotations documented in
+// `website/src/content/docs/reference/types.md` have stopped working.
+
+/** @type {import('@usehenri/core').Controller} */
+const tasks = {
+  before: {
+    all: [
+      (req, res, next) => {
+        // `req` is typed by the annotation on the object, nothing else
+        req.flash('notice', `request ${req.id}`);
+        next();
+      },
+    ],
+    'show,edit': async (req, res) => {
+      if (!req.params.id) {
+        return res.boom.notFound('No such task');
+      }
+
+      return undefined;
+    },
+  },
+
+  index: async (req, res) => {
+    const { page, perPage, skip, limit } = req.pagination();
+
+    return res.collection([], { page, perPage, total: 0 });
+  },
+
+  create: async (req, res) => {
+    const attributes = req.permit('title', 'body');
+
+    try {
+      return res.resource(attributes, { status: 201 });
+    } catch (error) {
+      const errors = henri.model.errors(error);
+
+      if (!errors) {
+        throw error;
+      }
+
+      return res.boom.badData('Invalid task', { errors });
+    }
+  },
+
+  // An action that returns without answering renders /tasks/show with it
+  show: async (req) => ({ id: req.params.id }),
+};
+
+/** @type {import('@usehenri/core').RoutesFile} */
+const routes = {
+  root: 'main#home',
+  'get /about': 'main#about',
+  'resources tasks': {
+    member: { 'post archive': 'archive' },
+    only: ['index', 'show', 'create'],
+  },
+  'namespace admin': { 'crud users': { roles: ['admin'] } },
+};
+
+/** @type {import('@usehenri/core').ModelFile} */
+const model = {
+  associate(models) {
+    void models;
+  },
+  options: { paranoid: true },
+  schema: {
+    body: 'text',
+    status: { default: 'todo', enum: ['todo', 'done'], type: 'string' },
+    title: { required: true, type: 'string' },
+  },
+};
+
+/** @type {import('@usehenri/core').Configuration} */
+const configuration = {
+  api: { maxPerPage: 100, perPage: 25 },
+  renderer: 'react',
+  stores: { default: { adapter: 'disk' } },
+  user: 'user',
+};
+
+// The global is there without requiring anything
+henri.pen.info('types', henri.release, henri.isProduction);
+
+module.exports = { configuration, model, routes, tasks };

--- a/types/core.test-d.ts
+++ b/types/core.test-d.ts
@@ -1,0 +1,252 @@
+// The declarations of @usehenri/core, checked.
+//
+// A line marked `@ts-expect-error` must fail to compile: tsc reports the
+// comment itself when the code below it turns out to be valid, so the wrong
+// calls here are as much a test as the right ones.
+
+import type {
+  Boom,
+  Configuration,
+  Controller,
+  Henri,
+  ModelFile,
+  Page,
+  Pagination,
+  PublicUser,
+  Request,
+  Response,
+  RoutesFile,
+  ViewOptions,
+} from '@usehenri/core';
+
+/** Asserts that `Actual` and `Expected` are the same type. */
+declare function expectType<Expected>(value: Expected): void;
+
+declare const req: Request;
+declare const res: Response;
+
+// --- the henri global -------------------------------------------------------
+
+expectType<Henri>(henri);
+expectType<string>(henri.release);
+expectType<boolean>(henri.isProduction);
+expectType<string>(henri.cwd());
+expectType<Promise<Error[]>>(henri.stop());
+expectType<boolean>(henri.addMiddleware('metrics', (router) => router.use()));
+
+// config.get() takes the type of the value from the caller
+expectType<string>(henri.config.get<string>('stores.default.adapter'));
+expectType<string | false>(henri.config.get<string>('mail', true));
+expectType<boolean>(henri.config.has('baseRole'));
+
+// pen.fatal() returns an error to throw, it does not throw one
+expectType<Error>(henri.pen.fatal('view', 'unknown renderer'));
+henri.pen.info('boot', 'ready', 42);
+
+expectType<PublicUser | null>(henri.user.publicUser(req.user));
+expectType<Promise<string>>(henri.user.encrypt('a-password', 12));
+expectType<Record<string, string> | null>(henri.model.errors(new Error('x')));
+expectType<string>(henri.gql`{ tasks { id } }`);
+
+// @ts-expect-error `henri.pen.fatal` needs a name, not an object
+henri.pen.fatal({ name: 'view' });
+
+// @ts-expect-error there is no `henri.logger`
+henri.logger.info('boot');
+
+// @ts-expect-error `addMiddleware` takes a name and a function, in that order
+henri.addMiddleware((router: unknown) => router, 'metrics');
+
+// --- request ----------------------------------------------------------------
+
+expectType<string>(req.id);
+expectType<string | null>(req.apiVersion);
+expectType<Record<string, unknown>>(req.permit('title', 'year'));
+expectType<Record<string, unknown>>(req.permit(['title', 'year']));
+expectType<Pagination>(req.pagination());
+expectType<number>(req.pagination({ maxPerPage: 500 }).skip);
+expectType<ViewOptions>(req._henri);
+expectType<string | null>(req._henri.csrf);
+
+// req.flash() is three functions in one
+expectType<Record<string, unknown[]>>(req.flash());
+expectType<unknown[]>(req.flash('notice'));
+expectType<unknown[]>(req.flash('notice', 'Task saved'));
+
+// express is still there
+expectType<string>(req.originalUrl);
+expectType<string | string[]>(req.params.id);
+
+// @ts-expect-error `pagination` is a method, not a property
+req.pagination.page;
+
+// @ts-expect-error `permit` takes field names, not an object
+req.permit({ title: true });
+
+// @ts-expect-error there is no `req.paginate`
+req.paginate();
+
+// --- response ---------------------------------------------------------------
+
+res.render('/tasks/index', { data: { tasks: [] } });
+res.render('/tasks/index', { graphql: '{ tasks }' });
+res.hbs('mail/welcome', { data: {} });
+expectType<Boom>(res.boom);
+res.boom.notFound('No such task', { id: 1 });
+res.boom.badData('Invalid', { errors: { title: 'is required' } });
+res.resource({ id: '1' }, { status: 201 });
+res.collection([{ id: '1' }], { page: 1, perPage: 25, total: 1 });
+res.collection([], { links: { search: '/tasks/search' } });
+res.negotiate({ html: () => res.render('/tasks'), json: () => res.json([]) });
+expectType<Promise<true>>(henri.user.compare('a-password', 'a-hash'));
+
+// express is still there
+res.status(204).json({ ok: true });
+res.redirect('/tasks');
+
+// @ts-expect-error `res.render()` does not take a callback, it is a promise
+res.render('/tasks', {}, () => {});
+
+// @ts-expect-error 500 is `internal`, there is no `res.boom.serverError`
+res.boom.serverError('nope');
+
+// @ts-expect-error `res.collection()` takes a list
+res.collection({ id: '1' });
+
+// @ts-expect-error `res.resource()` takes one record
+res.resource([{ id: '1' }]);
+
+// --- controllers ------------------------------------------------------------
+
+const tasks: Controller = {
+  before: {
+    all: [(req, res, next) => next()],
+    'show,edit': async (req) => {
+      expectType<string>(req.id);
+    },
+  },
+  index: async (req, res) => ({ tasks: await Promise.resolve([]) }),
+  show: async (req, res) => {
+    // the parameters are typed by the annotation alone
+    expectType<Record<string, unknown>>(req.permit('id'));
+
+    return res.boom.notFound();
+  },
+};
+
+const listOfHooks: Controller = {
+  before: [(req, res, next) => next(), { only: ['show'], run: async () => {} }],
+  show: async () => ({}),
+};
+
+expectType<Controller>(tasks);
+expectType<Controller>(listOfHooks);
+
+const badHook: Controller = {
+  // @ts-expect-error a `before` selector needs `run`
+  before: [{ only: ['show'] }],
+};
+
+// --- routes -----------------------------------------------------------------
+
+const routes: RoutesFile = {
+  root: 'main#home',
+  '/about': 'main#about',
+  'get /tasks/mine': { controller: 'tasks#mine', roles: ['user'] },
+  'post /tasks': 'tasks#create',
+  'delete /tasks/:id': 'tasks#destroy',
+  'resources tasks': {
+    only: ['index', 'show', 'create'],
+    collection: { 'get search': 'search' },
+    member: { 'post archive': 'archive' },
+    nested: { 'resources comments': 'comments' },
+  },
+  'crud items': { except: ['destroy'], roles: 'admin' },
+  'namespace admin': {
+    'resources users': { roles: ['admin'] },
+    'get /dashboard': 'dashboard#index',
+  },
+};
+
+expectType<RoutesFile>(routes);
+
+const badRoutes: RoutesFile = {
+  // @ts-expect-error `gett` is not a verb
+  'gett /tasks': 'tasks#index',
+};
+
+const badResource: RoutesFile = {
+  // @ts-expect-error `list` is not one of the seven resource actions
+  'resources tasks': { only: ['list'] },
+};
+
+const badNamespace: RoutesFile = {
+  // @ts-expect-error a namespace holds routes, not a controller name
+  'namespace admin': 'admin#index',
+};
+
+// --- models -----------------------------------------------------------------
+
+const model: ModelFile = {
+  store: 'default',
+  name: 'tasks',
+  options: { paranoid: true, timestamps: true },
+  schema: {
+    title: { type: 'string', required: true, unique: true },
+    body: 'text',
+    status: { type: 'string', enum: ['todo', 'done'], default: 'todo' },
+    meta: { type: 'json' },
+  },
+  associate(models) {
+    expectType<Record<string, unknown>>(models);
+  },
+};
+
+expectType<ModelFile>(model);
+
+const badModel: ModelFile = {
+  schema: {
+    // @ts-expect-error `varchar` is not a henri field type
+    title: { type: 'varchar', required: true },
+  },
+};
+
+declare const page: Page<{ id: string }>;
+expectType<{ id: string }[]>(page.records);
+expectType<number>(page.pages);
+
+// --- configuration ----------------------------------------------------------
+
+const config: Configuration = {
+  port: 3000,
+  renderer: 'react',
+  user: { model: 'user', public: ['name'], sessionMaxAge: 2592000000 },
+  baseRole: 'guest',
+  stores: { default: { adapter: 'disk', dbName: 'henri' } },
+  api: { perPage: 25, maxPerPage: 100, strict: true, idempotency: false },
+  rateLimit: { windowMs: 60000, max: 600, auth: { max: 10 } },
+  helmet: false,
+  requestTimeout: false,
+};
+
+expectType<Configuration>(config);
+
+const badConfig: Configuration = {
+  // @ts-expect-error `vue2` is not a renderer
+  renderer: 'vue2',
+};
+
+const badStore: Configuration = {
+  // @ts-expect-error `sqlite` is not an adapter package (use drizzle)
+  stores: { default: { adapter: 'sqlite' } },
+};
+
+export {
+  badConfig,
+  badHook,
+  badModel,
+  badNamespace,
+  badResource,
+  badRoutes,
+  badStore,
+};

--- a/types/packages.test-d.tsx
+++ b/types/packages.test-d.tsx
@@ -1,0 +1,156 @@
+// The declarations of @usehenri/react, @usehenri/inertia and
+// @usehenri/testing, checked. See core.test-d.ts for how `@ts-expect-error`
+// is used here.
+
+import withHenri, {
+  RequestError,
+  request,
+  useHenri,
+  type HenriView,
+  type PathHelper,
+} from '@usehenri/react';
+import {
+  Button,
+  Form,
+  FormError,
+  Input,
+  Radio,
+  Select,
+  messageFor,
+  sanitize,
+  useForm,
+  type FormState,
+} from '@usehenri/react/forms';
+import { build, type BuildResult } from '@usehenri/react/engine';
+import {
+  Link,
+  pathFor,
+  resolvePage,
+  useHenri as useInertiaHenri,
+  Form as InertiaForm,
+  request as inertiaRequest,
+} from '@usehenri/inertia';
+import { henriViteConfig } from '@usehenri/inertia/vite';
+import {
+  agent,
+  request as testRequest,
+  setup,
+  teardown,
+} from '@usehenri/testing';
+import type { Henri } from '@usehenri/core';
+
+/** Asserts that `Actual` and `Expected` are the same type. */
+declare function expectType<Expected>(value: Expected): void;
+
+// --- @usehenri/react --------------------------------------------------------
+
+const Tasks = ({ data, pathFor: pathForProp, user }: any) => (
+  <a href={String(pathForProp('index_tasks_path', {}))}>
+    {user ? user.email : 'anonymous'} {String(data.count)}
+  </a>
+);
+
+export default withHenri(Tasks);
+
+declare const view: HenriView;
+expectType<string | null>(view.csrf);
+expectType<Record<string, any>>(view.data);
+expectType<PathHelper | string | undefined>(
+  view.pathFor('show_tasks_path', '1')
+);
+expectType<string>(view.getRoute('index_tasks_path'));
+expectType<Promise<any | null>>(view.hydrate());
+expectType<HenriView>(useHenri());
+expectType<Promise<any>>(
+  request({ route: '/tasks', method: 'post', body: {} })
+);
+
+declare const requestError: RequestError;
+expectType<number>(requestError.status);
+expectType<number>(requestError.statusCode);
+expectType<string | null>(requestError.error);
+
+// @ts-expect-error `useHenri()` has no `query` (that is the Inertia one)
+view.query;
+
+// @ts-expect-error `request()` takes an options object, not a path
+request('/tasks');
+
+// --- @usehenri/react/forms --------------------------------------------------
+
+declare const form: FormState;
+expectType<Record<string, any>>(form.data);
+expectType<boolean>(form.disabled);
+expectType<string | true | null>(form.error);
+expectType<Record<string, string | null>>(form.errors);
+expectType<FormState>(useForm());
+expectType<Record<string, any>>(
+  sanitize({ title: ' a ' }, { title: { trim: true } })
+);
+expectType<string>(messageFor({ isEmail: 'not an email' }, 'isEmail'));
+
+export const NewTask = () => (
+  <Form action="/tasks" method="post" data={{ title: '' }} onFail="Try again">
+    <Input name="title" required validation={{ isLength: { min: 3 } }} />
+    <Select name="status" choices={['todo', 'done']} placeholder="Pick one" />
+    <Radio name="high" group="priority" label="High" />
+    <FormError />
+    <Button label="Save" />
+  </Form>
+);
+
+// @ts-expect-error `Input` needs a `name`
+export const NamelessInput = () => <Input required />;
+
+// @ts-expect-error a radio button belongs to a `group`
+export const GrouplessRadio = () => <Radio name="high" />;
+
+// @ts-expect-error `choices` is a list
+export const BadSelect = () => <Select name="status" choices="todo" />;
+
+expectType<Promise<BuildResult | null>>(
+  build({ cwd: '/app', config: { renderer: 'react' } })
+);
+
+// --- @usehenri/inertia ------------------------------------------------------
+
+const inertiaView = useInertiaHenri();
+expectType<Record<string, any>>(inertiaView.query);
+expectType<Record<string, any>>(inertiaView.errors);
+expectType<Promise<any>>(
+  inertiaRequest('/tasks', { method: 'post', data: {} })
+);
+expectType<Promise<any> | any>(
+  resolvePage({}, 'tasks/index', { dir: './pages' })
+);
+expectType<PathHelper | string | undefined>(
+  pathFor({}, 'show_tasks_path', '1')
+);
+
+export const InertiaPage = () => (
+  <InertiaForm action={pathFor({}, 'create_tasks_path')} method="post">
+    <Link href="/tasks">Back</Link>
+  </InertiaForm>
+);
+
+// @ts-expect-error the Inertia view has no `error` key, a failed request throws
+inertiaView.error;
+
+// @ts-expect-error `henriViteConfig` takes options, not a path
+henriViteConfig('app/views');
+
+// --- @usehenri/testing ------------------------------------------------------
+
+expectType<Promise<Henri>>(setup());
+expectType<Promise<Henri>>(setup({ workers: true }));
+expectType<Promise<boolean>>(teardown());
+expectType<Promise<unknown>>(testRequest().get('/tasks').expect(200));
+expectType<Promise<unknown>>(
+  agent().post('/login').send({ email: 'a@b.co', password: 'secret' })
+);
+
+// @ts-expect-error `setup()` only knows about `workers`
+setup({ port: 3000 });
+
+// @ts-expect-error `teardown()` takes nothing
+teardown(true);

--- a/types/packages.test-d.tsx
+++ b/types/packages.test-d.tsx
@@ -31,6 +31,11 @@ import {
   request as inertiaRequest,
 } from '@usehenri/inertia';
 import { henriViteConfig } from '@usehenri/inertia/vite';
+import InertiaEngine from '@usehenri/inertia/engine';
+import withHenriSubpath from '@usehenri/react/withHenri';
+import bindTestServersToLoopback from '@usehenri/testing/loopback';
+import globalSetup from '@usehenri/testing/global-setup';
+import '@usehenri/testing/setup-file';
 import {
   agent,
   request as testRequest,
@@ -154,3 +159,14 @@ setup({ port: 3000 });
 
 // @ts-expect-error `teardown()` takes nothing
 teardown(true);
+
+// --- the subpaths, so that every shipped declaration is compiled -----------
+
+expectType<typeof withHenri>(withHenriSubpath);
+expectType<boolean>(bindTestServersToLoopback());
+expectType<Promise<() => Promise<boolean>>>(globalSetup());
+expectType<string>(InertiaEngine.componentName('/tasks/'));
+expectType<Promise<{ client: string; duration: number; ssr: string | null }>>(
+  InertiaEngine.build({ cwd: '/app' })
+);
+expectType<boolean>(InertiaEngine.DEFAULTS.ssr);

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "//": "The type test: `pnpm test:types` runs tsc over this project. See README.md next to it.",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "exactOptionalPropertyTypes": false,
+    "jsx": "react-jsx",
+    "lib": ["ES2023", "DOM"],
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": false,
+    "strict": true,
+    "target": "ES2023",
+    "types": ["@usehenri/core"]
+  },
+  "include": ["**/*.ts", "**/*.tsx", "**/*.js"]
+}

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -53,7 +53,12 @@ export default defineConfig({
         },
         {
           label: 'Reference',
-          items: ['reference/cli', 'reference/api', 'reference/under-the-hood'],
+          items: [
+            'reference/cli',
+            'reference/api',
+            'reference/types',
+            'reference/under-the-hood',
+          ],
         },
       ],
     }),

--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -26,6 +26,8 @@ Configuration is JSON in the `config` directory. henri loads `config/<NODE_ENV>.
 
 The file is parsed on boot: a syntax error is reported with its line, and the boot stops when no file can be loaded. The loaded object is frozen.
 
+Every key below is declared in `@usehenri/core`, so an editor completes them as you type. `henri.config.get()` and a hand-built configuration object take the same shape, `import('@usehenri/core').Configuration` — see [Types](/reference/types/).
+
 ## Keys
 
 | Key                | Default       | Description                                                                                                                                    |

--- a/website/src/content/docs/guides/agents.md
+++ b/website/src/content/docs/guides/agents.md
@@ -17,6 +17,19 @@ henri is built to be driven by a coding agent as well as by a person. The conven
 
 `AGENTS.md` is written for the renderer and the database the app was scaffolded with, so it describes the app in front of the agent rather than henri in general. Edit it as the app grows: it is yours, and `henri generate agents` rewrites it when you want the current version back.
 
+## Types the agent can read
+
+Every published package ships hand-written TypeScript declarations, and the
+`jsconfig.json` of a scaffolded application already points at them. An agent
+editing a controller sees the signature of `res.render()`, the twelve names on
+`res.boom`, the keys `config/default.json` accepts and the actions
+`resources` expands to, instead of guessing them from the docs.
+
+The generators write the one JSDoc line that binds a file to its shape
+(`/** @type {import('@usehenri/core').Controller} */`), so a generated
+controller, model or routes file is typed from the moment it exists. See
+[Types](/reference/types/).
+
 ## Machine readable output
 
 Every informational command takes `--json`:

--- a/website/src/content/docs/guides/controllers.md
+++ b/website/src/content/docs/guides/controllers.md
@@ -9,6 +9,8 @@ Controllers live in `app/controllers`. Every `.js` file there is loaded on boot,
 
 A controller is a plain object of Express handlers, `(req, res)` or `(req, res, next)`, sync or async, plus an optional `before` block. Models are globals, `henri` is a global, and `res.render()` hands data to the view.
 
+A `/** @type {import('@usehenri/core').Controller} */` line above `module.exports` is what gives `req` and `res` completion in an editor; the generators write it for you. See [Types](/reference/types/).
+
 ```js
 // app/controllers/tasks.js
 const FIELDS = ['name', 'category', 'done'];

--- a/website/src/content/docs/guides/models.md
+++ b/website/src/content/docs/guides/models.md
@@ -51,6 +51,8 @@ module.exports = {
 
 On SQL, `associate()` runs before `sync()`, so the foreign keys end up in the tables.
 
+The keys above and the nine field types are declared in `@usehenri/core`: a `/** @type {import('@usehenri/core').ModelFile} */` line, which `henri generate model` writes, is enough for an editor to complete them. The model itself is the ORM's, and stays untyped — see [Types](/reference/types/).
+
 ## The schema format
 
 A field is `{ type, ...keys }` or a bare type. The type names and the keys below mean the same thing on every adapter, so a model written for the disk adapter moves to MongoDB or PostgreSQL unchanged.

--- a/website/src/content/docs/guides/routes.md
+++ b/website/src/content/docs/guides/routes.md
@@ -9,6 +9,8 @@ Routes are defined in `config/routes.js`. Any page in `app/views/pages` is also 
 
 A route is a key (a path, or an HTTP verb and a path) pointing to `controller#action`, or to an object with a `controller` and options (`roles`, `scope`, `only`, `except`, `member`, `collection`, `nested`).
 
+The keys and the options are typed: with the `/** @type {import('@usehenri/core').RoutesFile} */` line `henri new` writes, an editor completes them and refuses a verb or a resource action that does not exist. See [Types](/reference/types/).
+
 ```js
 // config/routes.js
 module.exports = {

--- a/website/src/content/docs/guides/testing.md
+++ b/website/src/content/docs/guides/testing.md
@@ -5,7 +5,7 @@ sidebar:
   order: 10
 ---
 
-Tests run on [Vitest](https://vitest.dev). `henri test` spawns the Vitest installed in the application with `NODE_ENV=test` and exits with its code; `@usehenri/testing` boots the application inside the test worker and binds [supertest](https://github.com/ladjs/supertest) to it. `henri new` sets all of this up; in an existing application:
+Tests run on [Vitest](https://vitest.dev). `henri test` spawns the Vitest installed in the application with `NODE_ENV=test` and exits with its code; `@usehenri/testing` boots the application inside the test worker and binds [supertest](https://github.com/ladjs/supertest) to it. The package ships its own types, so `request()` and the supertest chain behind it complete in an editor ([Types](/reference/types/)). `henri new` sets all of this up; in an existing application:
 
 ```bash
 pnpm add -D vitest @usehenri/testing

--- a/website/src/content/docs/reference/api.md
+++ b/website/src/content/docs/reference/api.md
@@ -5,6 +5,9 @@ sidebar:
   order: 2
 ---
 
+Every package here ships TypeScript declarations, so an editor completes and
+documents what follows without any setup: see [Types](/reference/types/).
+
 ## The `henri` global
 
 `henri` is the running instance (`global.henri`; under `NODE_ENV=test` it is `@usehenri/testing` that sets it). Every module is exposed under its name.

--- a/website/src/content/docs/reference/types.md
+++ b/website/src/content/docs/reference/types.md
@@ -1,0 +1,155 @@
+---
+title: Types
+description: The TypeScript declarations henri ships, what an editor needs to pick them up, and the JSDoc annotations that type a controller, a routes file, a model and the configuration.
+sidebar:
+  order: 3
+---
+
+henri is JavaScript and stays JavaScript: there is no build step, no `.ts` file
+in an application and no compiler between you and the framework. It does ship
+hand-written type declarations, so an editor — and a coding agent reading the
+same signatures — knows what `res.render()` takes, what `req.pagination()`
+answers and which keys `config/default.json` accepts.
+
+| Package             | Declares                                                                                                                       |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `@usehenri/core`    | The `henri` global, the request and response helpers, the controller, model and routes files, the whole configuration.         |
+| `@usehenri/react`   | `withHenri`, `useHenri`, `request`, `RequestError`, the form components and the engine's `build()`.                            |
+| `@usehenri/inertia` | `useHenri`, `Form`, `pathFor`, `getRoute`, `request`, `resolvePage`, `henriViteConfig()`. `Link` and `Head` come from Inertia. |
+| `@usehenri/testing` | `setup`, `teardown`, `request`, `agent`, `henri`.                                                                              |
+
+## What an editor needs
+
+Nothing, in an application scaffolded by `henri new`: the `jsconfig.json` it
+writes at the root of the project already says where to look.
+
+```json
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": false,
+    "module": "node16",
+    "moduleResolution": "node16",
+    "skipLibCheck": true,
+    "target": "es2023",
+    "types": ["@usehenri/core"]
+  },
+  "exclude": ["node_modules", "app/views", ".henri"]
+}
+```
+
+`types: ["@usehenri/core"]` is the load-bearing line. It is what makes the
+`henri` global known everywhere without requiring anything, and it is all an
+older application needs to add to catch up. `app/views` is excluded because the
+pages have a `jsconfig.json` of their own (Next.js and Vite each want theirs).
+
+`checkJs` is off, so an editor offers completion and documentation without
+turning a file red. Turn it on when you want the annotations below actually
+checked; the models are globals whose names henri only knows at runtime, so
+declare the ones you use in a `.d.ts` of your own when you do:
+
+```ts
+// globals.d.ts
+declare const Task: any;
+declare const User: any;
+```
+
+## Annotating a file
+
+A controller, a routes file and a model file are plain objects: nothing tells
+an editor what they are. One JSDoc line does, and `henri new` and
+`henri generate` write it for you.
+
+```js
+// app/controllers/tasks.js
+/** @type {import('@usehenri/core').Controller} */
+module.exports = {
+  before: { 'show,edit': loadTask },
+
+  index: async (req, res) => {
+    const { page, perPage, skip, limit } = req.pagination();
+    const tasks = await Task.find().skip(skip).limit(limit);
+
+    return res.collection(tasks, {
+      page,
+      perPage,
+      total: await Task.countDocuments(),
+    });
+  },
+};
+```
+
+`req` and `res` are typed from that annotation alone: `req.permit()`,
+`req.flash()`, `req.id`, `res.render()`, `res.boom.*`, `res.resource()`,
+`res.collection()`, `res.negotiate()` and everything Express already had.
+
+```js
+// config/routes.js
+/** @type {import('@usehenri/core').RoutesFile} */
+module.exports = {
+  root: 'main#home',
+  'resources tasks': {
+    only: ['index', 'show'],
+    member: { 'post archive': 'archive' },
+  },
+};
+```
+
+The keys are checked as far as a type can check them: `root`, a path, a verb
+and a path, `resources`, `crud` and `namespace`. `'gett /tasks'` is a type
+error, and so is `only: ['list']`.
+
+```js
+// app/models/Task.js
+/** @type {import('@usehenri/core').ModelFile} */
+module.exports = {
+  options: { timestamps: true },
+  schema: {
+    title: { type: 'string', required: true },
+    status: { type: 'string', enum: ['todo', 'done'], default: 'todo' },
+  },
+  store: 'default',
+};
+```
+
+The nine field types are checked; every other key of a field is passed to the
+adapter, so the shape stays open (see [Models](/guides/models/)).
+
+`Configuration` is the shape of `config/default.json`, and is worth an
+annotation when a helper builds part of it:
+
+```js
+/** @type {import('@usehenri/core').Configuration} */
+const config = { renderer: 'react', stores: { default: { adapter: 'disk' } } };
+```
+
+## What is not typed
+
+- **The models.** `Task` is a Mongoose `Model`, a Sequelize `ModelStatic` or a
+  Drizzle model class depending on the store, and its fields come from your
+  schema. henri does not pretend otherwise: the globals are `any` unless you
+  declare them. What every adapter adds is documented on
+  [`Page`](/guides/models/#pagination) — `paginate()` answers the same
+  `{ records, page, perPage, total, pages }` everywhere.
+- **`req.user`.** A model instance, same reason. `henri.user.publicUser(user)`
+  answers a typed `PublicUser`.
+- **`henri.config.get(key)`.** The value is whatever the JSON holds; pass the
+  type you expect (`henri.config.get<string>('secret')`).
+- **The adapters and the view engines** are typed as contracts
+  (`StoreAdapter`, `ViewEngine`), not as the ORMs behind them.
+
+## In TypeScript
+
+Nothing stops an application from being written in TypeScript — henri never
+loads a `.ts` file itself, so it has to be compiled to CommonJS first, and the
+declarations are the same ones. The framework is not tested that way; a
+JavaScript application with `checkJs` is the supported path.
+
+## Checking them
+
+The declarations live next to the code they describe
+(`packages/core/index.d.ts` and one file per package) and are checked in CI by
+`pnpm test:types`, which verifies that every declaration is shipped by npm and
+then runs `tsc --noEmit` over `types/` in the repository. Those fixtures call
+the API both correctly and — on the lines marked `@ts-expect-error` —
+incorrectly, so a declaration that stops catching a mistake fails the build.

--- a/website/src/content/docs/reference/under-the-hood.md
+++ b/website/src/content/docs/reference/under-the-hood.md
@@ -2,7 +2,7 @@
 title: Under the hood
 description: The module system, the boot sequence, reloads and shutdown.
 sidebar:
-  order: 3
+  order: 4
 ---
 
 ## Modules


### PR DESCRIPTION
There was not one type declaration in this repository and no package declared types, so a developer writing a henri application got no completion and no inline documentation for anything: not the henri global, not the render or hypermedia helpers, not permitted parameters, not the model format, not the configuration. Coding agents lost the most, and being good for agents is an explicit goal here.

Hand-written declarations for the four packages an application imports, covering the request and response additions, the henri modules, the model file format, every documented configuration key, the routes DSL and the client helpers. **No TypeScript conversion**: the codebase stays CommonJS by decision.

**The declarations are checked, not just written.** A type test compiles fixtures with about twenty deliberately wrong calls behind expect-error directives, so a declaration that stops catching a mistake fails the run exactly like one that rejects correct code. It also asserts every declaration is reachable and actually shipped in the package files. It runs in CI as its own step and takes about two seconds.

I verified that property myself rather than take it on trust: loosening the permitted-parameters signature to accept anything made the run fail, because an expect-error became unused.

**A scaffolded application gets this with no setup.** One line in a generated config file makes the henri global known and the rest resolve, and the generators annotate what they write so a controller, a model and the routes file are typed from the moment they exist. Verified in a scratch app and through the scaffold smoke test.

**What is deliberately left untyped** is listed in the report and in the files: the model globals above all, because they are a Mongoose model, a Sequelize model or a Drizzle class with application-defined fields, and typing that would be a lie. The docs give the two-line pattern for an application that wants it.

Suite green at 980, type test green, lint and format clean, smoke test passes.

One thing to know: the TypeScript devDependency resolved to 7, which is the current release and removed a setting the pre-existing Next.js config file uses. That file is read by Next, so it was left alone and flagged; it will want a rewrite eventually.