### PR TITLE
Find a free port by binding it, and drop detect-port

### DIFF
--- a/.changeset/drop-detect-port.md
+++ b/.changeset/drop-detect-port.md
@@ -1,0 +1,7 @@
+---
+'@usehenri/core': patch
+---
+
+The development server finds its port by binding rather than by asking first, and `detect-port` is no longer a dependency.
+
+Asking whether a port is free and binding it afterwards leaves a window for anything else to take it in between: the same race that made the test suite answer from the wrong server. The server now binds the port it wants and walks up on `EADDRINUSE` in development, where a busy port outside development stays an error the operator sees. That also removes a package from every henri application's dependency tree, which is one fewer thing that can lose its provenance.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,7 +52,6 @@
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.6",
     "debug": "^4.4.3",
-    "detect-port": "^2.1.0",
     "escape-html": "^1.0.3",
     "express": "^5.2.1",
     "express-rate-limit": "8.7.0",

--- a/packages/core/src/2.server.js
+++ b/packages/core/src/2.server.js
@@ -20,7 +20,6 @@ const { authLimiter, limiter } = require('./base/rate-limit');
 const { requestId } = require('./base/request-id');
 const requestTimeout = require('./base/timeout');
 const debug = require('debug')('henri:server');
-const { detect } = require('detect-port');
 
 /** How long a graceful stop may take before the process is killed (ms) */
 const STOP_TIMEOUT = 5000;
@@ -116,21 +115,17 @@ function safeUserConfig(config) {
   }
 }
 
+/** How many ports to try after the one asked for, in development */
+const PORT_ATTEMPTS = 20;
+
 /**
- * Find a usable port, starting with the one requested
+ * Is this the error of a port already taken?
  *
- * @param {number} port the port we would like to use
- * @param {Pen} pen henri's pen, to warn if we had to change port
- * @returns {Promise<number>} a free port
+ * @param {Error} error what listen() reported
+ * @returns {boolean} true when the port is busy
  */
