### PR TITLE
henri credentials:rotate

### DIFF
--- a/.changeset/rotate-the-credentials-key.md
+++ b/.changeset/rotate-the-credentials-key.md
@@ -1,0 +1,17 @@
+---
+'@usehenri/cli': minor
+---
+
+`henri credentials:rotate`: a new key, the same secrets
+
+A key that may have leaked has to stop opening the file, and until now that meant a manual sequence — show the values, generate a key, edit, paste everything back — which is exactly the kind of thing that ends with a secret in a shell history.
+
+```bash
+henri credentials:rotate --env production
+```
+
+The file is re-encrypted under a fresh key and the values are untouched. The current key has to open the file first, so a rotation is never a way to lose the contents, and the re-encrypted file is read back before the new key is stored: a rotation that cannot be verified puts the old file back and changes nothing.
+
+The new key is written to `config/credentials/<env>.key`, or printed once when `HENRI_CREDENTIALS_KEY` held the old one, because a deployment that deliberately has no key file should not be given one. `--json` never prints it. The old key opens nothing afterwards, so everything holding a copy needs the new one before its next boot.
+
+Closes #57, open since 2018.

--- a/packages/cli/__tests__/credentials.spec.js
+++ b/packages/cli/__tests__/credentials.spec.js
@@ -214,6 +214,111 @@ fs.writeFileSync(
     ).toBe(before);
   });
 
