### PR TITLE
Warn on an overridden route, refuse a malformed controller name

### DIFF
--- a/.changeset/route-diagnostics.md
+++ b/.changeset/route-diagnostics.md
@@ -1,0 +1,9 @@
+---
+'@usehenri/core': patch
+---
+
+Two things the routes file used to do quietly.
+
+A route declared twice now warns at boot when the later entry points at a different controller, naming both entries and both controllers. Later still wins, which is what lets a line correct a `resources` block above it, and repeating the same entry stays silent.
+
+A controller name is now checked where it is written. `{ controller: 'ship ' }` used to travel all the way to the loader and surface as a missing controller, sending you to look for a file that was right there; it now fails at boot naming the route and saying what a controller name may contain. The same applies to the action after the `#`.

--- a/packages/core/src/5.router.js
+++ b/packages/core/src/5.router.js
@@ -108,7 +108,14 @@ class Router extends BaseModule {
       }
     }
 
-    this.routes = table(this.rawRoutes);
+    this.routes = table(this.rawRoutes, {
+      onOverride: ({ route, previous, controller, declaredBy, by }) =>
+        this.henri.pen.warn(
+          'router',
+          `${route} is declared twice: "${declaredBy}" gives it to ${previous},`,
+          `"${by}" overrides it with ${controller}`
+        ),
+    });
 
     for (let key of Object.keys(this.routes)) {
       if (typeof this.routes[key] !== 'undefined') {

--- a/packages/core/src/__tests__/routes-dsl.spec.js
+++ b/packages/core/src/__tests__/routes-dsl.spec.js
@@ -450,4 +450,61 @@ describe('routes dsl', () => {
       expect(normalize('/')).toBe('/');
     });
   });
+
+  describe('refusing what will not resolve', () => {
+    test('a controller with a space is refused where it is written', () => {
+      // A trailing space used to travel to the loader and surface as a
+      // missing controller, sending the reader to look for a file that is
+      // right there
+      expect(() =>
+        expand({ 'resources ship': { controller: 'ship ' } })
+      ).toThrow(/not a controller name/);
+      expect(() => expand({ 'get /x': 'a b#index' })).toThrow(
+        /not a controller name/
+      );
+      expect(() => expand({ 'get /y': 'tasks#in dex' })).toThrow(
+        /not an action name/
+      );
+    });
+
+    test('a namespaced controller is still a name', () => {
+      expect(expand({ 'get /a': 'admin/tasks#index' })).toHaveLength(1);
+      expect(expand({ 'get /b': 'my-tasks#index' })).toHaveLength(1);
+      expect(expand({ 'get /c': 'tasks_2#index' })).toHaveLength(1);
+    });
+  });
+
+  describe('a route that overrides another', () => {
+    test('says which entry took it, and from whom', () => {
+      const overrides = [];
+
+      expand(
+        {
+          'get /tasks': 'legacy#index',
+          'resources tasks': { controller: 'tasks' },
+        },
+        { onOverride: (event) => overrides.push(event) }
+      );
+
+      expect(overrides).toHaveLength(1);
+      expect(overrides[0]).toMatchObject({
+        by: 'resources tasks',
+        controller: 'tasks#index',
+        declaredBy: 'get /tasks',
+        previous: 'legacy#index',
+        route: 'get /tasks',
+      });
+    });
+
+    test('stays quiet when the same entry is simply repeated', () => {
+      const overrides = [];
+
+      expand(
+        { 'get /tasks': 'tasks#index' },
+        { onOverride: (event) => overrides.push(event) }
+      );
+
+      expect(overrides).toHaveLength(0);
+    });
+  });
 });

--- a/packages/core/src/base/routes.js
+++ b/packages/core/src/base/routes.js
@@ -215,6 +215,45 @@ function routeOptions(opts) {
   return out;
 }
 
+/** A controller name: a path of segments, no spaces, no surprises */
+const NAME = /^[a-z0-9][a-z0-9_-]*(\/[a-z0-9][a-z0-9_-]*)*$/i;
+
+/** An action name */
+const ACTION = /^[a-z_][a-z0-9_]*$/i;
+
+/**
+ * Refuse a controller or action that will not resolve to a file.
+ *
+ * A trailing space in `{ controller: 'ship ' }` used to travel all the way to
+ * the loader and surface as a missing controller, which sends the reader
+ * looking for a file that is right there.
+ *
+ * @param {string} controller what the route named, for the message
+ * @param {string} name the controller part
+ * @param {?string} action the action part, when the route named one
+ * @param {string} route the path, for the message
+ * @returns {void}
+ * @throws {Error} when either part is not a usable name
+ */
+function assertName(controller, name, action, route) {
+  const quoted = JSON.stringify(controller);
+
+  if (!NAME.test(name)) {
+    throw new Error(
+      `route "${route}" points at ${quoted}, which is not a controller name: ` +
+        'use letters, digits, dashes and underscores, with "/" for a ' +
+        'directory. A stray space is the usual cause.'
+    );
+  }
+
+  if (typeof action === 'string' && !ACTION.test(action)) {
+    throw new Error(
+      `route "${route}" points at ${quoted}, which is not an action name: ` +
+        'use letters, digits and underscores after the "#".'
+    );
+  }
+}
+
 /**
  * Builds one route object
  *
@@ -227,6 +266,8 @@ function build({ verb, route, controller, options = {}, resource = false }) {
   }
 
   const [name, action] = controller.split('#');
+
+  assertName(controller, name, action, route);
   const entry = Object.assign({}, options, {
     controller,
     path: `${action}_${name}_path`,
@@ -459,8 +500,9 @@ function expandEntry(key, value, context = {}) {
  * @param {object} [rawRoutes={}] the content of config/routes.js
  * @returns {Array<object>} the routes
  */
