### PR TITLE
Say when a renderer is installed and never configured, and pin the 2019 logout report

### DIFF
--- a/.changeset/suggest-the-installed-renderer.md
+++ b/.changeset/suggest-the-installed-renderer.md
@@ -1,0 +1,17 @@
+---
+'@usehenri/core': patch
+---
+
+henri says when a renderer is installed and never configured
+
+`config.renderer` defaults to handlebars, which is right for an application with no view engine and confusing for one that installed `@usehenri/inertia`, wrote pages and wonders why they are not the ones being rendered. Nothing fails, so nothing said anything.
+
+The boot now names it once:
+
+```text
+  view ✏  @usehenri/inertia is installed but "renderer" is not set, so pages are rendered with handlebars => add "renderer": "inertia" to your configuration
+```
+
+Only when the key is absent. An explicit `"renderer": "template"` is a decision and is left alone.
+
+Closes #40, open since 2018.

--- a/packages/core/src/3.view.js
+++ b/packages/core/src/3.view.js
@@ -1,4 +1,5 @@
 const BaseModule = require('./base/module');
+const { suggestedRenderer } = require('./base/renderer');
 
 const allowed = {
   inertia: 'inertia',
@@ -52,9 +53,22 @@ class View extends BaseModule {
   async init() {
     const { config, pen } = this.henri;
 
-    this.renderer = config.has('renderer')
+    const configured = config.has('renderer');
+
+    this.renderer = configured
       ? config.get('renderer').toLowerCase()
       : 'template';
+
+    if (!configured) {
+      const suggestion = suggestedRenderer(process.cwd());
+
+      suggestion &&
+        pen.warn(
+          'view',
+          `${suggestion.package} is installed but "renderer" is not set, so pages are rendered with handlebars`,
+          `=> add "renderer": "${suggestion.renderer}" to your configuration`
+        );
+    }
 
     const engines = Object.assign({}, allowed);
 

--- a/packages/core/src/__tests__/auth-sqlite.spec.js
+++ b/packages/core/src/__tests__/auth-sqlite.spec.js
@@ -212,4 +212,39 @@ describe('auth (sequelize sqlite store)', () => {
     expect(res.body).toEqual({ ok: true });
     expect((await agent.get('/profile')).status).toBe(401);
   });
+
+  test('a session whose user is gone is anonymous, not an error (#65)', async () => {
+    const ghost = supertest.agent(app);
+
+    await henri._user.create({
+      email: 'ghost@usehenri.io',
+      name: 'Ghost',
+      password,
+    });
+
+    const login = await ghost
+      .post('/login')
+      .send({ email: 'ghost@usehenri.io', password });
+
+    expect(login.status).toBe(200);
+
+    const user = await henri.user.findByEmail('ghost@usehenri.io');
+
+    await henri._user.destroy({ force: true, where: { id: user.id } });
+
+    // Passport answers `done(null, false)` for a row that is no longer
+    // there, so the request is anonymous rather than failing to
+    // deserialize, and signing out of it works
+    const profile = await ghost
+      .get('/profile')
+      .set('Accept', 'application/json');
+
+    expect(profile.status).toBe(401);
+
+    const out = await ghost
+      .post('/logout')
+      .set('X-CSRF-Token', cookieOf(login, 'henri.csrf'));
+
+    expect(out.status).toBe(200);
+  });
 });

--- a/packages/core/src/__tests__/renderer.spec.js
+++ b/packages/core/src/__tests__/renderer.spec.js
@@ -1,0 +1,59 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { PACKAGES, suggestedRenderer } = require('../base/renderer');
+
+/**
+ * An application directory with a package.json of the given dependencies
+ *
+ * @param {object} manifest what package.json holds ({} for none)
+ * @returns {string} the directory
+ */
+const application = (manifest) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'henri-renderer-'));
+
+  manifest &&
+    fs.writeFileSync(
+      path.join(dir, 'package.json'),
+      JSON.stringify(manifest, null, 2)
+    );
+
+  return dir;
+};
+
+describe('the renderer an application installed', () => {
+  test('names the package and the value to configure', () => {
+    expect(
+      suggestedRenderer(
+        application({ dependencies: { '@usehenri/inertia': '^1.1.0' } })
+      )
+    ).toEqual({ package: '@usehenri/inertia', renderer: 'inertia' });
+
+    expect(
+      suggestedRenderer(
+        application({ devDependencies: { '@usehenri/react': '^1.1.0' } })
+      )
+    ).toEqual({ package: '@usehenri/react', renderer: 'react' });
+  });
+
+  test('suggests nothing when there is nothing to suggest', () => {
+    expect(
+      suggestedRenderer(application({ dependencies: { next: '^16' } }))
+    ).toBeNull();
+    // No package.json at all, and a directory that does not exist
+    expect(suggestedRenderer(application(null))).toBeNull();
+    expect(suggestedRenderer('/nowhere/at/all')).toBeNull();
+  });
+
+  test('every suggestion names a renderer the view module accepts', () => {
+    const view = fs.readFileSync(
+      path.join(__dirname, '..', '3.view.js'),
+      'utf8'
+    );
+
+    for (const [, renderer] of PACKAGES) {
+      expect(view).toContain(`${renderer}: '${renderer}'`);
+    }
+  });
+});