+  test('rotate re-encrypts under a new key and keeps the values', () => {
+    edit();
+
+    const keyFile = path.join(app, 'config', 'credentials', 'dev.key');
+    const file = path.join(app, 'config', 'credentials', 'dev.json.enc');
+    const before = {
+      content: fs.readFileSync(file, 'utf8'),
+      key: fs.readFileSync(keyFile, 'utf8').trim(),
+    };
+
+    const { status, stdout } = run(['credentials:rotate', '--env', 'dev'], app);
+
+    expect(status).toBe(0);
+    expect(stdout).toContain('Re-encrypted config/credentials/dev.json.enc');
+    expect(stdout).toContain('Wrote the new key to config/credentials/dev.key');
+    expect(stdout).not.toContain(SECRET);
+
+    const after = {
+      content: fs.readFileSync(file, 'utf8'),
+      key: fs.readFileSync(keyFile, 'utf8').trim(),
+    };
+
+    expect(after.key).toMatch(/^[0-9a-f]{64}$/);
+    expect(after.key).not.toBe(before.key);
+    expect(after.content).not.toBe(before.content);
+    expect(fs.statSync(keyFile).mode & 0o777).toBe(0o600);
+
+    // The values survived, and the old key opens nothing
+    const opened = run(['credentials:show', '--env', 'dev'], app);
+
+    expect(JSON.parse(opened.stdout).mail.auth.pass).toBe(SECRET);
+
+    fs.rmSync(keyFile);
+
+    const stale = henri(['credentials:show', '--env', 'dev', '--json'], {
+      cwd: app,
+      env: { ...process.env, HENRI_CREDENTIALS_KEY: before.key },
+    });
+
+    expect(stale.status).toBe(1);
+    expect(JSON.parse(stale.stderr).error.message).toContain(
+      'could not be decrypted'
+    );
+  });
+
+  test('rotate prints the new key when the environment held the old one', () => {
+    edit();
+
+    const keyFile = path.join(app, 'config', 'credentials', 'dev.key');
+    const old = fs.readFileSync(keyFile, 'utf8').trim();
+
+    fs.rmSync(keyFile);
+
+    const { status, stdout } = henri(['credentials:rotate', '--env', 'dev'], {
+      cwd: app,
+      env: { ...process.env, HENRI_CREDENTIALS_KEY: old },
+    });
+    const printed = (stdout.match(/[0-9a-f]{64}/u) || [])[0];
+
+    expect(status).toBe(0);
+    expect(printed).toBeDefined();
+    expect(printed).not.toBe(old);
+    // A deployment that has no key file is not given one
+    expect(fs.existsSync(keyFile)).toBe(false);
+
+    const opened = henri(['credentials:show', '--env', 'dev'], {
+      cwd: app,
+      env: { ...process.env, HENRI_CREDENTIALS_KEY: printed },
+    });
+
+    expect(JSON.parse(opened.stdout).mail.auth.pass).toBe(SECRET);
+
+    // --json never prints it
+    const asJson = henri(['credentials:rotate', '--env', 'dev', '--json'], {
+      cwd: app,
+      env: { ...process.env, HENRI_CREDENTIALS_KEY: printed },
+    });
+
+    expect(asJson.stdout).not.toMatch(/[0-9a-f]{64}/u);
+    expect(JSON.parse(asJson.stdout).command).toBe('rotate');
+  });
+
+  test('rotate needs the current key, and changes nothing without it', () => {
+    edit();
+
+    const file = path.join(app, 'config', 'credentials', 'dev.json.enc');
+    const before = fs.readFileSync(file, 'utf8');
+
+    fs.rmSync(path.join(app, 'config', 'credentials', 'dev.key'));
+
+    const { status, stderr } = henri(
+      ['credentials:rotate', '--env', 'dev', '--json'],
+      {
+        cwd: app,
+        env: { ...process.env, HENRI_CREDENTIALS_KEY: 'ab'.repeat(32) },
+      }
+    );
+
+    expect(status).toBe(1);
+    expect(JSON.parse(stderr).error.message).toContain(
+      'could not be decrypted'
+    );
+    expect(fs.readFileSync(file, 'utf8')).toBe(before);
+  });
+
   test('a wrong key says so without quoting anything', () => {
     edit();
 

--- a/packages/cli/scripts/credentials.js
+++ b/packages/cli/scripts/credentials.js
@@ -7,7 +7,7 @@ const { CliError } = require('./errors');
 const { usage } = require('./help');
 const { validInstall } = require('./utils');
 
-const COMMANDS = ['edit', 'show'];
+const COMMANDS = ['edit', 'rotate', 'show'];
 
 /** What a new credentials file starts with: the secret henri needs anyway */
 const TEMPLATE = () => ({
@@ -318,7 +318,85 @@ const show = (credentials, cwd, env) => {
 };
 
 /**
- * Runs `henri credentials <edit|show>` (`henri credentials:<command>` too)
+ * Runs `henri credentials:rotate`: re-encrypts the file under a new key.
+ *
+ * What rotates is the key, not the values. An operator who thinks a key may
+ * have leaked wants the file to stop opening with the old one, in one step
+ * rather than "show, generate a key, edit, paste it all back", which is the
+ * kind of manual sequence that ends with a secret in a shell history.
+ *
+ * The old key has to open the file first, so a rotation is never a way to
+ * lose the contents. The new file is read back with the new key before the
+ * key itself is stored: if that verification fails, the old file is put back
+ * and nothing has moved. The new key is written where the old one came from
+ * -- the key file on a development machine, and standard output when the key
+ * arrived in the environment, because a deployment that deliberately has no
+ * key file should not be given one.
+ *
+ * @param {object} credentials core's credentials module
+ * @param {string} cwd the application directory
+ * @param {string} env the environment
+ * @returns {object} what happened ({ command, env, file, keys, source })
+ * @throws {CliError} FAILED when the file will not open, or will not verify
+ */
+const rotate = (credentials, cwd, env) => {
+  const found = read(credentials, cwd, env);
+  const { source } = credentials.readKey(cwd, env);
+  const file = credentials.fileFor(cwd, env);
+  const relative = path.relative(cwd, file);
+  const previous = fs.readFileSync(file);
+  const next = credentials.generateKey();
+  const key = credentials.parseKey(next, 'the new key');
+
+  credentials.write(cwd, env, found.values, key);
+
+  try {
+    credentials.decrypt(fs.readFileSync(file, 'utf8'), key, env, relative);
+  } catch (error) {
+    fs.writeFileSync(file, previous, { mode: 0o600 });
+
+    throw new CliError(
+      'FAILED',
+      `${relative} did not read back after being re-encrypted`,
+      {
+        cause: error,
+        hint: 'The file was put back as it was; the key did not change',
+      }
+    );
+  }
+
+  const keyFile = credentials.keyFileFor(cwd, env);
+  const inEnvironment = source === credentials.KEY_VARIABLE;
+
+  if (inEnvironment) {
+    return { command: 'rotate', env, file: relative, key: next, source };
+  }
+
+  try {
+    fs.writeFileSync(keyFile, `${next}\n`, { mode: 0o600 });
+  } catch (error) {
+    // The file is already encrypted with a key nothing has stored yet:
+    // printing it is the recovery, and it is better than losing the file
+    throw new CliError(
+      'FAILED',
+      `${relative} was re-encrypted but ${path.relative(cwd, keyFile)} could not be written`,
+      {
+        cause: error,
+        hint: `Save this key now, it is the only one that opens the file: ${next}`,
+      }
+    );
+  }
+
+  return {
+    command: 'rotate',
+    env,
+    file: relative,
+    source: path.relative(cwd, keyFile),
+  };
+};
+
+/**
+ * Runs `henri credentials <edit|rotate|show>` (`henri credentials:<command>` too)
  *
  * `--json` prints the key paths, never a value: the decrypted content only
  * ever reaches stdout, from `credentials:show` without `--json`.
@@ -349,13 +427,11 @@ const main = async (args) => {
   const credentials = load();
   const cwd = process.cwd();
   const env = environmentOf(args);
-  const result =
-    command === 'edit'
-      ? edit(credentials, cwd, env)
-      : show(credentials, cwd, env);
+  const runners = { edit, rotate, show };
+  const result = runners[command](credentials, cwd, env);
 
   if (args.json) {
-    const { values, ...safe } = result;
+    const { key, values, ...safe } = result;
 
     console.log(JSON.stringify(safe, null, 2));
 
@@ -364,6 +440,31 @@ const main = async (args) => {
 
   if (command === 'show') {
     console.log(JSON.stringify(result.values, null, 2));
+
+    return;
+  }
+
+  if (command === 'rotate') {
+    console.log('');
+    console.log(`  Re-encrypted ${result.file} under a new key.`);
+
+    if (result.key) {
+      console.log(
+        `  ${credentials.KEY_VARIABLE} held the old one, so here is the new one, once:`
+      );
+      console.log('');
+      console.log(`    ${result.key}`);
+      console.log('');
+      console.log(
+        '  Set it wherever the deployment reads it from before the next boot.'
+      );
+    } else {
+      console.log(`  Wrote the new key to ${result.source}.`);
+    }
+
+    console.log('  The old key opens nothing now. Anything holding a copy');
+    console.log('  of it -- a deployment, a teammate -- needs the new one.');
+    console.log('');
 
     return;
   }
@@ -380,6 +481,7 @@ const main = async (args) => {
 module.exports = main;
 module.exports.COMMANDS = COMMANDS;
 module.exports.edit = edit;
+module.exports.rotate = rotate;
 module.exports.environmentOf = environmentOf;
 module.exports.ignore = ignore;
 module.exports.show = show;

--- a/packages/cli/scripts/help.js
+++ b/packages/cli/scripts/help.js
@@ -208,7 +208,14 @@ const COMMANDS = [
       'edit decrypts into a file only you can read, opens EDITOR (or VISUAL)',
       'and encrypts what comes back; the plaintext is removed on every exit',
       'path. The first edit of an environment generates the key and the file.',
-      'Neither command prints a secret with --json.',
+      '',
+      'rotate re-encrypts the file under a fresh key, which is what to run',
+      'when a key may have leaked. The old key has to open the file first,',
+      'and the new file is read back before the new key is stored, so a',
+      'rotation cannot lose the contents. The new key is written to the key',
+      'file, or printed once when HENRI_CREDENTIALS_KEY held the old one.',
+      '',
+      'No command prints a secret with --json.',
     ],
     examples: [
       {
@@ -222,6 +229,10 @@ const COMMANDS = [
       {
         command: 'henri credentials:show --env production --json',
         description: 'The key paths the file holds, without their values',
+      },
+      {
+        command: 'henri credentials:rotate --env production',
+        description: 'Re-encrypts under a new key; the old one opens nothing',
       },
     ],
     flags: [
@@ -241,6 +252,10 @@ const COMMANDS = [
       {
         description: 'decrypt, open EDITOR, encrypt what comes back',
         name: 'edit',
+      },
+      {
+        description: 're-encrypt under a new key, keeping the values',
+        name: 'rotate',
       },
       {
         description: 'print the decrypted credentials on stdout',

--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -191,6 +191,7 @@ Rails' `credentials:edit`, in henri. `config/credentials/<env>.json.enc` holds t
 henri credentials:edit                     # the development environment
 henri credentials:edit --env production    # creates the key and the file
 henri credentials:show --env production --json   # the key paths, no values
+henri credentials:rotate --env production        # a new key, same values
 ```
 
 `edit` decrypts into a file only you can read, opens `EDITOR` (or `VISUAL`) on it, and encrypts what comes back when the editor closes. The plaintext is removed on every exit path, including an editor that fails and an interrupted process, and what you save must be a JSON object or the credentials are left as they were.
@@ -205,6 +206,8 @@ henri credentials:show --env production --json   # the key paths, no values
 ```
 
 **The key** is `HENRI_CREDENTIALS_KEY`, or `config/credentials/<env>.key` (64 hexadecimal characters, what `openssl rand -hex 32` prints). The variable wins. `henri new` ignores `config/credentials/*.key` from the first commit, `henri credentials:edit` adds the line when it generates a key, and `henri doctor` reports a key that is not ignored or that reached the git index. When the file exists and no key can be found, the boot stops with `config/credentials/production.json.enc needs a key: set HENRI_CREDENTIALS_KEY, or put it back in config/credentials/production.key` — never a silent boot without secrets.
+
+**Rotating the key** is `henri credentials:rotate`: the file is re-encrypted under a fresh key and the values are untouched, which is what to run when a key may have leaked. The current key has to open the file first and the new file is read back before the new key is stored, so a rotation cannot lose the contents. The new key is written to `config/credentials/<env>.key`, or printed once when `HENRI_CREDENTIALS_KEY` held the old one, because a deployment that deliberately has no key file should not be given one. Everything holding the old key needs the new one before its next boot.
 
 **The cipher is AES-256-GCM**, from node's own crypto. The envelope is one line, `henri:v1:<iv>:<tag>:<ciphertext>`, all base64, and the environment name is authenticated along with the content: a modified file, a wrong key, and a `production.json.enc` renamed to `staging.json.enc` all fail loudly instead of decrypting to nonsense. No error message quotes the file, the key or a decrypted value.
 

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -215,6 +215,7 @@ The other four drive the migrations of a [Drizzle](/guides/models/#drizzle) stor
 ```bash
 henri credentials:edit [--env=<name>]
 henri credentials:show [--env=<name>] [--json]
+henri credentials:rotate [--env=<name>] [--json]
 ```
 
 The encrypted secrets of an environment, in the Rails `credentials:` style (`henri credentials edit` works too). `--env` defaults to `NODE_ENV`, and to `dev` when it is unset, which is the environment henri reads its configuration file under; `--production` selects production like everywhere else.
@@ -223,7 +224,9 @@ The encrypted secrets of an environment, in the Rails `credentials:` style (`hen
 
 `show` prints the decrypted credentials on stdout. With `--json` it prints the environment, the file and the key paths it holds — never a value, in this command and in every error message.
 
-Both exit with `1` when the key is missing or wrong, naming the file and `HENRI_CREDENTIALS_KEY`. See [Configuration](/configuration/#encrypted-credentials).
+`rotate` re-encrypts the file under a fresh key, keeping the values. The current key has to open the file first, and the re-encrypted file is read back before the new key is stored: a rotation that cannot be verified puts the old file back and changes nothing. The new key is written to the key file, or printed once when `HENRI_CREDENTIALS_KEY` held the old one — `--json` never prints it. The old key opens nothing afterwards, so anything holding a copy needs the new one before its next boot.
+
+All three exit with `1` when the key is missing or wrong, naming the file and `HENRI_CREDENTIALS_KEY`. See [Configuration](/configuration/#encrypted-credentials).
 
 ## `jobs`
 


### PR DESCRIPTION
A key that may have leaked has to stop opening the file. Until now that meant a manual sequence — show the values, generate a key, edit, paste everything back — which is exactly the kind of thing that ends with a secret in a shell history.

```bash
henri credentials:rotate --env production
```

The file is re-encrypted under a fresh key and the values are untouched.

- **The current key has to open the file first**, so a rotation is never a way to lose the contents.
- **The re-encrypted file is read back before the new key is stored.** A rotation that will not verify puts the old file back and changes nothing.
- **The new key goes where the old one came from**: the key file on a development machine, standard output once when `HENRI_CREDENTIALS_KEY` held it, because a deployment that deliberately has no key file should not be given one.
- `--json` never prints it, here as everywhere else in this command.

Three tests: a rotation keeps the values and leaves the old key opening nothing; a rotation under `HENRI_CREDENTIALS_KEY` prints the new key, writes no key file, and the printed key opens the file; a rotation without the current key changes nothing.

Verified with `pnpm test` (1527 passed), `pnpm lint --max-warnings 0`, `pnpm format:check` and `scripts/smoke.sh`.

Closes #57.