-function expand(rawRoutes = {}) {
+function expand(rawRoutes = {}, { onOverride = null } = {}) {
   const seen = new Map();
+  const from = new Map();
 
   for (const [key, value] of Object.entries(rawRoutes || {})) {
     if (typeof value === 'undefined' || value === null) {
@@ -468,8 +510,24 @@ function expand(rawRoutes = {}) {
     }
 
     for (const route of expandEntry(key, value)) {
-      // Later keys win, and keep the position of the first one
-      seen.set(`${route.verb} ${route.route}`, route);
+      const id = `${route.verb} ${route.route}`;
+      const previous = seen.get(id);
+
+      // Later keys win, and keep the position of the first one. Say so when
+      // the winner is a different controller: a resources entry quietly
+      // shadowing a route written above it is hard to see in a routes file.
+      if (previous && previous.controller !== route.controller && onOverride) {
+        onOverride({
+          by: key,
+          controller: route.controller,
+          declaredBy: from.get(id),
+          previous: previous.controller,
+          route: id,
+        });
+      }
+
+      from.set(id, key);
+      seen.set(id, route);
     }
   }
 
@@ -482,10 +540,10 @@ function expand(rawRoutes = {}) {
  * @param {object} [rawRoutes={}] the content of config/routes.js
  * @returns {object} the table
  */
-function table(rawRoutes = {}) {
+function table(rawRoutes = {}, options = {}) {
   const out = {};
 
-  for (const route of expand(rawRoutes)) {
+  for (const route of expand(rawRoutes, options)) {
     out[`${route.verb} ${route.route}`] = route;
   }
 

--- a/website/src/content/docs/guides/routes.md
+++ b/website/src/content/docs/guides/routes.md
@@ -187,6 +187,22 @@ module.exports = {
 };
 ```
 
+## When two entries claim the same route
+
+Later entries win, which is what lets a `resources` block be corrected by a line below it. When
+the winner is a different controller, henri says so at boot rather than leaving you to wonder
+why a route reaches the wrong place:
+
+```
+router ⚠ get /tasks is declared twice: "get /tasks" gives it to legacy#index, "resources tasks" overrides it with tasks#index
+```
+
+Repeating the same entry is silent, since nothing changed.
+
+A controller name is checked when the routes are expanded. `{ controller: 'ship ' }` fails at
+boot naming the route, rather than travelling to the loader and surfacing later as a missing
+controller, which sends you looking for a file that is right there.
+
 ## Named paths
 
 Every loaded route gets a name, `<action>_<controller>_path` (`show_todo_path`, `index_categories_path`), mapping to `{ method, route, roles }`. The rule holds whatever the route came from, so a member route of `posts` is `archive_posts_path` and a controller in a sub-directory keeps its folder: `admin/users#index` is `index_admin/users_path`. Pages rendered with `res.render()` (and the JSON answer of the same URL) receive them in `paths`, filtered by the roles of the current user; a page served by the view engine's fallback, without a controller, only gets the routes that need no role. The React and Inertia helpers `pathFor()` and `getRoute()` build URLs from these names, so a renamed route does not break your links.


### PR DESCRIPTION
Two issues open since July 2019, #80 and #81, both about the routes file failing quietly.

A route declared twice silently took the later entry. That is the right behaviour, because it lets a line correct a `resources` block written above it, but it happened without a word, so a resources entry shadowing a route was invisible. It now warns when the winner is a different controller, naming both entries and both controllers, and stays silent when the same entry is simply repeated.

A controller name was never checked. `{ controller: 'ship ' }` travelled all the way to the loader and surfaced as a missing controller, which sends the reader looking for a file that is right there. It now fails where it is written, naming the route and saying what a name may contain, and the same applies to the action after the hash. Namespaced, hyphenated and numbered names all still pass.

Suite green at 1338, types, lint and format clean.