-async function choosePort(port, pen) {
-  const free = await detect(port);
-
-  if (free !== port) {
-    pen.warn('server', `port ${port} is busy, using ${free} instead`);
-  }
-
-  return free;
+function isPortTaken(error) {
+  return error && (error.code === 'EADDRINUSE' || error.code === 'EACCES');
 }
 
 /* istanbul ignore next */
@@ -445,9 +440,31 @@ class Server extends BaseModule {
     // binding it are a single operation, where detecting a free port and
     // then binding it races with anything else binding meanwhile
     port = henri.isTest ? 0 : port;
-    port = henri.isDev ? await choosePort(port, pen) : port;
 
-    await this.listen(port, this.host);
+    // Binding is the only honest way to know a port is free: asking first and
+    // binding after leaves a window for anything else to take it, which is
+    // the same race that made the test suite answer from the wrong server.
+    // In development we walk up from the port asked for; elsewhere a busy
+    // port is an error the operator wants to see.
+    const wanted = port;
+    const attempts = henri.isDev ? PORT_ATTEMPTS : 0;
+
+    for (let attempt = 0; ; attempt++) {
+      try {
+        await this.listen(port, this.host);
+        break;
+      } catch (error) {
+        if (!isPortTaken(error.cause || error) || attempt >= attempts) {
+          throw error;
+        }
+
+        port = wanted + attempt + 1;
+      }
+    }
+
+    if (port !== wanted && wanted !== 0) {
+      pen.warn('server', `port ${wanted} is busy, using ${port} instead`);
+    }
 
     port = this.httpServer.address().port;
 
@@ -555,7 +572,9 @@ class Server extends BaseModule {
       const onError = (error) => {
         /* istanbul ignore next */
         if (error.code === 'EADDRINUSE') {
-          return reject(new Error(`port ${port} already in use`));
+          return reject(
+            new Error(`port ${port} already in use`, { cause: error })
+          );
         }
 
         /* istanbul ignore next */

--- a/packages/core/src/__tests__/server.spec.js
+++ b/packages/core/src/__tests__/server.spec.js
@@ -187,6 +187,35 @@ describe('server', () => {
     });
   });
 
+  describe('choosing a port', () => {
+    test('a busy port rejects, keeping the reason the retry reads', async () => {
+      const net = require('net');
+      const taken = net.createServer();
+
+      await new Promise((resolve) => taken.listen(0, '127.0.0.1', resolve));
+
+      const busy = taken.address().port;
+      const server = new Server();
+
+      server.henri = fakeHenri({ port: busy });
+      await server.init();
+
+      // In development, start() walks up from a busy port by binding and
+      // catching this, rather than asking whether the port is free and
+      // binding after, which leaves a window for anything else to take it
+      const failure = await server
+        .listen(busy, '127.0.0.1')
+        .then(() => null)
+        .catch((error) => error);
+
+      expect(failure).toBeInstanceOf(Error);
+      expect(failure.message).toContain(`port ${busy} already in use`);
+      expect(failure.cause && failure.cause.code).toBe('EADDRINUSE');
+
+      await new Promise((resolve) => taken.close(resolve));
+    }, 30000);
+  });
+
   describe('loopbackOnly', () => {
     const appWithAddress = (address) => {
       const app = express();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,9 +148,6 @@ importers:
       debug:
         specifier: ^4.4.3
         version: 4.4.3(supports-color@8.1.1)
-      detect-port:
-        specifier: ^2.1.0
-        version: 2.1.0
       escape-html:
         specifier: ^1.0.3
         version: 1.0.3
@@ -3655,10 +3652,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  address@2.0.3:
-    resolution: {integrity: sha512-XNAb/a6TCqou+TufU8/u11HCu9x1gYvOoxLwtlXgIqmkrYQADVv6ljyW2zwiPhHz9R1gItAWpuDrdJMmrOBFEA==}
-    engines: {node: '>= 16.0.0'}
-
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -4271,11 +4264,6 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
-
-  detect-port@2.1.0:
-    resolution: {integrity: sha512-epZuWb/6Q62L+nDHJc/hQAqf8pylsqgk3BpZXVBx1CDnr3nkrVNn73Uu1rXcFzkNcc+hkP3whuOg7JZYaQB65Q==}
-    engines: {node: '>= 16.0.0'}
-    hasBin: true
 
   devalue@5.9.2:
     resolution: {integrity: sha512-po4PAY5c53tw5XMocSnf8A/5OHhbbUftpr93aEN6BBoAdntUmK7vu7wOATqvt7cXO7m1Cl4gMVn6p7n6n4mj0w==}
@@ -10039,8 +10027,6 @@ snapshots:
 
   acorn@8.18.0: {}
 
-  address@2.0.3: {}
-
   agent-base@6.0.2(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
@@ -10706,10 +10692,6 @@ snapshots:
   destr@2.0.5: {}
 
   detect-libc@2.1.2: {}
-
-  detect-port@2.1.0:
-    dependencies:
-      address: 2.0.3
 
   devalue@5.9.2: {}
 


### PR DESCRIPTION
Reported from the field: `mise use --global npm:henri` fails with a supply-chain trust error, because `detect-port@1.6.1` has no provenance where 1.6.0 had it.

Two separate things came out of that.

**The immediate failure is a stale resolution, not this dependency.** The version being installed is 0.37.2, the 2020 release, whose tree pins the 1.x line. Current henri asks for the 2.x line, and that version does carry attestations, so an install of what is actually published today does not hit this. The published latest is 1.1.0.

**The dependency should go anyway**, and this removes it. It was used to ask whether a port was free and then bind it afterwards, which leaves a window for anything else to take it in between. That is the same check-then-bind race that made the test suite answer from the wrong server earlier today. The server now binds the port it wants and walks up on a busy one in development, while a busy port outside development stays an error the operator should see. One fewer package in every henri application's tree, and one fewer thing that can lose its provenance.

Tested at the level the change actually lives: a busy port rejects and keeps the reason the retry reads, so the retry can tell a taken port from a real failure. Suite green at 1253, types green, lint and format clean.