--- a/packages/core/src/base/renderer.js
+++ b/packages/core/src/base/renderer.js
@@ -1,0 +1,56 @@
+/**
+ * Which renderer an application meant to use.
+ *
+ * `config.renderer` decides, and its default is handlebars. That is right
+ * for an application with no view engine and confusing for one that
+ * installed `@usehenri/inertia` and wonders why its pages are not the ones
+ * being rendered: nothing fails, so nothing says anything.
+ */
+const fs = require('fs');
+const path = require('path');
+
+/** The renderer a package installs, in the order they are suggested */
+const PACKAGES = [
+  ['@usehenri/inertia', 'inertia'],
+  ['@usehenri/react', 'react'],
+];
+
+/**
+ * The renderer an application installed but never configured.
+ *
+ * Without `renderer` henri renders Handlebars, which is right for an
+ * application that has no engine and confusing for one that installed a
+ * renderer and expects its pages to be used: nothing fails, the pages are
+ * simply not the ones being rendered. An explicit `"renderer": "template"`
+ * is a decision and is left alone; a missing key is the case worth a word.
+ *
+ * @param {string} dir the application directory
+ * @returns {?{package: string, renderer: string}} the suggestion, or null
+ */
+function suggestedRenderer(dir) {
+  let manifest;
+
+  try {
+    manifest = JSON.parse(
+      fs.readFileSync(path.join(dir, 'package.json'), 'utf8')
+    );
+  } catch {
+    return null;
+  }
+
+  const declared = Object.assign(
+    {},
+    manifest.dependencies,
+    manifest.devDependencies
+  );
+
+  for (const [name, renderer] of PACKAGES) {
+    if (declared[name]) {
+      return { package: name, renderer };
+    }
+  }
+
+  return null;
+}
+
+module.exports = { PACKAGES, suggestedRenderer };


### PR DESCRIPTION
Two of the seven issues left open since 2018 and 2019, closed with code rather than with a comment.

## #40, from 2018: suggest a renderer that is installed but not configured

`config.renderer` defaults to handlebars. That is right for an application with no view engine, and confusing for one that installed `@usehenri/inertia`, wrote pages and wonders why they are not the ones being rendered. Nothing fails, so nothing said anything.

```text
  view ✏  @usehenri/inertia is installed but "renderer" is not set, so pages are rendered with handlebars => add "renderer": "inertia" to your configuration
```

Only when the key is absent. An explicit `"renderer": "template"` is a decision and is left alone. The suggestion lives in `base/renderer.js` so it can be tested on its own, and one of its tests asserts every renderer it can suggest is one the view module accepts, which is how this goes wrong a year from now.

## #65, from 2019: "failed to deserialized user on logout"

The report has no body and the user module has been rewritten since. Rather than close it as stale, this pins the behaviour it was about: the deserializer answers `done(null, false)` for a row that is no longer there, so a session whose user was deleted reads as anonymous rather than as an error, and signing out of it works. The test creates the account, signs in, deletes the row and then asks for a page and signs out.

## Verification

`pnpm test`, `pnpm lint --max-warnings 0`, `pnpm format:check`, and `scripts/smoke.sh` on a scaffolded application.

Closes #40. Closes #65.