### PR TITLE
File uploads: @usehenri/uploads

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -24,7 +24,8 @@
       "@usehenri/postgresql",
       "@usehenri/react",
       "@usehenri/sequelize",
-      "@usehenri/testing"
+      "@usehenri/testing",
+      "@usehenri/uploads"
     ]
   ],
   "linked": [],

--- a/.changeset/tall-jokes-shave.md
+++ b/.changeset/tall-jokes-shave.md
@@ -1,0 +1,38 @@
+---
+'@usehenri/uploads': minor
+'@usehenri/core': minor
+'@usehenri/cli': minor
+---
+
+File uploads, in a new package: `@usehenri/uploads`.
+
+An application installs it and gets `henri.uploads`, `req.files`,
+`req.file(field)` and `req.permitFiles(...fields)` — `req.permit()` for files,
+which removes what a controller did not ask for on the spot. `store()` moves a
+file into the storage and answers the record to write to a model
+(`{ key, name, type, size, checksum, storage, uploadedAt }`), and
+`henri.uploads.send(res, record)` streams it back as a download.
+
+The parser is busboy, and every bound is enforced as it reads rather than
+checked afterwards: `maxTotalSize` (25mb, checked against `Content-Length`
+first and counted again as the bytes arrive), `maxFileSize` (10mb), `maxFiles`
+(10), `maxFields` (100), `maxFieldNameSize` (100 bytes) and `maxFieldSize`,
+which defaults to `config.bodyLimit`. The type of a file is decided from its
+first bytes, never from the `Content-Type` or the extension the client sent,
+and `uploads.allow` matches that. The stored name is generated, so no name a
+client sends ever reaches a path. Files land in `storage/uploads` (`0700`,
+objects `0600`), outside everything the application serves, and nothing is kept
+unless a controller calls `store()` — a request that is refused, times out or is
+abandoned leaves no temporary file behind.
+
+The local disk is one implementation of a documented `HenriStorage` contract;
+an object store is another, named by module id in `config.uploads.storage` and
+resolved from the application. henri ships no S3 client.
+
+`@usehenri/core` gains the `uploads` configuration key (validated whether or
+not the package is installed), the `req.files`/`req.file`/`req.permitFiles`
+declarations, and `res.boom.payloadTooLarge()` and
+`res.boom.unsupportedMediaType()`.
+
+`henri audit` gains three checks: `uploads.limits-disabled` (V12.1.1),
+`uploads.type-check-disabled` (V12.2.1) and `uploads.root-served` (V12.4.1).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ an app and is what core's tests boot.
 | `packages/inertia`                      | `@usehenri/inertia`   | Inertia.js view engine on Vite + React 19; the default renderer of `henri new`                                                                                                                        |
 | `packages/jobs`                         | `@usehenri/jobs`      | Background jobs: a database backed queue with retries, a dead letter queue and recurring jobs (`henri jobs`), new in 1.1; ships its own module, left core in 1.2                                      |
 | `packages/graphql`                      | `@usehenri/graphql`   | GraphQL: the models' types and resolvers merged and served by Apollo Server; left core in 1.2                                                                                                         |
+| `packages/uploads`                      | `@usehenri/uploads`   | File uploads: bounded multipart parsing (busboy), files typed by their bytes and a storage seam; ships its own module, new in 1.2                                                                     |
 | `packages/testing`                      | `@usehenri/testing`   | Boots an app for Vitest and binds supertest to it                                                                                                                                                     |
 | `packages/mcp`                          | `@usehenri/mcp`       | `henri mcp`: stdio MCP server exposing routes, models, generators, tests and doctor to coding agents                                                                                                  |
 | `packages/websocket`                    | private               | Not published, never wired into core                                                                                                                                                                  |
@@ -121,8 +122,8 @@ an app and is what core's tests boot.
   (string or `{ model, public, loginPath, afterLogin, sessionMaxAge, signup,
 passwordReset, confirmation }`), `baseRole`, `policies`,
   `trustProxy`, `csrf`, `graphql`, `mail`, `mailers`, `api`, `jobs`,
-  `rateLimit`, `helmet`, `filterParameters`, `bodyLimit`, `requestTimeout`,
-  `errors`.
+  `rateLimit`, `helmet`, `filterParameters`, `bodyLimit`, `uploads`,
+  `requestTimeout`, `shutdown`, `errors`, `policies`.
 - The configuration is validated at boot, before any other module starts:
   `base/config-schema.js` declares every key henri owns (as data, in the order
   of the documentation page) and `base/config-validate.js` walks it. A wrong
@@ -301,6 +302,35 @@ request-id,redact,headers,pagination,timeout,health}.js`: `res.resource()` and
 perform|retry|discard` drive it. The module also registers
   `henri.mailers.onDeliverLater()`, so `deliverLater()` enqueues the rendered
   message as the built-in `henri/mail` job.
+- File uploads live in `@usehenri/uploads`. Core parses no multipart body:
+  the package ships the module (`"henri": { "module": "./module.js" }`), so
+  depending on it puts `henri.uploads` in the boot at runlevel 3, with
+  `before: ['user', 'router']` -- the parser has to run before the CSRF
+  middleware, because the `_csrf` field of a multipart form is inside the
+  body. It mounts one middleware that always adds `req.files`
+  (`{ [field]: UploadedFile[] }`), `req.file(field)` and
+  `req.permitFiles(...fields)` -- `req.permit()` for files, which unlinks
+  what the controller did not list -- and reads a multipart body with busboy
+  under the bounds of `config.uploads` (`maxTotalSize` 25mb, `maxFileSize`
+  10mb, `maxFiles` 10, `maxFields` 100, `maxFieldNameSize` 100 bytes,
+  `maxFieldSize` defaulting to `config.bodyLimit`; each of the first four
+  accepts `false`). Every bound reaches the parser, `Content-Length` is
+  checked before one is built, and a refused request is drained (capped) so
+  the client reads its `413`. A file's type comes from its first bytes
+  (`src/sniff.js`), never from the `Content-Type` or the extension; the
+  client's claim is kept as `declaredType`, `config.uploads.allow` matches
+  the sniffed type, and `text/html` and `image/svg+xml` are stored under
+  `.bin`. The stored name is generated
+  (`<yyyy>/<mm>/<32 hex>.<extension of the type>`), the original is cleaned
+  metadata, and the storage refuses any other key shape. Nothing is kept
+  unless a controller calls `store()`, which answers the record a model holds
+  (`{ key, name, type, size, checksum, storage, uploadedAt }`); everything
+  else is swept when the response closes. Storage backends implement
+  `HenriStorage` (JSDoc at the top of `packages/uploads/src/storage/local.js`:
+  `start`, `stop`, `temp`, `put`, `get`, `stat`, `delete`, `url`); the local
+  disk ships (`storage/uploads`, `0700`/`0600`, a `.gitignore` of its own),
+  anything else is a module id resolved from the application, and
+  `henri.uploads.send(res, record)` is how a file is handed back.
 - Controllers may export `before` (`base/hooks.js`): hooks the router runs
   between the role guard and the action, keyed by action (`all`,
   `'show,edit'`) or as `[fn, { run, only, except }]`; a hook that answers ends
@@ -423,6 +453,13 @@ the LICENSE and a README into every public package at publish time
   of the default store (`scripts/adapters.js` maps it to the mongoose,
   sequelize or drizzle flavour), which `henri new --adapter <name>` configures.
   The `template` and `vue` renderers get no generated pages.
+- `@usehenri/uploads` is new in 1.2. It recognizes a file rather than
+  validating it: a signature table plus a text inference over the first 4kb,
+  so a valid header followed by anything is that type, a `.docx` is
+  `application/zip` (archives are never opened), and a format with no
+  signature is `application/octet-stream`. Image processing, direct-to-S3
+  signed uploads, a CDN story and virus scanning are out of scope on purpose
+  and the guide says why. No S3 storage ships, only the local disk.
 - The idempotency and rate-limit stores are in memory unless the app plugs a
   shared store (`config.api.idempotency.store`, `config.rateLimit.store`).
 - `@usehenri/jobs` is new in 1.1. Its claim is covered against sqlite,

--- a/packages/cli/__tests__/audit.spec.js
+++ b/packages/cli/__tests__/audit.spec.js
@@ -323,6 +323,79 @@ describe('henri audit', () => {
     );
   });
 
