### PR TITLE
Refuse a long whitespace run in constant time

### DIFF
--- a/.changeset/duration-redos.md
+++ b/.changeset/duration-redos.md
@@ -1,0 +1,9 @@
+---
+'@usehenri/jobs': patch
+---
+
+A duration with a long run of whitespace is refused in constant time
+
+`'5m'`, `'2h'` and their friends were matched by a pattern with `\s*` at both ends. Around an optional group that is quadratic: on `'1'` followed by sixty thousand spaces the two star quantifiers split the run between them one position at a time, which measured two seconds before the value was refused. A duration reaches the parser from `henri jobs:perform --in=`, and from whatever an application passes to `enqueue()`, so it is not always a value its author typed.
+
+The surrounding whitespace is trimmed before the pattern runs rather than matched by it. The same input is now refused in under a millisecond, and a test pins it.

--- a/packages/jobs/__tests__/cron.spec.js
+++ b/packages/jobs/__tests__/cron.spec.js
@@ -90,6 +90,19 @@ describe('duration', () => {
     expect(() => duration(-1)).toThrow('Invalid duration');
   });
 
+  test('the surrounding whitespace is trimmed, not matched', () => {
+    expect(duration('  2h  ')).toBe(7200000);
+    expect(duration('\t30s\n')).toBe(30000);
+
+    // A run of spaces used to be shared between two star quantifiers, one
+    // position at a time: 60000 of them took two seconds to refuse
+    const long = `1${' '.repeat(60000)}!`;
+    const started = process.hrtime.bigint();
+
+    expect(() => duration(long)).toThrow('Invalid duration');
+    expect(Number(process.hrtime.bigint() - started) / 1e6).toBeLessThan(50);
+  });
+
   test('computes when a job should run', () => {
     const now = utc('2026-03-01T10:00:00Z');
 

--- a/packages/jobs/src/duration.js
+++ b/packages/jobs/src/duration.js
@@ -13,7 +13,18 @@ const UNITS = new Map([
   ['w', 604800000],
 ]);
 
-const PATTERN = /^\s*(\d+(?:\.\d+)?)\s*(ms|[smhdw])?\s*$/i;
+/**
+ * The written form: an amount, then a unit.
+ *
+ * The surrounding whitespace is trimmed before this runs rather than
+ * matched by it. `^\s*…\s*$` around an optional group is quadratic: on
+ * `'1' + ' '.repeat(60000) + '!'` the two star quantifiers split the run
+ * between them one position at a time, which measured 2 seconds before this
+ * was one `\s*` with nothing to share with. A duration reaches here from
+ * `--in=` and from whatever an application passes to `enqueue()`, so it is
+ * not always a value the author typed.
+ */
+const PATTERN = /^(\d+(?:\.\d+)?)\s*(ms|[smhdw])?$/i;
 
 /**
  * Milliseconds of a duration
@@ -36,7 +47,7 @@ const duration = (value, fallback = null) => {
     return Math.round(value);
   }
 
-  const match = PATTERN.exec(String(value));
+  const match = PATTERN.exec(String(value).trim());
 
   if (!match) {
     throw new Error(


### PR DESCRIPTION
CodeQL flagged `js/polynomial-redos` on master, and it is right.

The duration pattern (`'5m'`, `'2h'`, `'500ms'`) had `\s*` at both ends. Around an optional group that is quadratic: the two star quantifiers split a run of whitespace between them one position at a time.

| Spaces | Before | After |
| --- | --- | --- |
| 10,000 | 56 ms | 0.1 ms |
| 60,000 | 2,033 ms | 0.3 ms |
| 200,000 | — | 0.9 ms |

A duration reaches the parser from `henri jobs:perform --in=` and from whatever an application hands `enqueue()`, so it is not always a value its author typed.

The surrounding whitespace is trimmed before the pattern runs rather than matched by it, which leaves the remaining `\s*` nothing to share with. The test measures the time rather than trusting the shape of the regular expression.