### PR TITLE
Validate the configuration before the modules start

### DIFF
--- a/.changeset/validate-the-configuration.md
+++ b/.changeset/validate-the-configuration.md
@@ -1,0 +1,28 @@
+---
+'@usehenri/core': minor
+'@usehenri/cli': minor
+---
+
+The configuration is checked against a schema at boot, before any module starts.
+
+JavaScript is not strongly typed and TypeScript erases at runtime, so henri checks its own inputs — exhaustively at the boundaries, and the configuration is the first one. Every key henri owns is declared in `@usehenri/core` (`src/base/config-schema.js`) as data: the type it accepts, what to say when something else arrives, and what to do about it. `0.config.js` runs it once the file has loaded and the credentials and the environment have been applied over it, so a wrong value fails on the first line of the boot rather than three modules in, where the message would have named the reader instead of the mistake.
+
+**Every problem is reported, not the first one.** Somebody fixing a configuration file should not discover its faults one boot at a time.
+
+**An error names the key, what was expected, what arrived, and where the value came from** — the file, the credentials, or the variable, because `port must be a number` is unhelpful when the culprit is an environment variable three deployments away:
+
+```
+config ✖ "port" must be a port number between 1 and 65535, but it is the string "eight thousand" => from config/production.json
+config ✖ "stores.default.adapter" must be one of disk, drizzle, mariadb, mongoose, mssql, mysql, postgresql, but it is the string "redis" => from HENRI_CONFIG__stores__default__adapter
+config ✖ "secret" must be a string, but it is a number => from the credentials (config/credentials/production.json.enc)
+```
+
+A value the `filterParameters` name, and anything the credentials provided, is printed as its type alone; the password of a connection string is always masked. The boot fails with a `ConfigurationError` whose `code` is `CONFIG_INVALID` and which carries every problem, so `henri server --json` prints them as `{ "error": { "code", "message", "hint", "problems" } }` and exits `1`.
+
+**An unknown key is a warning, never a failure**: an application may carry keys of its own, and `henri.config.get()` is how it reads them. But a key that is a near miss of one henri owns says so and names the right one (`"renderers" is not a henri configuration key: did you mean "renderer"?`), because that is the actual mistake being made. Inside a store, where everything henri does not declare is forwarded to the driver, only a near miss is worth a word.
+
+**`henri doctor` runs the same schema** over every `config/*.json` without booting and without a database — the checks are `config.invalid`, `config.adapter` and `config.unknown`.
+
+Two smaller changes come with it. An environment variable now takes the type the schema declares when the configuration file has no value at that path (`HENRI_CONFIG__port=8080` is the number `8080` in an application whose file never names a port); the file still wins when it does have one, and a key henri does not own is still a string. And a boot failure reaches the command line through its error envelope — `henri server failed: ...` and the hint — instead of a raw object dump.
+
+The schema cannot drift from the type declarations or the documentation: `@usehenri/core`'s suite compares it key by key with the `Configuration` interface of `index.d.ts` and with the table of the configuration page, and refuses a key that lives in only one of the three.

--- a/.changeset/validate-the-configuration.md
+++ b/.changeset/validate-the-configuration.md
@@ -17,7 +17,7 @@ config ✖ "stores.default.adapter" must be one of disk, drizzle, mariadb, mongo
 config ✖ "secret" must be a string, but it is a number => from the credentials (config/credentials/production.json.enc)
 ```
 
-A value the `filterParameters` name, and anything the credentials provided, is printed as its type alone; the password of a connection string is always masked. The boot fails with a `ConfigurationError` whose `code` is `CONFIG_INVALID` and which carries every problem, so `henri server --json` prints them as `{ "error": { "code", "message", "hint", "problems" } }` and exits `1`.
+A value the `filterParameters` name, and anything the credentials provided, is printed as its type alone; the password of a connection string is always masked. The boot fails with a `ConfigurationError` whose `code` is `CONFIG_INVALID`, whose message names how many problems there are and on which keys, and which carries them all as `{ key, level, message, expected, received, source, hint }`. `henri server` prints them under the failure and exits `1`; `henri server --json` puts them in `{ "error": { "code", "message", "hint", "problems" } }` on stderr.
 
 **An unknown key is a warning, never a failure**: an application may carry keys of its own, and `henri.config.get()` is how it reads them. But a key that is a near miss of one henri owns says so and names the right one (`"renderers" is not a henri configuration key: did you mean "renderer"?`), because that is the actual mistake being made. Inside a store, where everything henri does not declare is forwarded to the driver, only a near miss is worth a word.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,12 +109,25 @@ an app and is what core's tests boot.
   over the file that loaded (`0.config.js`): `HENRI_SECRET` sets `secret`,
   `HENRI_HOST` `host`, `DATABASE_URL` `stores.default.url`, and
   `HENRI_CONFIG__<key>` (`HENRI_CONFIG_JSON__<key>` for JSON) any other key,
-  whose type comes from the file; every key the environment provided is
+  whose type comes from the file and, when the file has no value there, from
+  the schema; every key the environment provided is
   printed at boot with the `filterParameters` masked. Keys: `port`, `host`, `cors`,
   `renderer`, `inertia`, `experimental`, `stores`, `secret`, `user` (string or
   `{ model, public, loginPath, afterLogin, sessionMaxAge }`), `baseRole`,
   `trustProxy`, `csrf`, `graphql`, `mail`, `mailers`, `api`, `jobs`,
   `rateLimit`, `helmet`, `filterParameters`, `bodyLimit`, `requestTimeout`.
+- The configuration is validated at boot, before any other module starts:
+  `base/config-schema.js` declares every key henri owns (as data, in the order
+  of the documentation page) and `base/config-validate.js` walks it. A wrong
+  value is a `ConfigurationError` listing every problem at once with the key,
+  what was expected, what arrived and where the value came from -- the file,
+  the credentials file or the environment variable -- and it reaches the
+  command line as `CONFIG_INVALID`. An unknown key is a warning, with the
+  closest declared name when it is a near miss. `henri doctor` runs the same
+  schema over every `config/*.json` without booting. The schema, the
+  `Configuration` interface of `index.d.ts` and the table of
+  `website/src/content/docs/configuration.md` are compared key by key by
+  `src/__tests__/config-schema.spec.js`: a new key goes in all three.
 - The JSON API layer lives in `base/{api,hateoas,idempotency,rate-limit,
 request-id,redact,headers,pagination,timeout,health}.js`: `res.resource()` and
   `res.collection()` answer HAL with `_links` from the route helpers filtered

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -194,6 +194,9 @@ module.exports = [
       'eslint.config.js',
       '**/config/routes.js',
       '**/types.js',
+      // The configuration schema is a type map read next to the documentation
+      // page: its keys are in the order the page lists them, on purpose
+      'packages/core/src/base/config-schema.js',
     ],
     rules: {
       'sort-keys': 'off',

--- a/packages/cli/__tests__/doctor.spec.js
+++ b/packages/cli/__tests__/doctor.spec.js
@@ -196,6 +196,43 @@ describe('henri doctor', () => {
     );
   });
 
