### PR TITLE
Configure an application from the environment, and encrypted credentials

### DIFF
--- a/.changeset/config-from-the-environment.md
+++ b/.changeset/config-from-the-environment.md
@@ -1,0 +1,13 @@
+---
+'@usehenri/core': minor
+---
+
+The environment configures an application: `DATABASE_URL` and any configuration key.
+
+`DATABASE_URL` sets `stores.default.url`, the way Rails has read it forever and the way every hosting provider hands you a database. It carries no `HENRI_` prefix on purpose — a prefixed alias would mean writing `HENRI_DATABASE_URL=$DATABASE_URL` in every deployment — and it applies only when the configuration already declares a `stores.default`, since a url does not say which adapter to load; when it does not, the boot says so and moves on.
+
+Every other key is `HENRI_CONFIG__<key>`, `__` between the path segments and the segments verbatim: `HENRI_CONFIG__port=8080`, `HENRI_CONFIG__stores__reporting__url=...`, `HENRI_CONFIG__user__afterLogin=/dashboard`. **The type comes from the configuration file, henri never guesses it**: a number for `port`, `true`/`false` for a boolean, JSON for an object, and a string for a key no file declares, so a connection string that looks like a number stays a string. `HENRI_CONFIG_JSON__<key>` parses JSON in every case, which is how a nested object or an array is set. A value that does not fit its key fails the boot naming the variable and the type it expected, and so does a variable set to nothing: a missing variable is not an override and never becomes an empty string. No error message ever quotes the value.
+
+Precedence, lowest first: the configuration file, then `HENRI_SECRET` / `HENRI_HOST` / `DATABASE_URL`, then `HENRI_CONFIG__<key>` — the same story as the two overrides that already existed. Every key the environment provided is printed at boot (`config ✏ from the environment => port = 8080 => HENRI_CONFIG__port`), with the names `config.filterParameters` covers masked, plus the password of a connection string, which no filter list would name. `henri.config.fromEnv` holds the `{ key, variable }` pairs, never the values.
+
+A container image therefore needs no configuration file written at start time: commit `config/production.json` and pass the rest as environment variables.

--- a/.changeset/encrypted-credentials.md
+++ b/.changeset/encrypted-credentials.md
@@ -1,0 +1,15 @@
+---
+'@usehenri/core': minor
+'@usehenri/cli': minor
+---
+
+Encrypted credentials, per environment: `henri credentials:edit`.
+
+`config/credentials/<env>.json.enc` holds the secrets of one environment and is committed with the application; the key that opens it never is. A deployment then carries one secret instead of twenty, and adding a secret to staging is a commit rather than a round of environment variables.
+
+- **JSON, not YAML.** henri's configuration is JSON, and the decrypted object is applied over it key by key, so both files are written the same way and henri needs no parser it does not already have.
+- **The key** is `HENRI_CREDENTIALS_KEY`, or `config/credentials/<env>.key` (64 hexadecimal characters); the variable wins. `henri new` ignores `config/credentials/*.key` from the first commit, `henri credentials:edit` adds the line when it generates a key, and `henri doctor` reports a key that is not ignored (`credentials.ignored`) or that reached the git index (`credentials.committed`). A file with no key stops the boot naming both the file and the variable — never a silent boot without secrets.
+- **AES-256-GCM**, from node's own crypto. The envelope is one line, `henri:v1:<iv>:<tag>:<ciphertext>`, and the environment name is authenticated with the content, so a modified file, a wrong key and a `production.json.enc` renamed to `staging.json.enc` all fail loudly instead of decrypting to nonsense. No message quotes the file, the key or a decrypted value, in a log line, an error or `--json`.
+- **Precedence**: over the configuration file, under the environment. Each leaf of the decrypted object replaces that one key, so `{ "mail": { "auth": { "pass": "x" } } }` leaves the rest of `mail` alone, and the values are read with `henri.config.get('mail.auth.pass')`. The boot prints the paths the credentials provided and where the key came from, never the values; `henri.config.fromCredentials` holds the same paths.
+
+`henri credentials:edit [--env <name>]` decrypts into a file only you can read (`0600`, in a directory `mkdtemp` creates), opens `EDITOR` or `VISUAL` on it, and encrypts what comes back. The plaintext is removed on every exit path: the editor closing, the editor failing, invalid JSON, and an interrupted process. The first edit of an environment writes the key, the ignore line and a fresh `secret`. `henri credentials:show` prints the decrypted credentials on stdout, and with `--json` the key paths only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,8 +92,12 @@ an app and is what core's tests boot.
   (`global.henri`, `global.Task`). Under `NODE_ENV=test` core does not set the
   global; `@usehenri/testing` does.
 - Configuration is `config/<NODE_ENV>.json` (`dev.json` when unset) falling
-  back to `default.json`, plus `.env` in the app (`HENRI_SECRET` provides
-  `secret`, `HENRI_HOST` the bind address). Keys: `port`, `host`, `cors`,
+  back to `default.json`, plus `.env` in the app. The environment is applied
+  over the file that loaded (`0.config.js`): `HENRI_SECRET` sets `secret`,
+  `HENRI_HOST` `host`, `DATABASE_URL` `stores.default.url`, and
+  `HENRI_CONFIG__<key>` (`HENRI_CONFIG_JSON__<key>` for JSON) any other key,
+  whose type comes from the file; every key the environment provided is
+  printed at boot with the `filterParameters` masked. Keys: `port`, `host`, `cors`,
   `renderer`, `inertia`, `experimental`, `stores`, `secret`, `user` (string or
   `{ model, public, loginPath, afterLogin, sessionMaxAge }`), `baseRole`,
   `trustProxy`, `csrf`, `graphql`, `mail`, `mailers`, `api`, `rateLimit`, `helmet`,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,8 +10,11 @@
 # and replace the `henri new app --skip-install` step with `COPY . .` (keep
 # the .dockerignore next to it).
 #
-# Runtime configuration. @usehenri/core reads config/<NODE_ENV>.json and does
-# not expand environment variables, so entrypoint.sh writes
+# Runtime configuration. From @usehenri/core 1.2 the environment configures an
+# application on its own (`DATABASE_URL`, `HENRI_CONFIG__<key>`; see
+# showcase/Dockerfile in the repository, which needs no file written at start
+# time). This image installs `henri@latest` from npm and must keep working
+# with the versions that read no environment variable, so entrypoint.sh writes
 # config/production.json from these variables every time the container starts:
 #
 #   HENRI_STORE_URL      connection string of the default store, for example

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 #
 # Writes config/production.json from the environment (the variables are
-# documented in the Dockerfile), then runs the given command.
+# documented in the Dockerfile), then runs the given command. From
+# @usehenri/core 1.2 an application reads the environment itself and this file
+# is only needed by the images that install an older henri from npm.
 set -eu
 
 node - <<'EOF'

