### PR TITLE
Hold graphql at 16 while Apollo Server asks for it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,12 @@ updates:
       - dependency-name: string-width
         update-types:
           - version-update:semver-major
+      # @apollo/server 5 declares `graphql: ^16.11.0` as its peer, up to and
+      # including 5.4, so graphql 17 has nowhere to go in @usehenri/graphql.
+      # Drop this when Apollo widens the range.
+      - dependency-name: graphql
+        update-types:
+          - version-update:semver-major
     commit-message:
       prefix: 'chore(deps)'
 


### PR DESCRIPTION
`@apollo/server` 5 declares `graphql: ^16.11.0` as its peer dependency, and still does at 5.4:

```
$ npm view @apollo/server@5 peerDependencies
@apollo/server@5.4.0 { graphql: '^16.11.0' }
```

So graphql 17 has nowhere to go in `@usehenri/graphql`: the install either resolves two copies of graphql or fails outright, and Apollo refuses a schema built by the other one. Dependabot has opened that upgrade once a week.

The ignore is on the major only, so 16.x keeps flowing, and it comes off when Apollo widens the range. Closes #335.