+  test('runs the configuration through the schema of @usehenri/core', () => {
+    const file = path.join(app, 'config/default.json');
+    const original = fs.readFileSync(file, 'utf8');
+
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        ...JSON.parse(original),
+        port: 'eight thousand',
+        renderers: 'react',
+      })
+    );
+
+    const { ok, problems } = run(app);
+
+    fs.writeFileSync(file, original);
+
+    expect(ok).toBe(false);
+    expect(problems).toContainEqual(
+      expect.objectContaining({
+        check: 'config.invalid',
+        file: 'config/default.json',
+        level: 'error',
+        message: expect.stringContaining(
+          '"port" must be a port number between 1 and 65535'
+        ),
+      })
+    );
+    expect(problems).toContainEqual(
+      expect.objectContaining({
+        check: 'config.unknown',
+        hint: 'Did you mean "renderer"?',
+        level: 'warning',
+      })
+    );
+  });
+
   test('reports .env not ignored, and a missing .env as a warning', () => {
     const ignore = path.join(app, '.gitignore');
     const original = fs.readFileSync(ignore, 'utf8');

--- a/packages/cli/__tests__/doctor.spec.js
+++ b/packages/cli/__tests__/doctor.spec.js
@@ -227,7 +227,7 @@ describe('henri doctor', () => {
     expect(problems).toContainEqual(
       expect.objectContaining({
         check: 'config.unknown',
-        hint: 'Did you mean "renderer"?',
+        hint: 'Rename it to "renderer", or remove it',
         level: 'warning',
       })
     );

--- a/packages/cli/__tests__/main.spec.js
+++ b/packages/cli/__tests__/main.spec.js
@@ -2,7 +2,48 @@ const fs = require('fs');
 const path = require('path');
 
 const { commands, version } = require('../package.json');
+const { CliError, toCliError } = require('../scripts/errors');
 const { cleanup, henri, tmpdir } = require('./helpers');
+
+describe('errors', () => {
+  test('a coded error keeps its code, its hint and its problems', () => {
+    const invalid = Object.assign(new Error('invalid configuration'), {
+      code: 'CONFIG_INVALID',
+      hint: 'See the documentation',
+      problems: [{ key: 'port' }],
+    });
+    // How a boot failure reaches the command line: wrapped by henri.init()
+    const failure = toCliError(
+      new Error('henri - unable to execute init(): invalid configuration', {
+        cause: invalid,
+      })
+    );
+
+    expect(failure).toBeInstanceOf(CliError);
+    expect(failure.code).toBe('CONFIG_INVALID');
+    expect(failure.exitCode).toBe(1);
+    expect(failure.hint).toBe('See the documentation');
+    expect(failure.message).toBe('invalid configuration');
+    expect(failure.problems).toEqual([{ key: 'port' }]);
+  });
+
+  test('anything else is a FAILED wrapper', () => {
+    const failure = toCliError(new Error('boom'));
+
+    expect(failure.code).toBe('FAILED');
+    expect(failure.exitCode).toBe(1);
+    expect(failure.problems).toBeUndefined();
+  });
+
+  test('a cause chain that loops is walked once', () => {
+    const first = new Error('first');
+    const second = new Error('second', { cause: first });
+
+    first.cause = second;
+
+    expect(toCliError(second).code).toBe('FAILED');
+  });
+});
 
 describe('the cli', () => {
   let dir;

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -166,6 +166,20 @@ function fail(command, error, json = false) {
   } else {
     console.error(`\n  henri ${command} failed: ${failure.message}\n`);
 
+    for (const problem of failure.problems || []) {
+      console.error(
+        `  ${problem.message}${problem.source ? ` (from ${problem.source})` : ''}`
+      );
+
+      if (problem.hint) {
+        console.error(`    ${problem.hint}`);
+      }
+    }
+
+    if (failure.problems && failure.problems.length > 0) {
+      console.error('');
+    }
+
     if (failure.hint) {
       console.error(`  ${failure.hint}\n`);
     }

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -159,6 +159,7 @@ function fail(command, error, json = false) {
           exitCode: failure.exitCode,
           hint: failure.hint,
           message: failure.message,
+          ...(failure.problems ? { problems: failure.problems } : {}),
         },
       })
     );

--- a/packages/cli/scripts/doctor.js
+++ b/packages/cli/scripts/doctor.js
@@ -3,6 +3,7 @@ const path = require('path');
 
 const { APIS, packagesFor } = require('./adapters');
 const { CliError } = require('./errors');
+const { validate } = require('@usehenri/core/src/base/config-validate');
 const { controllerOf, expand } = require('./routing');
 const {
   detectPackageManager,
@@ -23,6 +24,24 @@ const MINIMUM_NODE = 22;
 
 /** The adapters core can load (scripts/adapters.js is the catalogue) */
 const ADAPTERS = Object.keys(APIS).sort();
+
+/**
+ * The check name a configuration problem is reported under. The schema is
+ * one thing; `henri doctor` has stable check names, so an unknown adapter
+ * keeps the one it has always had.
+ *
+ * @param {object} problem One problem of validate()
+ * @returns {string} The check name
+ */
+const checkFor = (problem) => {
+  if (problem.level === 'warning') {
+    return 'config.unknown';
+  }
+
+  return /^stores\.[^.]+\.adapter$/u.test(problem.key)
+    ? 'config.adapter'
+    : 'config.invalid';
+};
 
 /**
  * Packages the renderers need in the app's package.json. What a store
@@ -477,20 +496,24 @@ const check = (dir = process.cwd()) => {
       });
     }
 
-    for (const [name, store] of Object.entries(
-      (content && content.stores) || {}
-    )) {
-      if (!store || !ADAPTERS.includes(store.adapter)) {
-        problem(
-          'error',
-          'config.adapter',
-          `config/${file}: store "${name}" uses the unknown adapter "${store && store.adapter}"`,
-          {
-            file: `config/${file}`,
-            hint: `Adapters: ${ADAPTERS.join(', ')}`,
-          }
-        );
-      }
+    // The schema of @usehenri/core, the one the boot runs: an application
+    // never learns of a wrong key by booting when `henri doctor` can say it
+    for (const entry of validate(content, {
+      source: () => `config/${file}`,
+    }).problems) {
+      problem(
+        entry.level,
+        checkFor(entry),
+        `config/${file}: ${entry.message}`,
+        {
+          file: `config/${file}`,
+          hint:
+            entry.hint ||
+            (checkFor(entry) === 'config.adapter'
+              ? `Adapters: ${ADAPTERS.join(', ')}`
+              : null),
+        }
+      );
     }
   }
 

--- a/packages/cli/scripts/errors.js
+++ b/packages/cli/scripts/errors.js
@@ -40,6 +40,7 @@ const EXIT_CODES = [
  */
 const CODES = {
   CHECKS_FAILED: 1,
+  CONFIG_INVALID: 1,
   EXISTS: 1,
   FAILED: 1,
   NEEDS_TTY: 4,
@@ -72,14 +73,57 @@ class CliError extends Error {
 }
 
 /**
- * Coerce anything thrown into a CliError
+ * The first error of a `cause` chain that already carries one of CODES
+ *
+ * A boot failure reaches the command line wrapped ("henri - unable to
+ * execute init(): ..."), so the error that knows what went wrong -- the
+ * ConfigurationError of `@usehenri/core`, for one -- is a cause away.
  *
  * @param {*} error What was thrown
- * @returns {CliError} The same error, or a FAILED wrapper around it
+ * @returns {?object} The error carrying the code, or null
+ */
+const coded = (error) => {
+  const seen = new Set();
+  let current = error;
+
+  while (current && typeof current === 'object' && !seen.has(current)) {
+    seen.add(current);
+
+    if (typeof current.code === 'string' && CODES[current.code]) {
+      return current;
+    }
+
+    current = current.cause;
+  }
+
+  return null;
+};
+
+/**
+ * Coerce anything thrown into a CliError
+ *
+ * An error that already names one of CODES keeps it, along with its hint
+ * and its message, wherever it sits in the `cause` chain.
+ *
+ * @param {*} error What was thrown
+ * @returns {CliError} The same error, or a wrapper around it
  */
 const toCliError = (error) => {
   if (error instanceof CliError) {
     return error;
+  }
+
+  const known = coded(error);
+
+  if (known) {
+    const wrapped = new CliError(known.code, known.message, {
+      cause: error instanceof Error ? error : undefined,
+      hint: known.hint || null,
+    });
+
+    wrapped.problems = known.problems;
+
+    return wrapped;
   }
 
   const message = (error && error.message) || String(error);

--- a/packages/cli/scripts/server.js
+++ b/packages/cli/scripts/server.js
@@ -14,34 +14,29 @@ const resolveCore = () => {
 
 /**
  * Main entry point for henri cli
+ *
+ * A boot failure is thrown, not printed here: `henri <command> failed: ...`
+ * and `--json` are the command line's own envelope (index.js), and an error
+ * that names one of the codes -- an invalid configuration, for one -- keeps
+ * its message, its hint and its exit code through it.
+ *
  * @param {object} param0 if console only
  * @param {function} cb a callback (we use this for console)
- * @returns {void}
+ * @returns {Promise<void>} resolves once the application is up
+ * @throws whatever the boot threw
  */
-const main = ({ consoleOnly = false }, cb) => {
+const main = async ({ consoleOnly = false }, cb) => {
   if (consoleOnly) {
     process.env.CONSOLE_ONLY = 'true';
   }
 
-  /**
-   *  Init
-   * @returns {void}
-   */
-  async function init() {
-    try {
-      const start = await require(resolveCore());
+  const start = await require(resolveCore());
 
-      await start();
-      if (typeof cb === 'function') {
-        cb();
-      }
-    } catch (error) {
-      console.dir(error, { colors: true });
-      process.exit(1);
-    }
+  await start();
+
+  if (typeof cb === 'function') {
+    cb();
   }
-
-  init();
 };
 
 module.exports = main;

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -63,6 +63,8 @@ declare namespace start {
     opts?: Record<string, unknown>;
     /** mongoose and SQL: options of the session store. */
     session?: Record<string, unknown>;
+    /** drizzle: create the session table even without a user model. */
+    sessions?: boolean;
     /** disk: data directory, relative to the application (`.henri/data`). */
     path?: string;
     /** disk: database name (`henri`). */
@@ -126,6 +128,8 @@ declare namespace start {
       | {
           windowMs?: number;
           max?: number;
+          /** Alias of `max`, the name express-rate-limit 8 uses. */
+          limit?: number;
           /** Overrides the list of guarded paths. */
           paths?: string[];
         };
@@ -145,6 +149,16 @@ declare namespace start {
     ssrEntry?: string;
     /** Html shell, relative to `app/views` (`index.html`). */
     template?: string;
+  }
+
+  /** `config.mailers`: the defaults of the mailers in `app/mailers`. */
+  interface MailersConfig {
+    /** Sender of every message that does not set one. */
+    from?: string;
+    /** Layout in `app/views/mailers/layouts` (`mailer`); `false` for none. */
+    layout?: string | false;
+    /** `false` turns the development preview routes off. */
+    previews?: boolean;
   }
 
   /**
@@ -179,12 +193,13 @@ declare namespace start {
     graphql?: string;
     /** Nodemailer transport options, or `"test"` for an Ethereal account. */
     mail?: 'test' | Record<string, unknown>;
+    mailers?: MailersConfig;
     api?: ApiConfig;
     rateLimit?: boolean | RateLimitConfig;
     /** Options merged over henri's helmet defaults; `false` disables it. */
     helmet?: false | Record<string, unknown>;
-    /** Parameter names masked in the logs. */
-    filterParameters?: string[];
+    /** Parameter names masked in the logs; `false` masks nothing. */
+    filterParameters?: string[] | false;
     /** Maximum size of a JSON or form body (`"1mb"`). */
     bodyLimit?: string | number;
     /** Milliseconds before a running request is answered 503. */

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -151,6 +151,68 @@ declare namespace start {
     template?: string;
   }
 
+  /** A duration: milliseconds, or `'250ms'`, `'30s'`, `'5m'`, `'2h'`, `'1d'`. */
+  type Duration = number | string;
+
+  /** One entry of `config.jobs.recurring`, keyed by schedule name. */
+  interface RecurringConfig {
+    /** The job to enqueue (the schedule name by default). */
+    job?: string;
+    /** An alias of `job`. */
+    name?: string;
+    /** A cron expression, read in UTC; `cron` or `every`, never both. */
+    cron?: string;
+    /** How often to run it; `cron` or `every`, never both. */
+    every?: Duration;
+    /** The arguments handed to the job. */
+    args?: unknown;
+    /** The queue it goes to. */
+    queue?: string;
+    /** The higher, the sooner. */
+    priority?: number;
+  }
+
+  /** `config.jobs`: the background job queue of `@usehenri/jobs`. */
+  interface JobsConfig {
+    /** Which store of `stores` holds the queue (`default`). */
+    store?: string;
+    /** Table (or collection) name (`henri_jobs`); identifiers only. */
+    table?: string;
+    /** Queue of a job that names none (`default`). */
+    queue?: string;
+    /** Queues a runner takes from when given no `--queue`. */
+    queues?: string | string[];
+    /** How many jobs one runner performs at once (`5`). */
+    concurrency?: number;
+    /** Attempts before a job goes to the dead letter queue (`5`). */
+    maxAttempts?: number;
+    /** How long one attempt may take; `null` for no limit. */
+    timeout?: Duration | null;
+    /** Priority of a job that names none (`0`). */
+    priority?: number;
+    /** `base × factor^(attempt − 1)`, capped at `max`, spread by `jitter`. */
+    backoff?: {
+      base?: Duration;
+      factor?: number;
+      jitter?: number;
+      max?: Duration;
+    };
+    /** How often a runner looks for work (`1s`, never under 50ms). */
+    pollInterval?: Duration;
+    /** Without a heartbeat for that long, a running job is put back (`5m`). */
+    stuckAfter?: Duration;
+    /** How long finished jobs are kept (`1d`); `0` keeps them forever. */
+    keepCompleted?: Duration;
+    /** Size limit of the serialized arguments of one job (`524288`). */
+    maxArgsBytes?: number;
+    /** Queue of the messages `deliverLater()` hands over (`mailers`). */
+    mailQueue?: string;
+    /** Create the tables at boot (`true`). */
+    install?: boolean;
+    /** Schedules, by name. */
+    recurring?: Record<string, RecurringConfig>;
+  }
+
   /** `config.mailers`: the defaults of the mailers in `app/mailers`. */
   interface MailersConfig {
     /** Sender of every message that does not set one. */
@@ -195,6 +257,7 @@ declare namespace start {
     mail?: 'test' | Record<string, unknown>;
     mailers?: MailersConfig;
     api?: ApiConfig;
+    jobs?: JobsConfig;
     rateLimit?: boolean | RateLimitConfig;
     /** Options merged over henri's helmet defaults; `false` disables it. */
     helmet?: false | Record<string, unknown>;

--- a/packages/core/src/0.config.js
+++ b/packages/core/src/0.config.js
@@ -4,6 +4,11 @@ const fs = require('fs');
 const path = require('path');
 const { syntax } = require('./utils');
 const { MASK, filterParameters, isFiltered, redact } = require('./base/redact');
+const {
+  ConfigurationError,
+  coercionFor,
+  validate,
+} = require('./base/config-validate');
 
 /**
  * Prefix of the generic environment overrides. The rest of the name is the
@@ -191,10 +196,26 @@ function tryJson(raw) {
 }
 
 /**
- * The value of an environment variable, as the type the configuration file
- * already uses at that path
+ * The type a value already has, as the schema names it
  *
- * A path the file does not have is a string: henri does not guess. Use
+ * @param {any} value the value
+ * @returns {string} `number`, `boolean`, `object` or `string`
+ */
+function kindOf(value) {
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return typeof value;
+  }
+
+  return value !== null && typeof value === 'object' ? 'object' : 'string';
+}
+
+/**
+ * The value of an environment variable, as the type that key already has
+ *
+ * The type comes from the configuration file when it has a value at that
+ * path, and from henri's schema when it does not (`port` is a number even
+ * in an application whose file never names it). A key henri does not own
+ * and the file does not have is a string: henri never guesses. Use
  * `HENRI_CONFIG_JSON__<path>` for anything else.
  *
  * @param {string} raw the value of the variable
@@ -205,35 +226,38 @@ function tryJson(raw) {
  */
 function coerce(raw, current, entry) {
   const { key, variable } = entry;
+  const known = typeof current !== 'undefined';
+  const kind = known ? kindOf(current) : coercionFor(key, raw);
+  const where = known ? 'in the configuration' : "in henri's schema";
 
-  if (typeof current === 'number') {
+  if (kind === 'number') {
     const value = Number(raw);
 
     if (!Number.isFinite(value)) {
       throw new Error(
-        `${variable} is not a number, and "${key}" is one in the configuration`
+        `${variable} is not a number, and "${key}" is one ${where}`
       );
     }
 
     return value;
   }
 
-  if (typeof current === 'boolean') {
+  if (kind === 'boolean') {
     if (/^(true|false)$/i.test(raw)) {
       return /^true$/i.test(raw);
     }
 
     throw new Error(
-      `${variable} is not true or false, and "${key}" is a boolean in the configuration`
+      `${variable} is not true or false, and "${key}" is a boolean ${where}`
     );
   }
 
-  if (current !== null && typeof current === 'object') {
+  if (kind === 'object') {
     const value = tryJson(raw);
 
     if (value === null || typeof value !== 'object') {
       throw new Error(
-        `${variable} is not a JSON object, and "${key}" is one in the configuration`
+        `${variable} is not a JSON object, and "${key}" is one ${where}`
       );
     }
 
@@ -364,16 +388,16 @@ function withEnv(config, env = process.env) {
  * @param {string} cwd the application directory
  * @param {string} env the environment
  * @param {object} [environment=process.env] the environment variables
- * @returns {{applied: Array<string>, config: object, source: ?string}} the
- *   configuration, the paths the credentials provided and where the key
- *   came from
+ * @returns {{applied: Array<string>, config: object, file: ?string, source: ?string}}
+ *   the configuration, the paths the credentials provided, the file they
+ *   came from and where the key came from
  * @throws {Error} when the file exists and cannot be opened
  */
 function applyCredentials(config, cwd, env, environment = process.env) {
   const secrets = credentials.read(cwd, env, environment);
 
   if (!secrets) {
-    return { applied: [], config, source: null };
+    return { applied: [], config, file: null, source: null };
   }
 
   return {
@@ -382,7 +406,53 @@ function applyCredentials(config, cwd, env, environment = process.env) {
       (current, entry) => setPath(current, entry.key, entry.value),
       config
     ),
+    file: path.relative(cwd, secrets.file),
     source: secrets.source,
+  };
+}
+
+/**
+ * Where every value of a configuration came from
+ *
+ * A source registered at a path answers for everything under it, so the
+ * `rateLimit` an environment variable set is also the source of
+ * `rateLimit.max`. Anything no source claims comes from the file.
+ *
+ * @param {string} file the configuration file that loaded
+ * @param {object} secrets what applyCredentials() returned
+ * @param {Array<object>} applied what applyEnv() applied
+ * @returns {function} `(key) => string`, the source of a key
+ */
+function provenance(file, secrets, applied) {
+  const owners = [];
+
+  for (const key of secrets.applied) {
+    owners.push([key, `the credentials (${secrets.file})`]);
+  }
+
+  for (const entry of applied) {
+    if (!entry.ignored) {
+      owners.push([entry.key, entry.variable]);
+    }
+  }
+
+  return (key) => {
+    let found = file;
+    let longest = -1;
+
+    for (const [owned, label] of owners) {
+      const covers =
+        key === owned ||
+        key.startsWith(`${owned}.`) ||
+        key.startsWith(`${owned}[`);
+
+      if (covers && owned.length > longest) {
+        found = label;
+        longest = owned.length;
+      }
+    }
+
+    return found;
   };
 }
 
@@ -461,6 +531,7 @@ class Config extends BaseModule {
 
     let hasErrors = false;
     let loaded = null;
+    let source = null;
 
     for (const file of [configPath, defaultPath]) {
       if (loaded) {
@@ -469,6 +540,7 @@ class Config extends BaseModule {
 
       try {
         loaded = require(file);
+        source = path.relative(this.henri.cwd(), file);
       } catch (error) {
         if (await syntax(file, null, this.henri)) {
           hasErrors = true;
@@ -489,6 +561,7 @@ class Config extends BaseModule {
 
       Object.freeze(this.config);
       this.report(applied, secrets);
+      this.check(provenance(source, secrets, applied));
 
       return this.name;
     }
@@ -544,6 +617,49 @@ class Config extends BaseModule {
         entry.variable
       );
     }
+  }
+
+  /**
+   * Runs the whole configuration through the schema, before any other
+   * module starts. `config` is the first module of runlevel 0 and every
+   * other one is above it, so nothing has read a wrong value yet.
+   *
+   * Every problem is reported, not the first: warnings are printed and the
+   * boot goes on, errors are printed and thrown together as one
+   * ConfigurationError naming the key, what was expected, what arrived and
+   * where it came from -- the file, the credentials or the variable.
+   *
+   * @param {function} source `(key) => string`, where a value came from
+   * @returns {Array<object>} the warnings
+   * @throws {ConfigurationError} when a value is not what henri accepts
+   * @memberof Config
+   */
+  check(source) {
+    const { pen } = this.henri;
+    const filters = filterParameters({
+      get: (key) => getPath(this.config, key),
+      has: (key) => hasPath(this.config, key),
+    });
+    const mask = (key) =>
+      isFiltered(segments(key).pop() || key, filters) ||
+      String(source(key)).startsWith('the credentials');
+    const { errors, warnings } = validate(this.config, { mask, source });
+
+    for (const problem of [...warnings, ...errors]) {
+      const write = problem.level === 'error' ? pen.error : pen.warn;
+
+      write.call(pen, 'config', problem.message, `from ${problem.source}`);
+
+      if (problem.hint) {
+        write.call(pen, 'config', problem.hint);
+      }
+    }
+
+    if (errors.length > 0) {
+      throw new ConfigurationError(errors);
+    }
+
+    return warnings;
   }
 
   /**
@@ -608,6 +724,7 @@ module.exports.ALIASES = ALIASES;
 module.exports.ENV_JSON_PREFIX = ENV_JSON_PREFIX;
 module.exports.ENV_PREFIX = ENV_PREFIX;
 module.exports.applyCredentials = applyCredentials;
+module.exports.provenance = provenance;
 module.exports.applyEnv = applyEnv;
 module.exports.loadDotEnv = loadDotEnv;
 module.exports.withEnv = withEnv;

--- a/packages/core/src/__tests__/config-schema.spec.js
+++ b/packages/core/src/__tests__/config-schema.spec.js
@@ -1,0 +1,371 @@
+const fs = require('fs');
+const path = require('path');
+
+const { SCHEMA, STORE } = require('../base/config-schema');
+const {
+  ConfigurationError,
+  coercionFor,
+  describe: describeNode,
+  distance,
+  format,
+  nearest,
+  nodeAt,
+  received,
+  validate,
+} = require('../base/config-validate');
+
+const ROOT = path.resolve(__dirname, '..', '..', '..', '..');
+
+/** The keys of the `user` object form, the second branch of its union */
+const userKeys = () => Object.keys(SCHEMA.user.oneOf[1].keys);
+
+/** The keys of the `rateLimit` object form */
+const rateLimitKeys = () => Object.keys(SCHEMA.rateLimit.oneOf[1].keys);
+
+/**
+ * The member names of an interface of index.d.ts, at its own level (the
+ * keys of an inline object type are not members of the interface)
+ *
+ * @param {string} source the content of index.d.ts
+ * @param {string} name the interface name
+ * @returns {Array<string>} the member names
+ */
+const members = (source, name) => {
+  const start = source.indexOf(`interface ${name} {`);
+
+  expect(start).toBeGreaterThan(-1);
+
+  const found = [];
+  let depth = 0;
+
+  for (const line of source.slice(start).split('\n').slice(1)) {
+    const opens = (line.match(/\{/gu) || []).length;
+    const closes = (line.match(/\}/gu) || []).length;
+
+    if (depth === 0) {
+      const match = /^\s{4}(\w+)\??:/u.exec(line);
+
+      if (match) {
+        found.push(match[1]);
+      }
+    }
+
+    depth += opens - closes;
+
+    if (depth < 0) {
+      break;
+    }
+  }
+
+  return found;
+};
+
+/**
+ * The keys named in the main table of the documentation page
+ *
+ * @param {string} source the content of configuration.md
+ * @returns {Array<string>} the keys
+ */
+const documented = (source) => {
+  const section = source.slice(source.indexOf('\n## Keys'));
+  const table = section.slice(0, section.indexOf('\n## ', 1));
+
+  return [...table.matchAll(/^\|\s*`([A-Za-z]\w*)`\s*\|/gmu)].map(
+    (match) => match[1]
+  );
+};
+
+/**
+ * Every config/*.json of this repository, as [label, parsed] pairs
+ *
+ * @returns {Array<Array>} the configurations
+ */
+const configurations = () => {
+  const found = [];
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        if (
+          ![
+            '.claude',
+            '.git',
+            '.henri',
+            '.next',
+            '.tmp',
+            'coverage',
+            'dist',
+            'node_modules',
+          ].includes(entry.name)
+        ) {
+          walk(full);
+        }
+        continue;
+      }
+
+      if (
+        path.basename(dir) === 'config' &&
+        entry.name.endsWith('.json') &&
+        !entry.name.startsWith('.')
+      ) {
+        found.push([
+          path.relative(ROOT, full),
+          JSON.parse(fs.readFileSync(full, 'utf8')),
+        ]);
+      }
+    }
+  };
+
+  walk(ROOT);
+
+  return found;
+};
+
+describe('the configuration schema', () => {
+  test('accepts every configuration of this repository', () => {
+    const files = configurations();
+
+    expect(files.length).toBeGreaterThan(4);
+
+    for (const [label, config] of files) {
+      const { errors } = validate(config, { source: () => label });
+
+      expect(`${label}: ${format(errors)}`).toBe(
+        `${label}: invalid configuration (0 problems)`
+      );
+    }
+  });
+
+  test('takes the shapes the documentation shows', () => {
+    const { errors, warnings } = validate({
+      api: { idempotency: { store: null, ttl: 86400000 }, maxPerPage: 50 },
+      baseRole: ['guest', 'member'],
+      bodyLimit: '2mb',
+      cors: { origin: 'https://example.com' },
+      csrf: false,
+      experimental: { vue: true },
+      filterParameters: false,
+      graphql: '/_henri/gql',
+      helmet: false,
+      host: '0.0.0.0',
+      inertia: { entry: 'main.jsx', ssr: true },
+      mail: 'test',
+      mailers: { from: 'Acme <no-reply@acme.com>', layout: false },
+      port: 3000,
+      rateLimit: { auth: false, max: 10, store: './lib/limit' },
+      renderer: 'vue',
+      requestTimeout: false,
+      secret: 'a-secret',
+      stores: {
+        default: {
+          adapter: 'drizzle',
+          dialect: 'postgres',
+          url: 'postgres://',
+        },
+        legacy: { adapter: 'mysql', logging: false, pool: { max: 5 } },
+      },
+      trustProxy: 2,
+      user: { afterLogin: '/', model: 'user', public: ['name'] },
+    });
+
+    expect(errors).toEqual([]);
+    expect(warnings).toEqual([]);
+  });
+
+  test('refuses a value of the wrong type, naming the key and what arrived', () => {
+    const { errors } = validate(
+      { port: 'eight thousand' },
+      { source: () => 'config/default.json' }
+    );
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      expected: 'a port number between 1 and 65535',
+      key: 'port',
+      level: 'error',
+      received: 'the string "eight thousand"',
+      source: 'config/default.json',
+    });
+    expect(errors[0].message).toBe(
+      '"port" must be a port number between 1 and 65535, but it is the string "eight thousand"'
+    );
+    expect(errors[0].hint).toContain('{ "port": 3000 }');
+  });
+
+  test('reports every problem, not the first one', () => {
+    const { errors } = validate({
+      csrf: 'yes',
+      port: 0,
+      renderer: 'preact',
+      requestTimeout: -1,
+      stores: { default: { adapter: 'redis' } },
+    });
+
+    expect(errors.map((problem) => problem.key).sort()).toEqual([
+      'csrf',
+      'port',
+      'renderer',
+      'requestTimeout',
+      'stores.default.adapter',
+    ]);
+  });
+
+  test('a store needs an adapter, and only one henri can load', () => {
+    const { errors } = validate({ stores: { default: { url: 'x' } } });
+
+    expect(errors[0].key).toBe('stores.default.adapter');
+    expect(errors[0].message).toContain('is missing');
+  });
+
+  test('an unknown key is a warning, a near miss suggests the right one', () => {
+    const { errors, warnings } = validate({
+      appName: 'lineup',
+      rateLimits: false,
+      renderers: 'react',
+      trustproxy: true,
+    });
+
+    expect(errors).toEqual([]);
+    expect(warnings.map((problem) => [problem.key, problem.hint])).toEqual([
+      [
+        'appName',
+        'henri ignores it; remove it, or keep it if the application reads it with henri.config.get()',
+      ],
+      ['rateLimits', 'Did you mean "rateLimit"?'],
+      ['renderers', 'Did you mean "renderer"?'],
+      ['trustproxy', 'Did you mean "trustProxy"?'],
+    ]);
+  });
+
+  test('a store forwards what it does not know, but says so on a near miss', () => {
+    const { warnings } = validate({
+      stores: {
+        default: {
+          adapter: 'mysql',
+          dialectOptions: {},
+          logging: false,
+          pool: { max: 5 },
+          urls: 'mysql://',
+        },
+      },
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].hint).toBe('Did you mean "stores.default.url"?');
+  });
+
+  test('the vue renderer needs its experimental flag', () => {
+    expect(validate({ renderer: 'vue' }).errors[0].key).toBe('renderer');
+    expect(
+      validate({ experimental: { vue: true }, renderer: 'vue' }).errors
+    ).toEqual([]);
+  });
+
+  test('a value that must not be printed shows as its type', () => {
+    const { errors } = validate(
+      { secret: 42 },
+      { mask: (key) => key === 'secret' }
+    );
+
+    expect(errors[0].message).toContain('a number');
+    expect(errors[0].message).not.toContain('42');
+  });
+
+  test('the password of a connection string is always masked', () => {
+    expect(received('postgres://henri:hunter2@db:5432/app')).toBe(
+      'the string "postgres://henri:[FILTERED]@db:5432/app"'
+    );
+  });
+
+  test('a configuration that is not an object is refused', () => {
+    expect(validate(null).errors[0].message).toContain('must be an object');
+    expect(validate([]).errors[0].message).toContain('must be an object');
+  });
+
+  test('ConfigurationError carries the problems and the command line code', () => {
+    const { errors } = validate({ port: 'nope' }, { source: () => '.env' });
+    const error = new ConfigurationError(errors);
+
+    expect(error.code).toBe('CONFIG_INVALID');
+    expect(error.exitCode).toBe(1);
+    expect(error.problems).toBe(errors);
+    expect(error.message).toContain('invalid configuration (1 problem)');
+    expect(error.message).toContain('(from .env)');
+  });
+});
+
+describe('reading the schema', () => {
+  test('nodeAt walks records and the branches of a union', () => {
+    expect(nodeAt('port').type).toBe('number');
+    expect(nodeAt('stores.reporting.adapter').enum).toContain('mongoose');
+    expect(nodeAt('user.sessionMaxAge').type).toBe('number');
+    expect(nodeAt('rateLimit.auth.max').type).toBe('number');
+    expect(nodeAt('mail.host')).toBeNull();
+    expect(nodeAt('whatever')).toBeNull();
+  });
+
+  test('coercionFor types an environment variable from the schema', () => {
+    expect(coercionFor('port', '8080')).toBe('number');
+    expect(coercionFor('csrf', 'false')).toBe('boolean');
+    expect(coercionFor('stores.a.url', '5432')).toBe('string');
+    expect(coercionFor('requestTimeout', 'false')).toBe('boolean');
+    expect(coercionFor('requestTimeout', '5000')).toBe('number');
+    // Nothing plausible: the value reaches the validator, whose message
+    // names the key and what was expected
+    expect(coercionFor('port', 'nope')).toBeNull();
+    expect(coercionFor('mail.host', 'smtp')).toBeNull();
+  });
+
+  test('nearest only suggests a name that is actually close', () => {
+    expect(distance('renderers', 'renderer')).toBe(1);
+    expect(nearest('pool', Object.keys(STORE.keys))).toBeNull();
+    expect(nearest('adaptor', Object.keys(STORE.keys))).toBe('adapter');
+  });
+
+  test('describe says what a key accepts', () => {
+    expect(describeNode(SCHEMA.csrf)).toBe(
+      'false to disable the CSRF protection'
+    );
+    expect(describeNode({ type: 'boolean' })).toBe('true or false');
+    expect(describeNode({ enum: ['a', 'b'], type: 'string' })).toBe(
+      'one of a, b'
+    );
+    expect(describeNode({ const: false })).toBe('false');
+  });
+});
+
+describe('the schema, the declarations and the documentation', () => {
+  const source = fs.readFileSync(
+    path.join(ROOT, 'packages', 'core', 'index.d.ts'),
+    'utf8'
+  );
+
+  test.each([
+    ['Configuration', () => Object.keys(SCHEMA)],
+    ['StoreConfig', () => Object.keys(STORE.keys)],
+    ['UserConfig', userKeys],
+    ['ApiConfig', () => Object.keys(SCHEMA.api.keys)],
+    ['RateLimitConfig', rateLimitKeys],
+    ['InertiaConfig', () => Object.keys(SCHEMA.inertia.keys)],
+    ['MailersConfig', () => Object.keys(SCHEMA.mailers.keys)],
+  ])('%s declares exactly what the schema does', (name, keys) => {
+    expect(members(source, name).sort()).toEqual(keys().sort());
+  });
+
+  test('the documentation lists exactly the keys henri owns', () => {
+    const page = path.join(
+      ROOT,
+      'website',
+      'src',
+      'content',
+      'docs',
+      'configuration.md'
+    );
+
+    expect(fs.existsSync(page)).toBe(true);
+    expect(documented(fs.readFileSync(page, 'utf8')).sort()).toEqual(
+      Object.keys(SCHEMA).sort()
+    );
+  });
+});

--- a/packages/core/src/__tests__/config-schema.spec.js
+++ b/packages/core/src/__tests__/config-schema.spec.js
@@ -351,6 +351,11 @@ describe('the schema, the declarations and the documentation', () => {
     ['RateLimitConfig', rateLimitKeys],
     ['InertiaConfig', () => Object.keys(SCHEMA.inertia.keys)],
     ['MailersConfig', () => Object.keys(SCHEMA.mailers.keys)],
+    ['JobsConfig', () => Object.keys(SCHEMA.jobs.keys)],
+    [
+      'RecurringConfig',
+      () => Object.keys(SCHEMA.jobs.keys.recurring.values.keys),
+    ],
   ])('%s declares exactly what the schema does', (name, keys) => {
     expect(members(source, name).sort()).toEqual(keys().sort());
   });

--- a/packages/core/src/__tests__/config-schema.spec.js
+++ b/packages/core/src/__tests__/config-schema.spec.js
@@ -131,8 +131,8 @@ describe('the configuration schema', () => {
     for (const [label, config] of files) {
       const { errors } = validate(config, { source: () => label });
 
-      expect(`${label}: ${format(errors)}`).toBe(
-        `${label}: invalid configuration (0 problems)`
+      expect(errors.map((problem) => `${label}: ${problem.message}`)).toEqual(
+        []
       );
     }
   });
@@ -232,9 +232,9 @@ describe('the configuration schema', () => {
         'appName',
         'henri ignores it; remove it, or keep it if the application reads it with henri.config.get()',
       ],
-      ['rateLimits', 'Did you mean "rateLimit"?'],
-      ['renderers', 'Did you mean "renderer"?'],
-      ['trustproxy', 'Did you mean "trustProxy"?'],
+      ['rateLimits', 'Rename it to "rateLimit", or remove it'],
+      ['renderers', 'Rename it to "renderer", or remove it'],
+      ['trustproxy', 'Rename it to "trustProxy", or remove it'],
     ]);
   });
 
@@ -252,7 +252,10 @@ describe('the configuration schema', () => {
     });
 
     expect(warnings).toHaveLength(1);
-    expect(warnings[0].hint).toBe('Did you mean "stores.default.url"?');
+    expect(warnings[0].message).toContain('did you mean "stores.default.url"?');
+    expect(warnings[0].hint).toBe(
+      'Rename it to "stores.default.url", or remove it'
+    );
   });
 
   test('the vue renderer needs its experimental flag', () => {
@@ -290,8 +293,9 @@ describe('the configuration schema', () => {
     expect(error.code).toBe('CONFIG_INVALID');
     expect(error.exitCode).toBe(1);
     expect(error.problems).toBe(errors);
-    expect(error.message).toContain('invalid configuration (1 problem)');
-    expect(error.message).toContain('(from .env)');
+    // The message is one line: whoever prints it has the problems too
+    expect(error.message).toBe('invalid configuration (1 problem): port');
+    expect(format(error.problems)).toContain('(from .env)');
   });
 });
 
@@ -324,9 +328,7 @@ describe('reading the schema', () => {
   });
 
   test('describe says what a key accepts', () => {
-    expect(describeNode(SCHEMA.csrf)).toBe(
-      'false to disable the CSRF protection'
-    );
+    expect(describeNode(SCHEMA.port)).toBe('a port number between 1 and 65535');
     expect(describeNode({ type: 'boolean' })).toBe('true or false');
     expect(describeNode({ enum: ['a', 'b'], type: 'string' })).toBe(
       'one of a, b'

--- a/packages/core/src/__tests__/config.spec.js
+++ b/packages/core/src/__tests__/config.spec.js
@@ -395,10 +395,15 @@ describe('config from the environment', () => {
       expect(thrown).not.toBeNull();
       expect(thrown.cause.code).toBe('CONFIG_INVALID');
       expect(thrown.cause.problems).toHaveLength(1);
-      expect(thrown.cause.message).toContain(
-        '"port" must be a port number between 1 and 65535'
+      expect(thrown.cause.message).toBe(
+        'invalid configuration (1 problem): port'
       );
-      expect(thrown.cause.message).toContain(`from ${ENV_PREFIX}port`);
+      expect(thrown.cause.problems[0]).toMatchObject({
+        key: 'port',
+        message:
+          '"port" must be a port number between 1 and 65535, but it is the string "nope"',
+        source: `${ENV_PREFIX}port`,
+      });
     });
 
     test('an unknown key is a warning, and the boot goes on', async () => {

--- a/packages/core/src/__tests__/config.spec.js
+++ b/packages/core/src/__tests__/config.spec.js
@@ -347,6 +347,79 @@ describe('config from the environment', () => {
     });
   });
 
+  describe('the schema gate', () => {
+    const { provenance } = require('../0.config');
+
+    test('names where a value came from, the longest path winning', () => {
+      const source = provenance(
+        'config/test.json',
+        {
+          applied: ['secret', 'mail.auth.pass'],
+          file: 'config/credentials/test.json.enc',
+        },
+        [
+          { key: 'rateLimit', variable: `${ENV_JSON_PREFIX}rateLimit` },
+          {
+            ignored: 'the configuration has no "stores.default"',
+            key: 'stores.default.url',
+            variable: 'DATABASE_URL',
+          },
+        ]
+      );
+
+      expect(source('rateLimit.auth.max')).toBe(`${ENV_JSON_PREFIX}rateLimit`);
+      expect(source('mail.auth.pass')).toBe(
+        'the credentials (config/credentials/test.json.enc)'
+      );
+      expect(source('mail.host')).toBe('config/test.json');
+      // A shorthand that was ignored never claims its key
+      expect(source('stores.default.url')).toBe('config/test.json');
+      expect(source('')).toBe('config/test.json');
+    });
+
+    test('a wrong value from the environment fails the boot by name', async () => {
+      process.env[`${ENV_PREFIX}port`] = 'nope';
+
+      const henri = new Henri({ runlevel: 0 });
+      let thrown = null;
+
+      try {
+        await henri.init();
+      } catch (error) {
+        thrown = error;
+      } finally {
+        delete process.env[`${ENV_PREFIX}port`];
+        await henri.stop();
+      }
+
+      expect(thrown).not.toBeNull();
+      expect(thrown.cause.code).toBe('CONFIG_INVALID');
+      expect(thrown.cause.problems).toHaveLength(1);
+      expect(thrown.cause.message).toContain(
+        '"port" must be a port number between 1 and 65535'
+      );
+      expect(thrown.cause.message).toContain(`from ${ENV_PREFIX}port`);
+    });
+
+    test('an unknown key is a warning, and the boot goes on', async () => {
+      const henri = new Henri({ runlevel: 0 });
+
+      await henri.init();
+
+      try {
+        // The demo application carries an `env` key of its own
+        expect(henri.config.get('env')).toBe('test');
+        expect(
+          henri.config
+            .check(() => 'config/test.json')
+            .map((problem) => problem.key)
+        ).toEqual(['env']);
+      } finally {
+        await henri.stop();
+      }
+    });
+  });
+
   test('a booted henri reads a key from the environment', async () => {
     process.env[`${ENV_PREFIX}baseRole`] = 'from-the-environment';
 

--- a/packages/core/src/__tests__/credentials.spec.js
+++ b/packages/core/src/__tests__/credentials.spec.js
@@ -212,12 +212,14 @@ describe('credentials', () => {
       }
 
       expect(thrown.code).toBe('CONFIG_INVALID');
-      expect(thrown.message).toContain('"stores.default.adapter"');
-      expect(thrown.message).toContain(
-        'from the credentials (config/credentials/production.json.enc)'
+      expect(thrown.problems).toHaveLength(1);
+      expect(thrown.problems[0].key).toBe('stores.default.adapter');
+      expect(thrown.problems[0].source).toBe(
+        'the credentials (config/credentials/production.json.enc)'
       );
       // Every value of that file is a secret: only its type is printed
-      expect(thrown.message).toContain('it is a string');
+      expect(thrown.problems[0].received).toBe('a string');
+      expect(JSON.stringify(thrown.problems)).not.toContain(SECRET);
       expect(thrown.message).not.toContain(SECRET);
     });
 

--- a/packages/core/src/__tests__/credentials.spec.js
+++ b/packages/core/src/__tests__/credentials.spec.js
@@ -171,8 +171,54 @@ describe('credentials', () => {
       expect(applyCredentials(file, dir, 'production', {})).toEqual({
         applied: [],
         config: file,
+        file: null,
         source: null,
       });
+    });
+
+    test('a wrong value fails the boot naming the file, never the value', async () => {
+      const Config = require('../0.config');
+
+      fs.mkdirSync(path.join(dir, 'config'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'config', 'production.json'),
+        JSON.stringify({ stores: { default: { adapter: 'disk' } } })
+      );
+      credentials.write(
+        dir,
+        'production',
+        { stores: { default: { adapter: SECRET } } },
+        key
+      );
+
+      const config = new Config();
+
+      config.henri = {
+        cwd: () => dir,
+        env: 'production',
+        pen: { error: () => {}, info: () => {}, warn: () => {} },
+      };
+
+      process.env.HENRI_CREDENTIALS_KEY = key.toString('hex');
+
+      let thrown = null;
+
+      try {
+        await config.init();
+      } catch (error) {
+        thrown = error;
+      } finally {
+        delete process.env.HENRI_CREDENTIALS_KEY;
+      }
+
+      expect(thrown.code).toBe('CONFIG_INVALID');
+      expect(thrown.message).toContain('"stores.default.adapter"');
+      expect(thrown.message).toContain(
+        'from the credentials (config/credentials/production.json.enc)'
+      );
+      // Every value of that file is a secret: only its type is printed
+      expect(thrown.message).toContain('it is a string');
+      expect(thrown.message).not.toContain(SECRET);
     });
 
     test('the config module reads them, under the environment', async () => {

--- a/packages/core/src/base/config-schema.js
+++ b/packages/core/src/base/config-schema.js
@@ -67,6 +67,16 @@ const positive = (extra = {}) => ({
   ...extra,
 });
 
+/** A duration: milliseconds, or `'250ms'`, `'30s'`, `'5m'`, `'2h'`, `'1d'` */
+const duration = (extra = {}) => ({
+  describe: "a duration: milliseconds, or '30s', '5m', '2h', '1d'",
+  oneOf: [
+    { min: 0, type: 'number' },
+    { pattern: /^\s*\d+(?:\.\d+)?\s*(?:ms|[smhdw])?\s*$/iu, type: 'string' },
+  ],
+  ...extra,
+});
+
 /** One entry of `stores`: an adapter and how to reach its database */
 const STORE = {
   hint: 'A store is { "adapter": "disk" } and the keys that adapter needs',
@@ -336,6 +346,103 @@ const SCHEMA = {
         describe: 'true or false',
         hint: 'true refuses (500) a JSON answer without _links',
         type: 'boolean',
+      },
+    },
+    type: 'object',
+  },
+
+  jobs: {
+    describe: 'an object of job queue settings',
+    hint: 'The queue loads when this key is there or app/jobs holds a file',
+    keys: {
+      backoff: {
+        describe: 'an object ({ base, factor, jitter, max })',
+        keys: {
+          base: duration({ default: '5s' }),
+          factor: positive({ default: 4, describe: 'a number above zero' }),
+          jitter: {
+            default: 0.15,
+            describe: 'a number between 0 and 1',
+            max: 1,
+            min: 0,
+            type: 'number',
+          },
+          max: duration({ default: '1h' }),
+        },
+        type: 'object',
+      },
+      concurrency: {
+        default: 5,
+        describe: 'a whole number of jobs, above zero',
+        integer: true,
+        min: 1,
+        type: 'number',
+      },
+      install: {
+        default: true,
+        describe: 'true or false',
+        hint: 'false stops the boot from creating the tables (henri jobs:install does)',
+        type: 'boolean',
+      },
+      keepCompleted: duration({ default: '1d' }),
+      mailQueue: text({ default: 'mailers', describe: 'a queue name' }),
+      maxArgsBytes: {
+        default: 524288,
+        describe: 'a whole number of bytes, above zero',
+        integer: true,
+        min: 1,
+        type: 'number',
+      },
+      maxAttempts: {
+        default: 5,
+        describe: 'a whole number of attempts, above zero',
+        integer: true,
+        min: 1,
+        type: 'number',
+      },
+      pollInterval: duration({ default: '1s' }),
+      priority: {
+        default: 0,
+        describe: 'a number (the higher, the sooner)',
+        type: 'number',
+      },
+      queue: text({ default: 'default', describe: 'a queue name' }),
+      queues: {
+        describe: "a list of queue names, or one string ('a,b')",
+        oneOf: [text(), { of: text(), type: 'array' }],
+      },
+      recurring: {
+        describe: 'an object of schedules, by name',
+        type: 'record',
+        values: {
+          hint: 'A schedule needs a "cron" or an "every", never both',
+          keys: {
+            args: { describe: 'the arguments of the job', type: 'any' },
+            cron: text({ describe: 'a cron expression, read in UTC' }),
+            every: duration(),
+            job: text({
+              describe: 'the job name (the schedule name by default)',
+            }),
+            name: text({ describe: 'an alias of `job`' }),
+            priority: { describe: 'a number', type: 'number' },
+            queue: text({ describe: 'a queue name' }),
+          },
+          type: 'object',
+        },
+      },
+      store: text({
+        default: 'default',
+        describe: 'the name of a store of `stores`',
+      }),
+      stuckAfter: duration({ default: '5m' }),
+      table: text({
+        default: 'henri_jobs',
+        describe: 'a table name: letters, digits and underscores only',
+        pattern: /^[A-Za-z_][A-Za-z0-9_]*$/u,
+      }),
+      timeout: {
+        describe: "a duration, or null for 'no limit'",
+        oneOf: [{ const: null }, duration()],
       },
     },
     type: 'object',

--- a/packages/core/src/base/config-schema.js
+++ b/packages/core/src/base/config-schema.js
@@ -88,7 +88,8 @@ const STORE = {
     },
     host: text({ describe: 'a host name (or a url, on mongoose)' }),
     migrate: {
-      describe: 'true to apply db/migrations on a production boot (drizzle)',
+      describe: 'true or false',
+      hint: 'drizzle: true applies db/migrations on a production boot',
       type: 'boolean',
     },
     opts: {
@@ -114,11 +115,13 @@ const STORE = {
       unknown: 'allow',
     },
     sessions: {
-      describe: 'true to create the session table without a user model',
+      describe: 'true or false',
+      hint: 'drizzle: true creates the session table without a user model',
       type: 'boolean',
     },
     sync: {
-      describe: 'false to stop a development boot from pushing the schema',
+      describe: 'true or false',
+      hint: 'drizzle: false stops a development boot from pushing the schema',
       type: 'boolean',
     },
     url: text({ describe: 'a connection string' }),
@@ -159,7 +162,7 @@ const SCHEMA = {
     default: 'template',
     describe: `one of ${RENDERERS.join(', ')}`,
     enum: RENDERERS,
-    hint: 'vue also needs { "experimental": { "vue": true } }',
+    hint: 'henri new writes "react"; "vue" also needs { "experimental": { "vue": true } }',
     insensitive: true,
     type: 'string',
   },
@@ -253,7 +256,8 @@ const SCHEMA = {
 
   csrf: {
     default: true,
-    describe: 'false to disable the CSRF protection',
+    describe: 'true or false',
+    hint: 'false disables the double-submit CSRF protection',
     type: 'boolean',
   },
 
@@ -280,7 +284,8 @@ const SCHEMA = {
       },
       previews: {
         default: true,
-        describe: 'false to turn the development preview routes off',
+        describe: 'true or false',
+        hint: 'false turns the development preview routes off',
         type: 'boolean',
       },
     },
@@ -304,7 +309,8 @@ const SCHEMA = {
               },
               ttl: positive({
                 default: 86400000,
-                describe: 'how long answers are kept, in milliseconds',
+                describe: 'a number of milliseconds above zero',
+                hint: 'How long an Idempotency-Key answer is kept',
               }),
             },
             type: 'object',
@@ -327,7 +333,8 @@ const SCHEMA = {
       },
       strict: {
         default: false,
-        describe: 'true to refuse a JSON answer without _links',
+        describe: 'true or false',
+        hint: 'true refuses (500) a JSON answer without _links',
         type: 'boolean',
       },
     },
@@ -335,7 +342,7 @@ const SCHEMA = {
   },
 
   rateLimit: {
-    describe: 'false to disable the limits, or an object of limits',
+    describe: 'an object of limits, true for the defaults, or false for none',
     oneOf: [
       { type: 'boolean' },
       {
@@ -381,13 +388,13 @@ const SCHEMA = {
   },
 
   helmet: {
-    describe: 'false to disable helmet, or an object of helmet options',
+    describe: 'an object of helmet options, or false to disable helmet',
     oneOf: [{ const: false }, { type: 'object', unknown: 'allow' }],
   },
 
   filterParameters: {
     default: ['password', 'token', 'secret', 'authorization'],
-    describe: 'a list of parameter names to mask, or false to mask nothing',
+    describe: 'a list of parameter names to mask, or false',
     oneOf: [{ const: false }, { of: text(), type: 'array' }],
   },
 

--- a/packages/core/src/base/config-schema.js
+++ b/packages/core/src/base/config-schema.js
@@ -1,0 +1,407 @@
+/**
+ * The schema of the configuration henri owns.
+ *
+ * This is data, not code: every key of `config/<NODE_ENV>.json` that the
+ * framework reads is declared here with the type it accepts, what to say
+ * when something else arrives, and what to do about it. `config-validate.js`
+ * walks it, `0.config.js` runs it on every boot (over the file, the
+ * credentials and the environment alike) and `henri doctor` runs it without
+ * booting.
+ *
+ * The keys an application invents are none of henri's business: they are
+ * warned about, never refused, because `henri.config.get()` is how an
+ * application reads its own configuration.
+ *
+ * A node is a plain object:
+ *
+ * - `type`: `string`, `number`, `boolean`, `array`, `object`, `record`, `any`
+ * - `const`: the one value accepted (`false`, `'test'`)
+ * - `oneOf`: a list of nodes, any of which is accepted
+ * - `enum`, `insensitive`, `pattern`: constraints of a string
+ * - `integer`, `above`, `min`, `max`: constraints of a number
+ * - `of`: the node every item of an array must match
+ * - `keys`, `required`, `unknown`: the shape of an object
+ * - `values`: the node every value of a record must match
+ * - `describe`: what was expected, in words ("a whole number, at least 1")
+ * - `hint`: what to do about it
+ * - `default`: what henri uses when the key is absent (documentation only)
+ *
+ * `unknown` says what an object does with a key it does not declare:
+ * `warn` (the default) reports it, `near` reports it only when it looks
+ * like a misspelling of a declared one -- which is what a store does, since
+ * every key it does not know is forwarded to the driver -- and `allow`
+ * says nothing, for the option bags of other libraries (helmet, cors,
+ * nodemailer).
+ *
+ * Keeping this in step with `packages/core/index.d.ts` and with
+ * `website/src/content/docs/configuration.md` is not left to goodwill:
+ * `src/__tests__/config-schema.spec.js` compares the three and fails on the
+ * first key that is in one and not the others.
+ */
+
+/** The adapters `stores.<name>.adapter` accepts (`3.model.js` loads them) */
+const ADAPTERS = [
+  'disk',
+  'drizzle',
+  'mariadb',
+  'mongoose',
+  'mssql',
+  'mysql',
+  'postgresql',
+];
+
+/** The renderers `renderer` accepts (`3.view.js` loads them) */
+const RENDERERS = ['inertia', 'react', 'template', 'vue'];
+
+/** The dialects `stores.<name>.dialect` accepts on the drizzle adapter */
+const DIALECTS = ['mysql', 'postgres', 'sqlite'];
+
+/** A string that is not empty */
+const text = (extra = {}) => ({ pattern: /\S/u, type: 'string', ...extra });
+
+/** A number strictly above zero */
+const positive = (extra = {}) => ({
+  above: 0,
+  describe: 'a number of milliseconds above zero',
+  type: 'number',
+  ...extra,
+});
+
+/** One entry of `stores`: an adapter and how to reach its database */
+const STORE = {
+  hint: 'A store is { "adapter": "disk" } and the keys that adapter needs',
+  keys: {
+    adapter: {
+      describe: `one of ${ADAPTERS.join(', ')}`,
+      enum: ADAPTERS,
+      hint: 'Pick one and add its package to the application: @usehenri/<adapter>',
+      required: true,
+      type: 'string',
+    },
+    database: text({ describe: 'a database name' }),
+    dbName: text({ default: 'henri', describe: 'a database name (disk)' }),
+    dialect: {
+      describe: `one of ${DIALECTS.join(', ')} (drizzle)`,
+      enum: DIALECTS,
+      hint: 'The application installs the driver: better-sqlite3, pg or mysql2',
+      type: 'string',
+    },
+    host: text({ describe: 'a host name (or a url, on mongoose)' }),
+    migrate: {
+      describe: 'true to apply db/migrations on a production boot (drizzle)',
+      type: 'boolean',
+    },
+    opts: {
+      describe: 'an object of mongoose.connect() options',
+      type: 'object',
+      unknown: 'allow',
+    },
+    password: { type: 'string' },
+    path: text({
+      default: '.henri/data',
+      describe: 'a data directory, relative to the application (disk)',
+    }),
+    port: {
+      describe: 'a port number between 1 and 65535',
+      integer: true,
+      max: 65535,
+      min: 1,
+      type: 'number',
+    },
+    session: {
+      describe: 'an object of session store options',
+      type: 'object',
+      unknown: 'allow',
+    },
+    sessions: {
+      describe: 'true to create the session table without a user model',
+      type: 'boolean',
+    },
+    sync: {
+      describe: 'false to stop a development boot from pushing the schema',
+      type: 'boolean',
+    },
+    url: text({ describe: 'a connection string' }),
+    username: { type: 'string' },
+  },
+  // Everything else reaches the driver (Sequelize takes `logging`, `pool`,
+  // `dialectOptions`, ...), so only a misspelling is worth a word
+  type: 'object',
+  unknown: 'near',
+};
+
+/**
+ * The configuration henri owns, key by key. The order is the order of the
+ * documentation page.
+ */
+const SCHEMA = {
+  port: {
+    default: 3000,
+    describe: 'a port number between 1 and 65535',
+    hint: 'A port is a whole number: { "port": 3000 }. In development a busy one is replaced by the next free port',
+    integer: true,
+    max: 65535,
+    min: 1,
+    type: 'number',
+  },
+
+  host: text({
+    describe: 'an address to bind, as a string',
+    hint: 'An interface to bind: "127.0.0.1", "0.0.0.0". HENRI_HOST (what henri server --host sets) wins over the file',
+  }),
+
+  cors: {
+    describe: 'true for the cors defaults, or an object of cors options',
+    oneOf: [{ type: 'boolean' }, { type: 'object', unknown: 'allow' }],
+  },
+
+  renderer: {
+    default: 'template',
+    describe: `one of ${RENDERERS.join(', ')}`,
+    enum: RENDERERS,
+    hint: 'vue also needs { "experimental": { "vue": true } }',
+    insensitive: true,
+    type: 'string',
+  },
+
+  inertia: {
+    describe: 'an object of Inertia renderer options',
+    keys: {
+      entry: text({
+        default: 'main.jsx',
+        describe: 'a client entry, relative to app/views',
+      }),
+      id: text({ default: 'app', describe: 'the id of the root element' }),
+      ssr: { default: true, type: 'boolean' },
+      ssrEntry: text({
+        default: 'ssr.jsx',
+        describe: 'a server entry, relative to app/views',
+      }),
+      template: text({
+        default: 'index.html',
+        describe: 'an html shell, relative to app/views',
+      }),
+    },
+    type: 'object',
+  },
+
+  experimental: {
+    describe: 'an object of renderer opt-ins',
+    keys: { vue: { type: 'boolean' } },
+    type: 'object',
+  },
+
+  stores: {
+    describe: 'an object of named stores',
+    hint: 'A model picks one with its `store` key, or uses `default`',
+    type: 'record',
+    values: STORE,
+  },
+
+  secret: text({
+    describe: 'a string',
+    hint: 'Set it with HENRI_SECRET or the credentials, never in config/',
+  }),
+
+  user: {
+    describe:
+      'the name of the user model, or an object ({ model, public, loginPath, afterLogin, sessionMaxAge })',
+    oneOf: [
+      text(),
+      {
+        keys: {
+          afterLogin: text({
+            default: '/',
+            describe: 'a path to land on after a form login',
+          }),
+          loginPath: text({
+            default: '/login',
+            describe: 'a path to send denied browsers to',
+          }),
+          model: text({ default: 'user', describe: 'the user model name' }),
+          public: {
+            describe: 'a list of field names',
+            hint: 'externalId, email and roles are always public',
+            of: text(),
+            type: 'array',
+          },
+          sessionMaxAge: positive({
+            default: 2592000000,
+            describe: 'a session lifetime in milliseconds',
+          }),
+        },
+        type: 'object',
+      },
+    ],
+  },
+
+  baseRole: {
+    describe: 'a role name, or a list of them',
+    oneOf: [text(), { of: text(), type: 'array' }],
+  },
+
+  trustProxy: {
+    default: true,
+    describe:
+      "express' trust proxy setting: a boolean, a hop count or a list of addresses",
+    oneOf: [
+      { type: 'boolean' },
+      { integer: true, min: 0, type: 'number' },
+      text(),
+    ],
+  },
+
+  csrf: {
+    default: true,
+    describe: 'false to disable the CSRF protection',
+    type: 'boolean',
+  },
+
+  graphql: text({
+    default: '/_henri/gql',
+    describe: 'a path starting with /',
+    pattern: /^\//u,
+  }),
+
+  mail: {
+    describe: 'a nodemailer transport object, or "test"',
+    oneOf: [{ const: 'test' }, { type: 'object', unknown: 'allow' }],
+  },
+
+  mailers: {
+    describe: 'an object of mailer defaults',
+    keys: {
+      from: text({ describe: 'a sender address' }),
+      layout: {
+        default: 'mailer',
+        describe:
+          'the name of a layout in app/views/mailers/layouts, or false for none',
+        oneOf: [{ const: false }, text()],
+      },
+      previews: {
+        default: true,
+        describe: 'false to turn the development preview routes off',
+        type: 'boolean',
+      },
+    },
+    type: 'object',
+  },
+
+  api: {
+    describe: 'an object of JSON API settings',
+    keys: {
+      idempotency: {
+        describe:
+          'false, or an object ({ ttl, store }) of Idempotency-Key settings',
+        oneOf: [
+          { const: false },
+          {
+            keys: {
+              store: {
+                describe:
+                  'the module id of a shared { get, set, delete } store',
+                oneOf: [{ const: null }, text()],
+              },
+              ttl: positive({
+                default: 86400000,
+                describe: 'how long answers are kept, in milliseconds',
+              }),
+            },
+            type: 'object',
+          },
+        ],
+      },
+      maxPerPage: {
+        default: 100,
+        describe: 'a whole number of records, above zero',
+        integer: true,
+        min: 1,
+        type: 'number',
+      },
+      perPage: {
+        default: 25,
+        describe: 'a whole number of records, above zero',
+        integer: true,
+        min: 1,
+        type: 'number',
+      },
+      strict: {
+        default: false,
+        describe: 'true to refuse a JSON answer without _links',
+        type: 'boolean',
+      },
+    },
+    type: 'object',
+  },
+
+  rateLimit: {
+    describe: 'false to disable the limits, or an object of limits',
+    oneOf: [
+      { type: 'boolean' },
+      {
+        keys: {
+          auth: {
+            describe:
+              'false, or an object ({ windowMs, max, paths }) for the login paths',
+            oneOf: [
+              { const: false },
+              {
+                keys: {
+                  limit: positive({ describe: 'an alias of max' }),
+                  max: positive({
+                    default: 10,
+                    describe: 'a number of requests per window, above zero',
+                  }),
+                  paths: {
+                    describe: 'a list of paths to guard',
+                    of: text(),
+                    type: 'array',
+                  },
+                  windowMs: positive({ default: 60000 }),
+                },
+                type: 'object',
+              },
+            ],
+          },
+          limit: positive({ describe: 'an alias of max' }),
+          max: positive({
+            default: 600,
+            describe: 'a number of requests per window, above zero',
+          }),
+          store: {
+            describe:
+              'the module id of an express-rate-limit store, or of a (henri, { name }) => store factory',
+            oneOf: [{ const: null }, text()],
+          },
+          windowMs: positive({ default: 60000 }),
+        },
+        type: 'object',
+      },
+    ],
+  },
+
+  helmet: {
+    describe: 'false to disable helmet, or an object of helmet options',
+    oneOf: [{ const: false }, { type: 'object', unknown: 'allow' }],
+  },
+
+  filterParameters: {
+    default: ['password', 'token', 'secret', 'authorization'],
+    describe: 'a list of parameter names to mask, or false to mask nothing',
+    oneOf: [{ const: false }, { of: text(), type: 'array' }],
+  },
+
+  bodyLimit: {
+    default: '1mb',
+    describe: 'a size, as a string ("1mb") or a number of bytes',
+    oneOf: [text(), positive({ describe: 'a number of bytes above zero' })],
+  },
+
+  requestTimeout: {
+    default: 30000,
+    describe: 'a number of milliseconds above zero, or false',
+    oneOf: [{ const: false }, positive()],
+  },
+};
+
+module.exports = { ADAPTERS, DIALECTS, RENDERERS, SCHEMA, STORE };

--- a/packages/core/src/base/config-validate.js
+++ b/packages/core/src/base/config-validate.js
@@ -129,13 +129,15 @@ function received(value, masked = false) {
   }
 
   if (Array.isArray(value)) {
-    return value.length === 0 ? 'an empty list' : `a list of ${value.length}`;
+    if (value.length === 0) {
+      return 'an empty list';
+    }
+
+    return `a list of ${value.length} item${value.length === 1 ? '' : 's'}`;
   }
 
   if (typeof value === 'object') {
-    return masked
-      ? 'an object'
-      : `an object (${Object.keys(value).length} keys)`;
+    return 'an object';
   }
 
   if (masked) {
@@ -202,6 +204,53 @@ function matches(node, value) {
   walk(node, value, '', { mask: () => false, problems, source: () => null });
 
   return problems.every((problem) => problem.level !== 'error');
+}
+
+/**
+ * Is a value of the kind a node stands for? (a boolean for `boolean`, an
+ * object for `object`), whatever its content
+ *
+ * @param {object} node a schema node
+ * @param {any} value the value
+ * @returns {boolean} the right kind or not
+ */
+function accepts(node, value) {
+  if (Object.prototype.hasOwnProperty.call(node, 'const')) {
+    return value === node.const;
+  }
+
+  if (node.oneOf) {
+    return node.oneOf.some((branch) => accepts(branch, value));
+  }
+
+  if (node.type === 'array') {
+    return Array.isArray(value);
+  }
+
+  if (node.type === 'object' || node.type === 'record') {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+  }
+
+  return node.type === 'any' || typeof value === node.type;
+}
+
+/**
+ * The branch of a union a value belongs to
+ *
+ * The one it fully matches, or else the one it is the right kind for --
+ * `rateLimit: { max: "lots" }` is the object branch, and the message then
+ * names `rateLimit.max` rather than saying the whole key is wrong.
+ *
+ * @param {object} node a union node (`oneOf`)
+ * @param {any} value the value
+ * @returns {?object} the branch, or null when the value fits none
+ */
+function branchFor(node, value) {
+  return (
+    node.oneOf.find((branch) => matches(branch, value)) ||
+    node.oneOf.find((branch) => accepts(branch, value)) ||
+    null
+  );
 }
 
 /**
@@ -294,13 +343,13 @@ function walk(node, value, key, context) {
   }
 
   if (node.oneOf) {
-    if (!node.oneOf.some((branch) => matches(branch, value))) {
+    const branch = branchFor(node, value);
+
+    if (!branch) {
       wrong();
 
       return;
     }
-
-    const branch = node.oneOf.find((entry) => matches(entry, value));
 
     walk({ ...branch, hint: branch.hint || node.hint }, value, key, context);
 
@@ -431,7 +480,7 @@ function shape(node, value, key, context) {
     context.problems.push({
       expected: null,
       hint: suggestion
-        ? `Did you mean "${prefix}${suggestion}"?`
+        ? `Rename it to "${prefix}${suggestion}", or remove it`
         : 'henri ignores it; remove it, or keep it if the application reads it with henri.config.get()',
       key: path,
       level: 'warning',
@@ -534,17 +583,30 @@ function line(problem) {
 }
 
 /**
- * The problems as one message, in the shape the command line prints
+ * One line naming how many problems there are and which keys they are on
+ *
+ * @param {Array<object>} problems the problems of validate()
+ * @param {string} [header] what to say before them
+ * @returns {string} the line
+ */
+function summary(problems, header = 'invalid configuration') {
+  const count =
+    problems.length === 1 ? '1 problem' : `${problems.length} problems`;
+  const keys = [...new Set(problems.map((problem) => problem.key))];
+
+  return `${header} (${count}): ${keys.join(', ')}`;
+}
+
+/**
+ * The problems as one message: the summary, then a line per problem with
+ * where the value came from and what to do
  *
  * @param {Array<object>} problems the problems of validate()
  * @param {string} [header] what to say before them
  * @returns {string} the message
  */
 function format(problems, header = 'invalid configuration') {
-  const count =
-    problems.length === 1 ? '1 problem' : `${problems.length} problems`;
-
-  return [`${header} (${count})`, ...problems.map(line)].join('\n');
+  return [summary(problems, header), ...problems.map(line)].join('\n');
 }
 
 /**
@@ -560,7 +622,9 @@ class ConfigurationError extends Error {
    * @param {string} [header] what to say before them
    */
   constructor(problems, header = 'invalid configuration') {
-    super(format(problems, header));
+    // One line: the boot log and the command line both print `message`, and
+    // the problems are printed once, by whoever has the room for them
+    super(summary(problems, header));
     this.name = 'ConfigurationError';
     this.code = 'CONFIG_INVALID';
     this.exitCode = 1;
@@ -676,5 +740,6 @@ module.exports = {
   nearest,
   nodeAt,
   received,
+  summary,
   validate,
 };

--- a/packages/core/src/base/config-validate.js
+++ b/packages/core/src/base/config-validate.js
@@ -1,0 +1,680 @@
+/**
+ * The gate every configuration value goes through.
+ *
+ * `config-schema.js` says what henri accepts; this walks it and answers with
+ * every problem it found, never only the first: somebody fixing a
+ * configuration file should not discover its faults one boot at a time.
+ *
+ * A problem is `{ key, level, message, expected, received, source, hint }`.
+ * `error` fails the boot, `warning` never does -- an application may carry
+ * keys of its own, and `henri.config.get()` is how it reads them -- but a
+ * key that misspells one henri owns says so and names the right one.
+ *
+ * Values are never printed blindly: a key the configuration filters
+ * (`filterParameters`) and anything the credentials provided show up as
+ * their type alone, and the password of a connection string is always
+ * masked. `mask` in the options decides, key by key.
+ */
+
+const { MASK } = require('./redact');
+const { SCHEMA } = require('./config-schema');
+
+/** Longest string printed back in a message before it is cut */
+const MAX_LENGTH = 48;
+
+/** `scheme://user:password@host` -> `scheme://user:[FILTERED]@host` */
+const CREDENTIALS_IN_URL = /^([a-z][a-z0-9+.-]*:\/\/[^:@/\s]+):[^@\s/]*@/iu;
+
+/**
+ * Split a configuration key into path segments
+ *
+ * @param {string} key the key (`stores.default.adapter`)
+ * @returns {Array<string>} the segments
+ */
+const segments = (key) =>
+  String(key)
+    .split(/[.[\]]/u)
+    .filter((part) => part.length > 0);
+
+/**
+ * How far apart two names are (Levenshtein)
+ *
+ * @param {string} from the first name
+ * @param {string} to the second name
+ * @returns {number} the number of edits between them
+ */
+function distance(from, to) {
+  let previous = Array.from({ length: to.length + 1 }, (value, index) => index);
+
+  for (let row = 1; row <= from.length; row++) {
+    const current = [row];
+
+    for (let col = 1; col <= to.length; col++) {
+      current[col] = Math.min(
+        previous[col] + 1,
+        current[col - 1] + 1,
+        previous[col - 1] + (from[row - 1] === to[col - 1] ? 0 : 1)
+      );
+    }
+
+    previous = current;
+  }
+
+  return previous[to.length];
+}
+
+/**
+ * How wrong a name may be and still count as a misspelling of another
+ *
+ * @param {number} length the length of the name
+ * @returns {number} the largest distance that still suggests something
+ */
+function tolerance(length) {
+  if (length <= 4) {
+    return 1;
+  }
+
+  return length <= 8 ? 2 : 3;
+}
+
+/**
+ * The declared name an unknown one is probably a misspelling of
+ *
+ * A name that only has the case wrong always matches: the segments of
+ * `HENRI_CONFIG__<key>` are case sensitive, so `trustproxy` is the mistake
+ * people actually make.
+ *
+ * @param {string} name the unknown name
+ * @param {Array<string>} known the declared names
+ * @returns {?string} the closest one, or null when nothing is close
+ */
+function nearest(name, known) {
+  const lowered = name.toLowerCase();
+  const cased = known.find((candidate) => candidate.toLowerCase() === lowered);
+
+  if (cased) {
+    return cased;
+  }
+
+  const limit = tolerance(name.length);
+  let best = null;
+  let score = Infinity;
+
+  for (const candidate of known) {
+    const found = distance(lowered, candidate.toLowerCase());
+
+    if (found <= limit && found < score) {
+      best = candidate;
+      score = found;
+    }
+  }
+
+  return best;
+}
+
+/**
+ * A value, ready to be printed back in a message
+ *
+ * @param {any} value the value
+ * @param {boolean} [masked=false] print its type only
+ * @returns {string} what to print
+ */
+function received(value, masked = false) {
+  if (typeof value === 'undefined') {
+    return 'missing';
+  }
+
+  if (value === null) {
+    return 'null';
+  }
+
+  if (Array.isArray(value)) {
+    return value.length === 0 ? 'an empty list' : `a list of ${value.length}`;
+  }
+
+  if (typeof value === 'object') {
+    return masked
+      ? 'an object'
+      : `an object (${Object.keys(value).length} keys)`;
+  }
+
+  if (masked) {
+    return `a ${typeof value}`;
+  }
+
+  if (typeof value === 'string') {
+    const safe = value.replace(CREDENTIALS_IN_URL, `$1:${MASK}@`);
+    const cut =
+      safe.length > MAX_LENGTH ? `${safe.slice(0, MAX_LENGTH)}...` : safe;
+
+    return `the string "${cut}"`;
+  }
+
+  return `the ${typeof value} ${String(value)}`;
+}
+
+/**
+ * What a node accepts, in words
+ *
+ * @param {object} node a schema node
+ * @returns {string} the expectation ("a whole number between 1 and 65535")
+ */
+function describe(node) {
+  if (node.describe) {
+    return node.describe;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(node, 'const')) {
+    return JSON.stringify(node.const);
+  }
+
+  if (node.oneOf) {
+    return node.oneOf.map(describe).join(', or ');
+  }
+
+  if (node.enum) {
+    return `one of ${node.enum.join(', ')}`;
+  }
+
+  const words = {
+    any: 'anything',
+    array: 'a list',
+    boolean: 'true or false',
+    number: 'a number',
+    object: 'an object',
+    record: 'an object',
+    string: 'a string',
+  };
+
+  return words[node.type] || 'a valid value';
+}
+
+/**
+ * Does a value match a node? (no message, used to pick a branch of `oneOf`)
+ *
+ * @param {object} node a schema node
+ * @param {any} value the value
+ * @returns {boolean} matching or not
+ */
+function matches(node, value) {
+  const problems = [];
+
+  walk(node, value, '', { mask: () => false, problems, source: () => null });
+
+  return problems.every((problem) => problem.level !== 'error');
+}
+
+/**
+ * Check a number against its constraints
+ *
+ * @param {object} node a schema node
+ * @param {number} value the value
+ * @returns {boolean} valid or not
+ */
+function validNumber(node, value) {
+  if (!Number.isFinite(value)) {
+    return false;
+  }
+
+  if (node.integer && !Number.isInteger(value)) {
+    return false;
+  }
+
+  if (typeof node.above === 'number' && value <= node.above) {
+    return false;
+  }
+
+  if (typeof node.min === 'number' && value < node.min) {
+    return false;
+  }
+
+  return !(typeof node.max === 'number' && value > node.max);
+}
+
+/**
+ * Check a string against its constraints
+ *
+ * @param {object} node a schema node
+ * @param {string} value the value
+ * @returns {boolean} valid or not
+ */
+function validString(node, value) {
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  if (node.enum) {
+    const list = node.insensitive
+      ? node.enum.map((entry) => entry.toLowerCase())
+      : node.enum;
+
+    return list.includes(node.insensitive ? value.toLowerCase() : value);
+  }
+
+  return !(node.pattern && !node.pattern.test(value));
+}
+
+/**
+ * Walk a node and collect the problems of a value
+ *
+ * @param {object} node a schema node
+ * @param {any} value the value at that key
+ * @param {string} key the configuration key (`stores.default.url`)
+ * @param {object} context `{ problems, mask, source }`
+ * @returns {void}
+ */
+function walk(node, value, key, context) {
+  const report = (level, message, extra = {}) =>
+    context.problems.push({
+      expected: describe(node),
+      hint: node.hint || null,
+      key,
+      level,
+      message,
+      received: received(value, context.mask(key)),
+      source: context.source(key),
+      ...extra,
+    });
+  const wrong = () =>
+    report(
+      'error',
+      `"${key}" must be ${describe(node)}, but it is ${received(value, context.mask(key))}`
+    );
+
+  if (typeof value === 'undefined') {
+    return;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(node, 'const')) {
+    if (value !== node.const) {
+      wrong();
+    }
+
+    return;
+  }
+
+  if (node.oneOf) {
+    if (!node.oneOf.some((branch) => matches(branch, value))) {
+      wrong();
+
+      return;
+    }
+
+    const branch = node.oneOf.find((entry) => matches(entry, value));
+
+    walk({ ...branch, hint: branch.hint || node.hint }, value, key, context);
+
+    return;
+  }
+
+  switch (node.type) {
+    case 'any':
+      return;
+
+    case 'boolean':
+      if (typeof value !== 'boolean') {
+        wrong();
+      }
+
+      return;
+
+    case 'number':
+      if (!validNumber(node, value)) {
+        wrong();
+      }
+
+      return;
+
+    case 'string':
+      if (!validString(node, value)) {
+        wrong();
+      }
+
+      return;
+
+    case 'array':
+      if (!Array.isArray(value)) {
+        wrong();
+
+        return;
+      }
+
+      value.forEach((entry, index) =>
+        walk(node.of, entry, `${key}[${index}]`, context)
+      );
+
+      return;
+
+    case 'record':
+      if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        wrong();
+
+        return;
+      }
+
+      for (const [name, entry] of Object.entries(value)) {
+        walk(node.values, entry, `${key}.${name}`, context);
+      }
+
+      return;
+
+    case 'object':
+      if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        wrong();
+
+        return;
+      }
+
+      shape(node, value, key, context);
+
+      return;
+
+    default:
+      return;
+  }
+}
+
+/**
+ * Check the keys of an object node: the declared ones against their node,
+ * the required ones for their presence, the rest against `unknown`
+ *
+ * @param {object} node an object node
+ * @param {object} value the object
+ * @param {string} key the configuration key ('' at the root)
+ * @param {object} context `{ problems, mask, source }`
+ * @returns {void}
+ */
+function shape(node, value, key, context) {
+  const keys = node.keys || {};
+  const known = Object.keys(keys);
+  const prefix = key === '' ? '' : `${key}.`;
+  const unknown = node.unknown || (node.keys ? 'warn' : 'allow');
+
+  for (const [name, child] of Object.entries(keys)) {
+    const path = `${prefix}${name}`;
+
+    if (typeof value[name] === 'undefined') {
+      if (child.required) {
+        context.problems.push({
+          expected: describe(child),
+          hint: child.hint || null,
+          key: path,
+          level: 'error',
+          message: `"${path}" is missing and must be ${describe(child)}`,
+          received: 'missing',
+          source: context.source(key === '' ? name : key),
+        });
+      }
+
+      continue;
+    }
+
+    walk(child, value[name], path, context);
+  }
+
+  if (unknown === 'allow') {
+    return;
+  }
+
+  for (const name of Object.keys(value)) {
+    if (Object.prototype.hasOwnProperty.call(keys, name)) {
+      continue;
+    }
+
+    const path = `${prefix}${name}`;
+    const suggestion = nearest(name, known);
+
+    if (!suggestion && unknown === 'near') {
+      continue;
+    }
+
+    context.problems.push({
+      expected: null,
+      hint: suggestion
+        ? `Did you mean "${prefix}${suggestion}"?`
+        : 'henri ignores it; remove it, or keep it if the application reads it with henri.config.get()',
+      key: path,
+      level: 'warning',
+      message: suggestion
+        ? `"${path}" is not a henri configuration key: did you mean "${prefix}${suggestion}"?`
+        : `"${path}" is not a henri configuration key`,
+      received: received(value[name], context.mask(path)),
+      source: context.source(path),
+    });
+  }
+}
+
+/**
+ * The checks that need more than one key
+ *
+ * @param {object} config the configuration
+ * @param {object} context `{ problems, mask, source }`
+ * @returns {void}
+ */
+function related(config, context) {
+  const renderer = String(config.renderer || '').toLowerCase();
+  const experimental = config.experimental || {};
+
+  if (renderer === 'vue' && experimental.vue !== true) {
+    context.problems.push({
+      expected: '{ "experimental": { "vue": true } }',
+      hint: 'The vue renderer has not been exercised since 2020: prefer react, inertia or template',
+      key: 'renderer',
+      level: 'error',
+      message:
+        '"renderer" is "vue", which only loads with { "experimental": { "vue": true } }',
+      received: 'the string "vue"',
+      source: context.source('renderer'),
+    });
+  }
+}
+
+/**
+ * Validate a configuration against the schema
+ *
+ * @param {object} config the configuration, after the credentials and the
+ *   environment have been applied
+ * @param {object} [options] options
+ * @param {object} [options.schema=SCHEMA] the schema to validate against
+ * @param {function} [options.source] `(key) => string`, where a value came
+ *   from (a file name, a credentials file, an environment variable)
+ * @param {function} [options.mask] `(key) => boolean`, true to print the
+ *   type of a value instead of the value itself
+ * @returns {{errors: Array<object>, problems: Array<object>, warnings: Array<object>}} what was found
+ */
+function validate(config, options = {}) {
+  const context = {
+    mask: options.mask || (() => false),
+    problems: [],
+    source: options.source || (() => null),
+  };
+  const schema = options.schema || SCHEMA;
+
+  if (!config || typeof config !== 'object' || Array.isArray(config)) {
+    return {
+      errors: [
+        {
+          expected: 'an object',
+          hint: 'config/<NODE_ENV>.json holds a JSON object',
+          key: '',
+          level: 'error',
+          message: `the configuration must be an object, but it is ${received(config)}`,
+          received: received(config),
+          source: context.source(''),
+        },
+      ],
+      problems: [],
+      warnings: [],
+    };
+  }
+
+  shape({ keys: schema, type: 'object', unknown: 'warn' }, config, '', context);
+  related(config, context);
+
+  const { problems } = context;
+
+  return {
+    errors: problems.filter((problem) => problem.level === 'error'),
+    problems,
+    warnings: problems.filter((problem) => problem.level === 'warning'),
+  };
+}
+
+/**
+ * A problem on one line, with where the value came from and what to do
+ *
+ * @param {object} problem one problem of validate()
+ * @returns {string} the lines
+ */
+function line(problem) {
+  const from = problem.source ? ` (from ${problem.source})` : '';
+  const hint = problem.hint ? `\n    ${problem.hint}` : '';
+
+  return `  ${problem.message}${from}${hint}`;
+}
+
+/**
+ * The problems as one message, in the shape the command line prints
+ *
+ * @param {Array<object>} problems the problems of validate()
+ * @param {string} [header] what to say before them
+ * @returns {string} the message
+ */
+function format(problems, header = 'invalid configuration') {
+  const count =
+    problems.length === 1 ? '1 problem' : `${problems.length} problems`;
+
+  return [`${header} (${count})`, ...problems.map(line)].join('\n');
+}
+
+/**
+ * A boot failure carrying every problem found, shaped like the errors of
+ * the command line (`code`, `hint`, and a message that reads on its own)
+ *
+ * @class ConfigurationError
+ * @extends {Error}
+ */
+class ConfigurationError extends Error {
+  /**
+   * @param {Array<object>} problems the problems of validate()
+   * @param {string} [header] what to say before them
+   */
+  constructor(problems, header = 'invalid configuration') {
+    super(format(problems, header));
+    this.name = 'ConfigurationError';
+    this.code = 'CONFIG_INVALID';
+    this.exitCode = 1;
+    this.hint =
+      'Every key henri reads is documented at https://usehenri.io/reference/configuration/';
+    this.problems = problems;
+  }
+}
+
+/**
+ * The schema node at a configuration key, walking records and the branches
+ * of a union. This is what tells `0.config.js` the type an environment
+ * variable should be read as when the file has no value at that key.
+ *
+ * @param {string} key the configuration key (`stores.default.url`)
+ * @param {object} [schema=SCHEMA] the schema
+ * @returns {?object} the node, or null when henri does not own that key
+ */
+function nodeAt(key, schema = SCHEMA) {
+  let node = { keys: schema, type: 'object' };
+
+  for (const part of segments(key)) {
+    if (!node) {
+      return null;
+    }
+
+    if (node.type === 'record') {
+      node = node.values;
+      continue;
+    }
+
+    const branches = node.oneOf || [node];
+    const found = branches
+      .map((branch) => branch.keys && branch.keys[part])
+      .find(Boolean);
+
+    node = found || null;
+  }
+
+  return node;
+}
+
+/**
+ * The javascript types a node accepts
+ *
+ * @param {?object} node a schema node
+ * @returns {Array<string>} `boolean`, `number`, `object` and/or `string`
+ */
+function kinds(node) {
+  if (!node) {
+    return [];
+  }
+
+  if (Object.prototype.hasOwnProperty.call(node, 'const')) {
+    return node.const === null ? [] : [typeof node.const];
+  }
+
+  if (node.oneOf) {
+    return node.oneOf.flatMap(kinds);
+  }
+
+  if (node.type === 'record') {
+    return ['object'];
+  }
+
+  return ['boolean', 'number', 'object', 'string'].includes(node.type)
+    ? [node.type]
+    : [];
+}
+
+/**
+ * The type an environment variable should be read as, from the schema
+ *
+ * Only what the raw value can plausibly be counts: `HENRI_CONFIG__port=nope`
+ * answers null rather than `number`, so the value reaches the validator and
+ * fails there, naming the key, the variable and what was expected, instead
+ * of failing here on the type alone.
+ *
+ * @param {string} key the configuration key
+ * @param {string} raw the value of the variable
+ * @param {object} [schema=SCHEMA] the schema
+ * @returns {?string} `boolean`, `number`, `object`, `string`, or null when
+ *   henri owns no such key (or the value cannot be one of its types)
+ */
+function coercionFor(key, raw, schema = SCHEMA) {
+  const list = kinds(nodeAt(key, schema));
+
+  if (list.includes('boolean') && /^(true|false)$/iu.test(raw)) {
+    return 'boolean';
+  }
+
+  if (
+    list.includes('number') &&
+    raw.trim() !== '' &&
+    Number.isFinite(Number(raw))
+  ) {
+    return 'number';
+  }
+
+  if (list.includes('string')) {
+    return 'string';
+  }
+
+  return null;
+}
+
+module.exports = {
+  ConfigurationError,
+  coercionFor,
+  describe,
+  distance,
+  format,
+  nearest,
+  nodeAt,
+  received,
+  validate,
+};

--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -24,7 +24,7 @@ Configuration is JSON in the `config` directory. henri loads `config/<NODE_ENV>.
 }
 ```
 
-The file is parsed on boot: a syntax error is reported with its line, and the boot stops when no file can be loaded. The loaded object is frozen.
+The file is parsed on boot: a syntax error is reported with its line, and the boot stops when no file can be loaded. The loaded object is frozen, then [checked against henri's schema](#validation) before any other module starts.
 
 Every key below is declared in `@usehenri/core`, so an editor completes them as you type. `henri.config.get()` and a hand-built configuration object take the same shape, `import('@usehenri/core').Configuration` — see [Types](/reference/types/).
 
@@ -35,22 +35,22 @@ Every key below is declared in `@usehenri/core`, so an editor completes them as 
 | `port`             | `3000`        | Port to listen on. In development a busy port is replaced by the next free one; under `NODE_ENV=test` the kernel assigns one.                  |
 | `host`             | see below     | Interface to bind: `127.0.0.1` outside production, `0.0.0.0` in production. `HENRI_HOST` (what `henri server --host` sets) wins over the file. |
 | `cors`             | off           | `true` enables [cors](https://github.com/expressjs/cors) with its defaults; an object is passed to it as options.                              |
-| `renderer`         | `template`    | View engine: `react`, `inertia` or `template` (Handlebars). `henri new` writes `react`. See [Views](/guides/views/).                           |
+| `renderer`         | `template`    | View engine: `react`, `inertia` or `template` (Handlebars), whatever the case. `henri new` writes `react`. See [Views](/guides/views/).        |
 | `inertia`          |               | Options of the Inertia renderer: `ssr`, `id`, `entry`, `ssrEntry`, `template`. See [Views](/guides/views/#inertia).                            |
 | `experimental`     |               | Opt-in to unmaintained renderers: `{ "vue": true }`.                                                                                           |
 | `stores`           |               | Named database stores, see below. A model picks one with its `store` key or uses `default`.                                                    |
 | `secret`           |               | Session and token secret. Required as soon as a user model exists; usually provided by `HENRI_SECRET`.                                         |
 | `user`             | `user`        | Name of the user model, or an object (below). See [Users](/guides/users/).                                                                     |
 | `baseRole`         |               | Role, or list of roles, given to every new user.                                                                                               |
-| `trustProxy`       | `true`        | Express `trust proxy` setting: `X-Forwarded-*` headers from a reverse proxy are honoured. Set `false` without one.                             |
+| `trustProxy`       | `true`        | Express `trust proxy`: `true`, a hop count or a list of addresses; `X-Forwarded-*` headers are honoured. Set `false` without a proxy.          |
 | `csrf`             | `true`        | `false` disables the [CSRF protection](/guides/users/#csrf).                                                                                   |
 | `graphql`          | `/_henri/gql` | Path of the GraphQL endpoint. See [GraphQL](/guides/graphql/).                                                                                 |
 | `mail`             |               | Nodemailer transport options, or `"test"` for an Ethereal test account. See [Mail](/guides/mail/).                                             |
 | `mailers`          |               | Defaults of the [mailers](/guides/mail/): `from`, `layout` and `previews`, see below.                                                          |
 | `api`              |               | Pagination, strict HAL and idempotency settings of the [JSON API](/guides/api/), see below.                                                    |
-| `rateLimit`        | `600`/min     | Global, authentication and shared-store rate limits, see below. `false` disables them.                                                         |
+| `rateLimit`        | `600`/min     | Global, authentication and shared-store rate limits, see below. `false` disables them, `true` keeps the defaults.                              |
 | `helmet`           | on            | Options merged over henri's [helmet](https://helmetjs.github.io/) defaults; `false` disables it.                                               |
-| `filterParameters` | see below     | Parameter names masked in the logs.                                                                                                            |
+| `filterParameters` | see below     | Parameter names masked in the logs; `false` masks nothing.                                                                                     |
 | `bodyLimit`        | `1mb`         | Maximum size of a JSON or form body.                                                                                                           |
 | `requestTimeout`   | `30000`       | Milliseconds before a running request is answered `503`; `false` disables it.                                                                  |
 
@@ -84,6 +84,7 @@ Each entry of `stores` names an adapter and how to reach its database. The adapt
 | `host`, `port`, `database`, `username`, `password` | mongoose, SQL | Alternative to `url`. On mongoose, `host` may also be a full `mongodb://` url.                                                                                                                                           |
 | `opts`                                             | mongoose      | Options passed to `mongoose.connect()`; henri sets `connectTimeoutMS` and `serverSelectionTimeoutMS` to 10 seconds.                                                                                                      |
 | `session`                                          | mongoose, SQL | Options of the session store (connect-mongo, whose collection is `henriSessions`, or connect-session-sequelize).                                                                                                         |
+| `sessions`                                         | drizzle       | `true` creates the session table even when the application has no user model.                                                                                                                                            |
 | `path`, `dbName`, `port`                           | disk          | Data directory, relative to the application (`.henri/data`), database name (`henri`), and the port mongod listens on (one derived from the process id, between 20000 and 26999, so parallel boots never collide).        |
 | `logging`, `pool`, `dialectOptions`, ...           | SQL           | Every other key is forwarded to Sequelize. `logging` defaults to the `henri:sequelize` debug namespace.                                                                                                                  |
 | `dialect`                                          | drizzle       | `sqlite`, `postgres` or `mysql`; the app installs the driver (`better-sqlite3`, `pg` or `mysql2`).                                                                                                                       |
@@ -95,18 +96,30 @@ See [Models](/guides/models/#adapters) for each adapter.
 
 The keys of the [JSON API](/guides/api/), all optional:
 
-| Key                                   | Default                                            | Description                                                                                                                                                                                  |
-| ------------------------------------- | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `api.perPage`, `api.maxPerPage`       | `25`, `100`                                        | Page size read by `req.pagination()` and its upper bound.                                                                                                                                    |
-| `api.strict`                          | `false`                                            | Refuse (500) a JSON answer without `_links` on a `resources`/`crud` route instead of logging it.                                                                                             |
-| `api.idempotency`                     | `{ "ttl": 86400000, "store": null }`               | How long answers are kept for `Idempotency-Key` replays and the module exporting a shared `{ get, set, delete }` store; `false` disables the feature.                                        |
-| `rateLimit.windowMs`, `rateLimit.max` | `60000`, `600`                                     | The global limit per user or ip, not enforced in development.                                                                                                                                |
-| `rateLimit.auth`                      | `{ "windowMs": 60000, "max": 10 }`                 | The limit on `POST` to the login and register-style paths (`paths` overrides the list); `false` disables it.                                                                                 |
-| `rateLimit.store`                     |                                                    | Module exporting an express-rate-limit `Store` (or a `(henri, { name }) => store` factory) shared between processes.                                                                         |
-| `helmet`                              |                                                    | Options merged over henri's defaults (a development CSP that allows hot reloading, no HSTS outside production, `upgrade-insecure-requests` only on https requests); `false` disables helmet. |
-| `filterParameters`                    | `["password", "token", "secret", "authorization"]` | Substrings of the parameter names masked in everything `henri.pen` prints.                                                                                                                   |
-| `bodyLimit`                           | `"1mb"`                                            | Passed to the JSON and urlencoded body parsers.                                                                                                                                              |
-| `requestTimeout`                      | `30000`                                            | Milliseconds before a `503`; `false` disables the timeout.                                                                                                                                   |
+| Key                             | Default                              | Description                                                                                                                                           |
+| ------------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `api.perPage`, `api.maxPerPage` | `25`, `100`                          | Page size read by `req.pagination()` and its upper bound.                                                                                             |
+| `api.strict`                    | `false`                              | Refuse (500) a JSON answer without `_links` on a `resources`/`crud` route instead of logging it.                                                      |
+| `api.idempotency`               | `{ "ttl": 86400000, "store": null }` | How long answers are kept for `Idempotency-Key` replays and the module exporting a shared `{ get, set, delete }` store; `false` disables the feature. |
+
+## Rate limits
+
+`rateLimit` is `false` to lift every limit, `true` for the defaults, or an object. Nothing is enforced in development.
+
+| Key                                   | Default                            | Description                                                                                                          |
+| ------------------------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `rateLimit.windowMs`, `rateLimit.max` | `60000`, `600`                     | The global limit per user or ip. `limit` is accepted as an alias of `max`, the name express-rate-limit 8 uses.       |
+| `rateLimit.auth`                      | `{ "windowMs": 60000, "max": 10 }` | The limit on `POST` to the login and register-style paths (`paths` overrides the list); `false` disables it.         |
+| `rateLimit.store`                     |                                    | Module exporting an express-rate-limit `Store` (or a `(henri, { name }) => store` factory) shared between processes. |
+
+## Headers, logs and limits
+
+| Key                | Default                                            | Description                                                                                                                                                                                  |
+| ------------------ | -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `helmet`           |                                                    | Options merged over henri's defaults (a development CSP that allows hot reloading, no HSTS outside production, `upgrade-insecure-requests` only on https requests); `false` disables helmet. |
+| `filterParameters` | `["password", "token", "secret", "authorization"]` | Substrings of the parameter names masked in everything `henri.pen` prints; `false` masks nothing.                                                                                            |
+| `bodyLimit`        | `"1mb"`                                            | Passed to the JSON and urlencoded body parsers; a string (`"1mb"`) or a number of bytes.                                                                                                     |
+| `requestTimeout`   | `30000`                                            | Milliseconds before a `503`; `false` disables the timeout.                                                                                                                                   |
 
 ## Environment and `.env`
 
@@ -152,7 +165,7 @@ HENRI_CONFIG_JSON__rateLimit='{"windowMs":60000,"max":100}'
 
 The segments are the configuration keys **verbatim**, so their case matters: `HENRI_CONFIG__baseRole`, never `HENRI_CONFIG__BASEROLE`.
 
-**The type comes from the file, henri never guesses it.** When the configuration already has a value at that path, the variable is read as its type: a number for `port`, `true`/`false` for a boolean, JSON for an object. A path the file does not have is a string — a connection string stays a connection string even when it looks like a number. `HENRI_CONFIG_JSON__<key>` parses the value as JSON in every case, which is how you set a nested object, an array, or a key no file declares.
+**The type comes from the file, then from the schema; henri never guesses it.** When the configuration already has a value at that path, the variable is read as its type: a number for `port`, `true`/`false` for a boolean, JSON for an object. When it does not, the type is the one [the schema](#validation) declares for that key, so `HENRI_CONFIG__port=8080` is the number `8080` in an application whose file never names a port. A key henri does not own and the file does not have is a string — a connection string stays a connection string even when it looks like a number. `HENRI_CONFIG_JSON__<key>` parses the value as JSON in every case, which is how you set a nested object, an array, or a key no file declares.
 
 A value that does not fit its key fails the boot, naming the variable and the type it expected. A variable set to nothing fails too (`HENRI_CONFIG__port is set but empty: give it a value or unset it`): a missing variable is simply not an override and never becomes an empty string. The value itself is never part of an error message — it may be a secret.
 
@@ -267,6 +280,47 @@ Every duration is a number of milliseconds or a string: `'250ms'`, `'30s'`, `'5m
 ```
 
 `public` lists the fields, besides `externalId`, `email` and `roles`, that views and JSON answers may see; `loginPath` is where browsers are sent when a route denies them; `afterLogin` where they land after a form login; `sessionMaxAge` the session lifetime in milliseconds (30 days). See [Users](/guides/users/).
+
+## Validation
+
+Every key above is declared in a schema (`@usehenri/core`, `src/base/config-schema.js`) with the type it accepts. On boot, once the file has loaded and the credentials and the environment have been applied over it, the whole configuration goes through that schema — **before any other module starts**, so a wrong value fails on the first line of the boot rather than three modules in, where the message would name the reader instead of the mistake.
+
+**Every problem is reported, not the first one.** Somebody fixing a configuration file should not discover its faults one boot at a time.
+
+**A value henri cannot use fails the boot**, naming the key, what was expected, what arrived, and where the value came from — the file, the credentials, or the variable:
+
+```
+config ✖ "port" must be a port number between 1 and 65535, but it is the string "eight thousand" => from config/production.json
+config ✖ "stores.default.adapter" must be one of disk, drizzle, mariadb, mongoose, mssql, mysql, postgresql, but it is the string "redis" => from HENRI_CONFIG__stores__default__adapter
+config ✖ "secret" must be a string, but it is a number => from the credentials (config/credentials/production.json.enc)
+```
+
+The source matters: `port must be a number` is unhelpful when the culprit is an environment variable three deployments away. A value the [filters](#headers-logs-and-limits) name, and anything the credentials provided, is printed as its type alone; the password of a connection string is always masked.
+
+`henri server` exits `1` and `henri server --json` prints the same thing as `{ "error": { "code": "CONFIG_INVALID", "message", "hint", "problems": [...] } }`, where each problem is `{ key, level, message, expected, received, source, hint }`.
+
+**An unknown key is a warning, never a failure.** An application may carry keys of its own — `henri.config.get()` is how it reads them — so henri says it ignores the key and boots:
+
+```
+config ⚠ "appName" is not a henri configuration key => from config/default.json
+```
+
+**Unless it is a near miss of one henri owns**, which is the mistake actually being made:
+
+```
+config ⚠ "renderers" is not a henri configuration key: did you mean "renderer"? => from config/default.json
+```
+
+Inside a store this is the only unknown-key warning there is: everything a store adapter does not declare is forwarded to the driver (`logging`, `pool`, `dialectOptions`), so only `adaptor` or `urls` are worth a word.
+
+**`henri doctor` runs the same schema over every `config/*.json`**, without booting and without a database, which is the fastest way to find a broken configuration — and the one a coding agent reaches for:
+
+```bash
+henri doctor
+henri doctor --json    # problems as { check, level, message, file, hint }
+```
+
+The checks are `config.invalid` (an error), `config.adapter` (an unknown store adapter) and `config.unknown` (a warning). Being a file check, it sees neither the environment nor the credentials; the boot does.
 
 ## Reading the configuration in your code
 

--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -48,6 +48,7 @@ Every key below is declared in `@usehenri/core`, so an editor completes them as 
 | `mail`             |               | Nodemailer transport options, or `"test"` for an Ethereal test account. See [Mail](/guides/mail/).                                             |
 | `mailers`          |               | Defaults of the [mailers](/guides/mail/): `from`, `layout` and `previews`, see below.                                                          |
 | `api`              |               | Pagination, strict HAL and idempotency settings of the [JSON API](/guides/api/), see below.                                                    |
+| `jobs`             |               | Settings of the [job queue](/guides/jobs/), see below. The queue also loads when `app/jobs` holds a file.                                      |
 | `rateLimit`        | `600`/min     | Global, authentication and shared-store rate limits, see below. `false` disables them, `true` keeps the defaults.                              |
 | `helmet`           | on            | Options merged over henri's [helmet](https://helmetjs.github.io/) defaults; `false` disables it.                                               |
 | `filterParameters` | see below     | Parameter names masked in the logs; `false` masks nothing.                                                                                     |
@@ -246,6 +247,7 @@ Everything the [job queue](/guides/jobs/) reads, all of it optional. It only loa
 | Key             | Default      | Description                                                                                                                                  |
 | --------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | `store`         | `default`    | Which store of `stores` holds the queue.                                                                                                     |
+| `priority`      | `0`          | Priority of a job that names none; the higher, the sooner it is claimed.                                                                     |
 | `table`         | `henri_jobs` | Table (or collection) name; the schedules live in `<table>_schedules`. Letters, digits and underscores only.                                 |
 | `queue`         | `default`    | Queue of a job that names none.                                                                                                              |
 | `queues`        | all          | Queues a runner takes from when `henri jobs` is given no `--queue`.                                                                          |

--- a/website/src/content/docs/guides/agents.md
+++ b/website/src/content/docs/guides/agents.md
@@ -80,7 +80,7 @@ henri doctor          # a report, exit 1 when something is wrong
 henri doctor --json   # the same as JSON
 ```
 
-It checks the Node version, `config/default.json` and its syntax, the secret and the `.env` that holds it, the git ignore rules, the store adapter, the routes file and every route's controller and action, controller naming and unused controllers, model naming and location, the page files a `resources` route needs, the test configuration, the dependencies declared in `package.json` and the ones actually installed, and the presence of `AGENTS.md`. Problems are reported as errors or warnings, each with a file and a hint.
+It checks the Node version, every `config/*.json` — its syntax, then the whole file against [henri's configuration schema](/configuration/#validation), so a wrong value or a misspelled key is found without booting — the secret and the `.env` that holds it, the git ignore rules, the routes file and every route's controller and action, controller naming and unused controllers, model naming and location, the page files a `resources` route needs, the test configuration, the dependencies declared in `package.json` and the ones actually installed, and the presence of `AGENTS.md`. Problems are reported as errors or warnings, each with a file and a hint.
 
 ## The `henri` MCP server
 

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -249,7 +249,7 @@ Without a command, `henri jobs` runs a worker: it claims jobs, performs up to `-
 henri doctor [--json]
 ```
 
-Checks the application against the conventions without starting it: no database, no views, nothing booted. Reports the Node version, the configuration and its syntax, the secret and the `.env` holding it, the git ignore rules, the credentials keys (not ignored, or already in the git index), the store adapter, the routes and each route's controller and action, controller and model naming, the page files a `resources` route needs, the test configuration, the declared and installed dependencies, and `AGENTS.md`. Exits with `1` when it finds an error. See [Coding agents](/guides/agents/).
+Checks the application against the conventions without starting it: no database, no views, nothing booted. Reports the Node version, the syntax of every `config/*.json` and each one run through [henri's configuration schema](/configuration/#validation) (`config.invalid`, `config.adapter` and `config.unknown`, the last one for a key henri does not own), the secret and the `.env` holding it, the git ignore rules, the credentials keys (not ignored, or already in the git index), the routes and each route's controller and action, controller and model naming, the page files a `resources` route needs, the test configuration, the declared and installed dependencies, and `AGENTS.md`. Exits with `1` when it finds an error. See [Coding agents](/guides/agents/).
 
 ## `mcp`
 
@@ -329,4 +329,4 @@ A boot that fails prints the same chart with the module that threw, what was sti
 | `3`  | `NOT_A_PROJECT` | Not a henri application: run the command from the root of the app.           |
 | `4`  | `NEEDS_TTY`     | An interactive prompt was needed but stdin is not a terminal: pass the flag. |
 
-With `--json` a failure prints `{ "error": { "command", "message", "hint", "code", "exitCode" } }` on stderr. See [Coding agents](/guides/agents/).
+With `--json` a failure prints `{ "error": { "command", "message", "hint", "code", "exitCode" } }` on stderr. The `code` is finer grained than the exit code: `CONFIG_INVALID` when henri refuses a configuration, and that object then also carries a `problems` array (`{ key, level, message, expected, received, source, hint }`). See [Coding agents](/guides/agents/).

--- a/website/src/content/docs/reference/types.md
+++ b/website/src/content/docs/reference/types.md
@@ -142,6 +142,12 @@ annotation when a helper builds part of it:
 const config = { renderer: 'react', stores: { default: { adapter: 'disk' } } };
 ```
 
+It cannot drift from what henri actually accepts: the declarations and the
+[schema the boot runs](/configuration/#validation) are compared key by key by
+`@usehenri/core`'s own suite, along with the table of the
+[configuration page](/configuration/#keys). Adding a key means adding it in
+all three.
+
 ## What is not typed
 
 - **The models.** `Task` is a Mongoose `Model`, a Sequelize `ModelStatic` or a


### PR DESCRIPTION
A wrong configuration used to be found late or not at all: a misspelled key was silently absent, a string where a number belongs reached the code that used it, and a missing key threw only when something asked for it, several modules into the boot.

The whole configuration is now checked against a schema before anything starts, and every problem is reported at once rather than one boot at a time. This is the first piece of the owner's direction that henri should check its own inputs at the boundaries, since JavaScript is not typed and the type declarations vanish at runtime. Configuration comes first because it fails earliest and most confusingly.

An error names the key, what was expected, what arrived, where the value came from, and what to do:

```
config ✖ "port" must be a port number between 1 and 65535, but it is the string "eight thousand" => from HENRI_CONFIG__port
config ⚠ "trustproxy" is not a henri configuration key: did you mean "trustProxy"? => from config/production.json
```

I verified that myself on a real boot rather than from the report. Values arriving from the environment and from encrypted credentials go through the same gate, which matters because "port must be a number" is useless when the culprit is a variable in a deployment somewhere. An unknown key is a warning, not a failure, since applications carry their own, but a near miss of a key henri owns says so.

**Hand-written rather than a schema library**, and the argument is sound: the messages are the product, and no library emits provenance or henri's hints, so a mapping layer of comparable size would sit on top of a dependency shipped to every application. The repository already hand-writes its route expander, its redactor, its credentials cipher and its environment reader for the same reason.

**The schema, the type declarations and the documentation are held together by a test** that compares all three and fails when a key exists in one and not the others. It found real drift on its first run: eight places where the documentation or the declarations were wrong, including a whole configuration section that was documented and read by the code but absent from the types, and the jobs keys that landed today.

No configuration in the repository turned out to be invalid.

Doctor runs the same schema, so an agent catches it without booting.

Verified after the boot rework landed: the invariant it depends on still holds, configuration is alone at the first level and completes before anything else starts. Suite green at 1334, types, lint, format and the smoke test all pass.