--- a/packages/cli/__tests__/credentials.spec.js
+++ b/packages/cli/__tests__/credentials.spec.js
@@ -1,0 +1,353 @@
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const { check } = require('../scripts/doctor');
+const { cleanup, henri, scaffold, tmpdir } = require('./helpers');
+
+const SECRET = 'sk-live-do-not-print-me';
+
+/**
+ * A henri application with nothing in it but what the CLI checks
+ *
+ * @param {string} dir The temporary directory
+ * @returns {string} The application directory
+ */
+const application = (dir) => {
+  fs.mkdirSync(path.join(dir, 'app', 'views', 'pages'), { recursive: true });
+  fs.mkdirSync(path.join(dir, 'config'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({ henri: true, name: 'app' })
+  );
+  fs.writeFileSync(
+    path.join(dir, 'config', 'default.json'),
+    JSON.stringify({ port: 3000 })
+  );
+
+  return dir;
+};
+
+/**
+ * An EDITOR: a node script running `body` with the file as its argument
+ *
+ * @param {string} dir Where to write the script
+ * @param {string} name Its name
+ * @param {string} body The body, with `file` in scope
+ * @returns {string} The EDITOR command
+ */
+const editor = (dir, name, body) => {
+  const script = path.join(dir, `${name}.js`);
+
+  fs.writeFileSync(
+    script,
+    `const fs = require('fs');\nconst file = process.argv[2];\n${body}\n`
+  );
+
+  return `${process.execPath} ${script}`;
+};
+
+/**
+ * Run the CLI with an editor
+ *
+ * @param {Array<string>} args The arguments
+ * @param {string} app The application directory
+ * @param {string} [command] The EDITOR (unset when omitted)
+ * @returns {object} The spawnSync result
+ */
+const run = (args, app, command) =>
+  henri(args, {
+    cwd: app,
+    env: {
+      ...process.env,
+      EDITOR: command || '',
+      VISUAL: '',
+    },
+  });
+
+describe('henri credentials', () => {
+  let dir;
+  let app;
+  let saves;
+
+  beforeEach(() => {
+    dir = tmpdir('henri-credentials-');
+    app = application(dir);
+    saves = editor(
+      dir,
+      'save',
+      `const values = JSON.parse(fs.readFileSync(file, 'utf8'));
+values.mail = { auth: { pass: ${JSON.stringify(SECRET)} } };
+fs.writeFileSync(file, JSON.stringify(values, null, 2) + '\\n');
+fs.writeFileSync(
+  process.env.HENRI_TEST_REPORT,
+  JSON.stringify({ file, mode: fs.statSync(file).mode & 0o777 })
+);`
+    );
+  });
+
+  afterEach(() => {
+    cleanup(dir);
+  });
+
+  const report = () =>
+    JSON.parse(fs.readFileSync(path.join(dir, 'report.json'), 'utf8'));
+
+  const edit = (args = [], command = saves) =>
+    henri(['credentials:edit', '--env', 'dev', ...args], {
+      cwd: app,
+      env: {
+        ...process.env,
+        EDITOR: command,
+        HENRI_TEST_REPORT: path.join(dir, 'report.json'),
+        VISUAL: '',
+      },
+    });
+
+  test('the first edit writes the key, the file and the ignore line', () => {
+    const { status, stdout } = edit();
+
+    expect(status).toBe(0);
+    expect(stdout).toContain('Generated config/credentials/dev.key');
+    expect(stdout).toContain('Added it to .gitignore');
+
+    const key = path.join(app, 'config', 'credentials', 'dev.key');
+    const file = path.join(app, 'config', 'credentials', 'dev.json.enc');
+
+    expect(fs.readFileSync(key, 'utf8').trim()).toMatch(/^[0-9a-f]{64}$/);
+    expect(fs.statSync(key).mode & 0o777).toBe(0o600);
+    expect(fs.readFileSync(file, 'utf8')).toMatch(/^henri:v1:/);
+    expect(fs.readFileSync(file, 'utf8')).not.toContain(SECRET);
+    expect(fs.readFileSync(path.join(app, '.gitignore'), 'utf8')).toContain(
+      'config/credentials/*.key'
+    );
+  });
+
+  test('the plaintext is written 0600 and removed when the editor closes', () => {
+    edit();
+
+    const { file, mode } = report();
+
+    expect(mode).toBe(0o600);
+    expect(fs.existsSync(file)).toBe(false);
+    expect(fs.existsSync(path.dirname(file))).toBe(false);
+  });
+
+  test('a second edit opens what the first one wrote', () => {
+    edit();
+
+    const seen = editor(
+      dir,
+      'seen',
+      `fs.writeFileSync(process.env.HENRI_TEST_REPORT, JSON.stringify({ file, content: fs.readFileSync(file, 'utf8') }));`
+    );
+
+    edit([], seen);
+
+    expect(JSON.parse(report().content).mail.auth.pass).toBe(SECRET);
+  });
+
+  test('show prints the values, --json prints the key paths only', () => {
+    edit();
+
+    const plain = run(['credentials:show', '--env', 'dev'], app);
+
+    expect(plain.status).toBe(0);
+    expect(JSON.parse(plain.stdout).mail.auth.pass).toBe(SECRET);
+
+    const asJson = run(['credentials:show', '--env', 'dev', '--json'], app);
+    const result = JSON.parse(asJson.stdout);
+
+    expect(result).toEqual({
+      command: 'show',
+      env: 'dev',
+      file: 'config/credentials/dev.json.enc',
+      keys: ['secret', 'mail.auth.pass'],
+    });
+    expect(asJson.stdout).not.toContain(SECRET);
+  });
+
+  test('HENRI_CREDENTIALS_KEY opens the file without the key file', () => {
+    edit();
+
+    const key = fs
+      .readFileSync(path.join(app, 'config', 'credentials', 'dev.key'), 'utf8')
+      .trim();
+
+    fs.rmSync(path.join(app, 'config', 'credentials', 'dev.key'));
+
+    const { status, stdout } = henri(
+      ['credentials:show', '--env', 'dev', '--json'],
+      { cwd: app, env: { ...process.env, HENRI_CREDENTIALS_KEY: key } }
+    );
+
+    expect(status).toBe(0);
+    expect(JSON.parse(stdout).keys).toContain('mail.auth.pass');
+  });
+
+  test('a missing key is a failure naming the file, not a new one', () => {
+    edit();
+
+    const key = path.join(app, 'config', 'credentials', 'dev.key');
+    const before = fs.readFileSync(
+      path.join(app, 'config', 'credentials', 'dev.json.enc'),
+      'utf8'
+    );
+
+    fs.rmSync(key);
+
+    const { status, stderr } = henri(
+      ['credentials:edit', '--env', 'dev', '--json'],
+      { cwd: app, env: { ...process.env, EDITOR: saves, VISUAL: '' } }
+    );
+    const { error } = JSON.parse(stderr);
+
+    expect(status).toBe(1);
+    expect(error.message).toContain('config/credentials/dev.key is missing');
+    expect(error.hint).toContain('HENRI_CREDENTIALS_KEY');
+    expect(fs.existsSync(key)).toBe(false);
+    expect(
+      fs.readFileSync(
+        path.join(app, 'config', 'credentials', 'dev.json.enc'),
+        'utf8'
+      )
+    ).toBe(before);
+  });
+
+  test('a wrong key says so without quoting anything', () => {
+    edit();
+
+    const { status, stderr } = henri(
+      ['credentials:show', '--env', 'dev', '--json'],
+      {
+        cwd: app,
+        env: { ...process.env, HENRI_CREDENTIALS_KEY: 'ab'.repeat(32) },
+      }
+    );
+    const { error } = JSON.parse(stderr);
+
+    expect(status).toBe(1);
+    expect(error.message).toContain('could not be decrypted');
+    expect(stderr).not.toContain(SECRET);
+  });
+
+  test('without an editor it says which variables to set', () => {
+    const { status, stderr } = run(
+      ['credentials:edit', '--env', 'dev', '--json'],
+      app
+    );
+    const { error } = JSON.parse(stderr);
+
+    expect(status).toBe(2);
+    expect(error.code).toBe('USAGE');
+    expect(error.message).toContain('EDITOR and VISUAL');
+    expect(fs.existsSync(path.join(app, 'config', 'credentials'))).toBe(true);
+  });
+
+  test('an editor that fails leaves the credentials alone', () => {
+    edit();
+
+    const file = path.join(app, 'config', 'credentials', 'dev.json.enc');
+    const before = fs.readFileSync(file, 'utf8');
+    const angry = editor(dir, 'angry', 'process.exit(3);');
+    const { status, stderr } = edit(['--json'], angry);
+
+    expect(status).toBe(1);
+    expect(JSON.parse(stderr).error.message).toContain('exited with 3');
+    expect(fs.readFileSync(file, 'utf8')).toBe(before);
+  });
+
+  test('what is saved must be a JSON object', () => {
+    edit();
+
+    const file = path.join(app, 'config', 'credentials', 'dev.json.enc');
+    const before = fs.readFileSync(file, 'utf8');
+    const broken = editor(dir, 'broken', "fs.writeFileSync(file, '{ oops');");
+    const { status, stderr } = edit(['--json'], broken);
+
+    expect(status).toBe(1);
+    expect(JSON.parse(stderr).error.message).toBe(
+      'What you saved is not valid JSON'
+    );
+    expect(fs.readFileSync(file, 'utf8')).toBe(before);
+  });
+
+  test('an unknown command prints the usage', () => {
+    const { status, stderr } = run(['credentials:nope', '--json'], app);
+
+    expect(status).toBe(2);
+    expect(JSON.parse(stderr).error.message).toBe(
+      'Unknown credentials command "nope"'
+    );
+  });
+});
+
+describe('henri doctor and the credentials keys', () => {
+  let dir;
+  let app;
+  let key;
+
+  beforeAll(() => {
+    ({ app, dir } = scaffold(['--no-git']));
+    key = path.join(app, 'config', 'credentials', 'dev.key');
+
+    fs.mkdirSync(path.dirname(key), { recursive: true });
+    fs.writeFileSync(key, `${'a'.repeat(64)}\n`, { mode: 0o600 });
+  });
+
+  afterAll(() => {
+    cleanup(dir);
+  });
+
+  test('the scaffold ignores them from the first commit', () => {
+    expect(fs.readFileSync(path.join(app, '.gitignore'), 'utf8')).toMatch(
+      /^config\/credentials\/\*\.key$/m
+    );
+    expect(check(app).problems.map((problem) => problem.check)).not.toContain(
+      'credentials.ignored'
+    );
+  });
+
+  test('reports a key that is not ignored', () => {
+    const ignore = path.join(app, '.gitignore');
+    const original = fs.readFileSync(ignore, 'utf8');
+
+    fs.writeFileSync(ignore, original.replace(/^config\/credentials.*$/m, ''));
+
+    const { problems } = check(app);
+
+    fs.writeFileSync(ignore, original);
+
+    expect(problems).toContainEqual(
+      expect.objectContaining({
+        check: 'credentials.ignored',
+        file: '.gitignore',
+        level: 'error',
+      })
+    );
+  });
+
+  test('reports a key that reached the index', () => {
+    const git = (...args) =>
+      execFileSync('git', args, { cwd: app, stdio: 'ignore' });
+
+    git('init', '--quiet');
+    git('config', 'user.email', 'doctor@usehenri.io');
+    git('config', 'user.name', 'doctor');
+    git('add', '--force', 'config/credentials/dev.key');
+
+    const { ok, problems } = check(app);
+
+    expect(ok).toBe(false);
+    expect(problems).toContainEqual(
+      expect.objectContaining({
+        check: 'credentials.committed',
+        file: 'config/credentials/dev.key',
+        level: 'error',
+      })
+    );
+    expect(
+      problems.find((problem) => problem.check === 'credentials.committed').hint
+    ).toContain('git rm --cached');
+  });
+});

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -65,9 +65,11 @@ module.exports = (pkg, args) => {
   let command = argv._.shift();
 
   // Rails style: `henri db:migrate` is `henri db migrate`
-  if (command && command.startsWith('db:')) {
-    argv._.unshift(command.slice(3));
-    command = 'db';
+  for (const group of ['credentials', 'db']) {
+    if (command && command.startsWith(`${group}:`)) {
+      argv._.unshift(command.slice(group.length + 1));
+      command = group;
+    }
   }
 
   if (!command) {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,6 +51,7 @@
     "build",
     "clean",
     "console",
+    "credentials",
     "d",
     "db",
     "destroy",

--- a/packages/cli/scripts/credentials.js
+++ b/packages/cli/scripts/credentials.js
@@ -1,0 +1,385 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const spawn = require('cross-spawn');
+
+const { CliError } = require('./errors');
+const { usage } = require('./help');
+const { validInstall } = require('./utils');
+
+const COMMANDS = ['edit', 'show'];
+
+/** What a new credentials file starts with: the secret henri needs anyway */
+const TEMPLATE = () => ({
+  secret: require('crypto').randomBytes(32).toString('hex'),
+});
+
+/**
+ * Prefer the @usehenri/core the project depends on and fall back to the one
+ * shipped with this CLI (same rule as `henri db`)
+ *
+ * @returns {object} core's credentials module
+ */
+const load = () => {
+  try {
+    return require(
+      require.resolve('@usehenri/core/src/base/credentials', {
+        paths: [process.cwd()],
+      })
+    );
+  } catch {
+    return require('@usehenri/core/src/base/credentials');
+  }
+};
+
+/**
+ * The environment the command works on: `--env`, then NODE_ENV (which
+ * `--production` sets), then `dev` — the same name henri reads its
+ * configuration file under
+ *
+ * @param {object} args CLI arguments
+ * @returns {string} the environment
+ */
+const environmentOf = (args) => {
+  const name = typeof args.env === 'string' && args.env ? args.env : null;
+
+  return name || process.env.NODE_ENV || 'dev';
+};
+
+/**
+ * Make sure `.gitignore` covers the key files, adding the line when it does
+ * not: a key that reaches a commit is a leaked key
+ *
+ * @param {string} cwd the application directory
+ * @param {string} pattern the line to look for
+ * @returns {boolean} whether the line was added
+ */
+const ignore = (cwd, pattern) => {
+  const file = path.join(cwd, '.gitignore');
+  const current = fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : '';
+
+  if (
+    current.split(/\r?\n/).some((line) => line.trim() === pattern) ||
+    current.split(/\r?\n/).some((line) => line.trim() === `/${pattern}`)
+  ) {
+    return false;
+  }
+
+  fs.appendFileSync(
+    file,
+    `${current === '' || current.endsWith('\n') ? '' : '\n'}\n# Credentials keys: never commit them\n${pattern}\n`
+  );
+
+  return true;
+};
+
+/**
+ * The key of an environment, creating one when the file it opens does not
+ * exist yet
+ *
+ * @param {object} credentials core's credentials module
+ * @param {string} cwd the application directory
+ * @param {string} env the environment
+ * @param {boolean} create may a key be generated?
+ * @returns {{created: boolean, key: Buffer, source: string}} the key
+ * @throws {CliError} FAILED when there is no key and none may be created
+ */
+const keyFor = (credentials, cwd, env, create) => {
+  let found;
+
+  try {
+    found = credentials.readKey(cwd, env);
+  } catch (error) {
+    throw new CliError('FAILED', error.message, {
+      cause: error,
+      hint: 'A key is 64 hexadecimal characters, what `openssl rand -hex 32` prints',
+    });
+  }
+
+  if (found) {
+    return { ...found, created: false };
+  }
+
+  const file = credentials.keyFileFor(cwd, env);
+  const relative = path.relative(cwd, file);
+
+  if (!create) {
+    throw new CliError(
+      'FAILED',
+      `No key for the ${env} credentials: ${relative} is missing`,
+      {
+        hint: `Set ${credentials.KEY_VARIABLE}, or put ${relative} back. Without the key the file cannot be opened, by anyone.`,
+      }
+    );
+  }
+
+  const key = credentials.generateKey();
+
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${key}\n`, { mode: 0o600 });
+
+  const added = ignore(
+    cwd,
+    `${credentials.DIRECTORY}/*.key`.replace(/\\/g, '/')
+  );
+
+  console.log(`\n  Generated ${relative}`);
+  console.log('  Keep a copy: it is the only way to open the file.');
+
+  if (added) {
+    console.log('  Added it to .gitignore.');
+  }
+
+  return {
+    created: true,
+    key: credentials.parseKey(key, relative),
+    source: relative,
+  };
+};
+
+/**
+ * The editor of the current shell
+ *
+ * @returns {Array<string>} the command and its arguments
+ * @throws {CliError} USAGE when neither EDITOR nor VISUAL is set
+ */
+const editor = () => {
+  const command = process.env.EDITOR || process.env.VISUAL || '';
+
+  if (command.trim() === '') {
+    throw new CliError('USAGE', 'No editor: EDITOR and VISUAL are both unset', {
+      hint: 'EDITOR="code --wait" henri credentials:edit (the editor must not return before the file is saved)',
+    });
+  }
+
+  return command.trim().split(/\s+/);
+};
+
+/**
+ * Opens the decrypted file in the editor and waits for it
+ *
+ * @param {string} file the temporary file
+ * @returns {void}
+ * @throws {CliError} FAILED when the editor cannot start or answers non-zero
+ */
+const open = (file) => {
+  const [command, ...args] = editor();
+  const result = spawn.sync(command, [...args, file], { stdio: 'inherit' });
+
+  if (result.error) {
+    throw new CliError('FAILED', `The editor (${command}) could not start`, {
+      cause: result.error,
+      hint: 'EDITOR is run as a command with the file as its last argument',
+    });
+  }
+
+  if (result.status !== 0) {
+    throw new CliError(
+      'FAILED',
+      `The editor (${command}) exited with ${result.status}: nothing was written`
+    );
+  }
+};
+
+/**
+ * Runs `henri credentials:edit`: decrypts into a temporary file, opens the
+ * editor and encrypts what comes back
+ *
+ * The plaintext lives in a directory of its own that `mkdtemp` creates with
+ * `0700`, in a file created with `0600`, and it is removed on every exit
+ * path: a clean return, a throw, and an interrupted process.
+ *
+ * @param {object} credentials core's credentials module
+ * @param {string} cwd the application directory
+ * @param {string} env the environment
+ * @returns {object} what happened ({ command, env, file, keys, updated })
+ * @throws {CliError} FAILED when the editor or the content is wrong
+ */
+const edit = (credentials, cwd, env) => {
+  const file = credentials.fileFor(cwd, env);
+  const exists = fs.existsSync(file);
+  const { key } = keyFor(credentials, cwd, env, !exists);
+  const values = exists ? read(credentials, cwd, env).values : TEMPLATE();
+
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'henri-credentials-')
+  );
+  const plain = path.join(directory, `${env}.json`);
+  const clean = () => fs.rmSync(directory, { force: true, recursive: true });
+  const interrupted = () => {
+    clean();
+    process.exit(130);
+  };
+
+  process.once('SIGINT', interrupted);
+  process.once('SIGTERM', interrupted);
+  process.once('exit', clean);
+
+  let updated = false;
+  let entries;
+
+  try {
+    const before = `${JSON.stringify(values, null, 2)}\n`;
+
+    fs.writeFileSync(plain, before, { mode: 0o600 });
+    open(plain);
+
+    const after = fs.readFileSync(plain, 'utf8');
+
+    if (after !== before) {
+      let parsed = null;
+
+      try {
+        parsed = JSON.parse(after);
+      } catch {
+        // The parser's message quotes the file, and the file is plaintext
+        throw new CliError('FAILED', 'What you saved is not valid JSON', {
+          hint: `The ${env} credentials were left as they were`,
+        });
+      }
+
+      if (parsed === null || typeof parsed !== 'object') {
+        throw new CliError('FAILED', 'The credentials must be a JSON object', {
+          hint: `The ${env} credentials were left as they were`,
+        });
+      }
+
+      credentials.write(cwd, env, parsed, key);
+      updated = true;
+      entries = credentials.leaves(parsed).map((entry) => entry.key);
+    } else {
+      entries = credentials.leaves(values).map((entry) => entry.key);
+    }
+  } finally {
+    clean();
+    process.off('SIGINT', interrupted);
+    process.off('SIGTERM', interrupted);
+    process.off('exit', clean);
+  }
+
+  return {
+    command: 'edit',
+    env,
+    file: path.relative(cwd, file),
+    keys: entries,
+    updated,
+  };
+};
+
+/**
+ * The credentials of an environment, or a usage error when there are none
+ *
+ * @param {object} credentials core's credentials module
+ * @param {string} cwd the application directory
+ * @param {string} env the environment
+ * @returns {object} what `credentials.read()` answered
+ * @throws {CliError} USAGE when the file is missing, FAILED when it will not open
+ */
+const read = (credentials, cwd, env) => {
+  try {
+    const found = credentials.read(cwd, env);
+
+    if (!found) {
+      throw new CliError(
+        'USAGE',
+        `No credentials for ${env}: ${path.relative(cwd, credentials.fileFor(cwd, env))} does not exist`,
+        { hint: `henri credentials:edit --env ${env} creates it` }
+      );
+    }
+
+    return found;
+  } catch (error) {
+    if (error instanceof CliError) {
+      throw error;
+    }
+
+    throw new CliError('FAILED', error.message, { cause: error });
+  }
+};
+
+/**
+ * Runs `henri credentials:show`
+ *
+ * @param {object} credentials core's credentials module
+ * @param {string} cwd the application directory
+ * @param {string} env the environment
+ * @returns {object} the result, with the values (never printed by --json)
+ */
+const show = (credentials, cwd, env) => {
+  const found = read(credentials, cwd, env);
+
+  return {
+    command: 'show',
+    env,
+    file: path.relative(cwd, found.file),
+    keys: found.entries.map((entry) => entry.key),
+    values: found.values,
+  };
+};
+
+/**
+ * Runs `henri credentials <edit|show>` (`henri credentials:<command>` too)
+ *
+ * `--json` prints the key paths, never a value: the decrypted content only
+ * ever reaches stdout, from `credentials:show` without `--json`.
+ *
+ * @param {object} args CLI arguments
+ * @returns {Promise<void>} Resolves when done
+ * @throws {CliError} USAGE without a command
+ */
+const main = async (args) => {
+  const [command] = args._;
+
+  if (!command || !COMMANDS.includes(command)) {
+    if (!args.json) {
+      console.log(usage('credentials'));
+    }
+
+    throw new CliError(
+      'USAGE',
+      command
+        ? `Unknown credentials command "${command}"`
+        : 'Missing credentials command',
+      { hint: `Available commands: ${COMMANDS.join(', ')}` }
+    );
+  }
+
+  validInstall({ fatal: true });
+
+  const credentials = load();
+  const cwd = process.cwd();
+  const env = environmentOf(args);
+  const result =
+    command === 'edit'
+      ? edit(credentials, cwd, env)
+      : show(credentials, cwd, env);
+
+  if (args.json) {
+    const { values, ...safe } = result;
+
+    console.log(JSON.stringify(safe, null, 2));
+
+    return;
+  }
+
+  if (command === 'show') {
+    console.log(JSON.stringify(result.values, null, 2));
+
+    return;
+  }
+
+  console.log('');
+  console.log(
+    result.updated
+      ? `  Encrypted ${result.file} (${result.keys.length} key(s))`
+      : `  ${result.file} is unchanged`
+  );
+  console.log('');
+};
+
+module.exports = main;
+module.exports.COMMANDS = COMMANDS;
+module.exports.edit = edit;
+module.exports.environmentOf = environmentOf;
+module.exports.ignore = ignore;
+module.exports.show = show;

--- a/packages/cli/scripts/doctor.js
+++ b/packages/cli/scripts/doctor.js
@@ -48,6 +48,72 @@ const PAGES = {
 
 const PAGE_EXTENSIONS = ['.js', '.jsx'];
 
+/** Where the credentials of an environment and its key live */
+const CREDENTIALS = path.join('config', 'credentials');
+
+/**
+ * The credentials keys of an application, as posix paths relative to it
+ *
+ * @param {string} dir The application directory
+ * @returns {Array<string>} The key files (`config/credentials/dev.key`)
+ */
+const keyFiles = (dir) => {
+  const folder = path.join(dir, CREDENTIALS);
+
+  if (!fs.existsSync(folder)) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(folder)
+    .filter((name) => name.endsWith('.key'))
+    .map((name) => `${CREDENTIALS}/${name}`.replace(/\\/g, '/'));
+};
+
+/**
+ * Does a .gitignore cover the credentials keys? Anything that names every
+ * key of the folder counts, whichever way it is written.
+ *
+ * @param {string} ignore The content of .gitignore
+ * @returns {boolean} Covered or not
+ */
+const ignoresKeys = (ignore) =>
+  ignore
+    .split(/\r?\n/)
+    .map((line) => line.trim().replace(/^\//, ''))
+    .some((line) =>
+      ['*.key', '**/*.key', `${CREDENTIALS}/*.key`, `${CREDENTIALS}/`].includes(
+        line
+      )
+    );
+
+/**
+ * The credentials keys git has in its index: a key that reached a commit is
+ * a leaked key, whatever .gitignore says now
+ *
+ * @param {string} dir The application directory
+ * @returns {Array<string>} The tracked key files (none without git)
+ */
+const trackedKeys = (dir) => {
+  if (!fs.existsSync(path.join(dir, '.git'))) {
+    return [];
+  }
+
+  try {
+    const { execFileSync } = require('child_process');
+    const listed = execFileSync(
+      'git',
+      ['ls-files', '--cached', '--', `${CREDENTIALS}/*.key`],
+      { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }
+    );
+
+    return listed.split(/\r?\n/).filter((line) => line.trim() !== '');
+  } catch {
+    // No git binary, or not a repository: the .gitignore check stands alone
+    return [];
+  }
+};
+
 /**
  * Does a model name look plural? (ends with an s that is not part of
  * -ss, -us or -is: Tasks yes, Status, Address and Analysis no)
@@ -467,6 +533,23 @@ const check = (dir = process.cwd()) => {
         });
       }
     }
+  }
+
+  // --- credentials ----------------------------------------------------------
+  for (const key of keyFiles(dir)) {
+    if (!hasIgnore || !ignoresKeys(read('.gitignore'))) {
+      problem('error', 'credentials.ignored', `${key} is not ignored by git`, {
+        file: '.gitignore',
+        hint: 'Add a "config/credentials/*.key" line: the key opens every secret of that environment',
+      });
+    }
+  }
+
+  for (const key of trackedKeys(dir)) {
+    problem('error', 'credentials.committed', `${key} is committed`, {
+      file: key,
+      hint: `Remove it from the repository (git rm --cached ${key}), rotate the secrets it holds and write them again with henri credentials:edit`,
+    });
   }
 
   // --- agents, tests --------------------------------------------------------

--- a/packages/cli/scripts/help.js
+++ b/packages/cli/scripts/help.js
@@ -90,6 +90,63 @@ const COMMANDS = [
   },
   {
     description: [
+      'The secrets of an environment, encrypted with AES-256-GCM in',
+      'config/credentials/<env>.json.enc, which is committed. The key that',
+      'opens it is HENRI_CREDENTIALS_KEY or config/credentials/<env>.key,',
+      'which is never committed (henri new ignores it, henri doctor checks',
+      'it). On boot henri decrypts the file and applies it over the',
+      'configuration, under the environment variables: what is in there is',
+      'read with henri.config.get("mail.auth.pass").',
+      '',
+      'edit decrypts into a file only you can read, opens EDITOR (or VISUAL)',
+      'and encrypts what comes back; the plaintext is removed on every exit',
+      'path. The first edit of an environment generates the key and the file.',
+      'Neither command prints a secret with --json.',
+    ],
+    examples: [
+      {
+        command: 'henri credentials:edit',
+        description: 'Edits the credentials of the development environment',
+      },
+      {
+        command: 'henri credentials:edit --env production',
+        description: 'Creates them on the first run, with a fresh secret',
+      },
+      {
+        command: 'henri credentials:show --env production --json',
+        description: 'The key paths the file holds, without their values',
+      },
+    ],
+    flags: [
+      {
+        description:
+          'the environment (default: NODE_ENV, or dev when it is unset)',
+        flag: '--env=<name>',
+      },
+      {
+        description: 'print the environment, the file and its key paths',
+        flag: '--json',
+      },
+    ],
+    name: 'credentials',
+    summary: 'encrypted secrets, per environment',
+    targets: [
+      {
+        description: 'decrypt, open EDITOR, encrypt what comes back',
+        name: 'edit',
+      },
+      {
+        description: 'print the decrypted credentials on stdout',
+        name: 'show',
+      },
+    ],
+    usage: [
+      'henri credentials <command> [--env=<name>] [--json]',
+      'henri credentials:<command>',
+    ],
+  },
+  {
+    description: [
       'Boots the models only (no views, no workers) and drives the database.',
       'seed runs db/seeds.js on any adapter; the migration commands need the',
       'drizzle adapter and its db/migrations folder (drizzle-kit layout). In',

--- a/packages/cli/template/default/gitignore
+++ b/packages/cli/template/default/gitignore
@@ -12,8 +12,10 @@
 /.henri
 
 # configuration: config/default.json is committed, secrets live in .env
+# and in config/credentials/<env>.json.enc, whose key is never committed
 /config/local.json
 .env
+config/credentials/*.key
 
 # logs
 /logs/*.log

--- a/packages/cli/template/inertia/gitignore
+++ b/packages/cli/template/inertia/gitignore
@@ -12,8 +12,10 @@
 /.henri
 
 # configuration: config/default.json is committed, secrets live in .env
+# and in config/credentials/<env>.json.enc, whose key is never committed
 /config/local.json
 .env
+config/credentials/*.key
 
 # logs
 /logs/*.log

--- a/packages/core/src/0.config.js
+++ b/packages/core/src/0.config.js
@@ -1,4 +1,5 @@
 const BaseModule = require('./base/module');
+const credentials = require('./base/credentials');
 const fs = require('fs');
 const path = require('path');
 const { syntax } = require('./utils');
@@ -282,8 +283,9 @@ function overrides(env) {
 /**
  * The configuration, with the environment applied over it
  *
- * Precedence, lowest first: the configuration file, the named shorthands
- * (HENRI_SECRET, HENRI_HOST, DATABASE_URL), then the generic overrides
+ * Precedence, lowest first: the configuration file, the credentials of the
+ * environment (applyCredentials), the named shorthands (HENRI_SECRET,
+ * HENRI_HOST, DATABASE_URL), then the generic overrides
  * (HENRI_CONFIG__<path>), which name the key they set and win.
  *
  * @param {object} config the parsed configuration
@@ -352,6 +354,39 @@ function withEnv(config, env = process.env) {
 }
 
 /**
+ * The configuration, with `config/credentials/<env>.json.enc` applied over it
+ *
+ * Every leaf of the decrypted object replaces the value the file has at that
+ * path, so a credentials file holding `{ "mail": { "auth": { "pass": "x" } } }`
+ * leaves the rest of `mail` alone.
+ *
+ * @param {object} config parsed configuration
+ * @param {string} cwd the application directory
+ * @param {string} env the environment
+ * @param {object} [environment=process.env] the environment variables
+ * @returns {{applied: Array<string>, config: object, source: ?string}} the
+ *   configuration, the paths the credentials provided and where the key
+ *   came from
+ * @throws {Error} when the file exists and cannot be opened
+ */
+function applyCredentials(config, cwd, env, environment = process.env) {
+  const secrets = credentials.read(cwd, env, environment);
+
+  if (!secrets) {
+    return { applied: [], config, source: null };
+  }
+
+  return {
+    applied: secrets.entries.map((entry) => entry.key),
+    config: secrets.entries.reduce(
+      (current, entry) => setPath(current, entry.key, entry.value),
+      config
+    ),
+    source: secrets.source,
+  };
+}
+
+/**
  * A value of the environment, ready to be printed
  *
  * A key `config.filterParameters` matches (`secret`, `password`, `token`
@@ -401,6 +436,7 @@ class Config extends BaseModule {
     this.reloadable = true;
     this.henri = null;
     this.fromEnv = [];
+    this.fromCredentials = [];
 
     this.get = this.get.bind(this);
     this.has = this.has.bind(this);
@@ -419,11 +455,8 @@ class Config extends BaseModule {
   async init() {
     loadDotEnv(this.henri.cwd());
 
-    const configPath = path.join(
-      this.henri.cwd(),
-      'config',
-      `${this.henri.env || 'dev'}.json`
-    );
+    const env = this.henri.env || 'dev';
+    const configPath = path.join(this.henri.cwd(), 'config', `${env}.json`);
     const defaultPath = path.join(this.henri.cwd(), 'config', 'default.json');
 
     let hasErrors = false;
@@ -444,15 +477,18 @@ class Config extends BaseModule {
     }
 
     if (loaded) {
-      // Outside the try above: a wrong environment variable is a boot
-      // failure of its own, never a reason to fall back to another file
-      const { applied, config } = applyEnv(loaded);
+      // Outside the try above: a credentials file that will not open, and a
+      // wrong environment variable, are boot failures of their own, never a
+      // reason to fall back to another file
+      const secrets = applyCredentials(loaded, this.henri.cwd(), env);
+      const { applied, config } = applyEnv(secrets.config);
 
       this.config = config;
       this.fromEnv = applied.map(({ key, variable }) => ({ key, variable }));
+      this.fromCredentials = secrets.applied;
 
       Object.freeze(this.config);
-      this.report(applied);
+      this.report(applied, secrets);
 
       return this.name;
     }
@@ -467,18 +503,29 @@ class Config extends BaseModule {
   }
 
   /**
-   * Prints the keys the environment provided, so nobody debugs a value they
-   * cannot see. Filtered parameters are masked.
+   * Prints the keys the environment and the credentials provided, so nobody
+   * debugs a value they cannot see. Filtered parameters are masked, and a
+   * credentials line is names only: every value in that file is a secret.
    *
    * @param {Array<object>} applied what applyEnv() applied
+   * @param {object} [secrets] what applyCredentials() applied
    * @returns {void}
    * @memberof Config
    */
-  report(applied) {
+  report(applied, secrets = { applied: [], source: null }) {
     const filters = filterParameters({
       get: (key) => getPath(this.config, key),
       has: (key) => hasPath(this.config, key),
     });
+
+    if (secrets.applied.length > 0) {
+      this.henri.pen.info(
+        'config',
+        'from the credentials',
+        secrets.applied.join(', '),
+        `key: ${secrets.source}`
+      );
+    }
 
     for (const entry of applied) {
       if (entry.ignored) {
@@ -560,6 +607,7 @@ module.exports = Config;
 module.exports.ALIASES = ALIASES;
 module.exports.ENV_JSON_PREFIX = ENV_JSON_PREFIX;
 module.exports.ENV_PREFIX = ENV_PREFIX;
+module.exports.applyCredentials = applyCredentials;
 module.exports.applyEnv = applyEnv;
 module.exports.loadDotEnv = loadDotEnv;
 module.exports.withEnv = withEnv;

--- a/packages/core/src/0.config.js
+++ b/packages/core/src/0.config.js
@@ -2,6 +2,39 @@ const BaseModule = require('./base/module');
 const fs = require('fs');
 const path = require('path');
 const { syntax } = require('./utils');
+const { MASK, filterParameters, isFiltered, redact } = require('./base/redact');
+
+/**
+ * Prefix of the generic environment overrides. The rest of the name is the
+ * configuration path, `__` between the segments, verbatim (configuration
+ * keys are camelCase and environment variable names are case sensitive):
+ * `HENRI_CONFIG__stores__default__url` sets `stores.default.url`.
+ */
+const ENV_PREFIX = 'HENRI_CONFIG__';
+
+/**
+ * Same, with the value parsed as JSON instead of coerced to the type the
+ * configuration file already uses: `HENRI_CONFIG_JSON__inertia={"ssr":true}`
+ */
+const ENV_JSON_PREFIX = 'HENRI_CONFIG_JSON__';
+
+/** Segment separator inside those names (a shell name cannot hold a dot) */
+const ENV_SEPARATOR = '__';
+
+/**
+ * The named shorthands, applied in this order and before the generic
+ * overrides. `requires` is a path the configuration must already have for
+ * the variable to mean anything.
+ */
+const ALIASES = [
+  { key: 'secret', variable: 'HENRI_SECRET' },
+  { key: 'host', variable: 'HENRI_HOST' },
+  {
+    key: 'stores.default.url',
+    requires: 'stores.default',
+    variable: 'DATABASE_URL',
+  },
+];
 
 /**
  * Load the KEY=value lines of <cwd>/.env into process.env
@@ -36,20 +69,6 @@ function loadDotEnv(cwd) {
   }
 
   return loaded;
-}
-
-/**
- * Environment overrides: HENRI_SECRET provides (or replaces) `secret`
- *
- * @param {object} config parsed configuration
- * @returns {object} the configuration with the overrides applied
- */
-function withEnv(config) {
-  if (process.env.HENRI_SECRET) {
-    return Object.assign({}, config, { secret: process.env.HENRI_SECRET });
-  }
-
-  return config;
 }
 
 /**
@@ -102,6 +121,267 @@ function getPath(object, key) {
 }
 
 /**
+ * A copy of the object with the value set at the given path
+ *
+ * Only the containers along the path are copied, the rest is shared: the
+ * object the caller passed (the required configuration file, which node
+ * caches) is never modified. Missing containers are created.
+ *
+ * @param {object} object the object to copy
+ * @param {string} key the path (ex: 'stores.default.url')
+ * @param {any} value the value to set
+ * @returns {object} the copy
+ */
+function setPath(object, key, value) {
+  const parts = segments(key);
+  const copy = (node) => {
+    if (Array.isArray(node)) {
+      return node.slice();
+    }
+
+    return node !== null && typeof node === 'object' ? { ...node } : {};
+  };
+  const root = copy(object);
+  let current = root;
+
+  for (const part of parts.slice(0, -1)) {
+    current[part] = copy(current[part]);
+    current = current[part];
+  }
+
+  current[parts[parts.length - 1]] = value;
+
+  return root;
+}
+
+/**
+ * Parse a JSON value coming from the environment
+ *
+ * The value itself is never part of the error: it may be a secret.
+ *
+ * @param {string} raw the value of the variable
+ * @param {string} variable the name of the variable
+ * @returns {any} the parsed value
+ * @throws {Error} when the value is not valid JSON
+ */
+function parseJson(raw, variable) {
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    // No cause and no parser message on purpose: both quote the value, and
+    // the value of an environment variable may be a secret
+    // eslint-disable-next-line preserve-caught-error
+    throw new Error(`${variable} is not valid JSON`);
+  }
+}
+
+/**
+ * JSON.parse, or undefined when the value is not JSON
+ *
+ * @param {string} raw the value of the variable
+ * @returns {any} the parsed value, or undefined
+ */
+function tryJson(raw) {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The value of an environment variable, as the type the configuration file
+ * already uses at that path
+ *
+ * A path the file does not have is a string: henri does not guess. Use
+ * `HENRI_CONFIG_JSON__<path>` for anything else.
+ *
+ * @param {string} raw the value of the variable
+ * @param {any} current the value the configuration file has at that path
+ * @param {object} entry the override ({ key, variable })
+ * @returns {any} the value to set
+ * @throws {Error} when the value does not fit the type of the current one
+ */
+function coerce(raw, current, entry) {
+  const { key, variable } = entry;
+
+  if (typeof current === 'number') {
+    const value = Number(raw);
+
+    if (!Number.isFinite(value)) {
+      throw new Error(
+        `${variable} is not a number, and "${key}" is one in the configuration`
+      );
+    }
+
+    return value;
+  }
+
+  if (typeof current === 'boolean') {
+    if (/^(true|false)$/i.test(raw)) {
+      return /^true$/i.test(raw);
+    }
+
+    throw new Error(
+      `${variable} is not true or false, and "${key}" is a boolean in the configuration`
+    );
+  }
+
+  if (current !== null && typeof current === 'object') {
+    const value = tryJson(raw);
+
+    if (value === null || typeof value !== 'object') {
+      throw new Error(
+        `${variable} is not a JSON object, and "${key}" is one in the configuration`
+      );
+    }
+
+    return value;
+  }
+
+  return raw;
+}
+
+/**
+ * The generic overrides present in an environment, sorted by variable name
+ * so a boot is reproducible
+ *
+ * @param {object} env the environment (process.env)
+ * @returns {Array<object>} the overrides ({ json, key, variable })
+ * @throws {Error} when a variable carries no configuration path
+ */
+function overrides(env) {
+  const found = [];
+
+  for (const variable of Object.keys(env).sort()) {
+    const json = variable.startsWith(ENV_JSON_PREFIX);
+    const prefix = json ? ENV_JSON_PREFIX : ENV_PREFIX;
+
+    if (!json && !variable.startsWith(ENV_PREFIX)) {
+      continue;
+    }
+
+    const key = variable
+      .slice(prefix.length)
+      .split(ENV_SEPARATOR)
+      .filter((part) => part.length > 0)
+      .join('.');
+
+    if (key === '') {
+      throw new Error(
+        `${variable} names no configuration key: ${prefix}<key> (${prefix}stores${ENV_SEPARATOR}default${ENV_SEPARATOR}url)`
+      );
+    }
+
+    found.push({ json, key, variable });
+  }
+
+  return found;
+}
+
+/**
+ * The configuration, with the environment applied over it
+ *
+ * Precedence, lowest first: the configuration file, the named shorthands
+ * (HENRI_SECRET, HENRI_HOST, DATABASE_URL), then the generic overrides
+ * (HENRI_CONFIG__<path>), which name the key they set and win.
+ *
+ * @param {object} config the parsed configuration
+ * @param {object} [env=process.env] the environment
+ * @returns {{applied: Array<object>, config: object}} the configuration and
+ *   what the environment provided (one entry per variable)
+ * @throws {Error} when a variable is empty or does not fit its key
+ */
+function applyEnv(config, env = process.env) {
+  const applied = [];
+  let result = config;
+
+  for (const alias of ALIASES) {
+    const raw = env[alias.variable];
+
+    // An unset or empty shorthand is simply not an override
+    if (typeof raw !== 'string' || raw.trim() === '') {
+      continue;
+    }
+
+    if (alias.requires && !hasPath(result, alias.requires)) {
+      applied.push({
+        ignored: `the configuration has no "${alias.requires}"`,
+        key: alias.key,
+        variable: alias.variable,
+      });
+      continue;
+    }
+
+    const value = coerce(raw, getPath(result, alias.key), alias);
+
+    result = setPath(result, alias.key, value);
+    applied.push({ key: alias.key, value, variable: alias.variable });
+  }
+
+  for (const entry of overrides(env)) {
+    const raw = env[entry.variable];
+
+    if (raw.trim() === '') {
+      throw new Error(
+        `${entry.variable} is set but empty: give it a value or unset it`
+      );
+    }
+
+    const value = entry.json
+      ? parseJson(raw, entry.variable)
+      : coerce(raw, getPath(result, entry.key), entry);
+
+    result = setPath(result, entry.key, value);
+    applied.push({ key: entry.key, value, variable: entry.variable });
+  }
+
+  return { applied, config: result };
+}
+
+/**
+ * The configuration, with the environment applied over it
+ *
+ * @param {object} config parsed configuration
+ * @param {object} [env=process.env] the environment
+ * @returns {object} the configuration with the overrides applied
+ * @throws {Error} when a variable is empty or does not fit its key
+ */
+function withEnv(config, env = process.env) {
+  return applyEnv(config, env).config;
+}
+
+/**
+ * A value of the environment, ready to be printed
+ *
+ * A key `config.filterParameters` matches (`secret`, `password`, `token`
+ * and `authorization` by default) is masked, in the path and in the name of
+ * the variable; the password of a connection string always is, since a url
+ * carries one without ever being named like a secret.
+ *
+ * @param {object} entry an applied override ({ key, value, variable })
+ * @param {Array<string>} filters the filtered parameter names
+ * @returns {string} what to print
+ */
+function display(entry, filters) {
+  const { key, value, variable } = entry;
+  const last = segments(key).pop();
+
+  if (isFiltered(last, filters) || isFiltered(variable, filters)) {
+    return MASK;
+  }
+
+  if (value !== null && typeof value === 'object') {
+    return JSON.stringify(redact(value, filters));
+  }
+
+  return String(value).replace(
+    /^([a-z][a-z0-9+.-]*:\/\/[^:@/\s]+):[^@\s/]*@/i,
+    `$1:${MASK}@`
+  );
+}
+
+/**
  * Configuration module
  *
  * @class Config
@@ -120,6 +400,7 @@ class Config extends BaseModule {
     this.config = null;
     this.reloadable = true;
     this.henri = null;
+    this.fromEnv = [];
 
     this.get = this.get.bind(this);
     this.has = this.has.bind(this);
@@ -132,6 +413,7 @@ class Config extends BaseModule {
    * Called after being loaded by Modules
    *
    * @returns {!string} The name of the module
+   * @throws {Error} when a file cannot be parsed or the environment is wrong
    * @memberof Config
    */
   async init() {
@@ -145,29 +427,34 @@ class Config extends BaseModule {
     const defaultPath = path.join(this.henri.cwd(), 'config', 'default.json');
 
     let hasErrors = false;
+    let loaded = null;
 
-    try {
-      this.config = withEnv(require(configPath));
+    for (const file of [configPath, defaultPath]) {
+      if (loaded) {
+        break;
+      }
 
-      Object.freeze(this.config);
-
-      return this.name;
-    } catch (error) {
-      if (await syntax(configPath, null, this.henri)) {
-        hasErrors = true;
+      try {
+        loaded = require(file);
+      } catch (error) {
+        if (await syntax(file, null, this.henri)) {
+          hasErrors = true;
+        }
       }
     }
 
-    try {
-      this.config = withEnv(require(defaultPath));
+    if (loaded) {
+      // Outside the try above: a wrong environment variable is a boot
+      // failure of its own, never a reason to fall back to another file
+      const { applied, config } = applyEnv(loaded);
+
+      this.config = config;
+      this.fromEnv = applied.map(({ key, variable }) => ({ key, variable }));
 
       Object.freeze(this.config);
+      this.report(applied);
 
       return this.name;
-    } catch (error) {
-      if (await syntax(defaultPath, null, this.henri)) {
-        hasErrors = true;
-      }
     }
 
     if (hasErrors) {
@@ -177,6 +464,39 @@ class Config extends BaseModule {
     this.henri.pen.error('config', 'no configuration has been loaded...');
     this.henri.pen.error('config', 'attempted', configPath);
     this.henri.pen.error('config', 'attempted', defaultPath);
+  }
+
+  /**
+   * Prints the keys the environment provided, so nobody debugs a value they
+   * cannot see. Filtered parameters are masked.
+   *
+   * @param {Array<object>} applied what applyEnv() applied
+   * @returns {void}
+   * @memberof Config
+   */
+  report(applied) {
+    const filters = filterParameters({
+      get: (key) => getPath(this.config, key),
+      has: (key) => hasPath(this.config, key),
+    });
+
+    for (const entry of applied) {
+      if (entry.ignored) {
+        this.henri.pen.warn(
+          'config',
+          entry.variable,
+          `ignored: ${entry.ignored}`
+        );
+        continue;
+      }
+
+      this.henri.pen.info(
+        'config',
+        'from the environment',
+        `${entry.key} = ${display(entry, filters)}`,
+        entry.variable
+      );
+    }
   }
 
   /**
@@ -237,5 +557,9 @@ class Config extends BaseModule {
 }
 
 module.exports = Config;
+module.exports.ALIASES = ALIASES;
+module.exports.ENV_JSON_PREFIX = ENV_JSON_PREFIX;
+module.exports.ENV_PREFIX = ENV_PREFIX;
+module.exports.applyEnv = applyEnv;
 module.exports.loadDotEnv = loadDotEnv;
 module.exports.withEnv = withEnv;

--- a/packages/core/src/__tests__/__snapshots__/config.spec.js.snap
+++ b/packages/core/src/__tests__/__snapshots__/config.spec.js.snap
@@ -4,6 +4,7 @@ exports[`config > in test > should match snapshot 1`] = `
 Config {
   "config": null,
   "consoleOnly": false,
+  "fromEnv": [],
   "get": [Function],
   "has": [Function],
   "henri": null,

--- a/packages/core/src/__tests__/__snapshots__/config.spec.js.snap
+++ b/packages/core/src/__tests__/__snapshots__/config.spec.js.snap
@@ -4,6 +4,7 @@ exports[`config > in test > should match snapshot 1`] = `
 Config {
   "config": null,
   "consoleOnly": false,
+  "fromCredentials": [],
   "fromEnv": [],
   "get": [Function],
   "has": [Function],

--- a/packages/core/src/__tests__/config.spec.js
+++ b/packages/core/src/__tests__/config.spec.js
@@ -129,3 +129,239 @@ describe('config environment', () => {
     }
   });
 });
+
+describe('config from the environment', () => {
+  const {
+    ENV_JSON_PREFIX,
+    ENV_PREFIX,
+    applyEnv,
+    withEnv,
+  } = require('../0.config');
+
+  const file = () => ({
+    baseRole: 'guest',
+    filterParameters: ['password', 'token', 'secret', 'authorization'],
+    inertia: { ssr: false },
+    port: 3000,
+    secret: 'from-the-file',
+    stores: { default: { adapter: 'drizzle', url: 'postgres://file/db' } },
+    trustProxy: true,
+  });
+
+  test('a missing variable changes nothing', () => {
+    const { applied, config } = applyEnv(file(), {});
+
+    expect(applied).toEqual([]);
+    expect(config).toEqual(file());
+    expect(config.secret).toBe('from-the-file');
+    expect(Object.keys(config)).not.toContain('host');
+  });
+
+  test('the environment wins over the file, the generic form over an alias', () => {
+    const { config } = applyEnv(file(), {
+      DATABASE_URL: 'postgres://alias/db',
+      HENRI_SECRET: 'from-the-alias',
+      [`${ENV_PREFIX}secret`]: 'from-the-key',
+    });
+
+    expect(config.secret).toBe('from-the-key');
+    expect(config.stores.default.url).toBe('postgres://alias/db');
+    expect(config.stores.default.adapter).toBe('drizzle');
+  });
+
+  test('DATABASE_URL reaches the default store, HENRI_CONFIG__ a named one', () => {
+    const { config } = applyEnv(file(), {
+      DATABASE_URL: 'postgres://env/db',
+      [`${ENV_PREFIX}stores__reporting__adapter`]: 'drizzle',
+      [`${ENV_PREFIX}stores__reporting__url`]: 'postgres://env/reporting',
+    });
+
+    expect(config.stores.default.url).toBe('postgres://env/db');
+    expect(config.stores.reporting).toEqual({
+      adapter: 'drizzle',
+      url: 'postgres://env/reporting',
+    });
+  });
+
+  test('DATABASE_URL without a default store is reported, not applied', () => {
+    const { applied, config } = applyEnv(
+      { port: 3000 },
+      { DATABASE_URL: 'postgres://env/db' }
+    );
+
+    expect(config.stores).toBeUndefined();
+    expect(applied[0].ignored).toMatch(/no "stores.default"/);
+  });
+
+  test('the file gives the type: a number, a boolean, an object', () => {
+    const { config } = applyEnv(file(), {
+      [`${ENV_JSON_PREFIX}inertia`]: '{"ssr":true,"id":"app"}',
+      [`${ENV_PREFIX}port`]: '8080',
+      [`${ENV_PREFIX}trustProxy`]: 'false',
+    });
+
+    expect(config.port).toBe(8080);
+    expect(config.trustProxy).toBe(false);
+    expect(config.inertia).toEqual({ id: 'app', ssr: true });
+  });
+
+  test('a value the file types as a string stays one', () => {
+    const { config } = applyEnv(file(), {
+      [`${ENV_PREFIX}stores__default__url`]: '5432',
+    });
+
+    expect(config.stores.default.url).toBe('5432');
+  });
+
+  test('a key the file does not have is a string, unless it is JSON', () => {
+    const { config } = applyEnv(file(), {
+      [`${ENV_JSON_PREFIX}rateLimit`]: '{"max":10}',
+      [`${ENV_PREFIX}mail__host`]: 'smtp.example.com',
+    });
+
+    expect(config.mail).toEqual({ host: 'smtp.example.com' });
+    expect(config.rateLimit).toEqual({ max: 10 });
+  });
+
+  test('a value that does not fit its key fails the boot', () => {
+    expect(() => applyEnv(file(), { [`${ENV_PREFIX}port`]: 'nope' })).toThrow(
+      /HENRI_CONFIG__port is not a number/
+    );
+    expect(() =>
+      applyEnv(file(), { [`${ENV_PREFIX}trustProxy`]: 'yes' })
+    ).toThrow(/is not true or false/);
+    expect(() => applyEnv(file(), { [`${ENV_PREFIX}inertia`]: 'ssr' })).toThrow(
+      /is not a JSON object/
+    );
+  });
+
+  test('invalid JSON fails without quoting the value', () => {
+    let thrown = null;
+
+    try {
+      applyEnv(file(), { [`${ENV_JSON_PREFIX}secret`]: 'hunter2' });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown.message).toBe('HENRI_CONFIG_JSON__secret is not valid JSON');
+    expect(thrown.message).not.toContain('hunter2');
+  });
+
+  test('an empty variable is never a silent empty string', () => {
+    expect(() => applyEnv(file(), { [`${ENV_PREFIX}baseRole`]: '' })).toThrow(
+      /is set but empty/
+    );
+
+    // The shorthands keep their truthiness: an empty one is unset, not empty
+    const { applied, config } = applyEnv(file(), {
+      DATABASE_URL: '',
+      HENRI_SECRET: '',
+    });
+
+    expect(applied).toEqual([]);
+    expect(config.secret).toBe('from-the-file');
+  });
+
+  test('a variable naming no key is refused', () => {
+    expect(() => applyEnv(file(), { [ENV_PREFIX]: 'x' })).toThrow(
+      /names no configuration key/
+    );
+  });
+
+  test('the configuration file object is never modified', () => {
+    const original = file();
+
+    applyEnv(original, {
+      [`${ENV_PREFIX}stores__default__url`]: 'postgres://env/db',
+    });
+
+    expect(original.stores.default.url).toBe('postgres://file/db');
+  });
+
+  test('withEnv keeps its signature', () => {
+    expect(withEnv({ secret: 'file' }, {})).toEqual({ secret: 'file' });
+    expect(withEnv({ port: 3000 }, { HENRI_SECRET: 'env' })).toEqual({
+      port: 3000,
+      secret: 'env',
+    });
+  });
+
+  describe('the boot report', () => {
+    const report = (config, applied) => {
+      const lines = [];
+      const write = (name, ...args) => lines.push(args.join(' => '));
+      const instance = new Config();
+
+      instance.henri = { pen: { info: write, warn: write } };
+      instance.config = config;
+      instance.report(applied);
+
+      return lines;
+    };
+
+    test('prints the key and the variable, masking the secrets', () => {
+      const { applied, config } = applyEnv(file(), {
+        DATABASE_URL: 'postgres://henri:hunter2@db.internal:5432/app',
+        HENRI_SECRET: 'super-secret-value',
+        [`${ENV_PREFIX}port`]: '8080',
+      });
+      const lines = report(config, applied);
+
+      expect(lines).toEqual([
+        'from the environment => secret = [FILTERED] => HENRI_SECRET',
+        'from the environment => stores.default.url = postgres://henri:[FILTERED]@db.internal:5432/app => DATABASE_URL',
+        'from the environment => port = 8080 => HENRI_CONFIG__port',
+      ]);
+      expect(lines.join('\n')).not.toContain('super-secret-value');
+      expect(lines.join('\n')).not.toContain('hunter2');
+    });
+
+    test('masks what config.filterParameters names, and nothing else', () => {
+      const { applied, config } = applyEnv(
+        { filterParameters: ['apiKey'] },
+        {
+          [`${ENV_JSON_PREFIX}mail`]: '{"host":"smtp","auth":{"pass":"pw"}}',
+          [`${ENV_PREFIX}apiKey`]: 'ak-1',
+          [`${ENV_PREFIX}baseRole`]: 'guest',
+        }
+      );
+      const lines = report(config, applied).join('\n');
+
+      expect(lines).toContain('apiKey = [FILTERED]');
+      expect(lines).toContain('baseRole = guest');
+      expect(lines).not.toContain('ak-1');
+      // `pass` is not one of the names this configuration filters
+      expect(lines).toContain('{"host":"smtp","auth":{"pass":"pw"}}');
+    });
+
+    test('says when a variable was ignored', () => {
+      const { applied, config } = applyEnv(
+        { port: 3000 },
+        { DATABASE_URL: 'postgres://env/db' }
+      );
+
+      expect(report(config, applied)).toEqual([
+        'DATABASE_URL => ignored: the configuration has no "stores.default"',
+      ]);
+    });
+  });
+
+  test('a booted henri reads a key from the environment', async () => {
+    process.env[`${ENV_PREFIX}baseRole`] = 'from-the-environment';
+
+    const henri = new Henri({ runlevel: 0 });
+
+    await henri.init();
+
+    try {
+      expect(henri.config.get('baseRole')).toBe('from-the-environment');
+      expect(henri.config.fromEnv).toEqual([
+        { key: 'baseRole', variable: `${ENV_PREFIX}baseRole` },
+      ]);
+    } finally {
+      delete process.env[`${ENV_PREFIX}baseRole`];
+      await henri.stop();
+    }
+  });
+});

--- a/packages/core/src/__tests__/credentials.spec.js
+++ b/packages/core/src/__tests__/credentials.spec.js
@@ -1,0 +1,270 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const credentials = require('../base/credentials');
+const { applyCredentials } = require('../0.config');
+
+const SECRET = 'sk-live-do-not-print-me';
+
+describe('credentials', () => {
+  let dir;
+  let key;
+
+  const write = (env, values = { mail: { auth: { pass: SECRET } } }) =>
+    credentials.write(dir, env, values, key);
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'henri-credentials-'));
+    key = Buffer.from(credentials.generateKey(), 'hex');
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { force: true, recursive: true });
+  });
+
+  describe('the envelope', () => {
+    test('round trips', () => {
+      const values = { list: [1, 2], mail: { auth: { pass: SECRET } } };
+      const content = credentials.encrypt(values, key, 'production');
+
+      expect(content).toMatch(/^henri:v1:[^:]+:[^:]+:[^:]+\n$/);
+      expect(content).not.toContain(SECRET);
+      expect(credentials.decrypt(content, key, 'production')).toEqual(values);
+    });
+
+    test('a wrong key opens nothing, and says nothing', () => {
+      const content = credentials.encrypt({ pass: SECRET }, key, 'production');
+      const other = Buffer.from(credentials.generateKey(), 'hex');
+
+      expect(() => credentials.decrypt(content, other, 'production')).toThrow(
+        /could not be decrypted: wrong key, or the file was modified/
+      );
+    });
+
+    test('a tampered file fails instead of decrypting to nonsense', () => {
+      const content = credentials.encrypt({ pass: SECRET }, key, 'production');
+      const parts = content.trim().split(':');
+      const body = Buffer.from(parts[4], 'base64');
+
+      body[body.length - 1] ^= 0xff;
+      parts[4] = body.toString('base64');
+
+      expect(() =>
+        credentials.decrypt(parts.join(':'), key, 'production')
+      ).toThrow(/could not be decrypted/);
+    });
+
+    test('the environment is authenticated with the content', () => {
+      const content = credentials.encrypt({ pass: SECRET }, key, 'production');
+
+      expect(() => credentials.decrypt(content, key, 'staging')).toThrow(
+        /could not be decrypted/
+      );
+    });
+
+    test('anything else is not a credentials file', () => {
+      expect(() => credentials.decrypt('hello', key, 'dev')).toThrow(
+        /is not a henri credentials file/
+      );
+      expect(() => credentials.decrypt('henri:v2:a:b:c', key, 'dev')).toThrow(
+        /is not a henri credentials file/
+      );
+    });
+  });
+
+  describe('the key', () => {
+    test('is 64 hexadecimal characters', () => {
+      expect(credentials.generateKey()).toMatch(/^[0-9a-f]{64}$/);
+      expect(() => credentials.parseKey('short', 'the file')).toThrow(
+        /The credentials key in the file is not 64 hexadecimal characters/
+      );
+      expect(() => credentials.parseKey(undefined, 'HENRI_X')).toThrow(
+        /HENRI_X/
+      );
+    });
+
+    test('comes from the variable first, then the file', () => {
+      const file = credentials.keyFileFor(dir, 'dev');
+      const other = credentials.generateKey();
+
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      fs.writeFileSync(file, `${key.toString('hex')}\n`);
+
+      expect(credentials.readKey(dir, 'dev', {})).toEqual({
+        key,
+        source: path.join('config', 'credentials', 'dev.key'),
+      });
+      expect(
+        credentials.readKey(dir, 'dev', { HENRI_CREDENTIALS_KEY: other })
+      ).toEqual({
+        key: Buffer.from(other, 'hex'),
+        source: 'HENRI_CREDENTIALS_KEY',
+      });
+    });
+
+    test('missing, it is a failure naming the file and the variable', () => {
+      write('production');
+
+      expect(() => credentials.read(dir, 'production', {})).toThrow(
+        /production.json.enc needs a key: set HENRI_CREDENTIALS_KEY, or put it back in .*production.key/
+      );
+    });
+  });
+
+  describe('reading them', () => {
+    test('an application without a file has none', () => {
+      expect(credentials.read(dir, 'production', {})).toBeNull();
+    });
+
+    test('every leaf is a configuration key', () => {
+      write('production', {
+        list: ['a'],
+        mail: { auth: { pass: SECRET } },
+        secret: 'x',
+      });
+
+      const found = credentials.read(dir, 'production', {
+        HENRI_CREDENTIALS_KEY: key.toString('hex'),
+      });
+
+      expect(found.entries.map((entry) => entry.key)).toEqual([
+        'list',
+        'mail.auth.pass',
+        'secret',
+      ]);
+      expect(found.source).toBe('HENRI_CREDENTIALS_KEY');
+    });
+  });
+
+  describe('over the configuration', () => {
+    const environment = () => ({ HENRI_CREDENTIALS_KEY: key.toString('hex') });
+
+    test('a leaf replaces its key and leaves the rest of the file alone', () => {
+      write('production', { mail: { auth: { pass: SECRET } }, secret: 'from' });
+
+      const file = {
+        mail: { auth: { user: 'postmaster' }, host: 'smtp.example.com' },
+        port: 3000,
+      };
+      const { applied, config } = applyCredentials(
+        file,
+        dir,
+        'production',
+        environment()
+      );
+
+      expect(applied).toEqual(['mail.auth.pass', 'secret']);
+      expect(config.mail).toEqual({
+        auth: { pass: SECRET, user: 'postmaster' },
+        host: 'smtp.example.com',
+      });
+      expect(config.port).toBe(3000);
+      expect(config.secret).toBe('from');
+      // The parsed configuration file is never modified
+      expect(file.mail.auth).toEqual({ user: 'postmaster' });
+    });
+
+    test('an application without credentials is left alone', () => {
+      const file = { port: 3000 };
+
+      expect(applyCredentials(file, dir, 'production', {})).toEqual({
+        applied: [],
+        config: file,
+        source: null,
+      });
+    });
+
+    test('the config module reads them, under the environment', async () => {
+      const Config = require('../0.config');
+      const lines = [];
+      const record = (name, ...args) => lines.push(args.join(' => '));
+
+      fs.mkdirSync(path.join(dir, 'config'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'config', 'production.json'),
+        JSON.stringify({ port: 3000, secret: 'from-the-file' })
+      );
+      credentials.write(
+        dir,
+        'production',
+        { mail: { auth: { pass: SECRET } }, secret: 'from-the-credentials' },
+        key
+      );
+
+      const config = new Config();
+
+      config.henri = {
+        cwd: () => dir,
+        env: 'production',
+        pen: { error: record, info: record, warn: record },
+      };
+
+      process.env.HENRI_CREDENTIALS_KEY = key.toString('hex');
+      process.env.HENRI_CONFIG__port = '8080';
+
+      try {
+        await config.init();
+
+        expect(config.get('mail.auth.pass')).toBe(SECRET);
+        expect(config.get('port')).toBe(8080);
+        // The environment wins over the credentials, which win over the file
+        expect(config.get('secret')).toBe('from-the-credentials');
+        expect(config.fromCredentials).toEqual(['mail.auth.pass', 'secret']);
+
+        process.env.HENRI_SECRET = 'from-the-environment';
+        await config.reload();
+
+        expect(config.get('secret')).toBe('from-the-environment');
+      } finally {
+        delete process.env.HENRI_CREDENTIALS_KEY;
+        delete process.env.HENRI_CONFIG__port;
+        delete process.env.HENRI_SECRET;
+      }
+
+      const printed = lines.join('\n');
+
+      expect(printed).toContain(
+        'from the credentials => mail.auth.pass, secret'
+      );
+      expect(printed).not.toContain(SECRET);
+    });
+  });
+
+  test('no error ever holds a decrypted value', () => {
+    write('production', { secret: SECRET });
+
+    const content = fs.readFileSync(
+      credentials.fileFor(dir, 'production'),
+      'utf8'
+    );
+    const messages = [];
+    const collect = (run) => {
+      try {
+        run();
+      } catch (error) {
+        messages.push(error.message);
+      }
+    };
+
+    collect(() => credentials.read(dir, 'production', {}));
+    collect(() =>
+      credentials.decrypt(
+        content,
+        Buffer.from(credentials.generateKey(), 'hex'),
+        'production'
+      )
+    );
+    collect(() =>
+      credentials.decrypt(
+        credentials.encrypt('not an object', key, 'dev'),
+        key,
+        'dev'
+      )
+    );
+
+    expect(messages).toHaveLength(3);
+    expect(messages.join('\n')).not.toContain(SECRET);
+    expect(messages.join('\n')).not.toContain(key.toString('hex'));
+  });
+});

--- a/packages/core/src/base/credentials.js
+++ b/packages/core/src/base/credentials.js
@@ -1,0 +1,292 @@
+/**
+ * Encrypted credentials (Rails' `config/credentials/<env>.yml.enc`).
+ *
+ * `config/credentials/<env>.json.enc` is committed with the application and
+ * holds the secrets of that environment. The key that opens it is never
+ * committed: it is `HENRI_CREDENTIALS_KEY`, or `config/credentials/<env>.key`
+ * on a development machine. A deployment therefore carries one secret instead
+ * of twenty.
+ *
+ * JSON, not YAML: henri's configuration is JSON, the decrypted object is
+ * merged into it key by key, and it needs no parser henri does not already
+ * have.
+ *
+ * AES-256-GCM, from node's own crypto: the authentication tag turns a
+ * modified file into a loud failure instead of plausible nonsense, and the
+ * environment name is authenticated with it, so a file copied from another
+ * environment does not open either. The envelope is one line:
+ *
+ *   henri:v1:<base64 iv>:<base64 tag>:<base64 ciphertext>
+ *
+ * Nothing here ever puts a decrypted value, or the value of a key, in an
+ * error message.
+ */
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+/** Authenticated cipher, key length in bytes and iv length in bytes */
+const ALGORITHM = 'aes-256-gcm';
+const KEY_LENGTH = 32;
+const IV_LENGTH = 12;
+
+/** Envelope: `henri:v1:<iv>:<tag>:<ciphertext>`, all base64 */
+const PREFIX = 'henri';
+const VERSION = 'v1';
+
+/** Where the files live, and the variable that carries the key */
+const DIRECTORY = path.join('config', 'credentials');
+const KEY_VARIABLE = 'HENRI_CREDENTIALS_KEY';
+
+/**
+ * The encrypted file of an environment
+ *
+ * @param {string} cwd the application directory
+ * @param {string} env the environment (`production`, `dev`, ...)
+ * @returns {string} its path
+ */
+const fileFor = (cwd, env) => path.join(cwd, DIRECTORY, `${env}.json.enc`);
+
+/**
+ * The key file of an environment (never committed)
+ *
+ * @param {string} cwd the application directory
+ * @param {string} env the environment
+ * @returns {string} its path
+ */
+const keyFileFor = (cwd, env) => path.join(cwd, DIRECTORY, `${env}.key`);
+
+/**
+ * A new key: 32 random bytes, as 64 hexadecimal characters
+ *
+ * @returns {string} the key
+ */
+const generateKey = () => crypto.randomBytes(KEY_LENGTH).toString('hex');
+
+/**
+ * A key as bytes
+ *
+ * @param {string} raw the key
+ * @param {string} source where it comes from (a path or a variable name)
+ * @returns {Buffer} the key
+ * @throws {Error} when it is not 64 hexadecimal characters
+ */
+function parseKey(raw, source) {
+  const text = String(raw === undefined || raw === null ? '' : raw).trim();
+
+  if (!/^[0-9a-f]{64}$/i.test(text)) {
+    throw new Error(
+      `The credentials key in ${source} is not 64 hexadecimal characters`
+    );
+  }
+
+  return Buffer.from(text, 'hex');
+}
+
+/**
+ * The key of an environment: `HENRI_CREDENTIALS_KEY` first, then the key file
+ *
+ * @param {string} cwd the application directory
+ * @param {string} env the environment
+ * @param {object} [environment=process.env] the environment variables
+ * @returns {?{key: Buffer, source: string}} the key, or null when there is none
+ * @throws {Error} when what was found is not a key
+ */
+function readKey(cwd, env, environment = process.env) {
+  const fromEnv = environment[KEY_VARIABLE];
+
+  if (typeof fromEnv === 'string' && fromEnv.trim() !== '') {
+    return { key: parseKey(fromEnv, KEY_VARIABLE), source: KEY_VARIABLE };
+  }
+
+  const file = keyFileFor(cwd, env);
+
+  if (!fs.existsSync(file)) {
+    return null;
+  }
+
+  const source = path.relative(cwd, file);
+
+  return { key: parseKey(fs.readFileSync(file, 'utf8'), source), source };
+}
+
+/**
+ * Encrypt credentials
+ *
+ * @param {object} values the credentials
+ * @param {Buffer} key the key
+ * @param {string} env the environment, authenticated with the content
+ * @returns {string} the envelope, one line
+ */
+function encrypt(values, key, env) {
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+
+  cipher.setAAD(Buffer.from(`${PREFIX}:${VERSION}:${env}`, 'utf8'));
+
+  const body = Buffer.concat([
+    cipher.update(`${JSON.stringify(values, null, 2)}\n`, 'utf8'),
+    cipher.final(),
+  ]);
+
+  return `${[
+    PREFIX,
+    VERSION,
+    iv.toString('base64'),
+    cipher.getAuthTag().toString('base64'),
+    body.toString('base64'),
+  ].join(':')}\n`;
+}
+
+/**
+ * Decrypt credentials
+ *
+ * @param {string} content the envelope
+ * @param {Buffer} key the key
+ * @param {string} env the environment it was written for
+ * @param {string} [label='the credentials'] what to call the file
+ * @returns {object} the credentials
+ * @throws {Error} when the envelope, the key or the content is wrong
+ */
+function decrypt(content, key, env, label = 'the credentials') {
+  const parts = String(content).trim().split(':');
+
+  if (parts.length !== 5 || parts[0] !== PREFIX || parts[1] !== VERSION) {
+    throw new Error(`${label} is not a henri credentials file`);
+  }
+
+  const [, , iv, tag, body] = parts;
+  let plain;
+
+  try {
+    const decipher = crypto.createDecipheriv(
+      ALGORITHM,
+      key,
+      Buffer.from(iv, 'base64')
+    );
+
+    decipher.setAAD(Buffer.from(`${PREFIX}:${VERSION}:${env}`, 'utf8'));
+    decipher.setAuthTag(Buffer.from(tag, 'base64'));
+
+    plain = Buffer.concat([
+      decipher.update(Buffer.from(body, 'base64')),
+      decipher.final(),
+    ]).toString('utf8');
+  } catch {
+    // The cipher fails the same way for a wrong key and for a modified
+    // file, and its message says nothing useful: neither is echoed
+    throw new Error(
+      `${label} could not be decrypted: wrong key, or the file was modified`
+    );
+  }
+
+  try {
+    const values = JSON.parse(plain);
+
+    if (values === null || typeof values !== 'object') {
+      throw new Error('not an object');
+    }
+
+    return values;
+  } catch {
+    // The parser quotes what it choked on, and that is a decrypted secret
+    throw new Error(`${label} does not hold a JSON object`);
+  }
+}
+
+/**
+ * The leaves of an object, as `{ key, value }` pairs on dotted paths
+ *
+ * An array, a date or any other value that is not a plain object is a leaf:
+ * it replaces what the configuration file has at that path rather than being
+ * merged into it.
+ *
+ * @param {object} values the credentials
+ * @param {string} [prefix=''] the path of `values` (internal)
+ * @returns {Array<{key: string, value: any}>} the pairs
+ */
+function leaves(values, prefix = '') {
+  const found = [];
+
+  for (const [name, value] of Object.entries(values)) {
+    const key = prefix === '' ? name : `${prefix}.${name}`;
+    const plain =
+      value !== null &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      Object.getPrototypeOf(value) === Object.prototype;
+
+    if (plain && Object.keys(value).length > 0) {
+      found.push(...leaves(value, key));
+      continue;
+    }
+
+    found.push({ key, value });
+  }
+
+  return found;
+}
+
+/**
+ * The credentials of an environment, when the application has some
+ *
+ * @param {string} cwd the application directory
+ * @param {string} env the environment
+ * @param {object} [environment=process.env] the environment variables
+ * @returns {?{entries: Array, file: string, source: string, values: object}}
+ *   the credentials, or null when the application has no file
+ * @throws {Error} when the file cannot be read, opened or parsed
+ */
+function read(cwd, env, environment = process.env) {
+  const file = fileFor(cwd, env);
+
+  if (!fs.existsSync(file)) {
+    return null;
+  }
+
+  const label = path.relative(cwd, file);
+  const found = readKey(cwd, env, environment);
+
+  if (!found) {
+    throw new Error(
+      `${label} needs a key: set ${KEY_VARIABLE}, or put it back in ${path.relative(cwd, keyFileFor(cwd, env))}`
+    );
+  }
+
+  const values = decrypt(fs.readFileSync(file, 'utf8'), found.key, env, label);
+
+  return { entries: leaves(values), file, source: found.source, values };
+}
+
+/**
+ * Write the credentials of an environment, creating the directory
+ *
+ * @param {string} cwd the application directory
+ * @param {string} env the environment
+ * @param {object} values the credentials
+ * @param {Buffer} key the key
+ * @returns {string} the path of the file
+ */
+function write(cwd, env, values, key) {
+  const file = fileFor(cwd, env);
+
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, encrypt(values, key, env), { mode: 0o600 });
+
+  return file;
+}
+
+module.exports = {
+  DIRECTORY,
+  KEY_VARIABLE,
+  decrypt,
+  encrypt,
+  fileFor,
+  generateKey,
+  keyFileFor,
+  leaves,
+  parseKey,
+  read,
+  readKey,
+  write,
+};

--- a/showcase/.env.example
+++ b/showcase/.env.example
@@ -2,9 +2,22 @@
 #
 #   cp .env.example .env
 #
-# HENRI_SECRET signs the sessions and the tokens. henri reads .env on boot and
-# a variable already set in the environment wins over the file, which is how
-# the CI job and the container pass their own.
+# henri reads .env on boot and applies it over config/<NODE_ENV>.json; a
+# variable already set in the environment wins over the file, which is how the
+# CI job and the container pass their own.
 #
+# HENRI_SECRET signs the sessions and the tokens.
 # Generate one with:  openssl rand -hex 32
 HENRI_SECRET=change-me-a-development-secret-for-lineup-0000000000000000
+
+# DATABASE_URL points the default store at another PostgreSQL, so a machine
+# where 5432 is taken needs no configuration file of its own:
+#
+#   DATABASE_URL=postgres://henri:henri@127.0.0.1:55433/henri_showcase pnpm start
+#
+# Uncommenting it here applies it to every environment, the test suite
+# included, and the suite would then run against the database named below
+# instead of henri_showcase_test. Keep it on the command line, or use
+# config/dev.json (git-ignored) when you want the split to be permanent.
+#
+# DATABASE_URL=postgres://henri:henri@127.0.0.1:5432/henri_showcase

--- a/showcase/.gitignore
+++ b/showcase/.gitignore
@@ -7,6 +7,9 @@
 # lighter way to point the store somewhere else; this stays for the rest.
 config/dev.json
 
+# Credentials keys: never commit them (henri credentials:edit)
+config/credentials/*.key
+
 # Vite builds and the model globals henri records on boot
 app/views/dist
 .henri

--- a/showcase/.gitignore
+++ b/showcase/.gitignore
@@ -3,12 +3,9 @@
 .env
 
 # Local configuration overrides. henri reads config/dev.json before
-# config/default.json when NODE_ENV is unset, which is the place to point the
-# store at a PostgreSQL that is not on 127.0.0.1:5432.
+# config/default.json when NODE_ENV is unset. DATABASE_URL in .env is the
+# lighter way to point the store somewhere else; this stays for the rest.
 config/dev.json
-
-# Written by docker/entrypoint.sh inside the image
-config/production.json
 
 # Vite builds and the model globals henri records on boot
 app/views/dist

--- a/showcase/Dockerfile
+++ b/showcase/Dockerfile
@@ -11,8 +11,10 @@
 #     -e HENRI_SECRET=$(openssl rand -hex 32) \
 #     lineup
 #
-# The container writes config/production.json from the environment on every
-# start (see docker-entrypoint.sh) and applies db/migrations on boot.
+# Nothing is written at start time: config/production.json is committed and
+# henri applies the environment over it (DATABASE_URL, HENRI_SECRET and any
+# HENRI_CONFIG__<key>). The boot applies db/migrations; see
+# docker-entrypoint.sh for the handful of names it maps.
 
 ARG NODE_IMAGE=node:24-bookworm-slim
 ARG PNPM_VERSION=11.25.0

--- a/showcase/README.md
+++ b/showcase/README.md
@@ -36,11 +36,19 @@ Sign in with any of the seeded accounts; the password is always `showcase`.
 see `/admin`; `bruno@lineup.dev` and the twenty-one others are speakers.
 
 If your PostgreSQL is not on `127.0.0.1:5432` — `pnpm db:up` takes
-`HENRI_POSTGRES_PORT` when something else already listens there — copy
-`config/default.json` to `config/dev.json` and change `stores.default.url`.
-henri reads `config/dev.json` before `config/default.json` when `NODE_ENV` is
-unset, and that file is git-ignored. The test database is
-`config/test.json`.
+`HENRI_POSTGRES_PORT` when something else already listens there —
+`DATABASE_URL` points the store at it, with no file to copy:
+
+```bash
+export DATABASE_URL=postgres://henri:henri@127.0.0.1:55433/henri_showcase
+pnpm db:setup && pnpm start
+```
+
+henri applies it over `stores.default.url` and prints the key it took from the
+environment on boot. It applies to every environment, the test suite included,
+so unset it (or point it at `henri_showcase_test`) before `pnpm test`; copying
+`config/default.json` to the git-ignored `config/dev.json` is still the way to
+make the split permanent.
 
 `HENRI_SECRET` signs the sessions. It lives in `.env`, which is git-ignored,
 so `henri doctor` stays green and no secret is ever committed; a variable
@@ -150,12 +158,20 @@ docker run --rm -p 3000:3000 \
   lineup
 ```
 
-`docker-entrypoint.sh` writes `config/production.json` from the environment on
-every start (henri expands no environment variable in its configuration) and
-the boot applies `db/migrations`. `HENRI_SEED=true` runs `db/seeds.js` first,
-`HENRI_MIGRATE=false` leaves the schema alone, `PORT` moves the port. The
-container refuses to start without `DATABASE_URL` and `HENRI_SECRET`, and
-`GET /_henri/health` is its healthcheck.
+Nothing is written at start time. `config/production.json` is committed and
+carries what the application is; the environment carries what changes between
+deployments, and henri applies it over the file (see
+[Configuration](https://usehenri.io/configuration/)): `DATABASE_URL` is
+`stores.default.url`, `HENRI_SECRET` the secret, and any other key is
+`HENRI_CONFIG__<key>`, for instance
+`-e HENRI_CONFIG__api__perPage=25`. The boot prints every key it took from the
+environment, with the secrets masked.
+
+`docker-entrypoint.sh` only checks the two variables the application cannot
+start without, maps `PORT` to `HENRI_CONFIG__port` and `HENRI_MIGRATE=false` to
+`HENRI_CONFIG__stores__default__migrate`, and runs `db/seeds.js` first when
+`HENRI_SEED=true`. The boot applies `db/migrations`, and
+`GET /_henri/health` is the healthcheck.
 
 ## Layout
 

--- a/showcase/config/production.json
+++ b/showcase/config/production.json
@@ -1,0 +1,25 @@
+{
+  "port": 3000,
+  "renderer": "inertia",
+  "inertia": { "ssr": true },
+  "baseRole": "speaker",
+  "user": {
+    "model": "user",
+    "public": ["name", "company"],
+    "loginPath": "/login",
+    "afterLogin": "/proposals/mine"
+  },
+  "api": {
+    "perPage": 12,
+    "maxPerPage": 50,
+    "strict": true
+  },
+  "stores": {
+    "default": {
+      "adapter": "drizzle",
+      "dialect": "postgres",
+      "sync": false,
+      "migrate": true
+    }
+  }
+}

--- a/showcase/db/create.js
+++ b/showcase/db/create.js
@@ -5,6 +5,8 @@
 //   node db/create.js              the store of config/dev.json, else default
 //   node db/create.js --env=test   the store of config/test.json
 //
+// DATABASE_URL wins over the file, exactly as it does when henri boots.
+//
 // It connects to the `postgres` maintenance database on the same server and
 // issues a CREATE DATABASE when the one in the url is missing, so running it
 // twice is harmless.
@@ -50,6 +52,10 @@ const storeUrl = (configFile) => {
   return url;
 };
 
+// DATABASE_URL is applied over stores.default.url by henri, so the database
+// this creates is the one the application will connect to
+const url = process.env.DATABASE_URL || storeUrl(file);
+
 /**
  * Creates the database of a connection string when it does not exist yet
  *
@@ -87,7 +93,7 @@ const create = async (url) => {
   }
 };
 
-create(storeUrl(file)).catch((error) => {
+create(url).catch((error) => {
   console.error(`db/create.js failed: ${error.message}`);
   console.error(
     'is PostgreSQL running? `pnpm db:up` starts the one of compose.yaml'

--- a/showcase/docker-entrypoint.sh
+++ b/showcase/docker-entrypoint.sh
@@ -1,19 +1,19 @@
 #!/bin/sh
 #
-# Writes showcase/config/production.json from the environment, then runs the
-# given command. @usehenri/core reads config/<NODE_ENV>.json and expands no
-# environment variable, so a container writes the file at start time.
+# Lineup in a container. Nothing is written at start time: config/production.json
+# is committed and henri applies the environment over it, so this script only
+# checks what the application cannot start without, maps the two names the
+# platform owns to henri's configuration keys, and runs the optional seed.
 #
-#   DATABASE_URL   PostgreSQL connection string (required)
+#   DATABASE_URL   PostgreSQL connection string (required, stores.default.url)
 #   HENRI_SECRET   session and token secret (required)
-#   PORT           listening port, 3000 by default
-#   HENRI_MIGRATE  "false" to stop the boot from applying db/migrations
-#   HENRI_SEED     "true" to run db/seeds.js before starting
+#   PORT           listening port, 3000 by default (HENRI_CONFIG__port)
+#   HENRI_MIGRATE  "false" stops the boot from applying db/migrations
+#   HENRI_SEED     "true" runs db/seeds.js before starting
+#
+# Every other key is reachable as HENRI_CONFIG__<key>, no shim needed:
+#   -e HENRI_CONFIG__api__perPage=25 -e HENRI_CONFIG_JSON__inertia='{"ssr":false}'
 set -eu
-
-: "${PORT:=3000}"
-: "${HENRI_MIGRATE:=true}"
-: "${HENRI_SEED:=false}"
 
 if [ -z "${DATABASE_URL:-}" ]; then
   echo "lineup: DATABASE_URL is not set" >&2
@@ -25,43 +25,17 @@ if [ -z "${HENRI_SECRET:-}" ]; then
   exit 1
 fi
 
-node - <<'EOF'
-const fs = require('fs');
-const env = process.env;
+if [ -n "${PORT:-}" ]; then
+  HENRI_CONFIG__port="$PORT"
+  export HENRI_CONFIG__port
+fi
 
-const config = {
-  api: { maxPerPage: 50, perPage: 12, strict: true },
-  baseRole: 'speaker',
-  host: '0.0.0.0',
-  inertia: { ssr: true },
-  port: Number(env.PORT),
-  renderer: 'inertia',
-  secret: env.HENRI_SECRET,
-  stores: {
-    default: {
-      adapter: 'drizzle',
-      dialect: 'postgres',
-      // The production boot applies db/migrations when this is true
-      migrate: env.HENRI_MIGRATE !== 'false',
-      url: env.DATABASE_URL,
-    },
-  },
-  user: {
-    afterLogin: '/proposals/mine',
-    loginPath: '/login',
-    model: 'user',
-    public: ['name', 'company'],
-  },
-};
+if [ "${HENRI_MIGRATE:-true}" = "false" ]; then
+  HENRI_CONFIG__stores__default__migrate=false
+  export HENRI_CONFIG__stores__default__migrate
+fi
 
-fs.mkdirSync('config', { recursive: true });
-fs.writeFileSync(
-  'config/production.json',
-  `${JSON.stringify(config, null, 2)}\n`
-);
-EOF
-
-if [ "$HENRI_SEED" = "true" ]; then
+if [ "${HENRI_SEED:-false}" = "true" ]; then
   echo "lineup: seeding"
   node_modules/.bin/henri db:seed --production
 fi

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -2,6 +2,16 @@ const dns = require('node:dns');
 const net = require('node:net');
 
 /**
+ * The environment configures a henri application (see `0.config.js`), and
+ * `DATABASE_URL` is the one variable this repository does not own: a
+ * developer machine or a CI job may export it for something else entirely.
+ * The suites boot applications whose stores are their own (the demo app runs
+ * on @usehenri/disk, the SQL suites on sqlite), so the variable is dropped
+ * here rather than left to repoint them.
+ */
+delete process.env.DATABASE_URL;
+
+/**
  * Every test server binds the loopback address.
  *
  * `supertest(app)` starts an http server with `app.listen(0)` for each

--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -110,15 +110,62 @@ The keys of the [JSON API](/guides/api/), all optional:
 
 ## Environment and `.env`
 
-On boot henri reads `.env` in the application directory (`KEY=value` lines, optional `export`, quotes stripped, `#` comments; variables already set in the environment win) and applies these overrides:
+On boot henri reads `.env` in the application directory (`KEY=value` lines, optional `export`, quotes stripped, `#` comments; variables already set in the environment win), then applies what the environment says over the file it loaded. Every key is reachable, so a container image needs no configuration file written at start time: the committed `config/production.json` describes the application and the environment carries what changes between deployments.
 
-| Variable       | Effect                                                                 |
-| -------------- | ---------------------------------------------------------------------- |
-| `HENRI_SECRET` | Provides or replaces `secret`, so the secret can stay out of `config`. |
-| `HENRI_HOST`   | Replaces `host` (what `henri server --host` sets).                     |
-| `NODE_ENV`     | Selects the configuration file. `henri server --production` sets it.   |
+### Precedence
 
-Nothing else in the configuration is expanded from the environment: for a container, write `config/production.json` at start time (the repository's `docker/entrypoint.sh` does exactly that).
+Lowest first, one story for every variable:
+
+1. the configuration file: `config/<NODE_ENV>.json`, or `config/default.json` when it does not exist (the two are never merged);
+2. the named shorthands, in the table below;
+3. `HENRI_CONFIG__<key>`, which names the key it sets and wins over everything.
+
+Nothing is applied twice and nothing is merged into a value: the last writer of a key replaces it.
+
+### The shorthands
+
+| Variable       | Sets                                                                 |
+| -------------- | -------------------------------------------------------------------- |
+| `HENRI_SECRET` | `secret`, so the secret stays out of `config`.                       |
+| `HENRI_HOST`   | `host` (what `henri server --host` sets).                            |
+| `DATABASE_URL` | `stores.default.url`, the connection string of the default store.    |
+| `NODE_ENV`     | Selects the configuration file. `henri server --production` sets it. |
+
+`DATABASE_URL` carries no `HENRI_` prefix on purpose: it is the name Heroku, Render, Fly, Railway, Neon and Supabase already set for you, and the one Rails has read for a decade. A prefixed alias would mean writing `HENRI_DATABASE_URL=$DATABASE_URL` in every deployment, which is the papercut this removes. There is one name, not both.
+
+It applies only when the configuration already declares a `stores.default`: a url does not say which adapter to load, so the file stays the place where the store is declared. When it does not, the boot prints `DATABASE_URL => ignored: the configuration has no "stores.default"` and moves on. A store other than the default is reached by its path, below.
+
+An empty shorthand (`DATABASE_URL=`) is treated as unset.
+
+### Any other key
+
+`HENRI_CONFIG__<key>` sets one configuration key. `__` separates the path segments, since a shell variable name cannot hold a dot:
+
+```bash
+HENRI_CONFIG__port=8080
+HENRI_CONFIG__baseRole=member
+HENRI_CONFIG__stores__reporting__url=postgres://user:pw@warehouse/reports
+HENRI_CONFIG__user__afterLogin=/dashboard
+HENRI_CONFIG_JSON__rateLimit='{"windowMs":60000,"max":100}'
+```
+
+The segments are the configuration keys **verbatim**, so their case matters: `HENRI_CONFIG__baseRole`, never `HENRI_CONFIG__BASEROLE`.
+
+**The type comes from the file, henri never guesses it.** When the configuration already has a value at that path, the variable is read as its type: a number for `port`, `true`/`false` for a boolean, JSON for an object. A path the file does not have is a string — a connection string stays a connection string even when it looks like a number. `HENRI_CONFIG_JSON__<key>` parses the value as JSON in every case, which is how you set a nested object, an array, or a key no file declares.
+
+A value that does not fit its key fails the boot, naming the variable and the type it expected. A variable set to nothing fails too (`HENRI_CONFIG__port is set but empty: give it a value or unset it`): a missing variable is simply not an override and never becomes an empty string. The value itself is never part of an error message — it may be a secret.
+
+### What the boot prints
+
+Every key the environment provided is printed, so nobody debugs a value they cannot see:
+
+```
+config ✏ from the environment => secret = [FILTERED] => HENRI_SECRET
+config ✏ from the environment => stores.default.url = postgres://henri:[FILTERED]@db:5432/app => DATABASE_URL
+config ✏ from the environment => port = 8080 => HENRI_CONFIG__port
+```
+
+A key whose name matches `filterParameters` (`password`, `token`, `secret`, `authorization` by default) is masked, and so is the password of a connection string, which no filter list would ever name. `henri.config.fromEnv` holds the same list as `{ key, variable }` pairs — the paths and the variable names, never the values.
 
 ## The `user` object
 

--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -117,8 +117,9 @@ On boot henri reads `.env` in the application directory (`KEY=value` lines, opti
 Lowest first, one story for every variable:
 
 1. the configuration file: `config/<NODE_ENV>.json`, or `config/default.json` when it does not exist (the two are never merged);
-2. the named shorthands, in the table below;
-3. `HENRI_CONFIG__<key>`, which names the key it sets and wins over everything.
+2. the [encrypted credentials](#encrypted-credentials) of that environment, when the application has some;
+3. the named shorthands, in the table below;
+4. `HENRI_CONFIG__<key>`, which names the key it sets and wins over everything.
 
 Nothing is applied twice and nothing is merged into a value: the last writer of a key replaces it.
 
@@ -166,6 +167,45 @@ config ✏ from the environment => port = 8080 => HENRI_CONFIG__port
 ```
 
 A key whose name matches `filterParameters` (`password`, `token`, `secret`, `authorization` by default) is masked, and so is the password of a connection string, which no filter list would ever name. `henri.config.fromEnv` holds the same list as `{ key, variable }` pairs — the paths and the variable names, never the values.
+
+## Encrypted credentials
+
+Rails' `credentials:edit`, in henri. `config/credentials/<env>.json.enc` holds the secrets of one environment, encrypted, and is **committed with the application**; the key that opens it never is. A deployment then carries one secret instead of twenty, and adding a secret to staging is a commit rather than a round of environment variables.
+
+```bash
+henri credentials:edit                     # the development environment
+henri credentials:edit --env production    # creates the key and the file
+henri credentials:show --env production --json   # the key paths, no values
+```
+
+`edit` decrypts into a file only you can read, opens `EDITOR` (or `VISUAL`) on it, and encrypts what comes back when the editor closes. The plaintext is removed on every exit path, including an editor that fails and an interrupted process, and what you save must be a JSON object or the credentials are left as they were.
+
+**JSON, not YAML.** henri's configuration is JSON, and the decrypted object is applied over it key by key, so the two files are written the same way and henri needs no parser it does not already have.
+
+```json
+{
+  "secret": "a4f1...",
+  "mail": { "auth": { "user": "postmaster@example.com", "pass": "..." } }
+}
+```
+
+**The key** is `HENRI_CREDENTIALS_KEY`, or `config/credentials/<env>.key` (64 hexadecimal characters, what `openssl rand -hex 32` prints). The variable wins. `henri new` ignores `config/credentials/*.key` from the first commit, `henri credentials:edit` adds the line when it generates a key, and `henri doctor` reports a key that is not ignored or that reached the git index. When the file exists and no key can be found, the boot stops with `config/credentials/production.json.enc needs a key: set HENRI_CREDENTIALS_KEY, or put it back in config/credentials/production.key` — never a silent boot without secrets.
+
+**The cipher is AES-256-GCM**, from node's own crypto. The envelope is one line, `henri:v1:<iv>:<tag>:<ciphertext>`, all base64, and the environment name is authenticated along with the content: a modified file, a wrong key, and a `production.json.enc` renamed to `staging.json.enc` all fail loudly instead of decrypting to nonsense. No error message quotes the file, the key or a decrypted value.
+
+**Where it sits in the precedence**: over the configuration file, under the environment. The credentials are committed with the application, like the configuration files, and the environment is the deployment, so a container can still override with `DATABASE_URL` or `HENRI_CONFIG__<key>`. Each leaf of the decrypted object replaces that one key, so `{ "mail": { "auth": { "pass": "x" } } }` leaves the rest of `mail` alone, and the values are then read like any other configuration:
+
+```js
+henri.config.get('mail.auth.pass');
+```
+
+The boot prints the paths the credentials provided and where the key came from — the names only, since every value in that file is a secret:
+
+```
+config ✏ from the credentials => secret, mail.auth.pass => key: HENRI_CREDENTIALS_KEY
+```
+
+`henri.config.fromCredentials` holds the same paths.
 
 ## The `user` object
 

--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -166,7 +166,7 @@ config ✏ from the environment => stores.default.url = postgres://henri:[FILTER
 config ✏ from the environment => port = 8080 => HENRI_CONFIG__port
 ```
 
-A key whose name matches `filterParameters` (`password`, `token`, `secret`, `authorization` by default) is masked, and so is the password of a connection string, which no filter list would ever name. `henri.config.fromEnv` holds the same list as `{ key, variable }` pairs — the paths and the variable names, never the values.
+A key whose name matches `filterParameters` (`password`, `token`, `secret`, `authorization` by default) is masked, and so is the password of a connection string, which no filter list would ever name. The match is the same substring rule as everywhere else in the logs, so a key the defaults do not cover — `mail.auth.pass`, an `apiKey` — belongs in `filterParameters` if it is to be masked here too. `henri.config.fromEnv` holds the same list as `{ key, variable }` pairs — the paths and the variable names, never the values.
 
 ## Encrypted credentials
 

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -198,13 +198,28 @@ Seeds and migrations, in the Rails `db:` style (`henri db seed` works too). Ever
 
 The other four drive the migrations of a [Drizzle](/guides/models/#drizzle) store: `status` lists the applied and pending migrations of `db/migrations`, `generate` writes a migration from the schema changes, `migrate` applies the pending ones, and `push` makes the database match the models without a migration. `push` refuses statements that lose data and exits with `1` unless `--force` is passed. `--store=<name>` picks the store; stores on another adapter exit with `1`.
 
+## `credentials`
+
+```bash
+henri credentials:edit [--env=<name>]
+henri credentials:show [--env=<name>] [--json]
+```
+
+The encrypted secrets of an environment, in the Rails `credentials:` style (`henri credentials edit` works too). `--env` defaults to `NODE_ENV`, and to `dev` when it is unset, which is the environment henri reads its configuration file under; `--production` selects production like everywhere else.
+
+`edit` decrypts `config/credentials/<env>.json.enc` into a file only you can read, opens `EDITOR` (or `VISUAL`) on it, and encrypts what comes back. The first edit of an environment writes the key, adds it to `.gitignore` and starts the file with a fresh `secret`. The plaintext never survives the command: it is removed when the editor closes, when the editor fails, and when the process is interrupted. An editor that exits non-zero, or content that is not a JSON object, leaves the credentials as they were.
+
+`show` prints the decrypted credentials on stdout. With `--json` it prints the environment, the file and the key paths it holds — never a value, in this command and in every error message.
+
+Both exit with `1` when the key is missing or wrong, naming the file and `HENRI_CREDENTIALS_KEY`. See [Configuration](/configuration/#encrypted-credentials).
+
 ## `doctor`
 
 ```bash
 henri doctor [--json]
 ```
 
-Checks the application against the conventions without starting it: no database, no views, nothing booted. Reports the Node version, the configuration and its syntax, the secret and the `.env` holding it, the git ignore rules, the store adapter, the routes and each route's controller and action, controller and model naming, the page files a `resources` route needs, the test configuration, the declared and installed dependencies, and `AGENTS.md`. Exits with `1` when it finds an error. See [Coding agents](/guides/agents/).
+Checks the application against the conventions without starting it: no database, no views, nothing booted. Reports the Node version, the configuration and its syntax, the secret and the `.env` holding it, the git ignore rules, the credentials keys (not ignored, or already in the git index), the store adapter, the routes and each route's controller and action, controller and model naming, the page files a `resources` route needs, the test configuration, the declared and installed dependencies, and `AGENTS.md`. Exits with `1` when it finds an error. See [Coding agents](/guides/agents/).
 
 ## `mcp`
 


### PR DESCRIPTION
The configuration page used to say plainly that nothing but the secret and the host could come from the environment, and that a container should write a config file at startup. That bit the demo application in this repository and made an image awkward for no reason.

**A naming convention rather than placeholder expansion.** A variable names the path it sets. The argument, made in full in the report: expansion only reaches keys an author predicted and wrote a placeholder for, it produces strings so a port needs a coercion rule anyway, and it grows a small language for defaults and escaping. The convention reaches every key with no edit to any file, and the variable names are greppable in a deployment.

**Types come from the file, never a guess.** A path the configuration already declares is read as that type; a path it does not declare stays a string, so a connection string that looks like a number is not mangled. A variable set to empty is fatal rather than silently empty. No error message ever quotes a value.

**A database URL under the name every platform already sets**, applied only when the configuration declares a default store, since a URL does not say which adapter to load. A stray one exported for another project is reported as ignored rather than silently repointing the application.

**Encrypted credentials, per environment.** JSON rather than YAML, because henri's configuration is JSON. Authenticated encryption from Node's own crypto, with the environment name bound in, so a wrong key, a tampered file and a renamed file all fail loudly. Editing decrypts into a private temporary file, runs the editor and re-encrypts, removing the plaintext on every exit path. Precedence is: file, then credentials, then the environment, so a deployment can still override what is committed.

**A key can never be committed by accident**: both templates ignore key files, the editor adds the line when it generates one, and doctor reports a key that is present but not ignored, or already in the index, telling you to rotate.

I verified the sensitive parts myself rather than on report: the temporary plaintext and its directory are removed, the secret appears nowhere on disk, showing prints key paths and not values, and both a tampered file and a wrong key fail with the same message and no content echoed.

**The container proof**: the demo image boots against PostgreSQL with only environment variables, applies its migration, serves, and a nested numeric override reaches the API settings. The config file inside the container is byte-identical to the committed one, so nothing is written at startup. The entrypoint no longer writes a file and the workaround is gone from the README.

Suite green at 1026, type test green, lint and format clean, smoke test passes.

One shared file to note: the test setup now clears the database URL for the monorepo suite, because a developer who exports one for something else would otherwise repoint the demo application's store. That is the documented cost of using the unprefixed name.