+  test('reports what an application weakened about uploads', () => {
+    const { findings: found, names } = withConfig(
+      app,
+      'config/production.json',
+      {
+        uploads: {
+          maxFiles: false,
+          maxTotalSize: false,
+          root: 'app/views/public/uploads',
+          sniff: false,
+        },
+      }
+    );
+
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'uploads.limits-disabled',
+        'uploads.root-served',
+        'uploads.type-check-disabled',
+      ])
+    );
+    expect(found).toContainEqual(
+      expect.objectContaining({
+        asvs: 'V12.1.1',
+        check: 'uploads.limits-disabled',
+        file: 'config/production.json',
+        message: expect.stringContaining(
+          'uploads.maxFiles, uploads.maxTotalSize'
+        ),
+        severity: 'medium',
+      })
+    );
+    expect(found).toContainEqual(
+      expect.objectContaining({
+        asvs: 'V12.4.1',
+        check: 'uploads.root-served',
+        owasp: 'A05:2021 Security Misconfiguration',
+        severity: 'high',
+      })
+    );
+    expect(found).toContainEqual(
+      expect.objectContaining({
+        asvs: 'V12.2.1',
+        check: 'uploads.type-check-disabled',
+        severity: 'medium',
+      })
+    );
+
+    // Bounds that are raised, a root outside what is served, and the
+    // defaults: nothing to report
+    expect(
+      withConfig(app, 'config/production.json', {
+        uploads: {
+          allow: ['image/png'],
+          maxFiles: 50,
+          maxTotalSize: '200mb',
+          root: 'storage/uploads',
+        },
+      }).names
+    ).not.toEqual(
+      expect.arrayContaining([
+        'uploads.limits-disabled',
+        'uploads.root-served',
+        'uploads.type-check-disabled',
+      ])
+    );
+
+    // "uploads": false accepts no file at all, which is not a weakening
+    expect(
+      withConfig(app, 'config/production.json', { uploads: false }).names
+    ).not.toContain('uploads.limits-disabled');
+  });
+
   test('reports password hashes that are not bound to their row', () => {
     // An application that turned the binding off is telling anyone who can
     // write its database that a hash copied onto another row still works

--- a/packages/cli/__tests__/doctor.spec.js
+++ b/packages/cli/__tests__/doctor.spec.js
@@ -295,6 +295,33 @@ describe('henri doctor', () => {
     expect(run(app).names).not.toContain('deps.declared');
   });
 
+  // An `uploads` block says an application means to accept a file, and
+  // without the package nothing parses a multipart body at all
+  test('asks for @usehenri/uploads when the configuration accepts files', () => {
+    const file = path.join(app, 'config/default.json');
+    const original = fs.readFileSync(file, 'utf8');
+    const config = JSON.parse(original);
+
+    fs.writeFileSync(
+      file,
+      JSON.stringify({ ...config, uploads: { maxFileSize: '5mb' } }, null, 2)
+    );
+
+    const { problems } = run(app);
+
+    fs.writeFileSync(file, original);
+
+    expect(problems).toContainEqual(
+      expect.objectContaining({
+        check: 'deps.declared',
+        hint: expect.stringContaining('@usehenri/uploads'),
+        level: 'error',
+      })
+    );
+
+    expect(run(app).names).not.toContain('deps.declared');
+  });
+
   test('reports .env not ignored, and a missing .env as a warning', () => {
     const ignore = path.join(app, '.gitignore');
     const original = fs.readFileSync(ignore, 'utf8');

--- a/packages/cli/scripts/audit.js
+++ b/packages/cli/scripts/audit.js
@@ -289,6 +289,27 @@ const CHECKS = [
     what: '"trustProxy": true: a client can forge the address it is limited by',
   },
   {
+    asvs: 'V12.1.1',
+    check: 'uploads.limits-disabled',
+    level: 1,
+    owasp: 'A05',
+    what: 'an upload bound is false, so one request may write whatever it sends',
+  },
+  {
+    asvs: 'V12.4.1',
+    check: 'uploads.root-served',
+    level: 1,
+    owasp: 'A05',
+    what: 'uploads are stored inside a directory the application serves',
+  },
+  {
+    asvs: 'V12.2.1',
+    check: 'uploads.type-check-disabled',
+    level: 2,
+    owasp: 'A05',
+    what: '"sniff": false: the type of an uploaded file is whatever the client says it is',
+  },
+  {
     asvs: 'V5.3.3',
     check: 'views.unescaped',
     level: 1,
@@ -308,6 +329,15 @@ const THRESHOLDS = [...SEVERITIES, 'none'];
 
 /** The `config.graphql` bounds `base/graphql-guard.js` enforces */
 const GRAPHQL_BOUNDS = ['maxAliases', 'maxComplexity', 'maxDepth', 'maxTokens'];
+
+/** The `config.uploads` bounds a multipart body is refused by */
+const UPLOAD_BOUNDS = ['maxFields', 'maxFileSize', 'maxFiles', 'maxTotalSize'];
+
+/**
+ * The directory an application serves: `express.static` mounts
+ * `app/views/public`, and the Inertia dev server has `app/views` for a root
+ */
+const SERVED_ROOT = 'app/views';
 
 /** 30 days in milliseconds: henri's default session lifetime */
 const THIRTY_DAYS = 2592000000;
@@ -766,6 +796,50 @@ const configFindings = (config, { hasUser }) => {
       'Remove "requestTimeout": false, or raise it: { "requestTimeout": 120000 }',
       null
     );
+  }
+
+  if (isObject(config.uploads)) {
+    const unbounded = UPLOAD_BOUNDS.filter(
+      (key) => config.uploads[key] === false
+    );
+
+    if (unbounded.length > 0) {
+      add(
+        'medium',
+        'uploads.limits-disabled',
+        OWASP.A05,
+        `uploads.${unbounded.join(', uploads.')} ${unbounded.length === 1 ? 'is' : 'are'} false, so one request may write as much as it sends`,
+        `Raise the bound instead of removing it: { "uploads": { "${unbounded[0]}": "50mb" } }`,
+        'V12.1.1'
+      );
+    }
+
+    if (config.uploads.sniff === false) {
+      add(
+        'medium',
+        'uploads.type-check-disabled',
+        OWASP.A05,
+        'the type of an uploaded file is taken from the Content-Type the client sent, so a script named avatar.png is stored as an image',
+        'Remove "sniff": false and name the types you accept instead: { "uploads": { "allow": ["image/png", "image/jpeg"] } }',
+        'V12.2.1'
+      );
+    }
+
+    const root = String(config.uploads.root || '')
+      .replace(/\\/gu, '/')
+      .replace(/^\.\//u, '')
+      .replace(/\/+$/u, '');
+
+    if (root === SERVED_ROOT || root.startsWith(`${SERVED_ROOT}/`)) {
+      add(
+        'high',
+        'uploads.root-served',
+        OWASP.A05,
+        `uploads are stored in ${root}, under the directory the view engine and express.static serve: an uploaded page is then reachable on this application's own origin`,
+        'Store them outside it: { "uploads": { "root": "storage/uploads" } }, and hand a file back with henri.uploads.send()',
+        'V12.4.1'
+      );
+    }
   }
 
   if (isObject(config.user)) {

--- a/packages/cli/scripts/doctor.js
+++ b/packages/cli/scripts/doctor.js
@@ -651,6 +651,12 @@ const check = (dir = process.cwd()) => {
     needed.add('@usehenri/jobs');
   }
 
+  // And so is the multipart parser: an `uploads` block says an application
+  // means to accept a file, and without the package nothing reads one
+  if (config.uploads !== false && typeof config.uploads !== 'undefined') {
+    needed.add('@usehenri/uploads');
+  }
+
   const undeclared = [...needed].filter((name) => !declared[name]);
 
   if (undeclared.length > 0) {

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -583,11 +583,94 @@ declare namespace start {
     filterParameters?: string[] | false;
     /** Maximum size of a JSON or form body (`"1mb"`). */
     bodyLimit?: string | number;
+    /**
+     * File uploads, read by `@usehenri/uploads`; `false` accepts no file.
+     * Validated here whether or not the application has the package.
+     */
+    uploads?: false | UploadsConfig;
     /** Milliseconds before a running request is answered 503. */
     requestTimeout?: number | false;
     shutdown?: ShutdownConfig;
     errors?: ErrorsConfig;
     [key: string]: unknown;
+  }
+
+  /**
+   * `config.uploads`: what `@usehenri/uploads` accepts. Every bound is
+   * enforced by the parser as it reads, and `false` on one of them removes
+   * it (which `henri audit` reports).
+   */
+  interface UploadsConfig {
+    /**
+     * Media types that may be kept (`"image/png"`, `"image/*"`), matched
+     * against what the bytes say rather than what the client claimed.
+     * Without it, every type is accepted.
+     */
+    allow?: string[];
+    /** Longest field name, in bytes (`100`). */
+    maxFieldNameSize?: number;
+    /** Largest non-file part; defaults to `config.bodyLimit`. */
+    maxFieldSize?: string | number | false;
+    /** How many non-file fields one request may carry (`100`). */
+    maxFields?: number | false;
+    /** Largest single file (`"10mb"`). */
+    maxFileSize?: string | number | false;
+    /** How much of the original name is kept as metadata (`255`). */
+    maxFilenameLength?: number;
+    /** How many files one request may carry (`10`). */
+    maxFiles?: number | false;
+    /** Largest multipart body, all parts together (`"25mb"`). */
+    maxTotalSize?: string | number | false;
+    /** Path prefixes a multipart body is read under; all of them without it. */
+    paths?: string[];
+    /** Where the local storage keeps files (`"storage/uploads"`). */
+    root?: string;
+    /** Decide the type from the bytes (`true`). */
+    sniff?: boolean;
+    /** `"local"`, or the module id of a storage. */
+    storage?: string;
+  }
+
+  /**
+   * One file that arrived, as `req.files` holds it. It is temporary until
+   * `store()` is called; everything else is removed when the response
+   * closes. With `@usehenri/uploads`.
+   */
+  interface UploadedFile {
+    /** The form field it arrived in. */
+    field: string;
+    /** The original name, cleaned; never used to build a path. */
+    name: string;
+    /** What the client said it was, kept for the record only. */
+    declaredType: string | null;
+    /** What the bytes say it is. */
+    type: string;
+    /** Whether henri recognized those bytes. */
+    sniffed: boolean;
+    /** Whether the declared type and the real one disagree. */
+    readonly mistyped: boolean;
+    size: number;
+    /** sha256 of the content, hex. */
+    checksum: string;
+    /** Keeps the file and answers the record to write to a model. */
+    store(options?: {
+      prefix?: string;
+      storage?: unknown;
+    }): Promise<StoredFile>;
+    /** Removes it now rather than at the end of the request. */
+    discard(): Promise<boolean>;
+    toJSON(): Record<string, unknown>;
+  }
+
+  /** What `store()` resolves with: the record a model holds. */
+  interface StoredFile {
+    key: string;
+    name: string;
+    type: string;
+    size: number;
+    checksum: string;
+    storage: string;
+    uploadedAt: string;
   }
 
   /** `config.errors`: what henri does with the code of a failure. */
@@ -887,6 +970,10 @@ declare namespace start {
     methodNotAllowed(message?: string, data?: unknown): ExpressResponse;
     /** 409 */
     conflict(message?: string, data?: unknown): ExpressResponse;
+    /** 413 */
+    payloadTooLarge(message?: string, data?: unknown): ExpressResponse;
+    /** 415 */
+    unsupportedMediaType(message?: string, data?: unknown): ExpressResponse;
     /** 422 */
     badData(message?: string, data?: unknown): ExpressResponse;
     /** 429 */
@@ -950,6 +1037,21 @@ declare namespace start {
      * `scope`. The name defaults to what the route is about.
      */
     scope(name?: string, context?: object): Promise<any>;
+    /**
+     * The files of a multipart body, by field. Always present, empty when
+     * nothing was uploaded. With `@usehenri/uploads`.
+     */
+    files?: Record<string, UploadedFile[]>;
+    /** The first file of a field, or null. With `@usehenri/uploads`. */
+    file?(field: string): UploadedFile | null;
+    /**
+     * `permit()` for files: only the listed fields come back, and the files
+     * of every other one are removed from the disk on the spot. With
+     * `@usehenri/uploads`.
+     */
+    permitFiles?(
+      ...fields: Array<string | string[]>
+    ): Record<string, UploadedFile[]>;
     /** `{ page, perPage, skip, limit, offset }`, bounded by `config.api`. */
     pagination(overrides?: {
       perPage?: number;
@@ -1748,6 +1850,31 @@ declare namespace start {
     };
   }
 
+  /** `henri.uploads`, with `@usehenri/uploads`. */
+  interface UploadsModule {
+    name: 'uploads';
+    /** Whether this application accepts files. */
+    enabled: boolean;
+    /** `config.uploads`, normalized: every limit in bytes or `false`. */
+    settings: Record<string, unknown>;
+    /** The storage in use (`HenriStorage`). */
+    storage: unknown;
+    /**
+     * Streams a stored file back, as a download: `Content-Disposition:
+     * attachment` and `X-Content-Type-Options: nosniff`, so nothing that was
+     * uploaded is ever rendered on this application's origin.
+     */
+    send(
+      res: Response | ExpressResponse,
+      record: StoredFile | string,
+      options?: { disposition?: 'attachment' | 'inline'; maxAge?: number }
+    ): Promise<unknown>;
+    /** A readable stream of a stored file. */
+    get(record: StoredFile | string): Promise<NodeJS.ReadableStream>;
+    /** Removes a stored file. */
+    delete(record: StoredFile | string): Promise<boolean>;
+  }
+
   /** `henri.workers`. */
   interface WorkersModule {
     name: 'workers';
@@ -1809,6 +1936,12 @@ declare namespace start {
      * and a `deliverLater()` that asked for a delay says what to install.
      */
     jobs?: JobsModule;
+    /**
+     * Uploads, when the application depends on `@usehenri/uploads`. It is
+     * `undefined` when it does not -- core parses no multipart body of its
+     * own, and `req.files` is then absent as well.
+     */
+    uploads?: UploadsModule;
     workers: WorkersModule;
     api: ApiNamespace;
     /** Registration, the password reset and the address confirmation. */

--- a/packages/core/src/__tests__/config-schema.spec.js
+++ b/packages/core/src/__tests__/config-schema.spec.js
@@ -35,6 +35,9 @@ const graphqlKeys = () => Object.keys(SCHEMA.graphql.oneOf[1].keys);
 /** The keys of the `rateLimit` object form */
 const rateLimitKeys = () => Object.keys(SCHEMA.rateLimit.oneOf[1].keys);
 
+/** The keys of the `uploads` object form */
+const uploadsKeys = () => Object.keys(SCHEMA.uploads.oneOf[1].keys);
+
 /**
  * The member names of an interface of index.d.ts, at its own level (the
  * keys of an inline object type are not members of the interface)
@@ -181,6 +184,16 @@ describe('the configuration schema', () => {
         legacy: { adapter: 'mysql', logging: false, pool: { max: 5 } },
       },
       trustProxy: 2,
+      uploads: {
+        allow: ['image/png', 'image/*'],
+        maxFileSize: '5mb',
+        maxFiles: 3,
+        maxTotalSize: 20971520,
+        paths: ['/artworks'],
+        root: 'storage/uploads',
+        sniff: true,
+        storage: 'local',
+      },
       user: {
         afterLogin: '/',
         lockout: { max: 10, windowMs: 900000 },
@@ -379,6 +392,7 @@ describe('the schema, the declarations and the documentation', () => {
     ['PoliciesConfig', () => Object.keys(SCHEMA.policies.keys)],
     ['RateLimitConfig', rateLimitKeys],
     ['ShutdownConfig', () => Object.keys(SCHEMA.shutdown.keys)],
+    ['UploadsConfig', uploadsKeys],
     ['InertiaConfig', () => Object.keys(SCHEMA.inertia.keys)],
     ['MailersConfig', () => Object.keys(SCHEMA.mailers.keys)],
     ['JobsConfig', () => Object.keys(SCHEMA.jobs.keys)],

--- a/packages/core/src/__tests__/uploads.spec.js
+++ b/packages/core/src/__tests__/uploads.spec.js
@@ -1,0 +1,173 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const supertest = require('supertest');
+const Henri = require('../henri');
+
+const password = 'difference-engine';
+const email = 'ada@usehenri.io';
+
+/** A one pixel png */
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64'
+);
+
+/**
+ * Reads a cookie value from a response
+ *
+ * @param {object} res supertest response
+ * @param {string} name cookie name
+ * @returns {?string} the value or null
+ */
+const cookieOf = (res, name) => {
+  const line = (res.headers['set-cookie'] || []).find((cookie) =>
+    cookie.startsWith(`${name}=`)
+  );
+
+  return line ? line.split(';')[0].slice(name.length + 1) : null;
+};
+
+describe('uploads (demo app, @usehenri/uploads)', () => {
+  const skipWorkers = process.env.SKIP_WORKERS;
+  let henri;
+  let app;
+  let request;
+
+  beforeAll(async () => {
+    process.env.SKIP_WORKERS = '1';
+    henri = new Henri();
+    await henri.init();
+    global.henri = henri;
+    app = henri.server.app;
+    request = supertest(app);
+  }, 60000);
+
+  afterAll(async () => {
+    await henri.stop();
+    delete global.henri;
+
+    if (typeof skipWorkers === 'undefined') {
+      delete process.env.SKIP_WORKERS;
+    } else {
+      process.env.SKIP_WORKERS = skipWorkers;
+    }
+  });
+
+  test('the module comes from the package the application depends on', () => {
+    expect(henri.uploads).toBeDefined();
+    expect(henri.uploads.enabled).toBe(true);
+    expect(henri.uploads.name).toBe('uploads');
+    // Before the user module, which is where CSRF reads the body
+    expect(henri.uploads.runlevel).toBe(3);
+    expect(henri.uploads.before).toContain('user');
+  });
+
+  test('a file arrives, is typed by its bytes, and is handed back', async () => {
+    const answer = await request
+      .post('/uploads')
+      .field('title', 'a scan')
+      .attach('scan', PNG, { contentType: 'image/gif', filename: 'a.png' });
+
+    expect(answer.status).toBe(201);
+    expect(answer.body.title).toBe('a scan');
+    expect(answer.body.declaredType).toBe('image/gif');
+    expect(answer.body.mistyped).toBe(true);
+    expect(answer.body.file).toMatchObject({
+      name: 'a.png',
+      size: PNG.length,
+      storage: 'local',
+      type: 'image/png',
+    });
+    expect(answer.body.file.key).toMatch(
+      /^demo\/\d{4}\/\d{2}\/[0-9a-f]{32}\.png$/u
+    );
+
+    const stored = path.join(henri.uploads.storage.root, answer.body.file.key);
+
+    expect(fs.existsSync(stored)).toBe(true);
+
+    const download = await request.get(`/uploads/${answer.body.file.checksum}`);
+
+    expect(download.status).toBe(200);
+    expect(download.headers['content-type']).toBe('image/png');
+    expect(download.headers['x-content-type-options']).toBe('nosniff');
+    expect(download.headers['content-disposition']).toContain(
+      'attachment; filename="a.png"'
+    );
+    expect(Buffer.from(download.body).equals(PNG)).toBe(true);
+  });
+
+  test('the parser runs before CSRF, so a multipart form can carry its token', async () => {
+    const agent = supertest.agent(app);
+    const registered = await agent
+      .post('/register')
+      .send({ email, name: 'ada', password });
+
+    expect(registered.status).toBe(201);
+
+    const logged = await agent.post('/login').send({ email, password });
+
+    expect(logged.status).toBe(200);
+
+    const token = cookieOf(registered, 'henri.csrf');
+
+    expect(token).toBeTruthy();
+
+    const without = await agent
+      .post('/uploads')
+      .attach('scan', PNG, { filename: 'a.png' });
+
+    expect(without.status).toBe(403);
+
+    const with_ = await agent
+      .post('/uploads')
+      .field('_csrf', token)
+      .attach('scan', PNG, { filename: 'a.png' });
+
+    expect(with_.status).toBe(201);
+  });
+
+  test('the limits of the configuration are the ones enforced', async () => {
+    const big = await request
+      .post('/uploads')
+      .set('Accept', 'application/json')
+      .attach('scan', Buffer.alloc(600 * 1024, 0xf0), { filename: 'big.bin' });
+
+    expect(big.status).toBe(413);
+    expect(big.body.error).toBe('Payload Too Large');
+    expect(big.body.message).toContain('larger than the 524288 bytes');
+
+    const many = await request
+      .post('/uploads')
+      .set('Accept', 'application/json')
+      .attach('scan', PNG, { filename: 'a.png' })
+      .attach('scan', PNG, { filename: 'b.png' })
+      .attach('scan', PNG, { filename: 'c.png' });
+
+    expect(many.status).toBe(413);
+    expect(many.body.message).toContain('2 files');
+  });
+
+  test('a request with no file at all is answered, not refused', async () => {
+    const answer = await request
+      .post('/uploads')
+      .set('Accept', 'application/json')
+      .field('title', 'nothing');
+
+    expect(answer.status).toBe(400);
+    expect(answer.body.message).toContain('no file');
+  });
+
+  test('a JSON body is untouched by any of this', async () => {
+    const answer = await request.post('/echo').send({ hello: 'world' });
+
+    expect(answer.status).toBe(200);
+    expect(answer.body.body).toEqual({ hello: 'world' });
+  });
+
+  test('nothing is left in the temporary directory', async () => {
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    expect(fs.readdirSync(henri.uploads.storage.tmp)).toEqual([]);
+  });
+});

--- a/packages/core/src/__tests__/utils.spec.js
+++ b/packages/core/src/__tests__/utils.spec.js
@@ -134,6 +134,7 @@ describe('utils', () => {
         'main',
         'memos',
         'notes',
+        'uploads',
         'user',
       ]);
       expect(typeof controllers.artwork.index).toBe('function');

--- a/packages/core/src/base/boom.js
+++ b/packages/core/src/base/boom.js
@@ -23,9 +23,11 @@ const STATUSES = {
   methodNotAllowed: [405, 'Method Not Allowed'],
   notFound: [404, 'Not Found'],
   notImplemented: [501, 'Not Implemented'],
+  payloadTooLarge: [413, 'Payload Too Large'],
   serverUnavailable: [503, 'Service Unavailable'],
   tooManyRequests: [429, 'Too Many Requests'],
   unauthorized: [401, 'Unauthorized'],
+  unsupportedMediaType: [415, 'Unsupported Media Type'],
 };
 
 /**

--- a/packages/core/src/base/config-schema.js
+++ b/packages/core/src/base/config-schema.js
@@ -84,6 +84,23 @@ const duration = (extra = {}) => ({
   ...extra,
 });
 
+/** A size: a number of bytes, or `'10mb'` (what `bodyLimit` accepts) */
+const size = (extra = {}) => ({
+  describe: "a size: a number of bytes, or a string ('10mb')",
+  oneOf: [
+    { above: 0, type: 'number' },
+    { pattern: /^\s*\d+(?:\.\d+)?\s*(?:b|kb|mb|gb)?\s*$/iu, type: 'string' },
+  ],
+  ...extra,
+});
+
+/** The same, with `false` for "no limit" */
+const sizeLimit = (extra = {}) => ({
+  describe: "a size ('10mb', or a number of bytes), or false for no limit",
+  oneOf: [{ const: false }, ...size().oneOf],
+  ...extra,
+});
+
 /** One entry of `stores`: an adapter and how to reach its database */
 const STORE = {
   hint: 'A store is { "adapter": "disk" } and the keys that adapter needs',
@@ -868,17 +885,67 @@ const SCHEMA = {
     oneOf: [text(), positive({ describe: 'a number of bytes above zero' })],
   },
 
-  errors: {
-    describe: 'an object of error code settings',
-    keys: {
-      url: {
-        describe: 'a url template holding {code}',
-        hint: 'Unset by default: nothing prints a link. Point it at wherever the catalogue of https://usehenri.io/reference/errors/ is published (https://example.com/e/{code})',
-        pattern: /\{code\}/u,
-        type: 'string',
+  uploads: {
+    describe: 'an object of upload settings, or false to accept no file',
+    hint: 'Uploads are read by @usehenri/uploads, which the application installs; every key is optional',
+    oneOf: [
+      { const: false },
+      {
+        keys: {
+          allow: {
+            describe:
+              "a list of media types ('image/png', 'image/*'), matched against what the bytes say",
+            hint: 'Without it every type is accepted; the type never comes from the extension',
+            of: text(),
+            type: 'array',
+          },
+          maxFieldNameSize: {
+            default: 100,
+            describe: 'a whole number of bytes, above zero',
+            integer: true,
+            min: 1,
+            type: 'number',
+          },
+          maxFieldSize: sizeLimit({
+            hint: 'One non-file part of the form; defaults to config.bodyLimit',
+          }),
+          maxFields: limit(100),
+          maxFileSize: sizeLimit({ default: '10mb' }),
+          maxFilenameLength: {
+            default: 255,
+            describe: 'a whole number of characters, above zero',
+            hint: 'How much of the original name is kept as metadata; the stored name is generated',
+            integer: true,
+            min: 1,
+            type: 'number',
+          },
+          maxFiles: limit(10),
+          maxTotalSize: sizeLimit({ default: '25mb' }),
+          paths: {
+            describe: "a list of path prefixes ('/api/artworks')",
+            hint: 'Without it a multipart body is read on every route that takes one',
+            of: text({ pattern: /^\//u }),
+            type: 'array',
+          },
+          root: text({
+            default: 'storage/uploads',
+            describe: 'a directory, relative to the application',
+            hint: 'It must be outside app/views/public, which express serves',
+          }),
+          sniff: {
+            default: true,
+            describe: 'true or false',
+            hint: 'false trusts the Content-Type the client sent, which is not evidence',
+            type: 'boolean',
+          },
+          storage: text({
+            default: 'local',
+            describe: "'local', or the module id of a HenriStorage",
+          }),
+        },
+        type: 'object',
       },
-    },
-    type: 'object',
+    ],
   },
 
   requestTimeout: {
@@ -909,6 +976,19 @@ const SCHEMA = {
         describe: 'true or false',
         hint: 'false leaves SIGINT and SIGTERM to the application',
         type: 'boolean',
+      },
+    },
+    type: 'object',
+  },
+
+  errors: {
+    describe: 'an object of error code settings',
+    keys: {
+      url: {
+        describe: 'a url template holding {code}',
+        hint: 'Unset by default: nothing prints a link. Point it at wherever the catalogue of https://usehenri.io/reference/errors/ is published (https://example.com/e/{code})',
+        pattern: /\{code\}/u,
+        type: 'string',
       },
     },
     type: 'object',

--- a/packages/demo/app/controllers/uploads.js
+++ b/packages/demo/app/controllers/uploads.js
@@ -1,0 +1,54 @@
+/**
+ * Uploads, the way a controller writes them: `req.permit()` for the fields,
+ * `req.permitFiles()` for the files, `store()` for what reaches a model.
+ *
+ * The demo has no attachment model, so the record `store()` returns is kept
+ * in memory here; in an application it is a `json` column.
+ */
+const kept = new Map();
+
+module.exports = {
+  /**
+   * Accepts one file in the `scan` field and nothing else
+   *
+   * @param {object} req the request
+   * @param {object} res the response
+   * @returns {Promise<object>} the response
+   */
+  async create(req, res) {
+    const data = req.permit('title');
+    const { scan } = req.permitFiles('scan');
+
+    if (!scan || scan.length === 0) {
+      return res.boom.badRequest('no file in the "scan" field');
+    }
+
+    const record = await scan[0].store({ prefix: 'demo' });
+
+    kept.set(record.checksum, record);
+
+    return res.status(201).json({
+      declaredType: scan[0].declaredType,
+      file: record,
+      mistyped: scan[0].mistyped,
+      title: data.title || null,
+    });
+  },
+
+  /**
+   * Hands a stored file back, as a download
+   *
+   * @param {object} req the request
+   * @param {object} res the response
+   * @returns {Promise<object>} the response
+   */
+  async show(req, res) {
+    const record = kept.get(req.params.id);
+
+    if (!record) {
+      return res.boom.notFound('no such upload');
+    }
+
+    return henri.uploads.send(res, record);
+  },
+};

--- a/packages/demo/app/routes.js
+++ b/packages/demo/app/routes.js
@@ -17,6 +17,7 @@ module.exports = {
     rateLimit: { max: 2, windowMs: 60000 },
   },
   'get /profile': { controller: 'user#profile', roles: ['member'] },
+  'get /uploads/:id': 'uploads#show',
   'get /version': 'main#version',
   // A namespace: the controllers live in app/controllers/admin
   'namespace admin': {
@@ -27,6 +28,8 @@ module.exports = {
   'post /echo': { controller: 'main#echo', idempotent: false },
   'post /once': 'main#echo',
   'post /register': 'user#create',
+  // Multipart, read by @usehenri/uploads before sessions and csrf
+  'post /uploads': { controller: 'uploads#create', idempotent: false },
   // A versioned, scoped resource (/api/v1/artworks)
   'resources artworks': {
     controller: 'artworks',

--- a/packages/demo/config/default.json
+++ b/packages/demo/config/default.json
@@ -14,5 +14,12 @@
     "passwordReset": true,
     "confirmation": true
   },
+  "uploads": {
+    "root": ".tmp/uploads",
+    "maxFileSize": "512kb",
+    "maxTotalSize": "1mb",
+    "maxFiles": 2,
+    "maxFields": 10
+  },
   "env": "default"
 }

--- a/packages/demo/config/test.json
+++ b/packages/demo/config/test.json
@@ -18,5 +18,12 @@
   "rateLimit": {
     "auth": { "max": 200 }
   },
+  "uploads": {
+    "root": ".tmp/uploads",
+    "maxFileSize": "512kb",
+    "maxTotalSize": "1mb",
+    "maxFiles": 2,
+    "maxFields": 10
+  },
   "env": "test"
 }

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -9,7 +9,8 @@
     "@usehenri/core": "workspace:^",
     "@usehenri/disk": "workspace:^",
     "@usehenri/graphql": "workspace:^",
-    "@usehenri/jobs": "workspace:^"
+    "@usehenri/jobs": "workspace:^",
+    "@usehenri/uploads": "workspace:^"
   },
   "engines": {
     "node": ">=22"

--- a/packages/mcp/__tests__/server.spec.js
+++ b/packages/mcp/__tests__/server.spec.js
@@ -72,10 +72,14 @@ const fixture = async () => {
   const app = path.join(dir, 'app');
   const port = await freePort();
 
+  // The application, not what it wrote while running: `.henri` holds the
+  // store's data and `.tmp` the uploads, and another suite may be writing
+  // into either of them right now
   fs.cpSync(demo, app, {
     filter: (source) =>
       !source.includes(`${path.sep}node_modules`) &&
-      !source.includes(`${path.sep}.henri`),
+      !source.includes(`${path.sep}.henri`) &&
+      !source.includes(`${path.sep}.tmp`),
     recursive: true,
   });
   fs.symlinkSync(

--- a/packages/uploads/__tests__/cleanup.spec.js
+++ b/packages/uploads/__tests__/cleanup.spec.js
@@ -1,0 +1,208 @@
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+const supertest = require('supertest');
+
+const { PNG, application, objects, temporaries } = require('./helpers');
+
+/**
+ * Waits until a condition holds, or gives up
+ *
+ * @param {function} condition what to check
+ * @param {number} [ms=3000] how long to wait
+ * @returns {Promise<boolean>} whether it held
+ */
+const waitFor = async (condition, ms = 3000) => {
+  const deadline = Date.now() + ms;
+
+  while (Date.now() < deadline) {
+    if (condition()) {
+      return true;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+
+  return condition();
+};
+
+/**
+ * The bytes of a multipart body holding one file
+ *
+ * @param {string} boundary the boundary
+ * @param {Buffer} content the file
+ * @returns {{head: Buffer, tail: Buffer}} the two halves around the content
+ */
+const multipart = (boundary, content) => ({
+  head: Buffer.from(
+    `--${boundary}\r\nContent-Disposition: form-data; name="scan"; filename="a.bin"\r\nContent-Type: application/octet-stream\r\n\r\n`
+  ),
+  tail: Buffer.from(`\r\n--${boundary}--\r\n`),
+});
+
+describe('nothing is kept unless a controller says so', () => {
+  test('a file the controller never stores is swept when the response closes', async () => {
+    const { app, uploads } = await application(
+      {},
+      {
+        handler: (req, res) => res.json({ files: Object.keys(req.files) }),
+      }
+    );
+    const answer = await supertest(app)
+      .post('/upload')
+      .attach('scan', PNG, { filename: 'a.png' });
+
+    expect(answer.body.files).toEqual(['scan']);
+    expect(await waitFor(() => temporaries(uploads).length === 0)).toBe(true);
+    expect(objects(uploads)).toEqual([]);
+  });
+
+  test('permitFiles removes what the controller did not ask for, on the spot', async () => {
+    const { app, uploads } = await application(
+      {},
+      {
+        handler: (req, res) => {
+          const arrived = req._uploads.slice();
+          const kept = req.permitFiles('scan');
+
+          res.json({
+            after: Object.keys(req.files),
+            kept: Object.keys(kept),
+            // Released the moment permitFiles() ran, not at the end of the
+            // request: what a controller did not ask for is not held on to
+            released: arrived.map((file) => [file.field, file.released]),
+          });
+        },
+      }
+    );
+    const answer = await supertest(app)
+      .post('/upload')
+      .attach('scan', PNG, { filename: 'a.png' })
+      .attach('sneaky', PNG, { filename: 'b.png' });
+
+    expect(answer.body.kept).toEqual(['scan']);
+    expect(answer.body.after).toEqual(['scan']);
+    expect(answer.body.released).toEqual([
+      ['scan', false],
+      ['sneaky', true],
+    ]);
+    expect(await waitFor(() => temporaries(uploads).length === 0)).toBe(true);
+    expect(objects(uploads)).toEqual([]);
+  });
+
+  test('a stored file is not swept, and keeps its record', async () => {
+    const { app, uploads } = await application();
+    const answer = await supertest(app)
+      .post('/upload')
+      .attach('scan', PNG, { contentType: 'image/png', filename: 'a.png' });
+
+    expect(answer.status).toBe(201);
+    expect(answer.body.stored[0]).toMatchObject({
+      name: 'a.png',
+      size: PNG.length,
+      storage: 'local',
+      type: 'image/png',
+    });
+    expect(answer.body.stored[0].checksum).toMatch(/^[0-9a-f]{64}$/u);
+    expect(await waitFor(() => temporaries(uploads).length === 0)).toBe(true);
+    expect(objects(uploads)).toHaveLength(1);
+
+    const stored = fs.readFileSync(
+      path.join(uploads.storage.root, answer.body.stored[0].key)
+    );
+
+    expect(stored.equals(PNG)).toBe(true);
+  });
+
+  test('a handler that throws leaves nothing behind', async () => {
+    const { app, uploads } = await application(
+      {},
+      {
+        handler: () => {
+          throw new Error('boom');
+        },
+      }
+    );
+    const answer = await supertest(app)
+      .post('/upload')
+      .attach('scan', PNG, { filename: 'a.png' });
+
+    expect(answer.status).toBe(500);
+    expect(await waitFor(() => temporaries(uploads).length === 0)).toBe(true);
+    expect(objects(uploads)).toEqual([]);
+  });
+
+  test('store() after the request is over says so rather than half-working', async () => {
+    let escaped = null;
+    const { app } = await application(
+      {},
+      {
+        handler: (req, res) => {
+          escaped = req.file('scan');
+          res.json({ ok: true });
+        },
+      }
+    );
+
+    await supertest(app)
+      .post('/upload')
+      .attach('scan', PNG, { filename: 'a.png' });
+    await waitFor(() => escaped && escaped.released);
+
+    await expect(escaped.store()).rejects.toThrow('already released');
+  });
+});
+
+describe('a request that is abandoned half-way', () => {
+  test('leaves nothing on the disk', async () => {
+    const { app, uploads } = await application({ maxFileSize: '20mb' });
+    const server = app.listen(0, '127.0.0.1');
+
+    await new Promise((resolve) => server.once('listening', resolve));
+
+    const boundary = 'henriboundary';
+    const content = Buffer.alloc(4 * 1024 * 1024, 0x41);
+    const { head, tail } = multipart(boundary, content);
+    const request = http.request({
+      headers: {
+        'content-length': String(head.length + content.length + tail.length),
+        'content-type': `multipart/form-data; boundary=${boundary}`,
+      },
+      host: '127.0.0.1',
+      method: 'POST',
+      path: '/upload',
+      port: server.address().port,
+    });
+
+    request.on('error', () => {});
+    request.write(head);
+    request.write(content.subarray(0, 1024 * 1024));
+
+    // The server has a part open and bytes on the disk; the client vanishes
+    await waitFor(() => temporaries(uploads).length > 0);
+    expect(temporaries(uploads).length).toBeGreaterThan(0);
+
+    request.destroy();
+
+    expect(await waitFor(() => temporaries(uploads).length === 0)).toBe(true);
+    expect(objects(uploads)).toEqual([]);
+
+    await new Promise((resolve) => server.close(resolve));
+  }, 20000);
+});
+
+describe('what a process that was killed left behind', () => {
+  test('is swept when the storage starts', async () => {
+    const { uploads } = await application();
+    const stale = path.join(uploads.storage.tmp, 'deadbeef.part');
+
+    fs.writeFileSync(stale, 'left by a SIGKILL');
+    fs.writeFileSync(path.join(uploads.storage.tmp, 'not-a-part.txt'), 'kept');
+
+    expect(temporaries(uploads)).toHaveLength(2);
+
+    await uploads.storage.start();
+
+    expect(temporaries(uploads)).toEqual(['not-a-part.txt']);
+  });
+});

--- a/packages/uploads/__tests__/config.spec.js
+++ b/packages/uploads/__tests__/config.spec.js
@@ -1,0 +1,145 @@
+const supertest = require('supertest');
+
+const { DEFAULTS, covers, settings } = require('../src/config');
+const { bytes, format } = require('../src/bytes');
+const { PNG, application, fakeHenri } = require('./helpers');
+
+const MB = 1024 * 1024;
+
+describe('sizes', () => {
+  test.each([
+    ['10mb', 10 * MB],
+    ['512kb', 512 * 1024],
+    ['1gb', 1024 * MB],
+    ['900', 900],
+    ['1.5mb', Math.floor(1.5 * MB)],
+    [' 2 MB ', 2 * MB],
+    [4096, 4096],
+  ])('%s is %d bytes', (given, expected) => {
+    expect(bytes(given)).toBe(expected);
+  });
+
+  test('false is not a badly written number', () => {
+    expect(bytes(false)).toBe(false);
+    expect(bytes('nonsense', 42)).toBe(42);
+    expect(bytes(-1, 42)).toBe(42);
+    expect(bytes(null)).toBeNull();
+  });
+
+  test('and they print the way the documentation writes them', () => {
+    expect(format(10 * MB)).toBe('10mb');
+    expect(format(512 * 1024)).toBe('512kb');
+    expect(format(900)).toBe('900b');
+    expect(format(false)).toBe('no limit');
+  });
+});
+
+describe('the settings', () => {
+  test('are the documented defaults when the key is absent', () => {
+    const found = settings(fakeHenri('/tmp').config);
+
+    expect(found).toEqual({
+      allow: null,
+      enabled: true,
+      maxFieldNameSize: 100,
+      maxFieldSize: MB,
+      maxFields: 100,
+      maxFileSize: 10 * MB,
+      maxFilenameLength: 255,
+      maxFiles: 10,
+      maxTotalSize: 25 * MB,
+      paths: null,
+      root: DEFAULTS.root,
+      sniff: true,
+      storage: 'local',
+    });
+  });
+
+  test('maxFieldSize follows config.bodyLimit, which bounds the other encodings', () => {
+    const wide = settings(fakeHenri('/tmp', { bodyLimit: '4mb' }).config);
+
+    expect(wide.maxFieldSize).toBe(4 * MB);
+
+    const narrowed = settings(
+      fakeHenri('/tmp', { bodyLimit: '4mb', uploads: { maxFieldSize: 512 } })
+        .config
+    );
+
+    expect(narrowed.maxFieldSize).toBe(512);
+  });
+
+  test('"uploads": false accepts no file at all', () => {
+    expect(settings(fakeHenri('/tmp', { uploads: false }).config)).toEqual({
+      enabled: false,
+    });
+  });
+
+  test('a bound removed on purpose stays removed', () => {
+    const found = settings(
+      fakeHenri('/tmp', {
+        uploads: { maxFiles: false, maxTotalSize: false },
+      }).config
+    );
+
+    expect(found.maxTotalSize).toBe(false);
+    expect(found.maxFiles).toBe(false);
+  });
+
+  test('nonsense falls back to the default rather than to no limit', () => {
+    const found = settings(
+      fakeHenri('/tmp', {
+        uploads: {
+          allow: [],
+          maxFiles: 'lots',
+          maxTotalSize: 'as much as you like',
+          paths: ['relative', 42],
+          storage: 7,
+        },
+      }).config
+    );
+
+    expect(found.maxTotalSize).toBe(25 * MB);
+    expect(found.maxFiles).toBe(10);
+    expect(found.allow).toBeNull();
+    expect(found.paths).toBeNull();
+    expect(found.storage).toBe('local');
+  });
+});
+
+describe('which requests are read', () => {
+  test('only the methods that carry a body, and only the configured paths', () => {
+    expect(covers({ method: 'GET', path: '/x' }, null)).toBe(false);
+    expect(covers({ method: 'DELETE', path: '/x' }, null)).toBe(false);
+    expect(covers({ method: 'POST', path: '/x' }, null)).toBe(true);
+    expect(covers({ method: 'PUT', path: '/x' }, null)).toBe(true);
+    expect(covers({ method: 'PATCH', path: '/x' }, null)).toBe(true);
+    expect(covers({ method: 'POST', path: '/a' }, ['/a'])).toBe(true);
+    expect(covers({ method: 'POST', path: '/a/b' }, ['/a'])).toBe(true);
+    expect(covers({ method: 'POST', path: '/ab' }, ['/a'])).toBe(false);
+    expect(covers({ method: 'POST', path: '/b' }, ['/a'])).toBe(false);
+  });
+});
+
+describe('turning uploads off', () => {
+  test('leaves req.files there and empty, and reads no body', async () => {
+    const { app, uploads } = await application(false, {
+      handler: (req, res) =>
+        res.json({ files: req.files, has: typeof req.permitFiles }),
+    });
+
+    expect(uploads.enabled).toBe(false);
+    expect(uploads.storage).toBeNull();
+
+    const answer = await supertest(app)
+      .post('/upload')
+      .attach('scan', PNG, { filename: 'a.png' });
+
+    expect(answer.body).toEqual({ files: {}, has: 'function' });
+  });
+
+  test('and says what to do when something asks for a file anyway', async () => {
+    const { uploads } = await application(false);
+
+    expect(() => uploads.ready()).toThrow(/uploads are off/u);
+  });
+});

--- a/packages/uploads/__tests__/config.spec.js
+++ b/packages/uploads/__tests__/config.spec.js
@@ -26,6 +26,17 @@ describe('sizes', () => {
     expect(bytes(null)).toBeNull();
   });
 
+  test('a size with a long run of whitespace is refused in constant time', () => {
+    // `^\s*…\s*$` around an optional group is quadratic: the two star
+    // quantifiers share the run one position at a time, and 100k spaces
+    // took five seconds. The whitespace is trimmed before the match now.
+    const hostile = `9${' '.repeat(100000)}!`;
+    const started = process.hrtime.bigint();
+
+    expect(bytes(hostile, 42)).toBe(42);
+    expect(Number(process.hrtime.bigint() - started) / 1e6).toBeLessThan(50);
+  });
+
   test('and they print the way the documentation writes them', () => {
     expect(format(10 * MB)).toBe('10mb');
     expect(format(512 * 1024)).toBe('512kb');

--- a/packages/uploads/__tests__/helpers.js
+++ b/packages/uploads/__tests__/helpers.js
@@ -1,0 +1,164 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const express = require('express');
+
+const UploadsModule = require('../src/module');
+
+/**
+ * A throwaway application directory
+ *
+ * @returns {string} the directory
+ */
+const workspace = () =>
+  fs.mkdtempSync(path.join(os.tmpdir(), 'henri-uploads-'));
+
+/**
+ * Everything the uploads module reads off a henri instance
+ *
+ * @param {string} cwd the application directory
+ * @param {object} [config={}] the configuration
+ * @returns {object} a henri-shaped object
+ */
+const fakeHenri = (cwd, config = {}) => {
+  const values = Object.assign({ bodyLimit: '1mb' }, config);
+  const lines = [];
+
+  return {
+    config: {
+      get: (key) => values[key],
+      has: (key) => Object.prototype.hasOwnProperty.call(values, key),
+    },
+    cwd: () => cwd,
+    lines,
+    pen: {
+      error: (...args) => lines.push(['error', ...args]),
+      fatal: (...args) => new Error(args.join(' ')),
+      info: (...args) => lines.push(['info', ...args]),
+      warn: (...args) => lines.push(['warn', ...args]),
+    },
+    server: { app: null },
+    utils: {
+      resolveFrom: (request, dir) =>
+        require.resolve(request, { paths: [path.resolve(dir)] }),
+    },
+  };
+};
+
+/**
+ * An express application with the uploads middleware mounted the way the
+ * module mounts it, and one route that answers what arrived
+ *
+ * @param {object} [config={}] the `uploads` configuration
+ * @param {object} [options={}] `{ handler }` to answer differently
+ * @returns {Promise<object>} `{ app, cwd, henri, uploads }`
+ */
+const application = async (config = {}, options = {}) => {
+  const cwd = workspace();
+  const app = express();
+  const henri = fakeHenri(cwd, { uploads: config });
+  const uploads = new UploadsModule(henri);
+
+  henri.server.app = app;
+  henri.uploads = uploads;
+
+  await uploads.init();
+
+  app.post(
+    '/upload',
+    options.handler ||
+      (async (req, res) => {
+        const files = req.permitFiles('scan', 'scans');
+        const stored = [];
+
+        for (const list of Object.values(files)) {
+          for (const file of list) {
+            stored.push(await file.store());
+          }
+        }
+
+        res.status(201).json({ body: req.body, stored });
+      })
+  );
+
+  // The same shape core's error handler answers with
+  app.use((error, req, res, next) => {
+    res.status(error.status || 500).json({
+      code: error.code,
+      data: error.data,
+      message: error.message,
+    });
+  });
+
+  return { app, cwd, henri, uploads };
+};
+
+/**
+ * Every file left in the storage's temporary directory
+ *
+ * @param {object} uploads the uploads module
+ * @returns {Array<string>} the file names
+ */
+const temporaries = (uploads) => {
+  try {
+    return fs.readdirSync(uploads.storage.tmp);
+  } catch (error) {
+    return [];
+  }
+};
+
+/**
+ * Every stored object, as paths relative to the root
+ *
+ * @param {object} uploads the uploads module
+ * @returns {Array<string>} the paths
+ */
+const objects = (uploads) => {
+  const root = uploads.storage.root;
+  const found = [];
+  const walk = (dir, prefix) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === '.tmp' || entry.name === '.gitignore') {
+        continue;
+      }
+
+      const full = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        walk(full, `${prefix}${entry.name}/`);
+      } else {
+        found.push(`${prefix}${entry.name}`);
+      }
+    }
+  };
+
+  walk(root, '');
+
+  return found.sort();
+};
+
+/** A one pixel png, as bytes */
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64'
+);
+
+/** A PDF, as bytes */
+const PDF = Buffer.from('%PDF-1.4\n%âãÏÓ\n', 'latin1');
+
+/** An ELF executable header */
+const ELF = Buffer.concat([
+  Buffer.from([0x7f, 0x45, 0x4c, 0x46]),
+  Buffer.alloc(60),
+]);
+
+module.exports = {
+  ELF,
+  PDF,
+  PNG,
+  application,
+  fakeHenri,
+  objects,
+  temporaries,
+  workspace,
+};

--- a/packages/uploads/__tests__/limits.spec.js
+++ b/packages/uploads/__tests__/limits.spec.js
@@ -1,0 +1,244 @@
+const supertest = require('supertest');
+
+const {
+  ELF,
+  PDF,
+  PNG,
+  application,
+  objects,
+  temporaries,
+} = require('./helpers');
+
+const MB = 1024 * 1024;
+
+/** Bytes that are not text, so nothing is recognized but the size */
+const noise = (size) => Buffer.alloc(size, 0xf0);
+
+describe('the limits, which exist before the first byte is read', () => {
+  test('a 6mb file is refused when the limit is 5mb, and nothing is kept', async () => {
+    const { app, uploads } = await application({
+      maxFileSize: '5mb',
+      maxTotalSize: '50mb',
+    });
+    const answer = await supertest(app)
+      .post('/upload')
+      .attach('scan', noise(6 * MB), {
+        contentType: 'application/octet-stream',
+        filename: 'big.bin',
+      });
+
+    expect(answer.status).toBe(413);
+    expect(answer.body.code).toBe('FILE_TOO_LARGE');
+    expect(answer.body.data).toEqual({ field: 'scan', limit: 5 * MB });
+    expect(objects(uploads)).toEqual([]);
+    expect(temporaries(uploads)).toEqual([]);
+  });
+
+  test('a 5mb file is accepted when the limit is 5mb', async () => {
+    const { app, uploads } = await application({
+      maxFileSize: '5mb',
+      maxTotalSize: '50mb',
+    });
+    const answer = await supertest(app)
+      .post('/upload')
+      .attach('scan', noise(5 * MB), { filename: 'big.bin' });
+
+    expect(answer.status).toBe(201);
+    expect(answer.body.stored[0].size).toBe(5 * MB);
+    expect(objects(uploads)).toHaveLength(1);
+    expect(temporaries(uploads)).toEqual([]);
+  });
+
+  test('the whole body is bounded, whatever one file weighs', async () => {
+    const { app, uploads } = await application({
+      maxFileSize: '5mb',
+      maxTotalSize: '2mb',
+    });
+    const answer = await supertest(app)
+      .post('/upload')
+      .attach('scan', noise(3 * MB), { filename: 'big.bin' });
+
+    expect(answer.status).toBe(413);
+    expect(answer.body.code).toBe('TOTAL_TOO_LARGE');
+    expect(objects(uploads)).toEqual([]);
+    expect(temporaries(uploads)).toEqual([]);
+  });
+
+  test('a Content-Length past the total is refused before a parser is built', async () => {
+    const { app } = await application({ maxTotalSize: 1024 });
+    // Not a multipart body at all: had a parser been built, this would come
+    // back MALFORMED_MULTIPART. The header alone is what refuses it.
+    const answer = await supertest(app)
+      .post('/upload')
+      .set('Content-Type', 'multipart/form-data; boundary=x')
+      .send(Buffer.alloc(1200, 0x41));
+
+    expect(answer.status).toBe(413);
+    expect(answer.body.code).toBe('TOTAL_TOO_LARGE');
+    expect(answer.body.data).toEqual({ limit: 1024 });
+  });
+
+  test('how many files a request may carry', async () => {
+    const { app, uploads } = await application({ maxFiles: 2 });
+    const answer = await supertest(app)
+      .post('/upload')
+      .attach('scans', PNG, { filename: 'a.png' })
+      .attach('scans', PNG, { filename: 'b.png' })
+      .attach('scans', PNG, { filename: 'c.png' });
+
+    expect(answer.status).toBe(413);
+    expect(answer.body.code).toBe('TOO_MANY_FILES');
+    expect(objects(uploads)).toEqual([]);
+    expect(temporaries(uploads)).toEqual([]);
+  });
+
+  test('how many non-file fields it may carry', async () => {
+    const { app } = await application({ maxFields: 3 });
+    const request = supertest(app).post('/upload');
+
+    for (let index = 0; index < 5; index++) {
+      request.field(`f${index}`, 'x');
+    }
+
+    const answer = await request;
+
+    expect(answer.status).toBe(413);
+    expect(answer.body.code).toBe('TOO_MANY_FIELDS');
+  });
+
+  test('how long a field name may be', async () => {
+    const { app } = await application({ maxFieldNameSize: 8 });
+    const answer = await supertest(app)
+      .post('/upload')
+      .field('a-very-long-field-name', 'x');
+
+    expect(answer.status).toBe(413);
+    expect(answer.body.code).toBe('FIELD_NAME_TOO_LONG');
+  });
+
+  test('how long a field value may be, defaulting to config.bodyLimit', async () => {
+    const { app } = await application({ maxFieldSize: 16 });
+    const answer = await supertest(app)
+      .post('/upload')
+      .field('title', 'x'.repeat(64));
+
+    expect(answer.status).toBe(413);
+    expect(answer.body.code).toBe('VALUE_TOO_LARGE');
+    expect(answer.body.data).toEqual({ field: 'title', limit: 16 });
+  });
+
+  test('a body that is not a multipart body at all', async () => {
+    const { app } = await application();
+    const answer = await supertest(app)
+      .post('/upload')
+      .set('Content-Type', 'multipart/form-data')
+      .send('no boundary anywhere');
+
+    expect(answer.status).toBe(400);
+    expect(answer.body.code).toBe('MALFORMED_MULTIPART');
+  });
+
+  test('files keep the order the body had, not the order the disk answered in', async () => {
+    const { app } = await application();
+    const answer = await supertest(app)
+      .post('/upload')
+      .attach('scans', Buffer.alloc(512 * 1024, 0x41), { filename: 'slow.bin' })
+      .attach('scans', PNG, { filename: 'quick.png' })
+      .attach('scan', PDF, { filename: 'other.pdf' });
+
+    expect(answer.status).toBe(201);
+    expect(answer.body.stored.map((file) => file.name)).toEqual([
+      'slow.bin',
+      'quick.png',
+      'other.pdf',
+    ]);
+  });
+
+  test('a request that carries no file is not a refusal', async () => {
+    const { app } = await application();
+    const answer = await supertest(app).post('/upload').field('title', 'hi');
+
+    expect(answer.status).toBe(201);
+    expect(answer.body).toEqual({ body: { title: 'hi' }, stored: [] });
+  });
+});
+
+describe('the type is what the bytes say', () => {
+  test('a png named .png with the right header is accepted', async () => {
+    const { app } = await application({ allow: ['image/png'] });
+    const answer = await supertest(app)
+      .post('/upload')
+      .attach('scan', PNG, { contentType: 'image/png', filename: 'a.png' });
+
+    expect(answer.status).toBe(201);
+    expect(answer.body.stored[0].type).toBe('image/png');
+    expect(answer.body.stored[0].key).toMatch(/\.png$/u);
+  });
+
+  test('an executable calling itself a png is refused, and nothing is kept', async () => {
+    const { app, uploads } = await application({ allow: ['image/png'] });
+    const answer = await supertest(app).post('/upload').attach('scan', ELF, {
+      contentType: 'image/png',
+      filename: 'avatar.png',
+    });
+
+    expect(answer.status).toBe(415);
+    expect(answer.body.code).toBe('TYPE_NOT_ALLOWED');
+    expect(answer.body.data.type).toBe('application/x-elf');
+    expect(objects(uploads)).toEqual([]);
+    expect(temporaries(uploads)).toEqual([]);
+  });
+
+  test('the declared type is kept as a claim, never as the answer', async () => {
+    const { app } = await application({}, { handler: null });
+    const answer = await supertest(app)
+      .post('/upload')
+      .attach('scan', PDF, { contentType: 'image/png', filename: 'a.png' });
+
+    expect(answer.status).toBe(201);
+    expect(answer.body.stored[0].type).toBe('application/pdf');
+    expect(answer.body.stored[0].key).toMatch(/\.pdf$/u);
+  });
+
+  test('html and svg are stored under a name no web server renders', async () => {
+    const { app } = await application();
+    const answer = await supertest(app)
+      .post('/upload')
+      .attach('scan', Buffer.from('<svg onload="alert(1)"></svg>'), {
+        contentType: 'image/svg+xml',
+        filename: 'x.svg',
+      });
+
+    expect(answer.body.stored[0].type).toBe('image/svg+xml');
+    expect(answer.body.stored[0].key).toMatch(/\.bin$/u);
+  });
+
+  test('with sniffing off, the client decides -- which is the point of the audit check', async () => {
+    const { app } = await application({ allow: ['image/png'], sniff: false });
+    const answer = await supertest(app)
+      .post('/upload')
+      .attach('scan', ELF, { contentType: 'image/png', filename: 'a.png' });
+
+    expect(answer.status).toBe(201);
+    expect(answer.body.stored[0].type).toBe('image/png');
+  });
+});
+
+describe('the surface', () => {
+  test('paths narrow where a multipart body is read at all', async () => {
+    const { app } = await application({ paths: ['/elsewhere'] });
+    const answer = await supertest(app)
+      .post('/upload')
+      .attach('scan', PNG, { filename: 'a.png' });
+
+    expect(answer.status).toBe(201);
+    expect(answer.body.stored).toEqual([]);
+  });
+
+  test('a GET never carries one', async () => {
+    const { app } = await application();
+    const answer = await supertest(app).get('/upload');
+
+    expect(answer.status).toBe(404);
+  });
+});

--- a/packages/uploads/__tests__/names.spec.js
+++ b/packages/uploads/__tests__/names.spec.js
@@ -1,0 +1,117 @@
+const {
+  contentDisposition,
+  isKey,
+  keyFor,
+  safeName,
+  safePrefix,
+} = require('../src/names');
+
+describe('the original name', () => {
+  test.each([
+    ['../../etc/passwd', 'passwd'],
+    ['..\\..\\windows\\system32\\cmd.exe', 'cmd.exe'],
+    ['/etc/shadow', 'shadow'],
+    ['C:\\boot.ini', 'boot.ini'],
+    ['....//....//etc/passwd', 'passwd'],
+    ['..', 'file'],
+    ['.', 'file'],
+    ['...', 'file'],
+    ['', 'file'],
+    ['   ', 'file'],
+    ['.htaccess', 'htaccess'],
+    ['.env', 'env'],
+    ['photo.png', 'photo.png'],
+    ['a b c.png', 'a b c.png'],
+    ['résumé.pdf', 'résumé.pdf'],
+    ['trailing.  ', 'trailing'],
+  ])('%s becomes %s', (given, expected) => {
+    expect(safeName(given)).toBe(expected);
+  });
+
+  test('a NUL byte, and everything else that is not printable, is removed', () => {
+    expect(safeName('shell\u0000.png')).toBe('shell.png');
+    expect(safeName('a\u0007b\u001bc.png')).toBe('abc.png');
+    expect(safeName('a\nb.png')).toBe('ab.png');
+  });
+
+  test('the characters a shell or a filesystem would read are removed', () => {
+    expect(safeName('a"b<c>d|e*f?g:h.png')).toBe('abcdefgh.png');
+  });
+
+  test('a windows device name cannot be one', () => {
+    expect(safeName('CON')).toBe('_CON');
+    expect(safeName('con.txt')).toBe('_con.txt');
+    expect(safeName('LPT9.png')).toBe('_LPT9.png');
+    expect(safeName('COMPANY.txt')).toBe('COMPANY.txt');
+  });
+
+  test('a name of four thousand characters is cut, keeping its extension', () => {
+    const long = `${'a'.repeat(4000)}.png`;
+    const kept = safeName(long);
+
+    expect(kept).toHaveLength(255);
+    expect(kept.endsWith('.png')).toBe(true);
+  });
+
+  test('anything that is not a string is a name all the same', () => {
+    expect(safeName(null)).toBe('file');
+    expect(safeName(42)).toBe('file');
+    expect(safeName(undefined)).toBe('file');
+  });
+});
+
+describe('the stored name', () => {
+  test('is generated: nothing the client sent takes part in it', () => {
+    const key = keyFor({ extension: 'png' });
+
+    expect(key).toMatch(/^\d{4}\/\d{2}\/[0-9a-f]{32}\.png$/u);
+    expect(isKey(key)).toBe(true);
+  });
+
+  test('two keys are never the same', () => {
+    const keys = new Set(
+      Array.from({ length: 500 }, () => keyFor({ extension: 'bin' }))
+    );
+
+    expect(keys.size).toBe(500);
+  });
+
+  test('a prefix is reduced to what a key may hold', () => {
+    expect(safePrefix('artworks')).toBe('artworks');
+    expect(safePrefix('../../etc')).toBe('etc');
+    expect(safePrefix('a/b/c/d/e/f')).toBe('a/b/c/d');
+    expect(safePrefix('Users/../..')).toBe('users');
+    expect(safePrefix('...')).toBeNull();
+    expect(safePrefix(42)).toBeNull();
+    expect(isKey(keyFor({ extension: 'png', prefix: '../../etc' }))).toBe(true);
+  });
+
+  test('a storage refuses anything henri did not generate', () => {
+    expect(isKey('../../etc/passwd')).toBe(false);
+    expect(isKey('/etc/passwd')).toBe(false);
+    expect(isKey('2026/09/../../../etc/passwd')).toBe(false);
+    expect(isKey('2026/09/abc.png')).toBe(false);
+    expect(isKey(`2026/09/${'0'.repeat(32)}.png\u0000.txt`)).toBe(false);
+    expect(isKey('')).toBe(false);
+    expect(isKey(null)).toBe(false);
+    expect(isKey(`${'a/'.repeat(400)}${'0'.repeat(32)}.png`)).toBe(false);
+  });
+});
+
+describe('handing a name to a browser', () => {
+  test('is an attachment, in both encodings', () => {
+    expect(contentDisposition('résumé.pdf')).toBe(
+      'attachment; filename="r_sum_.pdf"; filename*=UTF-8\'\'r%C3%A9sum%C3%A9.pdf'
+    );
+  });
+
+  test('a quote cannot end the header early', () => {
+    expect(contentDisposition('a";x=y.png')).not.toContain('";x=y');
+  });
+
+  test('inline is asked for, never assumed', () => {
+    expect(contentDisposition('a.png', 'inline')).toContain(
+      'inline; filename='
+    );
+  });
+});

--- a/packages/uploads/__tests__/names.spec.js
+++ b/packages/uploads/__tests__/names.spec.js
@@ -28,6 +28,18 @@ describe('the original name', () => {
     expect(safeName(given)).toBe(expected);
   });
 
+  test('a name that is one long run of whitespace is cleaned in constant time', () => {
+    // The filename is whatever the client sent, and it is cleaned before
+    // maxFilenameLength ever applies, so the cleaner is reachable with as
+    // much as a multipart header allows. Trimming the edges by matching
+    // `[\s.]+$` was quadratic: 100k tabs took 5.8 seconds.
+    const hostile = `${'\t'.repeat(100000)}x`;
+    const started = process.hrtime.bigint();
+
+    expect(safeName(hostile)).toBe('x');
+    expect(Number(process.hrtime.bigint() - started) / 1e6).toBeLessThan(50);
+  });
+
   test('a NUL byte, and everything else that is not printable, is removed', () => {
     expect(safeName('shell\u0000.png')).toBe('shell.png');
     expect(safeName('a\u0007b\u001bc.png')).toBe('abc.png');

--- a/packages/uploads/__tests__/sniff.spec.js
+++ b/packages/uploads/__tests__/sniff.spec.js
@@ -1,0 +1,101 @@
+const { accepts, allowed, extensionFor, sniff } = require('../src/sniff');
+const { ELF, PDF, PNG } = require('./helpers');
+
+/**
+ * A sample from a hex signature, padded so the text inference never sees a
+ * short buffer as a whole file
+ *
+ * @param {string} hex the leading bytes
+ * @returns {Buffer} the sample
+ */
+const sample = (hex) =>
+  Buffer.concat([Buffer.from(hex, 'hex'), Buffer.alloc(64, 0xff)]);
+
+describe('what the bytes say', () => {
+  test.each([
+    ['png', PNG, 'image/png'],
+    ['jpeg', sample('ffd8ffe0'), 'image/jpeg'],
+    ['gif', sample('474946383961'), 'image/gif'],
+    ['webp', sample('52494646000000005745425056503820'), 'image/webp'],
+    ['pdf', PDF, 'application/pdf'],
+    ['zip (and every docx)', sample('504b03041400'), 'application/zip'],
+    ['gzip', sample('1f8b08'), 'application/gzip'],
+    ['mp4', sample('0000001c6674797069736f6d'), 'video/mp4'],
+    ['webm', sample('1a45dfa3'), 'video/webm'],
+  ])('recognizes a %s', (name, bytes, type) => {
+    expect(sniff(bytes)).toEqual({ sniffed: true, type });
+  });
+
+  test('an executable is named, so an allow list can refuse it', () => {
+    expect(sniff(ELF).type).toBe('application/x-elf');
+    expect(sniff(sample('4d5a90')).type).toBe('application/x-msdownload');
+    expect(sniff(Buffer.from('#!/bin/sh\nrm -rf /\n')).type).toBe(
+      'text/x-shellscript'
+    );
+  });
+
+  test('text is recognized as text, and scripts inside it are named', () => {
+    expect(sniff(Buffer.from('a,b,c\n1,2,3\n'), true).type).toBe('text/plain');
+    expect(sniff(Buffer.from('{"a":1}'), true).type).toBe('text/plain');
+    expect(
+      sniff(Buffer.from('<!DOCTYPE html><script>x</script>'), true).type
+    ).toBe('text/html');
+    expect(sniff(Buffer.from('<svg onload="alert(1)"></svg>'), true).type).toBe(
+      'image/svg+xml'
+    );
+  });
+
+  test('what henri does not recognize stays unrecognized', () => {
+    const noise = Buffer.from([0x00, 0x01, 0x02, 0xfe, 0xff, 0x03, 0x04]);
+
+    expect(sniff(noise, true)).toEqual({
+      sniffed: false,
+      type: 'application/octet-stream',
+    });
+    expect(sniff(null)).toEqual({ sniffed: true, type: 'text/plain' });
+  });
+
+  test('invalid utf-8 is not text', () => {
+    expect(sniff(Buffer.from([0xc3, 0x28, 0x41, 0x42]), true).sniffed).toBe(
+      false
+    );
+  });
+
+  test('a png called .jpg is still a png', () => {
+    expect(sniff(PNG).type).toBe('image/png');
+  });
+});
+
+describe('the extension a stored object gets', () => {
+  test('comes from the type, not from the name', () => {
+    expect(extensionFor('image/png')).toBe('png');
+    expect(extensionFor('image/jpeg')).toBe('jpg');
+    expect(extensionFor('application/pdf')).toBe('pdf');
+    expect(extensionFor('application/octet-stream')).toBe('bin');
+    expect(extensionFor('application/x-php')).toBe('bin');
+  });
+
+  test('is never one a web server would act on', () => {
+    expect(extensionFor('text/html')).toBe('bin');
+    expect(extensionFor('image/svg+xml')).toBe('bin');
+    expect(extensionFor('text/x-shellscript')).toBe('bin');
+    expect(extensionFor('application/x-msdownload')).toBe('bin');
+  });
+});
+
+describe('the allow list', () => {
+  test('matches a type, a subtype wildcard, or everything', () => {
+    expect(accepts('image/png', 'image/png')).toBe(true);
+    expect(accepts('image/png', 'IMAGE/PNG')).toBe(true);
+    expect(accepts('image/png', 'image/*')).toBe(true);
+    expect(accepts('image/png', '*')).toBe(true);
+    expect(accepts('image/png', 'image/jpeg')).toBe(false);
+    expect(accepts('text/html', 'image/*')).toBe(false);
+  });
+
+  test('without one, every type is accepted', () => {
+    expect(allowed('application/x-elf', null)).toBe(true);
+    expect(allowed('application/x-elf', ['image/*'])).toBe(false);
+    expect(allowed('image/png', ['image/*', 'application/pdf'])).toBe(true);
+  });
+});

--- a/packages/uploads/__tests__/storage.spec.js
+++ b/packages/uploads/__tests__/storage.spec.js
@@ -1,0 +1,154 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const LocalStorage = require('../src/storage/local');
+const { createStorage } = require('../src/storage');
+const { keyFor } = require('../src/names');
+const { fakeHenri, workspace } = require('./helpers');
+
+/**
+ * A started local storage in a throwaway directory
+ *
+ * @returns {Promise<{cwd: string, storage: LocalStorage}>} the storage
+ */
+const started = async () => {
+  const cwd = workspace();
+  const storage = new LocalStorage(
+    'local',
+    { root: 'storage/uploads' },
+    fakeHenri(cwd)
+  );
+
+  await storage.start();
+
+  return { cwd, storage };
+};
+
+describe('the local disk', () => {
+  test('creates its root private, and keeps it out of the repository', async () => {
+    const { storage } = await started();
+    const stats = fs.statSync(storage.root);
+
+    expect(stats.mode & 0o777).toBe(0o700);
+    expect(
+      fs.readFileSync(path.join(storage.root, '.gitignore'), 'utf8')
+    ).toContain('*');
+  });
+
+  test('a stored object is private and readable back', async () => {
+    const { storage } = await started();
+    const temp = await storage.temp();
+
+    fs.writeFileSync(temp.path, 'hello');
+
+    const key = await storage.put(temp.path, keyFor({ extension: 'txt' }));
+    const full = path.join(storage.root, key);
+
+    expect(fs.statSync(full).mode & 0o777).toBe(0o600);
+    expect(fs.existsSync(temp.path)).toBe(false);
+    expect(await storage.stat(key)).toMatchObject({ size: 5 });
+
+    const stream = await storage.get(key);
+    const chunks = [];
+
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+    }
+
+    expect(Buffer.concat(chunks).toString()).toBe('hello');
+    expect(await storage.delete(key)).toBe(true);
+    expect(await storage.delete(key)).toBe(false);
+    expect(await storage.stat(key)).toBeNull();
+  });
+
+  test.each([
+    '../../etc/passwd',
+    '/etc/passwd',
+    '2026/09/../../../../etc/passwd',
+    'passwd',
+    '2026/09/aaa.png',
+    '',
+  ])('refuses to write %s', async (key) => {
+    const { storage } = await started();
+    const temp = await storage.temp();
+
+    fs.writeFileSync(temp.path, 'x');
+
+    await expect(storage.put(temp.path, key)).rejects.toThrow(
+      /unsafe|escapes/u
+    );
+    expect(fs.existsSync(path.resolve(storage.root, '..', 'passwd'))).toBe(
+      false
+    );
+  });
+
+  test('a key that escapes the root cannot be read either', async () => {
+    const { storage } = await started();
+
+    await expect(storage.get('../../etc/passwd')).rejects.toThrow(/unsafe/u);
+    expect(await storage.stat('../../etc/passwd')).toBeNull();
+    expect(await storage.delete('../../etc/passwd')).toBe(false);
+  });
+
+  test('has no public url: a file is reached through a controller', async () => {
+    const { storage } = await started();
+
+    expect(storage.url('2026/09/x.png')).toBeNull();
+  });
+});
+
+describe('the storage seam', () => {
+  test('local is what the configuration names by default', () => {
+    const cwd = workspace();
+    const storage = createStorage(fakeHenri(cwd), {
+      root: 'storage/uploads',
+      storage: 'local',
+    });
+
+    expect(storage).toBeInstanceOf(LocalStorage);
+    expect(storage.root).toBe(path.join(cwd, 'storage/uploads'));
+  });
+
+  test('anything else is a module of the application', () => {
+    const cwd = workspace();
+
+    fs.writeFileSync(
+      path.join(cwd, 'store.js'),
+      `class Fake {
+         async start() {}
+         async stop() {}
+         async temp() { return { path: '/tmp/x' }; }
+         async put(source, key) { return key; }
+         async get() { return null; }
+         async stat() { return null; }
+         async delete() { return true; }
+         url() { return 'https://cdn.example.com'; }
+       }
+       module.exports = Fake;`
+    );
+
+    const storage = createStorage(fakeHenri(cwd), {
+      root: 'storage/uploads',
+      storage: './store.js',
+    });
+
+    expect(storage.url()).toBe('https://cdn.example.com');
+  });
+
+  test('a module that is not a storage says so', () => {
+    const cwd = workspace();
+
+    fs.writeFileSync(
+      path.join(cwd, 'nope.js'),
+      'module.exports = { hello: 1 };'
+    );
+
+    expect(() =>
+      createStorage(fakeHenri(cwd), { root: 'x', storage: './nope.js' })
+    ).toThrow(/does not implement HenriStorage/u);
+
+    expect(() =>
+      createStorage(fakeHenri(cwd), { root: 'x', storage: './missing.js' })
+    ).toThrow(/unable to load the storage/u);
+  });
+});

--- a/packages/uploads/index.js
+++ b/packages/uploads/index.js
@@ -1,0 +1,38 @@
+/**
+ * `@usehenri/uploads`: bounded multipart parsing, files typed by their bytes,
+ * and a storage seam.
+ *
+ * An application installs the package and gets the module (`henri.uploads`),
+ * `req.files`, `req.file()` and `req.permitFiles()`. What is exported here is
+ * for the two things an application does beyond that: writing a storage of
+ * its own against `HenriStorage`, and reusing the name and type helpers in a
+ * validation of its own.
+ *
+ * See https://usehenri.io/guides/uploads/
+ */
+const UploadsModule = require('./src/module');
+const LocalStorage = require('./src/storage/local');
+
+const { DEFAULTS, settings } = require('./src/config');
+const { UploadError } = require('./src/errors');
+const { UploadedFile } = require('./src/file');
+const { bytes, format } = require('./src/bytes');
+const { contentDisposition, keyFor, safeName } = require('./src/names');
+const { createStorage } = require('./src/storage');
+const { extensionFor, sniff } = require('./src/sniff');
+
+module.exports = UploadsModule;
+module.exports.DEFAULTS = DEFAULTS;
+module.exports.LocalStorage = LocalStorage;
+module.exports.UploadError = UploadError;
+module.exports.UploadedFile = UploadedFile;
+module.exports.UploadsModule = UploadsModule;
+module.exports.bytes = bytes;
+module.exports.contentDisposition = contentDisposition;
+module.exports.createStorage = createStorage;
+module.exports.extensionFor = extensionFor;
+module.exports.format = format;
+module.exports.keyFor = keyFor;
+module.exports.safeName = safeName;
+module.exports.settings = settings;
+module.exports.sniff = sniff;

--- a/packages/uploads/module.js
+++ b/packages/uploads/module.js
@@ -1,0 +1,8 @@
+/**
+ * The henri module this package ships.
+ *
+ * `package.json` points at this file with `"henri": { "module": "./module.js" }`,
+ * which is all core reads: an application depending on `@usehenri/uploads`
+ * has the module in its boot, as `henri.uploads`.
+ */
+module.exports = require('./src/module');

--- a/packages/uploads/package.json
+++ b/packages/uploads/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@usehenri/uploads",
+  "version": "1.1.0",
+  "description": "henri file uploads: bounded multipart parsing, files typed by their bytes and a storage seam",
+  "license": "MIT",
+  "author": "Felix-Antoine Paradis",
+  "homepage": "https://usehenri.io",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/usehenri/henri.git",
+    "directory": "packages/uploads"
+  },
+  "bugs": {
+    "url": "https://github.com/usehenri/henri/issues"
+  },
+  "keywords": [
+    "henri",
+    "uploads",
+    "multipart",
+    "files",
+    "busboy",
+    "storage"
+  ],
+  "main": "index.js",
+  "henri": {
+    "module": "./module.js"
+  },
+  "files": [
+    "index.js",
+    "module.js",
+    "src",
+    "CHANGELOG.md"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "dependencies": {
+    "busboy": "^1.6.0",
+    "debug": "^4.4.3"
+  },
+  "peerDependencies": {
+    "@usehenri/core": "workspace:^"
+  },
+  "devDependencies": {
+    "@usehenri/core": "workspace:^",
+    "express": "^5.2.1",
+    "supertest": "^7.2.2"
+  }
+}

--- a/packages/uploads/src/bytes.js
+++ b/packages/uploads/src/bytes.js
@@ -12,7 +12,15 @@
 const UNITS = { gb: 1024 * 1024 * 1024, kb: 1024, mb: 1024 * 1024 };
 
 /** A size: a number, with an optional unit */
-const SIZE = /^\s*(\d+(?:\.\d+)?)\s*(b|kb|mb|gb)?\s*$/iu;
+/**
+ * The written form: an amount, then a unit.
+ *
+ * The surrounding whitespace is trimmed before this runs rather than
+ * matched by it: `^\s*…\s*$` around an optional group is quadratic, and
+ * `'9' + ' '.repeat(100000) + '!'` took five seconds to refuse when the two
+ * star quantifiers had a run of spaces to share between them.
+ */
+const SIZE = /^(\d+(?:\.\d+)?)\s*(b|kb|mb|gb)?$/iu;
 
 /**
  * A size in bytes
@@ -34,7 +42,7 @@ function bytes(value, fallback = null) {
     return fallback;
   }
 
-  const match = SIZE.exec(value);
+  const match = SIZE.exec(value.trim());
 
   if (!match) {
     return fallback;

--- a/packages/uploads/src/bytes.js
+++ b/packages/uploads/src/bytes.js
@@ -1,0 +1,78 @@
+/**
+ * Sizes, the way the configuration writes them.
+ *
+ * `config.bodyLimit` is `"1mb"` or a number of bytes, and the upload limits
+ * are read the same way so that the two are comparable at a glance. This is
+ * the parser: no dependency, no unit henri does not document, and `false`
+ * kept as `false` because a limit an application removed on purpose is not
+ * the same thing as a limit it wrote badly.
+ */
+
+/** Multipliers of the suffixes a size accepts (no suffix is bytes) */
+const UNITS = { gb: 1024 * 1024 * 1024, kb: 1024, mb: 1024 * 1024 };
+
+/** A size: a number, with an optional unit */
+const SIZE = /^\s*(\d+(?:\.\d+)?)\s*(b|kb|mb|gb)?\s*$/iu;
+
+/**
+ * A size in bytes
+ *
+ * @param {*} value a number of bytes, a string (`'10mb'`), or `false`
+ * @param {(number|false|null)} [fallback=null] what an unreadable value becomes
+ * @returns {(number|false|null)} the size, `false` for no limit, or the fallback
+ */
+function bytes(value, fallback = null) {
+  if (value === false) {
+    return false;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
+  }
+
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+
+  const match = SIZE.exec(value);
+
+  if (!match) {
+    return fallback;
+  }
+
+  const unit = String(match[2] || '').toLowerCase();
+  const size = Number(match[1]) * (UNITS[unit] || 1);
+
+  return size > 0 ? Math.floor(size) : fallback;
+}
+
+/**
+ * A size, printed the way the documentation writes it
+ *
+ * @param {(number|false)} value a size in bytes, or `false`
+ * @returns {string} `'10mb'`, `'512kb'`, `'900b'` or `'no limit'`
+ */
+function format(value) {
+  if (value === false || value === null) {
+    return 'no limit';
+  }
+
+  for (const unit of ['gb', 'mb', 'kb']) {
+    if (value >= UNITS[unit]) {
+      return `${Math.round((value / UNITS[unit]) * 10) / 10}${unit}`;
+    }
+  }
+
+  return `${value}b`;
+}
+
+/**
+ * A limit as busboy wants it: a number, or `Infinity` for no limit
+ *
+ * @param {(number|false|null)} value the limit
+ * @returns {number} the limit, or `Infinity`
+ */
+const orInfinity = (value) =>
+  typeof value === 'number' && value > 0 ? value : Infinity;
+
+module.exports = { UNITS, bytes, format, orInfinity };

--- a/packages/uploads/src/config.js
+++ b/packages/uploads/src/config.js
@@ -1,0 +1,164 @@
+/**
+ * `config.uploads`, normalized.
+ *
+ * Every limit here is enforced by the parser as it reads, which is the only
+ * kind of limit worth writing: a check that runs once the file is on disk
+ * has already let the disk fill. `false` is accepted on the four that bound
+ * a request, because an application that means "no limit" should have to
+ * write it -- and `henri audit` reports it when it does.
+ *
+ * `maxFieldSize` defaults to `config.bodyLimit` rather than to a number of
+ * its own. The two bound the same thing from two directions: `bodyLimit`
+ * is what `express.json()` and `express.urlencoded()` accept for a whole
+ * body, and a multipart body is bounded by `maxTotalSize` instead, with
+ * `maxFieldSize` bounding one of its non-file parts. Giving the part the
+ * same ceiling as a whole urlencoded body keeps `"name"` costing the same
+ * whichever encoding a form was posted with.
+ */
+const { bytes } = require('./bytes');
+
+/** The defaults, and the table the documentation prints */
+const DEFAULTS = {
+  allow: null,
+  maxFieldNameSize: 100,
+  maxFieldSize: null,
+  maxFields: 100,
+  maxFileSize: '10mb',
+  maxFilenameLength: 255,
+  maxFiles: 10,
+  maxTotalSize: '25mb',
+  paths: null,
+  root: 'storage/uploads',
+  sniff: true,
+  storage: 'local',
+};
+
+/** The methods a body is read from; anything else never carries an upload */
+const METHODS = new Set(['PATCH', 'POST', 'PUT']);
+
+/**
+ * A whole number above zero, `false`, or the fallback
+ *
+ * @param {*} value the value
+ * @param {(number|false)} fallback what an unreadable value becomes
+ * @returns {(number|false)} the count
+ */
+const count = (value, fallback) => {
+  if (value === false) {
+    return false;
+  }
+
+  const number = Number(value);
+
+  return Number.isInteger(number) && number > 0 ? number : fallback;
+};
+
+/**
+ * A plain object, or an empty one
+ *
+ * @param {*} value the value
+ * @returns {object} a plain object
+ */
+const objectOf = (value) =>
+  value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+
+/**
+ * The list of media types an application accepts, or null for every type
+ *
+ * @param {*} value what the configuration holds
+ * @returns {?Array<string>} the list, or null
+ */
+const allowList = (value) => {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+
+  const entries = value
+    .filter((entry) => typeof entry === 'string' && entry.trim().length > 0)
+    .map((entry) => entry.trim().toLowerCase());
+
+  return entries.length > 0 ? entries : null;
+};
+
+/**
+ * The path prefixes multipart is parsed under, or null for every path
+ *
+ * @param {*} value what the configuration holds
+ * @returns {?Array<string>} the prefixes, or null
+ */
+const pathList = (value) => {
+  const entries = (Array.isArray(value) ? value : [value])
+    .filter((entry) => typeof entry === 'string' && entry.startsWith('/'))
+    .map((entry) => (entry.length > 1 ? entry.replace(/\/+$/u, '') : entry));
+
+  return entries.length > 0 ? entries : null;
+};
+
+/**
+ * The settings of the uploads module
+ *
+ * @param {object} config henri's config module (anything with get/has)
+ * @returns {object} the settings, or `{ enabled: false }` when the
+ *   application wrote `"uploads": false`
+ */
+function settings(config) {
+  const has = (key) =>
+    Boolean(config) && typeof config.has === 'function' && config.has(key);
+  const get = (key, fallback) => (has(key) ? config.get(key) : fallback);
+  const declared = get('uploads', {});
+
+  if (declared === false) {
+    return { enabled: false };
+  }
+
+  const uploads = objectOf(declared);
+  const bodyLimit = bytes(get('bodyLimit', '1mb'), 1024 * 1024);
+
+  return {
+    allow: allowList(uploads.allow),
+    enabled: true,
+    maxFieldNameSize: count(
+      uploads.maxFieldNameSize,
+      DEFAULTS.maxFieldNameSize
+    ),
+    maxFieldSize: bytes(uploads.maxFieldSize, bodyLimit),
+    maxFields: count(uploads.maxFields, DEFAULTS.maxFields),
+    maxFileSize: bytes(uploads.maxFileSize, bytes(DEFAULTS.maxFileSize)),
+    maxFilenameLength: count(
+      uploads.maxFilenameLength,
+      DEFAULTS.maxFilenameLength
+    ),
+    maxFiles: count(uploads.maxFiles, DEFAULTS.maxFiles),
+    maxTotalSize: bytes(uploads.maxTotalSize, bytes(DEFAULTS.maxTotalSize)),
+    paths: pathList(uploads.paths),
+    root: typeof uploads.root === 'string' ? uploads.root : DEFAULTS.root,
+    sniff: uploads.sniff !== false,
+    storage:
+      typeof uploads.storage === 'string' ? uploads.storage : DEFAULTS.storage,
+  };
+}
+
+/**
+ * Does this request take a body a multipart parser should read?
+ *
+ * @param {Express.Request} req the request
+ * @param {?Array<string>} paths the configured prefixes, or null
+ * @returns {boolean} true when the parser runs for it
+ */
+function covers(req, paths) {
+  if (!METHODS.has(req.method)) {
+    return false;
+  }
+
+  if (!Array.isArray(paths)) {
+    return true;
+  }
+
+  const url = (req.path || req.url || '/').split('?')[0];
+
+  return paths.some(
+    (prefix) => url === prefix || url.startsWith(`${prefix}/`) || prefix === '/'
+  );
+}
+
+module.exports = { DEFAULTS, METHODS, allowList, count, covers, settings };

--- a/packages/uploads/src/errors.js
+++ b/packages/uploads/src/errors.js
@@ -1,0 +1,50 @@
+/**
+ * What a refused upload is.
+ *
+ * Every refusal is an `UploadError` carrying an HTTP status and a code, and
+ * it reaches the client through `next(error)` -- core's error handler
+ * negotiates it into the JSON shape a client expects or the page a browser
+ * does, and its own logging quotes the request id. Nothing here writes a
+ * response itself: an upload is refused in a middleware, and the middleware
+ * that owns the answer is the one at the end of the chain.
+ */
+
+/** The codes a refusal carries, and the status each one answers with */
+const CODES = {
+  FIELD_NAME_TOO_LONG: 413,
+  FILE_TOO_LARGE: 413,
+  MALFORMED_MULTIPART: 400,
+  TOO_MANY_FIELDS: 413,
+  TOO_MANY_FILES: 413,
+  TOTAL_TOO_LARGE: 413,
+  TYPE_NOT_ALLOWED: 415,
+  VALUE_TOO_LARGE: 413,
+};
+
+/**
+ * A refused upload
+ *
+ * @class UploadError
+ * @extends {Error}
+ */
+class UploadError extends Error {
+  /**
+   * Creates an instance of UploadError.
+   *
+   * @param {string} code one of `CODES`
+   * @param {string} message what to tell the client
+   * @param {object} [data={}] what to add to the answer (a field name, a limit)
+   * @memberof UploadError
+   */
+  constructor(code, message, data = {}) {
+    super(message);
+
+    this.name = 'UploadError';
+    this.code = code;
+    this.status = CODES[code] || 400;
+    this.statusCode = this.status;
+    this.data = data;
+  }
+}
+
+module.exports = { CODES, UploadError };

--- a/packages/uploads/src/file.js
+++ b/packages/uploads/src/file.js
@@ -1,0 +1,194 @@
+/**
+ * One file that arrived.
+ *
+ * It exists on disk from the moment the parser finished reading it until the
+ * end of the request, and it is temporary for the whole of that time: an
+ * upload is not kept because it arrived, it is kept because a controller
+ * said so with `store()`. Everything else is swept when the response closes,
+ * whether the request was answered, refused, timed out or abandoned
+ * half-way.
+ *
+ * What `store()` resolves with is the record: the plain object a controller
+ * writes to a model. It holds the key, the cleaned original name, the type
+ * the *bytes* were recognized as, the size and a sha256 of the content --
+ * everything needed to hand the file back later, and nothing that would let
+ * the row alone reconstruct where on the machine it sits.
+ */
+const fsp = require('node:fs/promises');
+const debug = require('debug')('henri:uploads');
+
+const { extensionFor } = require('./sniff');
+const { keyFor, safeName } = require('./names');
+
+/**
+ * A file the parser read and put somewhere private
+ *
+ * @class UploadedFile
+ */
+class UploadedFile {
+  /**
+   * Creates an instance of UploadedFile.
+   *
+   * @param {object} options what the parser found out
+   * @param {string} options.field the form field it arrived in
+   * @param {string} options.name the cleaned original name
+   * @param {string} options.declaredType what the client called it
+   * @param {string} options.type what the bytes say it is
+   * @param {boolean} options.sniffed whether henri recognized those bytes
+   * @param {number} options.size how many bytes arrived
+   * @param {string} options.checksum sha256 of the content, hex
+   * @param {string} options.path where it is, until the response closes
+   * @param {object} options.storage the storage that will keep it
+   * @param {number} [options.order=0] which part of the body it was, so that
+   *   `req.files.photos[0]` is the first photo the form sent whatever order
+   *   the reads happened to finish in
+   * @memberof UploadedFile
+   */
+  constructor({
+    checksum,
+    declaredType,
+    field,
+    name,
+    order = 0,
+    path: temporary,
+    size,
+    sniffed,
+    storage,
+    type,
+  }) {
+    this.order = order;
+    this.field = field;
+    this.name = name;
+    this.declaredType = declaredType;
+    this.type = type;
+    this.sniffed = sniffed;
+    this.size = size;
+    this.checksum = checksum;
+    this.path = temporary;
+    this.storage = storage;
+
+    /** The record `store()` resolved with, once it has */
+    this.stored = null;
+
+    /** True once the temporary file is gone, however it went */
+    this.released = false;
+  }
+
+  /**
+   * Did the client say one thing and the bytes another?
+   *
+   * @returns {boolean} true when the declared type is not the real one
+   * @memberof UploadedFile
+   */
+  get mistyped() {
+    return (
+      this.sniffed &&
+      Boolean(this.declaredType) &&
+      this.declaredType !== this.type
+    );
+  }
+
+  /**
+   * Keeps the file, and answers the record to write to a model
+   *
+   * @async
+   * @param {object} [options={}] the options
+   * @param {string} [options.prefix] a directory to file it under
+   * @param {object} [options.storage] another storage than the default one
+   * @returns {Promise<object>} `{ checksum, key, name, size, storage, type, uploadedAt }`
+   * @throws when there is nothing left to store, or the storage refuses
+   * @memberof UploadedFile
+   */
+  async store(options = {}) {
+    if (this.stored) {
+      return this.stored;
+    }
+
+    if (this.released) {
+      throw new Error(
+        `the upload "${this.name}" was already released; store() has to be called before the response closes`
+      );
+    }
+
+    const storage = options.storage || this.storage;
+    const key = await storage.put(
+      this.path,
+      keyFor({
+        extension: extensionFor(this.type),
+        prefix: options.prefix || null,
+      })
+    );
+
+    this.released = true;
+    this.stored = {
+      checksum: this.checksum,
+      key,
+      name: this.name,
+      size: this.size,
+      storage: storage.name,
+      type: this.type,
+      uploadedAt: new Date().toISOString(),
+    };
+
+    return this.stored;
+  }
+
+  /**
+   * Throws the file away now, rather than at the end of the request
+   *
+   * @async
+   * @returns {Promise<boolean>} true when something was removed
+   * @memberof UploadedFile
+   */
+  async discard() {
+    if (this.released) {
+      return false;
+    }
+
+    this.released = true;
+
+    try {
+      await fsp.unlink(this.path);
+
+      return true;
+    } catch (error) {
+      debug('unable to remove %s: %s', this.path, error.message);
+
+      return false;
+    }
+  }
+
+  /**
+   * What a view or a JSON answer gets: the record when it was stored, the
+   * facts without the temporary path when it was not
+   *
+   * @returns {object} a plain object
+   * @memberof UploadedFile
+   */
+  toJSON() {
+    return (
+      this.stored || {
+        checksum: this.checksum,
+        field: this.field,
+        name: this.name,
+        size: this.size,
+        type: this.type,
+      }
+    );
+  }
+}
+
+/**
+ * An UploadedFile, with its name cleaned and its type decided
+ *
+ * @param {object} options see the constructor, plus `maxFilenameLength`
+ * @returns {UploadedFile} the file
+ */
+const fileOf = (options) =>
+  new UploadedFile(
+    Object.assign({}, options, {
+      name: safeName(options.name, options.maxFilenameLength),
+    })
+  );
+
+module.exports = { UploadedFile, fileOf };

--- a/packages/uploads/src/module.js
+++ b/packages/uploads/src/module.js
@@ -1,0 +1,410 @@
+const BaseModule = require('@usehenri/core/module');
+
+const debug = require('debug')('henri:uploads');
+
+const { DEFAULTS, settings: settingsOf } = require('./config');
+const { format } = require('./bytes');
+const { contentDisposition } = require('./names');
+const { createStorage } = require('./storage');
+const { middleware } = require('./multipart');
+const { UploadedFile } = require('./file');
+
+/**
+ * File uploads: the henri module this package ships.
+ *
+ * ---------------------------------------------------------------------------
+ * The design, and why it is this one
+ * ---------------------------------------------------------------------------
+ *
+ * **A package, not core, and not core behind a key.** An upload needs a
+ * multipart parser, and a multipart parser is a dependency of every
+ * application that installs the framework -- including the many that will
+ * never accept a file. henri already has the shape for this: `@usehenri/jobs`
+ * carries the queue, `@usehenri/graphql` carries Apollo, a store adapter is
+ * resolved from the application rather than bundled, and a package says it
+ * ships a module with `"henri": { "module": "./module.js" }` in its own
+ * package.json. So busboy is a dependency of this package and of nothing
+ * else, and an application accepts files by installing it. The one thing
+ * that does live in core is the `uploads` *key* of the configuration schema,
+ * validated at boot whether or not the package is there -- exactly as
+ * `graphql` is, so that a typo is a boot error rather than a silence.
+ *
+ * **busboy.** It is what the ecosystem sits on (multer is a thin Express
+ * wrapper around it, and so are most of the others), it is a streaming
+ * parser with no opinion about the filesystem, and its limits are enforced
+ * by the state machine as it reads rather than by a check afterwards, which
+ * is the property this whole feature is built on. formidable writes files
+ * itself, with its own naming and its own temporary directory, which is
+ * precisely the part henri wants to own; multer would mean wrapping busboy
+ * in something that then has to be un-wrapped to control where the bytes go.
+ *
+ * **Where it sits in the request.** Runlevel 3, `before: ['user', 'router']`.
+ * It has to be before the user module, because the `_csrf` field of a
+ * `multipart/form-data` form is *inside the body*, and the CSRF middleware
+ * reads `req.body`: parse later and no plain HTML upload form can ever pass
+ * the token check. The consequence is that the parser is the first thing an
+ * unauthenticated request meets, which is why every limit is enforced before
+ * a byte is read, why `paths` exists to narrow the surface further, and why
+ * nothing is ever kept unless a controller says so.
+ *
+ * **The limits, and how they relate to `bodyLimit`.** `config.bodyLimit`
+ * (1mb) is what `express.json()` and `express.urlencoded()` accept for a
+ * whole body; it does not apply to `multipart/form-data`, which those
+ * parsers never look at. The multipart equivalents are `maxTotalSize` for
+ * the whole body (25mb), `maxFileSize` for one file (10mb), `maxFiles` (10),
+ * `maxFields` (100), `maxFieldNameSize` (100 bytes) and `maxFieldSize`,
+ * which defaults to `config.bodyLimit` itself so that one text field of a
+ * form costs the same whichever encoding the form was posted with. Every one
+ * of them reaches busboy as a limit; the total is also counted as the bytes
+ * arrive, because `Content-Length` is absent from a chunked request and
+ * optional in the honesty of any other.
+ *
+ * **The type is the bytes.** A part's `Content-Type` and its filename are
+ * written by whoever is uploading. henri reads the first 4kb instead and
+ * matches a signature table (`sniff.js`); what it recognizes is the type,
+ * what it does not is `application/octet-stream`, and the client's claim is
+ * kept as `declaredType` for the record and used for nothing. It does not
+ * guess a type from an extension, ever, and it does not open archives: a
+ * `.docx` is `application/zip`, which is what it is. `allow` matches the
+ * type henri decided on, so `allow: ['image/png']` cannot be satisfied by
+ * naming a zip `avatar.png`.
+ *
+ * **The name never reaches the filesystem.** The stored name is generated:
+ * `<yyyy>/<mm>/<32 hex characters>.<extension from the sniffed type>`. The
+ * original is cleaned and kept as metadata, for the record and for the
+ * `Content-Disposition` of a download. That is one answer to a long list of
+ * problems that are really one problem -- `../../etc/passwd`, `/etc/passwd`,
+ * `C:\boot.ini`, a NUL byte, `CON`, `.htaccess`, `avatar.php`, four thousand
+ * characters -- because none of them are consulted when a path is built.
+ *
+ * **Where the files go.** `storage/uploads` in the application, outside
+ * `app/views/public` (which `express.static` serves) and outside `.henri`
+ * (which `henri clean` removes). The directory is created `0700`, every
+ * object `0600`, and a `.gitignore` is written into it the first time so
+ * that uploads never reach a commit. Nothing is ever served from it: a file
+ * is handed back by `henri.uploads.send()`, which streams it with
+ * `Content-Disposition: attachment`, `X-Content-Type-Options: nosniff` and
+ * the type henri recognized -- through a controller, which is where the
+ * decision about who may read it belongs. The two scriptable types henri
+ * recognizes, `text/html` and `image/svg+xml`, are stored under a `.bin`
+ * extension as well, so that a web server misconfigured to serve the
+ * directory still has nothing there it would render.
+ *
+ * **The storage seam.** `HenriStorage` (documented at the top of
+ * `src/storage/local.js`) is to uploads what `HenriAdapter` is to the
+ * stores: `start`, `stop`, `temp`, `put`, `get`, `stat`, `delete`, `url`.
+ * The local disk is one implementation and ships; an object store is
+ * another, named by module id in `config.uploads.storage` and resolved from
+ * the application the way a rate limit store is. henri ships no S3 client.
+ * `temp()` is part of the contract because only the storage knows where a
+ * part should land so that keeping it is cheap -- a rename on the same
+ * filesystem, locally.
+ *
+ * **Nothing is kept by default.** A parsed file lives in the storage's
+ * temporary area until a controller calls `store()`. Everything else is
+ * removed when the response closes -- answered, refused, timed out or
+ * abandoned, which is the whole list of ways a request ends -- and
+ * `permitFiles()` removes what a controller did not ask for immediately
+ * rather than at the end. A `SIGKILL` is the one case a request cannot clean
+ * up after, so the storage sweeps its temporary area at boot.
+ *
+ * ---------------------------------------------------------------------------
+ * What an application sees
+ * ---------------------------------------------------------------------------
+ *
+ * ```js
+ * // app/controllers/artworks.js
+ * async create(req, res) {
+ *   const data = req.permit('title', 'year');
+ *   const { scan } = req.permitFiles('scan');
+ *
+ *   if (scan) {
+ *     data.scan = await scan[0].store({ prefix: 'artworks' });
+ *   }
+ *
+ *   const artwork = await Artwork.create(data);
+ *
+ *   return res.resource(artwork);
+ * }
+ * ```
+ *
+ * `req.files` is `{ [field]: UploadedFile[] }`, `req.file('scan')` is the
+ * first one of a field, and `req.permitFiles(...)` is `req.permit(...)` for
+ * files. `store()` resolves with the record to write to a model:
+ * `{ checksum, key, name, size, storage, type, uploadedAt }`.
+ *
+ * @class UploadsModule
+ * @extends {BaseModule}
+ */
+class UploadsModule extends BaseModule {
+  /**
+   * Creates an instance of UploadsModule.
+   *
+   * @param {object} [henri=null] A henri instance
+   * @memberof UploadsModule
+   */
+  constructor(henri = null) {
+    super();
+
+    this.reloadable = true;
+    this.needs = ['config', 'server'];
+    this.before = ['user', 'router'];
+    this.runlevel = 3;
+    this.name = 'uploads';
+    this.henri = henri;
+
+    this.enabled = false;
+    this.settings = null;
+    this.storage = null;
+
+    this._mounted = false;
+
+    this.init = this.init.bind(this);
+    this.reload = this.reload.bind(this);
+    this.stop = this.stop.bind(this);
+    this.send = this.send.bind(this);
+  }
+
+  /**
+   * Module initialization
+   * Called after being loaded by Modules
+   *
+   * @async
+   * @returns {Promise<string>} The name of the module
+   * @throws when the storage cannot be prepared
+   * @memberof UploadsModule
+   */
+  async init() {
+    const { pen, server } = this.henri;
+
+    this.settings = settingsOf(this.henri.config);
+
+    // Mounted whether or not uploads are on: `req.files`, `req.file()` and
+    // `req.permitFiles()` exist on every request the way `req.permit()` does,
+    // and a reload that turns uploads on finds the middleware already in
+    // place -- an express app cannot be given one later, only more of them.
+    this.mount(server);
+
+    if (!this.settings.enabled) {
+      pen.info('uploads', 'disabled by configuration');
+
+      return this.name;
+    }
+
+    this.storage = createStorage(this.henri, this.settings);
+
+    try {
+      await this.storage.start();
+    } catch (error) {
+      pen.error('uploads', 'unable to prepare the storage', error.message);
+      throw error;
+    }
+
+    this.enabled = true;
+
+    const { maxFiles, maxFileSize, maxTotalSize } = this.settings;
+
+    pen.info(
+      'uploads',
+      `${this.storage.name} storage`,
+      `${format(maxFileSize)} per file, ${format(maxTotalSize)} per request, ${
+        maxFiles === false ? 'any number of' : maxFiles
+      } files`
+    );
+
+    if (this.settings.allow) {
+      pen.info('uploads', 'accepted types', this.settings.allow.join(', '));
+    }
+
+    if (!this.settings.sniff) {
+      pen.warn(
+        'uploads',
+        'content sniffing is off: the type of a file is whatever the client says it is'
+      );
+    }
+
+    return this.name;
+  }
+
+  /**
+   * Mounts the parser, once: a reload changes what it reads, never where it
+   * sits in the chain (an express app has no way to remove a middleware, and
+   * the position is the whole point -- before sessions and CSRF)
+   *
+   * @param {object} server the server module
+   * @returns {boolean} whether it was mounted by this call
+   * @memberof UploadsModule
+   */
+  mount(server) {
+    if (this._mounted || !server || !server.app) {
+      return false;
+    }
+
+    server.app.use(middleware(this));
+
+    this._mounted = true;
+
+    return true;
+  }
+
+  /**
+   * Re-reads the configuration and the storage
+   *
+   * @async
+   * @returns {Promise<string>} The name of the module
+   * @memberof UploadsModule
+   */
+  async reload() {
+    const previous = this.storage;
+
+    this.settings = settingsOf(this.henri.config);
+    this.mount(this.henri.server);
+
+    if (!this.settings.enabled) {
+      this.enabled = false;
+      previous && (await previous.stop());
+      this.storage = null;
+
+      return this.name;
+    }
+
+    this.storage = createStorage(this.henri, this.settings);
+    await this.storage.start();
+    this.enabled = true;
+
+    if (previous && previous !== this.storage) {
+      await previous.stop();
+    }
+
+    return this.name;
+  }
+
+  /**
+   * Hands a stored file back to a client.
+   *
+   * A download, not a page: `Content-Disposition: attachment` and
+   * `X-Content-Type-Options: nosniff`, so nothing an application stored is
+   * ever rendered on its own origin. `{ disposition: 'inline' }` is there for
+   * the types an application knows it can trust -- an image it generated, a
+   * PDF it wrote -- and is never the default.
+   *
+   * @async
+   * @param {Express.Response} res the response
+   * @param {object} record what `store()` returned, as read back from a model
+   * @param {object} [options={}] `{ disposition, maxAge }`
+   * @returns {Promise<Express.Response>} the response
+   * @throws when the record names no key
+   * @memberof UploadsModule
+   */
+  async send(res, record, options = {}) {
+    const { disposition = 'attachment', maxAge = 0 } = options;
+    const file = typeof record === 'string' ? { key: record } : record || {};
+
+    if (!file.key) {
+      throw new Error('henri.uploads.send() needs the record store() returned');
+    }
+
+    const stream = await this.ready().get(file.key);
+
+    res.set('Content-Type', file.type || 'application/octet-stream');
+    res.set('X-Content-Type-Options', 'nosniff');
+    res.set(
+      'Content-Disposition',
+      contentDisposition(file.name || 'file', disposition)
+    );
+    res.set(
+      'Cache-Control',
+      maxAge > 0 ? `private, max-age=${Math.floor(maxAge / 1000)}` : 'private'
+    );
+
+    if (typeof file.size === 'number') {
+      res.set('Content-Length', String(file.size));
+    }
+
+    // The headers go out before the first chunk, so the response is
+    // committed by the time this resolves: a controller that returns what
+    // `send()` gives it has answered, and the action wrapper knows it
+    typeof res.flushHeaders === 'function' && res.flushHeaders();
+
+    await new Promise((resolve) => {
+      stream.on('error', (error) => {
+        debug('unable to stream %s: %s', file.key, error.message);
+        res.destroy();
+        resolve();
+      });
+      res.on('close', resolve);
+      res.on('finish', resolve);
+      stream.pipe(res);
+    });
+
+    return res;
+  }
+
+  /**
+   * A readable stream of a stored file
+   *
+   * @async
+   * @param {(object|string)} record the record, or its key
+   * @returns {Promise<stream.Readable>} the stream
+   * @memberof UploadsModule
+   */
+  async get(record) {
+    return this.ready().get(typeof record === 'string' ? record : record.key);
+  }
+
+  /**
+   * Removes a stored file
+   *
+   * @async
+   * @param {(object|string)} record the record, or its key
+   * @returns {Promise<boolean>} true when something was removed
+   * @memberof UploadsModule
+   */
+  async delete(record) {
+    return this.ready().delete(
+      typeof record === 'string' ? record : record.key
+    );
+  }
+
+  /**
+   * The storage, or a readable error
+   *
+   * @returns {object} the storage
+   * @throws when uploads are turned off
+   * @memberof UploadsModule
+   */
+  ready() {
+    if (this.enabled && this.storage) {
+      return this.storage;
+    }
+
+    throw this.henri.pen.fatal(
+      'uploads',
+      `
+      this application asked for an uploaded file, but uploads are off.
+      Remove "uploads": false from the configuration`
+    );
+  }
+
+  /**
+   * Stops the module: releases the storage
+   *
+   * @async
+   * @returns {Promise<(string|boolean)>} the module name, or false
+   * @memberof UploadsModule
+   */
+  async stop() {
+    if (!this.storage) {
+      return false;
+    }
+
+    await this.storage.stop();
+    this.enabled = false;
+
+    return this.name;
+  }
+}
+
+module.exports = UploadsModule;
+module.exports.DEFAULTS = DEFAULTS;
+module.exports.UploadedFile = UploadedFile;

--- a/packages/uploads/src/multipart.js
+++ b/packages/uploads/src/multipart.js
@@ -1,0 +1,696 @@
+/**
+ * Reading a multipart body, within limits that exist before the first byte.
+ *
+ * Every bound below is handed to the parser, not checked afterwards. That is
+ * the only arrangement that means anything: a size checked once the file is
+ * on disk has already let the disk fill, and a count checked once the parts
+ * are parsed has already paid for parsing them. busboy stops at the limit
+ * and says which one it hit; henri turns that into a refusal and removes
+ * what had been written so far.
+ *
+ * Three of the bounds are henri's own rather than busboy's:
+ *
+ * - the **total** size of the body. `Content-Length` is checked before the
+ *   parser is even built, and then counted again as the bytes arrive, because
+ *   a chunked request has no `Content-Length` to check and a request that has
+ *   one is under no obligation to be honest about it.
+ * - the **type** of each file, from its bytes (see `sniff.js`).
+ * - the **name** of each file, which never reaches a path (see `names.js`).
+ *
+ * The parser runs before sessions and CSRF, because it has to: the `_csrf`
+ * field of a `multipart/form-data` form is inside the body, and the CSRF
+ * middleware reads `req.body`. That ordering is what makes an ordinary HTML
+ * upload form work at all, and it is why the limits above matter as much as
+ * they do -- they are what an unauthenticated request meets first.
+ */
+const busboy = require('busboy');
+const { Transform } = require('node:stream');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const fsp = require('node:fs/promises');
+const { pipeline } = require('node:stream/promises');
+const debug = require('debug')('henri:uploads');
+
+const { UploadError } = require('./errors');
+const { allowed, SAMPLE, sniff } = require('./sniff');
+const { covers } = require('./config');
+const { fileOf } = require('./file');
+const { orInfinity } = require('./bytes');
+
+/**
+ * Keys a form field never becomes, whatever it is called.
+ *
+ * The same list `req.permit()` refuses in core (`base/params.js`): a body
+ * ends up merged, assigned and serialized, and `__proto__` arriving as a
+ * form field is the oldest way to make all three interesting.
+ */
+const FORBIDDEN = new Set(['__proto__', 'constructor', 'prototype']);
+
+/** How many header pairs one part may carry (busboy allows 2000) */
+const HEADER_PAIRS = 100;
+
+/**
+ * The size limits busboy takes are "stop at", not "refuse past": it
+ * truncates a part the moment it *reaches* the number, so a 5mb file under a
+ * 5mb limit is reported as truncated. henri hands it one byte more and reads
+ * the truncation as "larger than the limit", which is what the configuration
+ * says and what an application expects.
+ *
+ * @param {(number|false|null)} limit the configured limit
+ * @returns {number} what busboy is given
+ */
+const stopAt = (limit) => orInfinity(limit) + 1;
+
+/**
+ * Is this field name longer than the configuration allows?
+ *
+ * busboy only enforces `fieldNameSize` on urlencoded bodies -- in a
+ * multipart body the name comes out of a part header, and `nameTruncated`
+ * is always false there. So henri measures it.
+ *
+ * @param {string} name the field name
+ * @param {(number|false)} limit the configured limit
+ * @returns {boolean} true when it is too long
+ */
+const nameTooLong = (name, limit) =>
+  limit !== false && Buffer.byteLength(String(name), 'utf8') > limit;
+
+/** How long a refused request is drained before its socket is closed (ms) */
+const DRAIN_TIMEOUT = 5000;
+
+/**
+ * How much more than the total limit a refused request may still send before
+ * its socket is closed. A form whose file was a little too big is drained to
+ * the end and reads its `413`; a deliberate flood is hung up on.
+ */
+const DRAIN_FACTOR = 2;
+
+/**
+ * Reads and throws away what is left of a refused request.
+ *
+ * A client told to stop is usually still sending, and answering while it
+ * writes is what turns a `413` into a connection reset on its side -- the
+ * status nobody sees is the status nobody fixes. So the rest of the body is
+ * read and discarded, which costs no memory and no disk, and the wait is
+ * bounded twice: `cap` bytes, and `ms` milliseconds. Past either, the socket
+ * is closed and the client is left to work out what happened, which is the
+ * right answer for something that was told no and kept sending.
+ *
+ * @param {Express.Request} req the request
+ * @param {object} [options={}] `{ cap, ms }`
+ * @param {(number|false)} [options.cap] how many more bytes to accept
+ * @param {number} [options.ms=DRAIN_TIMEOUT] how long to wait
+ * @returns {Promise<void>} resolves once the body is over, or the wait is
+ */
+function drain(req, { cap = false, ms = DRAIN_TIMEOUT } = {}) {
+  if (req.complete || req.destroyed || req.readableEnded) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      req.destroy();
+      resolve();
+    }, ms);
+
+    /**
+     * Stops waiting
+     *
+     * @returns {void}
+     */
+    const done = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+
+    let seen = 0;
+
+    timer.unref();
+    req.on('data', (chunk) => {
+      seen += chunk.length;
+
+      if (cap !== false && seen > cap) {
+        debug('a refused request kept sending: closing the socket');
+        req.destroy();
+        done();
+      }
+    });
+    req.on('end', done);
+    req.on('close', done);
+    req.on('error', done);
+    req.resume();
+  });
+}
+
+/**
+ * Is this a body a multipart parser should read?
+ *
+ * @param {Express.Request} req the request
+ * @returns {boolean} true when the content type is multipart
+ */
+const isMultipart = (req) =>
+  /^multipart\//iu.test(String(req.headers['content-type'] || ''));
+
+/**
+ * A stream that counts what goes through it and stops past a limit
+ *
+ * @param {(number|false)} limit the number of bytes allowed, or false
+ * @returns {Transform} the stream
+ */
+function meter(limit) {
+  let seen = 0;
+
+  return new Transform({
+    transform(chunk, encoding, done) {
+      seen += chunk.length;
+
+      if (limit !== false && seen > limit) {
+        return done(
+          new UploadError(
+            'TOTAL_TOO_LARGE',
+            `the request body is larger than the ${limit} bytes this application accepts`,
+            { limit }
+          )
+        );
+      }
+
+      return done(null, chunk);
+    },
+  });
+}
+
+/**
+ * A stream that hashes, measures and samples what goes through it
+ *
+ * @param {object} state where to record what it saw
+ * @returns {Transform} the stream
+ */
+function inspector(state) {
+  const hash = crypto.createHash('sha256');
+  const head = [];
+  let sampled = 0;
+
+  return new Transform({
+    flush(done) {
+      state.checksum = hash.digest('hex');
+      state.sample = Buffer.concat(head);
+      done();
+    },
+    transform(chunk, encoding, done) {
+      hash.update(chunk);
+      state.size += chunk.length;
+
+      if (sampled < SAMPLE) {
+        const wanted = chunk.subarray(0, SAMPLE - sampled);
+
+        head.push(wanted);
+        sampled += wanted.length;
+      }
+
+      done(null, chunk);
+    },
+  });
+}
+
+/**
+ * Adds a value to a body, the way a repeated form field becomes a list
+ *
+ * @param {object} body the body being built
+ * @param {string} name the field name
+ * @param {string} value the value
+ * @returns {void}
+ */
+function addField(body, name, value) {
+  if (FORBIDDEN.has(name)) {
+    debug('dropping the field %s', name);
+
+    return;
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(body, name)) {
+    body[name] = value;
+
+    return;
+  }
+
+  body[name] = Array.isArray(body[name])
+    ? [...body[name], value]
+    : [body[name], value];
+}
+
+/**
+ * Reads one file part into the storage's temporary area
+ *
+ * @param {object} options the options
+ * @param {string} options.field the form field
+ * @param {stream.Readable} options.stream the part
+ * @param {object} options.info what busboy read from the part headers
+ * @param {number} options.order which part of the body it was
+ * @param {object} options.settings the normalized settings
+ * @param {object} options.storage the storage
+ * @returns {Promise<UploadedFile>} the file, on disk and typed
+ * @throws {UploadError} when the file is too large or of a refused type
+ */
+async function readFile({ field, info, order, settings, storage, stream }) {
+  const state = { checksum: '', sample: Buffer.alloc(0), size: 0 };
+  const temp = await storage.temp();
+  const target = fs.createWriteStream(temp.path, { flags: 'wx', mode: 0o600 });
+  let truncated = false;
+
+  stream.on('limit', () => {
+    truncated = true;
+  });
+
+  try {
+    await pipeline(stream, inspector(state), target);
+  } catch (error) {
+    await fsp.unlink(temp.path).catch(() => {});
+    throw error;
+  }
+
+  if (truncated) {
+    await fsp.unlink(temp.path).catch(() => {});
+    throw new UploadError(
+      'FILE_TOO_LARGE',
+      `"${field}" is larger than the ${settings.maxFileSize} bytes this application accepts`,
+      { field, limit: settings.maxFileSize }
+    );
+  }
+
+  const declaredType = String(info.mimeType || '')
+    .toLowerCase()
+    .split(';')[0]
+    .trim();
+  const found = settings.sniff
+    ? sniff(state.sample, state.size <= SAMPLE)
+    : { sniffed: false, type: declaredType || 'application/octet-stream' };
+
+  if (!allowed(found.type, settings.allow)) {
+    await fsp.unlink(temp.path).catch(() => {});
+    throw new UploadError(
+      'TYPE_NOT_ALLOWED',
+      `"${field}" is ${found.type}, which this application does not accept`,
+      { allow: settings.allow, field, type: found.type }
+    );
+  }
+
+  return fileOf({
+    checksum: state.checksum,
+    declaredType: declaredType || null,
+    field,
+    maxFilenameLength: settings.maxFilenameLength,
+    name: info.filename,
+    order,
+    path: temp.path,
+    size: state.size,
+    sniffed: found.sniffed,
+    storage,
+    type: found.type,
+  });
+}
+
+/**
+ * Reads a whole multipart body
+ *
+ * @param {Express.Request} req the request
+ * @param {object} options `{ collected, settings, storage }`
+ * @returns {Promise<object>} the fields, once every file is on disk
+ * @throws {UploadError} on any of the limits, or on a malformed body
+ */
+function collect(req, { collected, settings, storage }) {
+  return new Promise((resolve, reject) => {
+    const fields = {};
+    const pending = [];
+    let failure = null;
+    let done = false;
+    let parts = 0;
+
+    /**
+     * The first refusal wins; the rest of the body is drained so the client
+     * can read the answer instead of seeing its socket reset
+     *
+     * @param {Error} error what went wrong
+     * @returns {void}
+     */
+    const fail = (error) => {
+      if (failure) {
+        return;
+      }
+
+      failure = error;
+      req.unpipe(counter);
+      counter.unpipe(bus);
+      // Destroying the parser makes it emit `close`, which is the ordinary
+      // way this ends: it has to stop meaning "answer now", or the refusal
+      // goes out while the client is still writing and it reads a connection
+      // reset instead of the status
+      bus.off('close', finish);
+      bus.destroy();
+      drain(req, { cap: settings.maxTotalSize }).then(finish, finish);
+    };
+
+    /**
+     * Answers once every file has been written (or removed)
+     *
+     * @returns {void}
+     */
+    const finish = () => {
+      if (done) {
+        return;
+      }
+
+      done = true;
+      Promise.allSettled(pending).then(() =>
+        failure ? reject(failure) : resolve(fields)
+      );
+    };
+
+    let bus;
+
+    try {
+      bus = busboy({
+        defParamCharset: 'utf8',
+        headers: req.headers,
+        limits: {
+          fieldNameSize: stopAt(settings.maxFieldNameSize),
+          fieldSize: stopAt(settings.maxFieldSize),
+          fields: orInfinity(settings.maxFields),
+          fileSize: stopAt(settings.maxFileSize),
+          files: orInfinity(settings.maxFiles),
+          headerPairs: HEADER_PAIRS,
+          parts: orInfinity(
+            settings.maxFiles === false || settings.maxFields === false
+              ? false
+              : settings.maxFiles + settings.maxFields
+          ),
+        },
+      });
+    } catch (error) {
+      return reject(
+        new UploadError('MALFORMED_MULTIPART', error.message, {
+          cause: error.message,
+        })
+      );
+    }
+
+    const counter = meter(settings.maxTotalSize);
+
+    bus.on('field', (name, value, info) => {
+      if (info.nameTruncated || nameTooLong(name, settings.maxFieldNameSize)) {
+        return fail(
+          new UploadError(
+            'FIELD_NAME_TOO_LONG',
+            `a field name is longer than the ${settings.maxFieldNameSize} bytes this application accepts`,
+            { limit: settings.maxFieldNameSize }
+          )
+        );
+      }
+
+      if (info.valueTruncated) {
+        return fail(
+          new UploadError(
+            'VALUE_TOO_LARGE',
+            `"${name}" is larger than the ${settings.maxFieldSize} bytes this application accepts`,
+            { field: name, limit: settings.maxFieldSize }
+          )
+        );
+      }
+
+      return addField(fields, name, value);
+    });
+
+    bus.on('file', (name, stream, info) => {
+      if (failure || FORBIDDEN.has(name)) {
+        return stream.resume();
+      }
+
+      if (nameTooLong(name, settings.maxFieldNameSize)) {
+        stream.resume();
+
+        return fail(
+          new UploadError(
+            'FIELD_NAME_TOO_LONG',
+            `a field name is longer than the ${settings.maxFieldNameSize} bytes this application accepts`,
+            { limit: settings.maxFieldNameSize }
+          )
+        );
+      }
+
+      const order = parts++;
+
+      return pending.push(
+        readFile({ field: name, info, order, settings, storage, stream }).then(
+          (file) => collected.push(file),
+          (error) => {
+            stream.resume();
+            fail(error);
+          }
+        )
+      );
+    });
+
+    bus.on('fieldsLimit', () =>
+      fail(
+        new UploadError(
+          'TOO_MANY_FIELDS',
+          `this application accepts ${settings.maxFields} fields in a form`,
+          { limit: settings.maxFields }
+        )
+      )
+    );
+
+    bus.on('filesLimit', () =>
+      fail(
+        new UploadError(
+          'TOO_MANY_FILES',
+          `this application accepts ${settings.maxFiles} files in a request`,
+          { limit: settings.maxFiles }
+        )
+      )
+    );
+
+    bus.on('partsLimit', () =>
+      fail(
+        new UploadError(
+          'TOO_MANY_FIELDS',
+          'this application accepts fewer parts in a request',
+          { limit: settings.maxFields }
+        )
+      )
+    );
+
+    bus.on('error', (error) =>
+      fail(
+        error instanceof UploadError
+          ? error
+          : new UploadError(
+              'MALFORMED_MULTIPART',
+              'the multipart body could not be read',
+              {
+                cause: error.message,
+              }
+            )
+      )
+    );
+
+    bus.on('close', finish);
+
+    counter.on('error', fail);
+
+    // A client that goes away half-way: the socket closes before the body is
+    // complete. `close` fires at the end of every request too, which is why
+    // `complete` is what is asked about rather than the event.
+    req.on('close', () => {
+      if (!req.complete) {
+        fail(
+          new UploadError('MALFORMED_MULTIPART', 'the request was abandoned', {
+            aborted: true,
+          })
+        );
+      }
+    });
+
+    return req.pipe(counter).pipe(bus);
+  });
+}
+
+/**
+ * `req.files`, `req.file()` and `req.permitFiles()`, on every request.
+ *
+ * They exist whether or not anything was uploaded, so a controller reads
+ * them without asking first -- the same reason `req.permit()` exists on a
+ * `GET`.
+ *
+ * @param {Express.Request} req the request
+ * @returns {Array<UploadedFile>} the list the sweep reads
+ */
+function decorate(req) {
+  const collected = [];
+
+  req.files = {};
+  req._uploads = collected;
+
+  /**
+   * The first file of a field, or null
+   *
+   * @param {string} field the form field
+   * @returns {?UploadedFile} the file
+   */
+  req.file = (field) => (req.files[field] || [])[0] || null;
+
+  /**
+   * The listed file fields, as `req.permit()` does for the body: what was
+   * not asked for is not returned, and -- unlike a body field, which only
+   * costs memory until the request ends -- it is removed from the disk on
+   * the spot.
+   *
+   * @param {...(string|Array<string>)} fields the file fields to accept
+   * @returns {object} `{ [field]: Array<UploadedFile> }`, only the listed ones
+   */
+  req.permitFiles = (...fields) => {
+    const wanted = new Set(
+      fields
+        .flat(Infinity)
+        .filter((field) => typeof field === 'string' && !FORBIDDEN.has(field))
+    );
+    const kept = {};
+
+    for (const [field, list] of Object.entries(req.files)) {
+      if (wanted.has(field)) {
+        kept[field] = list;
+        continue;
+      }
+
+      for (const file of list) {
+        file
+          .discard()
+          .catch((error) => debug('unable to discard: %s', error.message));
+      }
+    }
+
+    req.files = kept;
+
+    return kept;
+  };
+
+  return collected;
+}
+
+/**
+ * Removes, when the response closes, every file the request did not keep.
+ *
+ * `close` fires on an answered request, on a refused one, on one the
+ * timeout answered `503` and on one whose client went away, which is the
+ * whole list of ways a request ends. A file `store()` moved into the
+ * storage is already released and is not touched.
+ *
+ * @param {Express.Response} res the response
+ * @param {Array<UploadedFile>} collected the files of this request
+ * @returns {void}
+ */
+function sweepOnClose(res, collected) {
+  res.on('close', () => {
+    for (const file of collected) {
+      if (!file.released) {
+        file
+          .discard()
+          .catch((error) => debug('unable to sweep: %s', error.message));
+      }
+    }
+  });
+}
+
+/**
+ * The middleware the module mounts.
+ *
+ * It reads the settings and the storage off the module on every request
+ * rather than closing over them, because an express app has no way to
+ * remove a middleware: a reload changes what this one does, never where it
+ * sits in the chain -- and where it sits, before sessions and CSRF, is the
+ * part that cannot move.
+ *
+ * @param {object} module the uploads module (`henri.uploads`)
+ * @returns {function} express middleware
+ */
+function middleware(module) {
+  return function uploads(req, res, next) {
+    const collected = decorate(req);
+    const { pen } = module.henri || {};
+    const { settings, storage } = module;
+
+    if (!module.enabled || !settings || !storage) {
+      return next();
+    }
+
+    if (!isMultipart(req) || !covers(req, settings.paths)) {
+      return next();
+    }
+
+    const declared = Number(req.headers['content-length']);
+
+    if (
+      settings.maxTotalSize !== false &&
+      Number.isFinite(declared) &&
+      declared > settings.maxTotalSize
+    ) {
+      const refusal = new UploadError(
+        'TOTAL_TOO_LARGE',
+        `the request body is larger than the ${settings.maxTotalSize} bytes this application accepts`,
+        { limit: settings.maxTotalSize }
+      );
+
+      // Nothing has been read, so the whole budget is still there: a body a
+      // little over the limit is drained and the client reads its 413
+      return drain(req, {
+        cap: settings.maxTotalSize * DRAIN_FACTOR,
+      }).then(() => next(refusal));
+    }
+
+    sweepOnClose(res, collected);
+
+    return collect(req, { collected, settings, storage })
+      .then((fields) => {
+        req.body = Object.assign({}, req.body, fields);
+        // The reads finish in whatever order the disk answers in; the body
+        // had an order, and that is the one an application sees
+        collected.sort((one, two) => one.order - two.order);
+
+        for (const file of collected) {
+          req.files[file.field] = req.files[file.field] || [];
+          req.files[file.field].push(file);
+        }
+
+        next();
+      })
+      .catch(async (error) => {
+        // A refusal frees the disk now, rather than waiting for the sweep:
+        // what was already read is what a flood would have left lying around
+        await Promise.all(collected.map((file) => file.discard()));
+
+        pen &&
+          pen.warn(
+            'uploads',
+            `${req.method} ${req.path}`,
+            error.code || 'refused',
+            error.message
+          );
+        next(error);
+      });
+  };
+}
+
+module.exports = {
+  DRAIN_FACTOR,
+  DRAIN_TIMEOUT,
+  FORBIDDEN,
+  HEADER_PAIRS,
+  collect,
+  covers,
+  decorate,
+  drain,
+  isMultipart,
+  meter,
+  middleware,
+  readFile,
+  sweepOnClose,
+};

--- a/packages/uploads/src/names.js
+++ b/packages/uploads/src/names.js
@@ -1,0 +1,168 @@
+/**
+ * Names.
+ *
+ * There are two of them and they never meet. The **stored name** is the one
+ * the filesystem sees; henri generates it and nothing a client sends takes
+ * part in it. The **original name** is metadata: it is cleaned, kept in the
+ * record and used for the `Content-Disposition` of a download, and it never
+ * reaches a path.
+ *
+ * That split is the whole answer to a long list of problems that are really
+ * one problem -- `../../etc/passwd`, `/etc/passwd`, `C:\boot.ini`,
+ * `a\0.png`, `.htaccess`, `CON`, `avatar.php`, a name 4000 characters long,
+ * a name that is only dots. None of them can matter, because none of them
+ * are consulted when a path is built. They are cleaned anyway, because the
+ * original name is shown to people and handed to browsers, and because a
+ * value that is only safe when nobody misuses it is not safe.
+ */
+const crypto = require('node:crypto');
+
+/** How long a cleaned original name may be, when nothing else is configured */
+const MAX_NAME = 255;
+
+/** What a name that cleaned down to nothing is called */
+const FALLBACK = 'file';
+
+/** Characters that never survive: separators, controls, quotes, wildcards */
+// eslint-disable-next-line no-control-regex
+const UNSAFE = /[\u0000-\u001f\u007f-\u009f/\\:*?"<>|]/gu;
+
+/**
+ * The device names Windows refuses to have a file called, whatever the
+ * extension. Reserved before the first dot, so `CON.txt` is one too.
+ */
+const RESERVED =
+  /^(?:con|prn|aux|nul|com[0-9\u00b9\u00b2\u00b3]|lpt[0-9\u00b9\u00b2\u00b3])$/iu;
+
+/** What a generated key looks like, and the only shape a storage accepts */
+const KEY = /^(?:[0-9a-z][0-9a-z-]{0,63}\/)*[0-9a-f]{32}\.[0-9a-z]{1,8}$/u;
+
+/**
+ * The original name, cleaned: safe to store, to print and to hand a browser
+ *
+ * @param {*} original what the client called the file
+ * @param {number} [max=MAX_NAME] how many characters to keep
+ * @returns {string} a name, never empty and never a path
+ */
+function safeName(original, max = MAX_NAME) {
+  if (typeof original !== 'string') {
+    return FALLBACK;
+  }
+
+  // Both separators, because a Windows client sends a Windows path
+  const base = original.split(/[/\\]/u).pop() || '';
+  const cleaned = base
+    .replace(UNSAFE, '')
+    .replace(/^[\s.]+/u, '')
+    .replace(/[\s.]+$/u, '')
+    .trim();
+
+  if (cleaned.length === 0) {
+    return FALLBACK;
+  }
+
+  const stem = cleaned.split('.')[0];
+  const named = RESERVED.test(stem) ? `_${cleaned}` : cleaned;
+
+  return named.length > max ? truncate(named, max) : named;
+}
+
+/**
+ * A name shortened to `max` characters, keeping its extension
+ *
+ * @param {string} name the name
+ * @param {number} max how many characters to keep
+ * @returns {string} the shortened name
+ */
+function truncate(name, max) {
+  const dot = name.lastIndexOf('.');
+  const extension = dot > 0 && name.length - dot <= 12 ? name.slice(dot) : '';
+
+  return `${name.slice(0, Math.max(1, max - extension.length))}${extension}`;
+}
+
+/**
+ * The name a stored object is given.
+ *
+ * `<yyyy>/<mm>/<32 hex characters>.<extension>`: the date so a directory
+ * never grows without end and a retention rule has something to read, 128
+ * bits of randomness so a key is never guessed from another one, and an
+ * extension that comes from the type the *bytes* were recognized as -- never
+ * from the name the client sent.
+ *
+ * @param {object} options the options
+ * @param {string} options.extension the extension, without its dot
+ * @param {?string} [options.prefix] a directory to put it under
+ * @param {Date} [options.now] the moment, for the dated directories
+ * @returns {string} the key
+ */
+function keyFor({ extension, now = new Date(), prefix = null }) {
+  const year = String(now.getUTCFullYear());
+  const month = String(now.getUTCMonth() + 1).padStart(2, '0');
+  const random = crypto.randomBytes(16).toString('hex');
+  const safe = safePrefix(prefix);
+  const directory = safe ? `${safe}/${year}/${month}` : `${year}/${month}`;
+
+  return `${directory}/${random}.${extension}`;
+}
+
+/**
+ * A prefix an application asked for, reduced to what a key may hold
+ *
+ * @param {*} prefix what the application passed to `store()`
+ * @returns {?string} the prefix, or null when there is nothing usable left
+ */
+function safePrefix(prefix) {
+  if (typeof prefix !== 'string') {
+    return null;
+  }
+
+  const segments = prefix
+    .toLowerCase()
+    .split('/')
+    .map((segment) => segment.replace(/[^0-9a-z-]/gu, ''))
+    .filter((segment) => segment.length > 0 && segment.length <= 64);
+
+  return segments.length > 0 ? segments.slice(0, 4).join('/') : null;
+}
+
+/**
+ * Is this a key henri generated? (a storage refuses anything else)
+ *
+ * @param {*} key the key
+ * @returns {boolean} true when it is safe to build a path from
+ */
+const isKey = (key) =>
+  typeof key === 'string' &&
+  key.length <= 512 &&
+  !key.includes('..') &&
+  KEY.test(key);
+
+/**
+ * The two forms of a filename a `Content-Disposition` header needs: the
+ * ASCII one every client understands, and the percent-encoded UTF-8 one
+ * (RFC 5987) for the rest of the alphabet
+ *
+ * @param {string} name a name from `safeName()`
+ * @param {string} [disposition='attachment'] `attachment` or `inline`
+ * @returns {string} the header value
+ */
+function contentDisposition(name, disposition = 'attachment') {
+  const safe = safeName(name);
+  const ascii = safe.replace(/[^\u0020-\u007e]/gu, '_').replace(/["\\]/gu, '_');
+  const encoded = encodeURIComponent(safe);
+
+  return `${disposition}; filename="${ascii}"; filename*=UTF-8''${encoded}`;
+}
+
+module.exports = {
+  FALLBACK,
+  KEY,
+  MAX_NAME,
+  RESERVED,
+  contentDisposition,
+  isKey,
+  keyFor,
+  safeName,
+  safePrefix,
+};

--- a/packages/uploads/src/names.js
+++ b/packages/uploads/src/names.js
@@ -38,6 +38,33 @@ const RESERVED =
 const KEY = /^(?:[0-9a-z][0-9a-z-]{0,63}\/)*[0-9a-f]{32}\.[0-9a-z]{1,8}$/u;
 
 /**
+ * A name without the leading and trailing whitespace and dots.
+ *
+ * Scanned rather than matched: `[\s.]+$` is quadratic on a name that is a
+ * long run of whitespace followed by anything else, and a filename is
+ * whatever the client sent -- a hundred thousand tabs took five seconds
+ * here before this was two index walks.
+ *
+ * @param {string} value the name so far
+ * @returns {string} the name without its edges
+ */
+function trimmed(value) {
+  const strip = (char) => char === '.' || /\s/u.test(char);
+  let start = 0;
+  let end = value.length;
+
+  while (start < end && strip(value[start])) {
+    start += 1;
+  }
+
+  while (end > start && strip(value[end - 1])) {
+    end -= 1;
+  }
+
+  return value.slice(start, end);
+}
+
+/**
  * The original name, cleaned: safe to store, to print and to hand a browser
  *
  * @param {*} original what the client called the file
@@ -51,11 +78,7 @@ function safeName(original, max = MAX_NAME) {
 
   // Both separators, because a Windows client sends a Windows path
   const base = original.split(/[/\\]/u).pop() || '';
-  const cleaned = base
-    .replace(UNSAFE, '')
-    .replace(/^[\s.]+/u, '')
-    .replace(/[\s.]+$/u, '')
-    .trim();
+  const cleaned = trimmed(base.replace(UNSAFE, ''));
 
   if (cleaned.length === 0) {
     return FALLBACK;

--- a/packages/uploads/src/sniff.js
+++ b/packages/uploads/src/sniff.js
@@ -1,0 +1,292 @@
+/**
+ * What the bytes say a file is.
+ *
+ * A multipart part carries a `Content-Type` and a filename, both written by
+ * whoever is uploading. Neither is evidence: `avatar.png` with
+ * `Content-Type: image/png` is one HTTP header and one string away from
+ * being a PHP script, and every framework that stored the declared type and
+ * served it back has learned that the hard way.
+ *
+ * So henri reads the first bytes instead. A signature it recognizes is the
+ * type; the declared one is kept beside it as `declaredType`, for the record
+ * and for nothing else. What henri recognizes is the table below plus one
+ * inference -- a sample that decodes as UTF-8 with no control characters is
+ * text -- and everything else is `application/octet-stream`. That last line
+ * is the honest part: henri never guesses a type from an extension, so a
+ * format with no signature stays unrecognized rather than being described by
+ * its name.
+ *
+ * Two entries exist only to be refused: `text/html` and `image/svg+xml` are
+ * text formats that carry script. They are named so that an `allow` list can
+ * exclude them, so that a descriptor never claims a scriptable file is
+ * `text/plain`, and so that `extensionFor()` can store them under a name no
+ * web server would render.
+ */
+
+/** How many bytes of a file are enough to recognize it */
+const SAMPLE = 4096;
+
+/**
+ * The signatures henri recognizes, longest and most specific first.
+ *
+ * `at` is where the bytes sit, `hex` is what they are, and `also` is a second
+ * run of bytes the container format needs (RIFF and ISO base media both put
+ * the interesting part after a length).
+ */
+const SIGNATURES = [
+  // Executables, first: whatever else they look like, this is what they are
+  { hex: '7f454c46', type: 'application/x-elf' },
+  { hex: '4d5a', type: 'application/x-msdownload' },
+  { hex: 'cffaedfe', type: 'application/x-mach-binary' },
+  { hex: 'cefaedfe', type: 'application/x-mach-binary' },
+  { hex: 'feedface', type: 'application/x-mach-binary' },
+  { hex: 'feedfacf', type: 'application/x-mach-binary' },
+  { hex: 'cafebabe', type: 'application/x-mach-binary' },
+  { hex: '23212f', type: 'text/x-shellscript' },
+
+  // Images
+  { hex: '89504e470d0a1a0a', type: 'image/png' },
+  { hex: 'ffd8ff', type: 'image/jpeg' },
+  { hex: '474946383761', type: 'image/gif' },
+  { hex: '474946383961', type: 'image/gif' },
+  { also: { at: 8, hex: '57454250' }, hex: '52494646', type: 'image/webp' },
+  { hex: '424d', type: 'image/bmp' },
+  { hex: '49492a00', type: 'image/tiff' },
+  { hex: '4d4d002a', type: 'image/tiff' },
+  {
+    also: { at: 8, hex: '61766966' },
+    at: 4,
+    hex: '66747970',
+    type: 'image/avif',
+  },
+  {
+    also: { at: 8, hex: '68656963' },
+    at: 4,
+    hex: '66747970',
+    type: 'image/heic',
+  },
+
+  // Documents and archives
+  { hex: '255044462d', type: 'application/pdf' },
+  { hex: '504b0304', type: 'application/zip' },
+  { hex: '504b0506', type: 'application/zip' },
+  { hex: '504b0708', type: 'application/zip' },
+  { hex: '1f8b', type: 'application/gzip' },
+  { hex: '377abcaf271c', type: 'application/x-7z-compressed' },
+  { hex: '526172211a07', type: 'application/vnd.rar' },
+  { hex: '425a68', type: 'application/x-bzip2' },
+  { hex: 'd0cf11e0a1b11ae1', type: 'application/x-cfb' },
+
+  // Audio and video
+  { also: { at: 8, hex: '57415645' }, hex: '52494646', type: 'audio/wav' },
+  { hex: '494433', type: 'audio/mpeg' },
+  { hex: 'fffb', type: 'audio/mpeg' },
+  { hex: '4f676753', type: 'audio/ogg' },
+  { hex: '664c6143', type: 'audio/flac' },
+  { hex: '1a45dfa3', type: 'video/webm' },
+  { at: 4, hex: '66747970', type: 'video/mp4' },
+];
+
+/**
+ * The extension a stored object is given, by type.
+ *
+ * The name on disk is generated, so this is cosmetic -- except for the two
+ * scriptable types, which are stored as `.bin` on purpose. Uploads are never
+ * served from a directory the application serves, and this is the second
+ * lock on that door: a web server accidentally pointed at the storage
+ * directory still has nothing there it would render or execute.
+ */
+const EXTENSIONS = {
+  'application/gzip': 'gz',
+  'application/pdf': 'pdf',
+  'application/vnd.rar': 'rar',
+  'application/x-7z-compressed': '7z',
+  'application/x-bzip2': 'bz2',
+  'application/x-cfb': 'bin',
+  'application/x-elf': 'bin',
+  'application/x-mach-binary': 'bin',
+  'application/x-msdownload': 'bin',
+  'application/zip': 'zip',
+  'audio/flac': 'flac',
+  'audio/mpeg': 'mp3',
+  'audio/ogg': 'ogg',
+  'audio/wav': 'wav',
+  'image/avif': 'avif',
+  'image/bmp': 'bmp',
+  'image/gif': 'gif',
+  'image/heic': 'heic',
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/svg+xml': 'bin',
+  'image/tiff': 'tiff',
+  'image/webp': 'webp',
+  'text/html': 'bin',
+  'text/plain': 'txt',
+  'text/x-shellscript': 'bin',
+  'video/mp4': 'mp4',
+  'video/webm': 'webm',
+};
+
+/** What a file henri recognizes nothing about is called */
+const UNKNOWN = 'application/octet-stream';
+
+/** The extension of everything else */
+const UNKNOWN_EXTENSION = 'bin';
+
+/** Control characters a text file may hold: tab, newline, carriage return */
+const TEXT_CONTROLS = new Set([9, 10, 13]);
+
+/**
+ * Does the sample start with these bytes at this offset?
+ *
+ * @param {Buffer} sample the first bytes of the file
+ * @param {number} at the offset
+ * @param {string} hex the bytes, as hex
+ * @returns {boolean} true when they match
+ */
+function matches(sample, at, hex) {
+  const wanted = Buffer.from(hex, 'hex');
+
+  return (
+    sample.length >= at + wanted.length &&
+    sample.compare(wanted, 0, wanted.length, at, at + wanted.length) === 0
+  );
+}
+
+/**
+ * Is this sample text? (valid UTF-8, no control characters but tab and the
+ * two newline ones)
+ *
+ * The sample is a prefix of the file, so it may end in the middle of a
+ * multi-byte character; the last three bytes are dropped before decoding
+ * rather than being read as a broken encoding.
+ *
+ * @param {Buffer} sample the first bytes of the file
+ * @param {boolean} complete whether the sample is the whole file
+ * @returns {boolean} true when every byte is printable text
+ */
+function isText(sample, complete) {
+  if (sample.length === 0) {
+    return true;
+  }
+
+  const usable = complete ? sample : sample.subarray(0, sample.length - 3);
+
+  for (const byte of usable) {
+    if (byte < 32 && !TEXT_CONTROLS.has(byte)) {
+      return false;
+    }
+  }
+
+  try {
+    new TextDecoder('utf-8', { fatal: true }).decode(usable);
+  } catch (error) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * The type of a text sample: the two scriptable ones, or plain text
+ *
+ * @param {Buffer} sample the first bytes of the file
+ * @returns {string} a media type
+ */
+function textType(sample) {
+  const head = sample.subarray(0, 1024).toString('utf8').trimStart();
+  const lower = head.toLowerCase();
+
+  if (lower.startsWith('<!doctype html') || lower.startsWith('<html')) {
+    return 'text/html';
+  }
+
+  if (
+    lower.startsWith('<svg') ||
+    (lower.startsWith('<?xml') && lower.includes('<svg'))
+  ) {
+    return 'image/svg+xml';
+  }
+
+  return 'text/plain';
+}
+
+/**
+ * What the bytes say this file is
+ *
+ * @param {Buffer} sample the first bytes of the file (up to `SAMPLE`)
+ * @param {boolean} [complete=false] whether the sample is the whole file
+ * @returns {{type: string, sniffed: boolean}} the type, and whether henri
+ *   recognized it rather than giving up
+ */
+function sniff(sample, complete = false) {
+  const buffer = Buffer.isBuffer(sample) ? sample : Buffer.alloc(0);
+
+  for (const entry of SIGNATURES) {
+    if (
+      matches(buffer, entry.at || 0, entry.hex) &&
+      (!entry.also || matches(buffer, entry.also.at, entry.also.hex))
+    ) {
+      return { sniffed: true, type: entry.type };
+    }
+  }
+
+  if (isText(buffer, complete)) {
+    return { sniffed: true, type: textType(buffer) };
+  }
+
+  return { sniffed: false, type: UNKNOWN };
+}
+
+/**
+ * The extension a stored object gets for a type
+ *
+ * @param {string} type a media type
+ * @returns {string} an extension, without its dot
+ */
+const extensionFor = (type) => EXTENSIONS[type] || UNKNOWN_EXTENSION;
+
+/**
+ * Does a type match one entry of an `allow` list?
+ *
+ * An entry is a media type (`image/png`), a wildcard subtype (`image/*`) or
+ * `*` for everything. Nothing else: a pattern language is a place for a
+ * mistake to hide.
+ *
+ * @param {string} type the type of the file
+ * @param {string} pattern one entry of the list
+ * @returns {boolean} true when it matches
+ */
+function accepts(type, pattern) {
+  const wanted = String(pattern).trim().toLowerCase();
+
+  if (wanted === '*' || wanted === '*/*') {
+    return true;
+  }
+
+  return wanted.endsWith('/*')
+    ? type.startsWith(`${wanted.slice(0, -1)}`)
+    : type === wanted;
+}
+
+/**
+ * Is this type allowed?
+ *
+ * @param {string} type the type of the file
+ * @param {?Array<string>} allow the allow list, or null for every type
+ * @returns {boolean} true when the file may be kept
+ */
+const allowed = (type, allow) =>
+  !Array.isArray(allow) || allow.some((pattern) => accepts(type, pattern));
+
+module.exports = {
+  EXTENSIONS,
+  SAMPLE,
+  SIGNATURES,
+  UNKNOWN,
+  accepts,
+  allowed,
+  extensionFor,
+  isText,
+  sniff,
+};

--- a/packages/uploads/src/storage/index.js
+++ b/packages/uploads/src/storage/index.js
@@ -1,0 +1,87 @@
+/**
+ * Which storage an application uses.
+ *
+ * `"storage": "local"` is the disk below. Anything else is a module id,
+ * resolved from the application the way `config.rateLimit.store` and
+ * `config.api.idempotency.store` are (`base/api.js` in core does the same
+ * thing for the same reason): a package henri does not ship, installed by
+ * the application that wants it, exporting either a storage or a
+ * `(henri, { name, config }) => storage` factory.
+ *
+ * henri ships the local disk and no client for anybody's object store. An
+ * S3 client is a dependency, a credential chain, a region, a retry policy
+ * and a bill, and none of that belongs in a framework that would then own
+ * its upgrades.
+ */
+const path = require('node:path');
+
+const LocalStorage = require('./local');
+
+/** The storage names henri implements itself */
+const BUILTIN = { local: LocalStorage };
+
+/**
+ * Builds the storage the configuration names
+ *
+ * @param {object} henri the henri instance
+ * @param {object} settings the normalized upload settings
+ * @returns {object} a storage implementing `HenriStorage`
+ * @throws when the module cannot be loaded, or is not a storage
+ */
+function createStorage(henri, settings) {
+  const { root, storage: name } = settings;
+
+  if (BUILTIN[name]) {
+    return new BUILTIN[name](name, { root }, henri);
+  }
+
+  const cwd = henri.cwd();
+  const target = name.startsWith('.') ? path.resolve(cwd, name) : name;
+  let loaded;
+
+  try {
+    loaded = require(henri.utils.resolveFrom(target, cwd));
+  } catch (error) {
+    throw new Error(`unable to load the storage '${name}': ${error.message}`, {
+      cause: error,
+    });
+  }
+
+  const mod = loaded && loaded.default ? loaded.default : loaded;
+  const built = build(mod, name, settings, henri);
+
+  if (!built || typeof built.put !== 'function') {
+    throw new Error(
+      `the storage '${name}' does not implement HenriStorage (put, get, stat, delete, temp)`
+    );
+  }
+
+  return built;
+}
+
+/**
+ * The storage a module exported: a class to build, a factory to call, or an
+ * object that is already one
+ *
+ * A class is told apart from a factory by its prototype carrying `put`,
+ * which is the one method of the contract nothing else has a reason to have.
+ *
+ * @param {*} mod what the module exported
+ * @param {string} name the storage name
+ * @param {object} settings the normalized upload settings
+ * @param {object} henri the henri instance
+ * @returns {*} the storage
+ */
+function build(mod, name, settings, henri) {
+  if (typeof mod !== 'function') {
+    return mod;
+  }
+
+  const Storage = mod;
+
+  return Storage.prototype && typeof Storage.prototype.put === 'function'
+    ? new Storage(name, { config: settings, root: settings.root }, henri)
+    : Storage(henri, { config: settings, name });
+}
+
+module.exports = { BUILTIN, LocalStorage, createStorage };

--- a/packages/uploads/src/storage/local.js
+++ b/packages/uploads/src/storage/local.js
@@ -1,0 +1,310 @@
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const fsp = require('node:fs/promises');
+const path = require('node:path');
+const debug = require('debug')('henri:uploads');
+
+const { isKey } = require('../names');
+
+/**
+ * Storage contract, the way `HenriAdapter` is the store contract.
+ *
+ * The module builds one with `new Storage(name, config, henri)` and calls
+ * `start()` before the first request. Everything else is called per file.
+ * The local disk below is one implementation; an object store is another,
+ * and the seam is deliberately narrow so that writing the second one is a
+ * hundred lines rather than a fork.
+ *
+ * `temp()` is part of the contract on purpose. A multipart part is streamed
+ * somewhere before anything has authorized keeping it, and only the storage
+ * knows where that somewhere should be: on the local disk it is a directory
+ * inside the root, so promoting a file is a rename on the same filesystem
+ * rather than a copy; on an object store it is whatever the machine has.
+ *
+ * @interface HenriStorage
+ * @property {string} name The storage name (`local`, or the module id)
+ * @method async start() Prepares the storage; called once, before the server
+ *   answers
+ * @method async stop() Releases what it holds; `start()` may be called again
+ * @method async temp() `{ path }`: a private file to stream a part into
+ * @method async put(source, key) Moves `source` in under `key`; resolves with
+ *   the key that was written
+ * @method async get(key) A readable stream of the object
+ * @method async stat(key) `{ size, modifiedAt }`, or null when there is none
+ * @method async delete(key) Removes it; resolves false when there was none
+ * @method url(key) A public url, or null when there is no such thing
+ */
+
+/** The mode of the storage root and of the temporary directory */
+const DIR_MODE = 0o700;
+
+/** The mode of every stored object: readable by the process, nobody else */
+const FILE_MODE = 0o600;
+
+/** Where the parts being read are kept, inside the root */
+const TMP = '.tmp';
+
+/**
+ * What is written into the storage root the first time it is created.
+ *
+ * The root is a directory of an application's repository by default, and an
+ * upload directory that reached a commit is the sort of thing that is found
+ * later rather than sooner.
+ */
+const GITIGNORE = `# Uploaded files: never committed, never served.\n*\n!.gitignore\n`;
+
+/**
+ * The local disk
+ *
+ * @class LocalStorage
+ * @implements {HenriStorage}
+ */
+class LocalStorage {
+  /**
+   * Creates an instance of LocalStorage.
+   *
+   * @param {string} name The storage name
+   * @param {object} config `{ root }`, resolved against the application
+   * @param {object} henri The henri instance
+   * @memberof LocalStorage
+   */
+  constructor(name, config = {}, henri = null) {
+    this.name = name || 'local';
+    this.henri = henri;
+    this.root = path.resolve(
+      (henri && henri.cwd && henri.cwd()) || process.cwd(),
+      config.root || 'storage/uploads'
+    );
+    this.tmp = path.join(this.root, TMP);
+    this.started = false;
+  }
+
+  /**
+   * Creates the root and the temporary directory, and leaves a `.gitignore`
+   * behind the first time
+   *
+   * @async
+   * @returns {Promise<string>} the root
+   * @memberof LocalStorage
+   */
+  async start() {
+    await fsp.mkdir(this.tmp, { mode: DIR_MODE, recursive: true });
+    await fsp.chmod(this.root, DIR_MODE).catch(() => {});
+
+    const ignore = path.join(this.root, '.gitignore');
+
+    try {
+      await fsp.writeFile(ignore, GITIGNORE, { flag: 'wx' });
+    } catch (error) {
+      debug('%s already has a .gitignore', this.root);
+    }
+
+    await this.sweep();
+
+    this.started = true;
+
+    return this.root;
+  }
+
+  /**
+   * Nothing to release: the disk is the disk
+   *
+   * @async
+   * @returns {Promise<boolean>} true
+   * @memberof LocalStorage
+   */
+  async stop() {
+    this.started = false;
+
+    return true;
+  }
+
+  /**
+   * Removes the parts a previous process was reading when it died.
+   *
+   * Every request cleans up after itself, so this only ever finds what a
+   * `SIGKILL` or a power cut left behind. It runs at boot, where a stale
+   * file is a leak nobody is watching rather than a bug in the request.
+   *
+   * @async
+   * @returns {Promise<number>} how many were removed
+   * @memberof LocalStorage
+   */
+  async sweep() {
+    let entries;
+
+    try {
+      entries = await fsp.readdir(this.tmp);
+    } catch (error) {
+      return 0;
+    }
+
+    let removed = 0;
+
+    for (const entry of entries) {
+      if (!entry.endsWith('.part')) {
+        continue;
+      }
+
+      try {
+        await fsp.unlink(path.join(this.tmp, entry));
+        removed++;
+      } catch (error) {
+        debug('unable to remove the stale part %s: %s', entry, error.message);
+      }
+    }
+
+    removed > 0 && debug('removed %d stale part(s)', removed);
+
+    return removed;
+  }
+
+  /**
+   * A private file to stream a part into
+   *
+   * @async
+   * @returns {Promise<{path: string}>} where to write
+   * @memberof LocalStorage
+   */
+  async temp() {
+    await fsp.mkdir(this.tmp, { mode: DIR_MODE, recursive: true });
+
+    return {
+      path: path.join(
+        this.tmp,
+        `${crypto.randomBytes(16).toString('hex')}.part`
+      ),
+    };
+  }
+
+  /**
+   * The absolute path of a key, refusing anything henri did not generate.
+   *
+   * Two locks, because one of them is a regular expression: the key must
+   * have the shape `keyFor()` writes, and the path it resolves to must be
+   * inside the root. A key that passes the first and fails the second does
+   * not exist, which is the point of checking both.
+   *
+   * @param {string} key the key
+   * @returns {string} the absolute path
+   * @throws when the key is not one henri could have generated
+   * @memberof LocalStorage
+   */
+  pathOf(key) {
+    if (!isKey(key)) {
+      throw new Error(`unsafe storage key: ${JSON.stringify(String(key))}`);
+    }
+
+    const full = path.resolve(this.root, key);
+
+    if (full !== this.root && !full.startsWith(this.root + path.sep)) {
+      throw new Error(`storage key escapes the root: ${key}`);
+    }
+
+    return full;
+  }
+
+  /**
+   * Moves a part in under its key
+   *
+   * @async
+   * @param {string} source the temporary file
+   * @param {string} key the key to store it under
+   * @returns {Promise<string>} the key
+   * @throws when the key is unsafe, or the file cannot be written
+   * @memberof LocalStorage
+   */
+  async put(source, key) {
+    const target = this.pathOf(key);
+
+    await fsp.mkdir(path.dirname(target), { mode: DIR_MODE, recursive: true });
+
+    try {
+      await fsp.rename(source, target);
+    } catch (error) {
+      // A different filesystem (a bind mount, a tmpfs root): copy, then drop
+      // the part. `COPYFILE_EXCL` keeps a key that already exists from being
+      // overwritten, which a generated key never is.
+      if (error.code !== 'EXDEV') {
+        throw error;
+      }
+
+      await fsp.copyFile(source, target, fs.constants.COPYFILE_EXCL);
+      await fsp.unlink(source).catch(() => {});
+    }
+
+    await fsp.chmod(target, FILE_MODE).catch(() => {});
+
+    return key;
+  }
+
+  /**
+   * A readable stream of a stored object
+   *
+   * @async
+   * @param {string} key the key
+   * @returns {Promise<fs.ReadStream>} the stream
+   * @throws when the key is unsafe or there is no such object
+   * @memberof LocalStorage
+   */
+  async get(key) {
+    const target = this.pathOf(key);
+
+    await fsp.access(target, fs.constants.R_OK);
+
+    return fs.createReadStream(target);
+  }
+
+  /**
+   * What is known about a stored object
+   *
+   * @async
+   * @param {string} key the key
+   * @returns {Promise<?{size: number, modifiedAt: Date}>} the facts, or null
+   * @memberof LocalStorage
+   */
+  async stat(key) {
+    try {
+      const stats = await fsp.stat(this.pathOf(key));
+
+      return { modifiedAt: stats.mtime, size: stats.size };
+    } catch (error) {
+      return null;
+    }
+  }
+
+  /**
+   * Removes a stored object
+   *
+   * @async
+   * @param {string} key the key
+   * @returns {Promise<boolean>} true when something was removed
+   * @memberof LocalStorage
+   */
+  async delete(key) {
+    try {
+      await fsp.unlink(this.pathOf(key));
+
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  /**
+   * The local disk has no public url, and that is the whole idea: a stored
+   * file is reached through a controller that decides who may
+   *
+   * @returns {null} null
+   * @memberof LocalStorage
+   */
+  url() {
+    return null;
+  }
+}
+
+module.exports = LocalStorage;
+module.exports.DIR_MODE = DIR_MODE;
+module.exports.FILE_MODE = FILE_MODE;
+module.exports.GITIGNORE = GITIGNORE;
+module.exports.TMP = TMP;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
       '@usehenri/jobs':
         specifier: workspace:^
         version: link:../jobs
+      '@usehenri/uploads':
+        specifier: workspace:^
+        version: link:../uploads
     devDependencies:
       '@usehenri/testing':
         specifier: workspace:^
@@ -492,6 +495,25 @@ importers:
       vitest:
         specifier: ^5.0.0
         version: 5.0.0(@types/node@26.4.1)(@vitest/coverage-v8@5.0.0)(jsdom@30.0.1(@noble/hashes@1.8.0))(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.104.0)(tsx@4.23.13)(yaml@2.9.0))
+
+  packages/uploads:
+    dependencies:
+      busboy:
+        specifier: ^1.6.0
+        version: 1.6.0
+      debug:
+        specifier: ^4.4.3
+        version: 4.4.3(supports-color@8.1.1)
+    devDependencies:
+      '@usehenri/core':
+        specifier: workspace:^
+        version: link:../core
+      express:
+        specifier: ^5.2.1
+        version: 5.2.1(supports-color@8.1.1)
+      supertest:
+        specifier: ^7.2.2
+        version: 7.2.2(supports-color@8.1.1)
 
   packages/websocket:
     dependencies:
@@ -3972,6 +3994,10 @@ packages:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
 
+  busboy@1.6.0:
+    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
+    engines: {node: '>=10.16.0'}
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -6466,6 +6492,10 @@ packages:
 
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  streamsearch@1.1.0:
+    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
+    engines: {node: '>=10.0.0'}
 
   streamx@2.28.1:
     resolution: {integrity: sha512-zEzXb0s5Cds7tqMH6rhZ05lcJydCWiQPEwiNngVqzsxCc962vLY4Uw+mW7od8kDH258k2Uz/JrOkdIAAhSh9VA==}
@@ -10321,6 +10351,10 @@ snapshots:
     dependencies:
       run-applescript: 7.1.0
 
+  busboy@1.6.0:
+    dependencies:
+      streamsearch: 1.1.0
+
   bytes@3.1.2: {}
 
   cac@7.0.0: {}
@@ -12999,6 +13033,8 @@ snapshots:
   statuses@2.0.2: {}
 
   std-env@4.2.0: {}
+
+  streamsearch@1.1.0: {}
 
   streamx@2.28.1:
     dependencies:

--- a/types/core.test-d.ts
+++ b/types/core.test-d.ts
@@ -25,6 +25,8 @@ import type {
   Request,
   Response,
   RoutesFile,
+  StoredFile,
+  UploadedFile,
   ViewOptions,
 } from '@usehenri/core';
 
@@ -203,6 +205,37 @@ if (henri.graphql) {
 
 // @ts-expect-error `henri.graphql` may be undefined: check it first
 henri.graphql.run('{ tasks }');
+
+// --- uploads ----------------------------------------------------------------
+
+// The module arrives from @usehenri/uploads, so an application that does not
+// depend on it has neither `henri.uploads` nor `req.files`
+expectType<boolean | undefined>(henri.uploads?.enabled);
+
+const uploads = henri.uploads!;
+const scan = req.files!.scan[0];
+
+expectType<UploadedFile>(scan);
+expectType<string>(scan.type);
+expectType<string | null>(scan.declaredType);
+expectType<boolean>(scan.mistyped);
+expectType<Promise<StoredFile>>(scan.store());
+expectType<Promise<StoredFile>>(scan.store({ prefix: 'artworks' }));
+expectType<Promise<boolean>>(scan.discard());
+expectType<UploadedFile | null>(req.file!('scan'));
+expectType<Record<string, UploadedFile[]>>(req.permitFiles!('scan', 'cv'));
+expectType<Promise<boolean>>(uploads.delete(await scan.store()));
+
+uploads.send(res, await scan.store(), { disposition: 'inline' });
+
+// @ts-expect-error `henri.uploads` may be undefined: check it first
+henri.uploads.send(res, 'a-key');
+
+// @ts-expect-error a disposition is `attachment` or `inline`, nothing else
+uploads.send(res, 'a-key', { disposition: 'embed' });
+
+// @ts-expect-error `uploads` is not a configuration key of the file store
+const badUploads: Configuration = { uploads: { maxFileSize: true } };
 
 // --- request ----------------------------------------------------------------
 

--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -55,6 +55,7 @@ Every key below is declared in `@usehenri/core`, so an editor completes them as 
 | `helmet`           | on            | Options merged over henri's [helmet](https://helmetjs.github.io/) defaults; `false` disables it.                                                |
 | `filterParameters` | see below     | Parameter names masked in the logs; `false` masks nothing.                                                                                      |
 | `bodyLimit`        | `1mb`         | Maximum size of a JSON or form body.                                                                                                            |
+| `uploads`          |               | File uploads: where they go, the limits and the accepted types, see below; needs `@usehenri/uploads`. `false` accepts no file.                  |
 | `requestTimeout`   | `30000`       | Milliseconds before a running request is answered `503`; `false` disables it.                                                                   |
 | `shutdown`         |               | What a `SIGTERM` does before the modules stop: `delay`, `drain` and `signals`, see below.                                                       |
 | `errors`           |               | What henri does with the code of a failure: `url`, a template holding `{code}`. See [Error codes](/reference/errors/).                          |
@@ -143,6 +144,36 @@ The keys of the [JSON API](/guides/api/), all optional:
 | `filterParameters` | `["password", "token", "secret", "authorization"]` | Substrings of the parameter names masked in everything `henri.pen` prints; `false` masks nothing.                                                                                                                                                                 |
 | `bodyLimit`        | `"1mb"`                                            | Passed to the JSON and urlencoded body parsers; a string (`"1mb"`) or a number of bytes.                                                                                                                                                                          |
 | `requestTimeout`   | `30000`                                            | Milliseconds before a `503`; `false` disables the timeout.                                                                                                                                                                                                        |
+
+## Uploads
+
+`uploads` is read by [`@usehenri/uploads`](/guides/uploads/), which the application installs; without the package nothing parses a multipart body. `false` accepts no file. Every key is optional, and every limit is enforced by the parser as it reads rather than checked once the file is on disk.
+
+| Key                         | Default             | Description                                                                                                                                               |
+| --------------------------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `uploads.storage`           | `"local"`           | `"local"` for the disk, or the module id of a `HenriStorage` resolved from the application.                                                               |
+| `uploads.root`              | `"storage/uploads"` | Where the local storage keeps files, relative to the application. It must be outside `app/views/public`, which `express.static` serves.                   |
+| `uploads.maxFileSize`       | `"10mb"`            | Largest single file; `false` removes the bound.                                                                                                           |
+| `uploads.maxTotalSize`      | `"25mb"`            | Largest multipart body, all parts together. Checked against `Content-Length` before the parser is built, then counted as the bytes arrive.                |
+| `uploads.maxFiles`          | `10`                | How many files one request may carry.                                                                                                                     |
+| `uploads.maxFields`         | `100`               | How many non-file fields one request may carry.                                                                                                           |
+| `uploads.maxFieldNameSize`  | `100`               | Longest field name, in bytes.                                                                                                                             |
+| `uploads.maxFieldSize`      | `bodyLimit`         | Largest non-file part. It defaults to [`bodyLimit`](#headers-logs-and-limits) so one text field costs the same whichever encoding a form was posted with. |
+| `uploads.maxFilenameLength` | `255`               | How much of the original name is kept as metadata. The stored name is generated, so this never bounds a path.                                             |
+| `uploads.allow`             |                     | Media types that may be kept (`"image/png"`, `"image/*"`), matched against what the bytes say. Without it every type is accepted.                         |
+| `uploads.sniff`             | `true`              | Decide the type from the first bytes. `false` trusts the `Content-Type` the client sent, which is not evidence; `henri audit` reports it.                 |
+| `uploads.paths`             |                     | Path prefixes a multipart body is read under (`["/artworks"]`). Without it, any route that takes a body may receive one.                                  |
+
+```json
+{
+  "uploads": {
+    "allow": ["image/png", "image/jpeg", "application/pdf"],
+    "maxFileSize": "5mb",
+    "maxFiles": 3,
+    "paths": ["/artworks"]
+  }
+}
+```
 
 ## Shutdown
 

--- a/website/src/content/docs/guides/security.md
+++ b/website/src/content/docs/guides/security.md
@@ -43,6 +43,7 @@ Nothing below needs a configuration key. It is on unless you turn it off, and
 | V5 Validation and encoding | `req.permit('title', 'body')` is the only way a request bag reaches a model in the generated controllers, and it refuses `__proto__`, `constructor` and `prototype`. Queries go through Sequelize, Mongoose or Drizzle, which parameterize. React, Inertia and Handlebars escape what they interpolate. Bodies are bounded by `bodyLimit` (1mb).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | V7 Errors and logging      | Every answer carries `X-Request-Id`, generated or taken from the client, and every log line of that request quotes it. `filterParameters` (`password`, `token`, `secret`, `authorization`, matched as substrings) are masked in everything `henri.pen` prints, query strings included. A `500` in production answers the reason phrase and nothing else; the stack is only in development and test.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | V8 Data protection         | A user reaches a view or a JSON answer only as `publicUser()`: `externalId`, `email`, `roles` and whatever `user.public` names. Every record carries an `externalId` (a UUID v7) and the numeric primary key is removed from what `res.render()`, `res.resource()` and `res.collection()` send. A signed-in answer carries `Cache-Control: no-store`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| V12 File upload            | With [`@usehenri/uploads`](/guides/uploads/): a multipart body is bounded before the first byte is read (25mb in total, 10mb a file, 10 files, 100 fields), the type of a file is decided from its bytes and not from the `Content-Type` or the extension the client sent, the stored name is generated (`<yyyy>/<mm>/<32 hex>.<extension of the sniffed type>`) so no name a client sends ever reaches a path, files are written `0600` into a `0700` directory outside everything the application serves, `text/html` and `image/svg+xml` are stored under `.bin`, a stored file is only ever handed back by a controller with `Content-Disposition: attachment` and `X-Content-Type-Options: nosniff`, and nothing is kept unless a controller calls `store()` -- a request that is refused, times out or is abandoned leaves nothing behind.                                                                                                                                                                                                                                |
 | V13 API                    | Rate limits (600 requests a minute per user or address), `Idempotency-Key` on every mutating route, `Accept: application/vnd.henri.vN+json` versioning, a `requestTimeout` of 30 seconds, and HAL answers whose `_links` are filtered by role. A GraphQL query is bounded before a resolver runs -- 15 aliases, 1000 fields with fragments expanded, 10 levels of nesting, 5000 tokens -- and introspection is off in production.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | V14 Configuration          | [helmet](https://helmetjs.github.io/) sets the headers, with a Content Security Policy that names its origins (no `https:` wildcard) and lets the dev servers work, no HSTS outside production, and `X-Powered-By` off. `Permissions-Policy` denies the camera, the microphone, the location and the other powerful browser features until an application names one. CORS is off unless you ask for it. A double-submit CSRF token (`henri.csrf`, `X-CSRF-Token`) guards every `POST`, `PUT`, `PATCH` and `DELETE` of a session, and the request must also come from an origin this application recognizes (`Sec-Fetch-Site`, then `Origin`), which is the half the token alone does not cover. Secrets live in `.env` or in [encrypted credentials](/configuration/#encrypted-credentials). The configuration is validated against a schema before the first module starts.                                                                                                                                                                                                    |
 
@@ -101,6 +102,13 @@ henri could do and does not yet:
 - **The session cookie is `Secure` when `NODE_ENV` is `production`**, not when
   the request arrives over https. An https deployment under another environment
   name gets a cookie without the attribute.
+- **An uploaded file is recognized, not validated.** `@usehenri/uploads`
+  matches the first bytes against a signature table, which is enough to tell a
+  PNG from an executable named `avatar.png` and not enough to tell a valid PNG
+  from a header followed by anything. It does not open archives (a `.docx` is
+  `application/zip`), it does not scan for malware, and it does not process
+  images: all three are jobs to run after `store()`, not defaults a framework
+  sets. See [Uploads](/guides/uploads/#out-of-scope-on-purpose).
 - **A drained shutdown needs the platform to play along.** `SIGTERM` closes the
   port, finishes the requests in flight within `shutdown.drain` and then stops
   the modules, but a container killed with `SIGKILL` -- a termination grace
@@ -163,8 +171,10 @@ high when a user model exists), `user.lockout: false` (`lockout.disabled`), a
 GraphQL bound set to false (`graphql.limits-disabled`),
 `user.password.binding: false` (`password.binding-disabled`, which is what
 lets a hash copied onto another row sign that row in), `filterParameters:
-false` (`log.filters-disabled`) and `requestTimeout: false`
-(`request-timeout.disabled`).
+false` (`log.filters-disabled`), `requestTimeout: false`
+(`request-timeout.disabled`), an upload bound set to false
+(`uploads.limits-disabled`) and `uploads.sniff: false`, which takes the
+client's word for the type of a file (`uploads.type-check-disabled`).
 
 **Settings that open a door** — a `cors` that accepts any origin, or reflects
 the caller while allowing credentials (`cors.permissive`); `trustProxy: true`
@@ -173,7 +183,10 @@ written by hand, which lets a client choose the address it is rate limited by
 defaults instead of extending them and drops one of them
 (`log.filters-narrowed`); a `user.sessionMaxAge` beyond the 30 days ASVS asks a
 re-authentication within (`session.long-lifetime`); a `user.public` naming a
-field that looks like a credential (`session.public-fields`).
+field that looks like a credential (`session.public-fields`); an
+`uploads.root` inside `app/views`, which `express.static` and the Inertia dev
+server serve, so an uploaded page would be reachable on the application's own
+origin (`uploads.root-served`).
 
 **Code** — a model write that takes `req.body` or `req.query` whole
 (`params.mass-assignment`), `{ unsafe: true }`, which turns off the guard

--- a/website/src/content/docs/guides/uploads.md
+++ b/website/src/content/docs/guides/uploads.md
@@ -1,0 +1,224 @@
+---
+title: Uploads
+description: Multipart parsing with limits that exist before the first byte, files typed by their content, generated names, a storage seam and cleanup that never leaves a temporary file behind.
+sidebar:
+  order: 10
+---
+
+An upload is the one request where a stranger writes to your disk. Everything on this page follows from that: the limits are enforced by the parser as it reads, the type comes from the bytes rather than from what the client called them, the name that reaches the filesystem is generated, and nothing is kept unless a controller says so.
+
+```bash
+npm install @usehenri/uploads     # once, in your application
+```
+
+Uploads live in [`@usehenri/uploads`](https://www.npmjs.com/package/@usehenri/uploads). The package [ships a henri module](/reference/under-the-hood/#where-it-goes-a-module-that-arrives-from-a-package), so depending on it is all there is to do: it is in the boot as `henri.uploads`, at level 3, and `req.files`, `req.file()` and `req.permitFiles()` are on every request. An application that does not depend on it parses no multipart body at all — `henri new` does not install it, because most applications never accept a file, and a multipart parser nobody uses is a dependency nobody wanted.
+
+## A controller that accepts a file
+
+```jsx
+// app/views/pages/artworks/new.jsx
+<form action="/artworks" method="post" encType="multipart/form-data">
+  <input type="hidden" name="_csrf" value={csrf} />
+  <input name="title" />
+  <input type="file" name="scan" accept="image/png,image/jpeg" />
+  <button>Save</button>
+</form>
+```
+
+```js
+// app/controllers/artworks.js
+module.exports = {
+  async create(req, res) {
+    const data = req.permit('title', 'year');
+    const { scan } = req.permitFiles('scan');
+
+    if (scan) {
+      data.scan = await scan[0].store({ prefix: 'artworks' });
+    }
+
+    const artwork = await Artwork.create(data);
+
+    return res.resource(artwork);
+  },
+};
+```
+
+`req.permit()` is the fields, `req.permitFiles()` is the files, and they behave the same way: only what the controller listed comes back. The difference is what happens to the rest — a body field it did not ask for merely stays unread, while a **file** it did not ask for is removed from the disk on the spot.
+
+`store()` resolves with the record, which is what a model holds (a `json` column, or a `text` one):
+
+```json
+{
+  "key": "artworks/2026/09/6f1c…9ab.png",
+  "name": "Portrait of Ada.png",
+  "type": "image/png",
+  "size": 184320,
+  "checksum": "c414cd0e…ce77",
+  "storage": "local",
+  "uploadedAt": "2026-09-06T07:05:25.247Z"
+}
+```
+
+Three helpers are on the request, always — they exist on a `GET` with an empty body the way `req.permit()` does:
+
+| Call                            | What it answers                                                                                 |
+| ------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `req.files`                     | `{ [field]: UploadedFile[] }`, everything that arrived and passed the limits.                   |
+| `req.file('scan')`              | The first file of a field, or `null`.                                                           |
+| `req.permitFiles('scan', 'cv')` | Only those fields; the files of every other one are discarded immediately. `req.files` follows. |
+
+An `UploadedFile` carries `field`, `name` (the original, cleaned), `type` (what the bytes say), `declaredType` (what the client claimed), `mistyped`, `sniffed`, `size` and `checksum`, plus `store(options)` and `discard()`.
+
+## Handing a file back
+
+Nothing uploaded is ever served from a directory the application serves, so a stored file is reached through a controller, which is where the decision about who may read it belongs:
+
+```js
+async show(req, res) {
+  const artwork = await Artwork.findOne({ externalId: req.params.id });
+
+  if (!artwork || !(await artwork.readableBy(req.user))) {
+    return res.boom.notFound();
+  }
+
+  return henri.uploads.send(res, artwork.scan);
+}
+```
+
+`send()` streams it with `Content-Disposition: attachment`, `X-Content-Type-Options: nosniff`, the type henri recognized and `Cache-Control: private`. `{ disposition: 'inline' }` is there for the types an application knows it can trust — an image it generated, a PDF it wrote — and is never the default: a file rendered on your own origin is a file that runs on your own origin. `henri.uploads.get(record)` gives the raw stream, and `henri.uploads.delete(record)` removes it.
+
+## The limits
+
+Every one of these is handed to the parser, not checked afterwards. A size checked once the file is on disk has already let the disk fill.
+
+| Key                         | Default     | Bounds                                             |
+| --------------------------- | ----------- | -------------------------------------------------- |
+| `uploads.maxTotalSize`      | `"25mb"`    | The whole multipart body, all parts together.      |
+| `uploads.maxFileSize`       | `"10mb"`    | One file.                                          |
+| `uploads.maxFiles`          | `10`        | How many files one request may carry.              |
+| `uploads.maxFields`         | `100`       | How many non-file fields it may carry.             |
+| `uploads.maxFieldNameSize`  | `100`       | How long one field name may be, in bytes.          |
+| `uploads.maxFieldSize`      | `bodyLimit` | One non-file part.                                 |
+| `uploads.maxFilenameLength` | `255`       | How much of the original name is kept as metadata. |
+
+Past any of them the request is refused — `413`, or `415` for a type — and everything already written is removed before the answer goes out. The body is then read and discarded to the end (for at most five seconds) so the client sees the status instead of a connection reset while it is still uploading.
+
+`maxTotalSize` is checked twice: against `Content-Length` before a parser is even built, and again as the bytes arrive, because a chunked request has no `Content-Length` and a request that has one is under no obligation to be honest about it.
+
+### How this relates to `bodyLimit`
+
+[`config.bodyLimit`](/configuration/#headers-logs-and-limits) (`1mb`) is what `express.json()` and `express.urlencoded()` accept for a whole body. It does not apply to `multipart/form-data`, which those parsers never look at — so a `bodyLimit` of `1mb` has never bounded an upload, and `maxTotalSize` is what does. The one place they meet is `maxFieldSize`, which **defaults to `bodyLimit`**: one text field of a form then costs the same whichever encoding the form was posted with.
+
+Each of `maxTotalSize`, `maxFileSize`, `maxFiles` and `maxFields` accepts `false`, which removes the bound. `henri audit` reports it (`uploads.limits-disabled`); raise the number instead.
+
+### Narrowing the surface
+
+The parser runs before sessions and CSRF (see below), so it is the first thing an unauthenticated request meets. `uploads.paths` narrows that to the routes that actually take a file:
+
+```json
+{ "uploads": { "paths": ["/artworks", "/api/v1/artworks"] } }
+```
+
+A multipart body posted anywhere else is not read at all, and `req.files` stays empty.
+
+## The type is what the bytes say
+
+A part's `Content-Type` and its filename are written by whoever is uploading. Neither is evidence. henri reads the first 4kb and matches a signature table: what it recognizes is the type, and the client's claim is kept as `declaredType` for the record and used for nothing.
+
+```js
+const file = req.file('scan');
+
+file.declaredType; // 'image/png'  — what the client said
+file.type; // 'application/x-elf' — what it is
+file.mistyped; // true
+```
+
+`uploads.allow` matches the type henri decided on, so `allow: ["image/png"]` cannot be satisfied by naming an executable `avatar.png`:
+
+```json
+{ "uploads": { "allow": ["image/png", "image/jpeg", "application/pdf"] } }
+```
+
+**What this does not do**, plainly:
+
+- **It does not guess a type from an extension.** Ever. A format henri has no signature for is `application/octet-stream`, not "probably a CSV because it ends in `.csv`".
+- **It does not open archives.** A `.docx`, an `.xlsx` and a `.odt` are all `application/zip`, which is what they are. Whether the zip holds a document or a zip bomb is not something a signature knows.
+- **It reads a prefix, not the whole file.** A valid PNG header followed by anything at all is `image/png` to henri, as it is to every browser. If a format has to be _valid_ and not merely _recognized_, parse it in the controller.
+- **Text is inferred, not signed.** A sample that decodes as UTF-8 with no control characters is text: `text/plain` for CSV, JSON and Markdown alike, and `text/html` or `image/svg+xml` when it opens with those. Those last two are named so an `allow` list can refuse them — both carry script, and neither should be served inline from your own origin.
+- **`uploads.sniff: false`** turns all of it off and takes the client's word. `henri audit` reports it (`uploads.type-check-disabled`).
+
+## Names, and why the stored one is generated
+
+There are two names and they never meet.
+
+The **stored name** is `<yyyy>/<mm>/<32 hex characters>.<extension>`, where the extension comes from the type the bytes were recognized as. Nothing the client sent takes part in it. That is one answer to a list of problems that is really one problem — `../../etc/passwd`, `/etc/passwd`, `C:\boot.ini`, a NUL byte in the middle, `CON`, `.htaccess`, `avatar.php`, a name four thousand characters long — because none of them are consulted when a path is built. The storage refuses any key that does not have that exact shape, and refuses again if the path it resolves to is not inside the root.
+
+The **original name** is metadata: separators, control characters, quotes and wildcards removed, leading and trailing dots stripped, Windows device names prefixed, cut to `maxFilenameLength`. It is what the record holds and what a download is called.
+
+The two scriptable types henri recognizes, `text/html` and `image/svg+xml`, are stored under a `.bin` extension, so a web server misconfigured to serve the storage directory still has nothing there it would render.
+
+## Where the files go
+
+`storage/uploads` in the application, by default. Outside `app/views/public`, which `express.static` serves; outside `app/views`, which the Inertia dev server has for a root; outside `.henri`, which `henri clean` removes. The directory is created `0700`, every stored object `0600`, and a `.gitignore` is written into it the first time so uploads never reach a commit.
+
+`henri audit` reports a `root` inside a directory the application serves (`uploads.root-served`), which is the mistake this default exists to avoid.
+
+## Nothing is kept unless you say so
+
+A parsed file lives in a private temporary area until `store()` moves it in. Everything else is removed when the response closes — answered, refused, timed out or abandoned by the client, which is the whole list of ways a request ends. `permitFiles()` removes what the controller did not ask for immediately rather than at the end, and a refusal frees what it had already read before the answer goes out.
+
+The one case a request cannot clean up after is a process that was killed outright, so the storage sweeps its temporary area when it starts.
+
+Calling `store()` after the response has closed throws rather than half-working: a file is stored during the request or not at all.
+
+## Where the parser sits, and why
+
+Runlevel 3, before the user module. It has to be: the `_csrf` field of a `multipart/form-data` form is _inside the body_, and the CSRF middleware reads `req.body`. Parse any later and no ordinary HTML upload form could pass the token check.
+
+The consequence is that an unauthenticated `POST` reaches the parser before it reaches a session, which is why every limit above is enforced before a byte is read, why `uploads.paths` exists, and why nothing is kept by default.
+
+## A storage of your own
+
+`HenriStorage` is to uploads what `HenriAdapter` is to the stores. henri ships the local disk and no client for anybody's object store — an S3 client is a dependency, a credential chain, a region, a retry policy and a bill, and none of that belongs in a framework that would then own its upgrades.
+
+```js
+// lib/s3-storage.js
+class S3Storage {
+  constructor(name, config, henri) {}
+  async start() {}
+  async stop() {}
+  async temp() {} // { path }: a private local file to stream a part into
+  async put(source, key) {} // upload, remove the part, answer the key
+  async get(key) {} // a readable stream
+  async stat(key) {} // { size, modifiedAt } or null
+  async delete(key) {} // true when something was removed
+  url(key) {} // a public url, or null
+}
+
+module.exports = S3Storage;
+```
+
+```json
+{ "uploads": { "storage": "./lib/s3-storage" } }
+```
+
+The module id is resolved from the application, the way [`rateLimit.store`](/configuration/#rate-limits) is, and it may export a class, a `(henri, { name, config }) => storage` factory, or an object that is already one.
+
+`temp()` is part of the contract because only the storage knows where a part should land so that keeping it is cheap: on the local disk it is a directory inside the root, so promoting a file is a rename on the same filesystem rather than a copy.
+
+## Out of scope, on purpose
+
+These are all real, and each of them is a feature rather than half a feature. henri does none of them, and says so here rather than doing one badly:
+
+- **Image processing, variants and thumbnails.** A resize is a native dependency (sharp, libvips), a queue, a cache and a set of decisions about quality that belong to an application, not to a framework. Do it in a [job](/guides/jobs/) after `store()` — the record has the key, and the queue is already there.
+- **Direct-to-S3 signed uploads.** They are the right answer above a certain size, and they are the _opposite_ design: the bytes never reach the application, so none of the limits, the sniffing or the cleanup on this page apply. Getting that right means signing a policy, verifying the object afterwards and reconciling what was uploaded but never claimed. A storage that does it can be written against the seam above; henri does not pretend the two are the same feature.
+- **A CDN story.** `url()` exists in the contract for a storage that has public urls. What is cached where, for how long, and how a private file is signed for one viewer is a deployment decision.
+- **Virus scanning.** It is a daemon (ClamAV) or a paid API, it is the sort of thing that must not run inside a request, and a scanner henri shipped would be a scanner henri kept up to date. Call one from a job before the file is shown to anyone else.
+
+## Turning uploads off
+
+```json
+{ "uploads": false }
+```
+
+The module stays in the boot — `req.files` is there and empty, so nothing in a controller has to ask first — no storage is prepared, and no multipart body is read. Anything that reaches for a file says what to do about it.


### PR DESCRIPTION
An application built on henri could not accept a file. No multipart parsing, no limits, no place to put what arrived, so every application invented it. That is also where the security goes wrong: every one of AdonisJS's 2026 advisories clustered in multipart handling.

## A package, not core

`@usehenri/uploads` ships its own henri module the way `@usehenri/jobs` and `@usehenri/graphql` do, so busboy is a dependency of that package and of nothing else. The one thing in core is the `uploads` configuration key, validated at boot whether or not the package is installed, so a typo is a boot error rather than silence.

busboy because the ecosystem sits on it, it has no opinion about the filesystem, and its limits are enforced by the state machine as it reads. formidable writes files itself with its own naming and temp directory, which is exactly the part henri wants to own.

**Runlevel 3, before the user module.** The `_csrf` field of a `multipart/form-data` form is inside the body, and the CSRF middleware reads `req.body`: parse later and no plain HTML upload form can pass the token check. The consequence, that an unauthenticated POST meets the parser first, is why every limit is pre-emptive and why nothing is kept by default.

## The limits

| Key | Default |
| --- | --- |
| `maxTotalSize` | 25mb, checked against `Content-Length` before a parser is built, then counted as bytes arrive |
| `maxFileSize` | 10mb |
| `maxFiles` | 10 |
| `maxFields` | 100 |
| `maxFieldNameSize` | 100 bytes |
| `maxFieldSize` | `config.bodyLimit` |

## Verified against a booted application, not taken on report

| Sent | What happened |
| --- | --- |
| a filename of `../../../../tmp/pwned.png` | stored as `demo/2026/09/<32 hex>.png`, nothing written outside the root, the original kept only as metadata |
| a PNG declared as `application/pdf` | `declaredType: application/pdf`, `type: image/png`, `mistyped: true` |
| 700 kB against a 512 kB limit | `413` |
| three files against a limit of two | `413` |
| after all of the above | the temp directory holds nothing, objects are `0600`, the root is `0700` |

The type comes from the first 4 kB, never from the extension and never from what the client said. The stored name is generated and the storage re-checks that the resolved path is inside the root.

## Where files go, and the seam

`storage/uploads`, outside `app/views/public`, outside Vite's dev root, and outside `.henri` which `henri clean` removes. Nothing is served from it: `henri.uploads.send()` streams with `Content-Disposition: attachment` and `nosniff`. `HenriStorage` is the contract, the local disk is the implementation that ships, and no S3 client is included.

## Deliberately out of scope

Image processing and variants, direct-to-S3 signed uploads, a CDN story, virus scanning. Each is named in the guide with the reason, along with two honest limits: henri recognizes a file, it does not validate it, and it never opens archives, so a `.docx` is a zip.

## Also in the branch

`henri audit` gained three checks (`uploads.limits-disabled`, `uploads.type-check-disabled`, `uploads.root-served`), `henri doctor` asks for the package when a configuration has an `uploads` block, and core gained `res.boom.payloadTooLarge()` and `res.boom.unsupportedMediaType()` so the negotiated error page gets the right reason phrase.

## Verification

`pnpm test` 1842 passed, `pnpm test:types`, `pnpm lint --max-warnings 0`, `pnpm format:check`, and `scripts/smoke.sh`. The uploads suite alone is 100 tests, run twelve times consecutively by its author after fixing two real flakes.

**Before the release**: `@usehenri/uploads` is a new package, so it needs `node scripts/npm-bootstrap.mjs @usehenri/uploads` and a trusted publisher registered, like `@usehenri/graphql` and `@usehenri/jobs`. It is already in the `fixed` group.