### PR TITLE
Say why the pepper pre-hash is not a password hash

### DIFF
--- a/packages/core/src/base/password.js
+++ b/packages/core/src/base/password.js
@@ -362,6 +362,9 @@ function peppered(password, key) {
     return password;
   }
 
+  // Not a password hash: bcrypt takes no key, so the pepper is applied by
+  // pre-hashing and the digest below is what bcrypt then hashes properly.
+  // codeql[js/insufficient-password-hash]
   return crypto.createHmac('sha256', key).update(password).digest('base64');
 }
 


### PR DESCRIPTION
CodeQL flagged the pepper as insecure password hashing on #347. It is a false positive, and I checked rather than assumed: bcrypt takes no key, so a pepper is applied by pre-hashing with a keyed digest, and that digest is passed straight to bcrypt for hashing and comparison. It is never stored as the password hash. Both call sites confirm it.

This adds the explanation in the code, where the next reader of that function will need it, and the suppression so the alert stops recurring on a construction that is correct.