### PR TITLE
henri openapi: what an application exposes, described from what it actually does

### DIFF
--- a/.changeset/openapi-description.md
+++ b/.changeset/openapi-description.md
@@ -1,0 +1,23 @@
+---
+'@usehenri/core': minor
+'@usehenri/cli': minor
+'@usehenri/mcp': minor
+---
+
+`henri openapi`: a machine-readable description of what an application exposes, generated from its routes rather than hand-written.
+
+```bash
+henri openapi                      # the OpenAPI 3.1 document, on stdout
+henri openapi --out openapi.json   # written to a file the application commits
+henri openapi --summary            # what it covers, and what henri cannot know
+```
+
+Most frameworks cannot generate a good one, because they know nothing about their own answers, and the description ends up a second copy of the application that drifts. henri knows the routes (`config/routes.js`, expanded the way the router expands it), the models (its own schema format, plus the columns the adapters add), the answers (HAL with `_links`, the boom error envelope with its code, the paging, `Idempotency-Key`, the versioned media type), who may call what (`roles` on a route, a policy per record) and what leaves (a field marked `personal: { expose: false }` is dropped; a declared foreign key travels as the related row's `externalId`). All of that is derived, and nothing in the document is a convention henri hopes an application follows.
+
+The other half is what henri **cannot** know, and it is the half that makes the document worth reading. A controller can answer anything: `res.render()` is not JSON, and a hand-written route points at an action henri never wrapped. Those operations carry no success status at all — only the failures henri answers before the action runs, plus a `default` response that says, in words, that the body is the application's. Nothing in a response schema is `required` and every schema is open, because an action may present its records before sending them. A request body is the model's writable columns, all optional, and a foreign key gets no type, because `req.permit()` is the controller's decision. Every operation carries `x-henri.known`, so a reader never has to guess how much was derived. An honest `unknown` beats a wrong `object`.
+
+The document is OpenAPI **3.1** (JSON Schema 2020-12: a published foreign key is `type: ["string", "null"]`, and "anything" is `{}` — neither is expressible in 3.0). It is validated against the specification by the test suites of core, the command line and the showcase, and the showcase suite calls the application and checks that the status, the shape and the headers of a real answer are the ones the document named.
+
+It lives as a file the application commits, and as `GET /_openapi.json` on a booted application — development only and from the loopback interface only, like `/_routes` and `/_controllers`, because the document names every route, its roles and its policy. `henri mcp` exposes it as the `openapi` tool, which is the fastest way for a coding agent to learn an application's HTTP surface.
+
+Out of scope on purpose: a UI, request validation from the document, client generation, and GraphQL, which has a schema of its own. The guide is `usehenri.io/guides/openapi/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,28 +59,28 @@ an app and is what core's tests boot.
 
 ## Layout
 
-| Path                                    | Package               | Role                                                                                                                                                                                                             |
-| --------------------------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `packages/henri`                        | `henri`               | The CLI binary users install; delegates to `@usehenri/cli`.                                                                                                                                                      |
-| `packages/cli`                          | `@usehenri/cli`       | `new`, `init`, `server`, `console`, `routes`, `generate` (incl. `authentication`), `destroy`, `build`, `test`, `db`, `jobs`, `privacy`, `doctor`, `audit`, `mcp`, `clean`, `about`, `analyze`; the app templates |
-| `packages/core`                         | `@usehenri/core`      | The framework: modules, server, router, models, views, users, policies, mail                                                                                                                                     |
-| `packages/mongoose`                     | `@usehenri/mongoose`  | MongoDB adapter (Mongoose 9)                                                                                                                                                                                     |
-| `packages/disk`                         | `@usehenri/disk`      | Zero-config local MongoDB (mongodb-memory-server) on top of mongoose                                                                                                                                             |
-| `packages/sequelize`                    | `@usehenri/sequelize` | Shared SQL adapter (Sequelize 6)                                                                                                                                                                                 |
-| `packages/mysql`, `postgresql`, `mssql` | `@usehenri/*`         | Dialect packages on top of `@usehenri/sequelize`                                                                                                                                                                 |
-| `packages/drizzle`                      | `@usehenri/drizzle`   | SQL adapter on Drizzle ORM (sqlite, postgres, mysql) with drizzle-kit migrations (`henri db:*`), new in 1.1                                                                                                      |
-| `packages/react`                        | `@usehenri/react`     | Next.js 16 view engine (pages router), `withHenri`, `useHenri`, form components; supported and frozen                                                                                                            |
-| `packages/inertia`                      | `@usehenri/inertia`   | Inertia.js view engine on Vite + React 19; the default renderer of `henri new`                                                                                                                                   |
-| `packages/jobs`                         | `@usehenri/jobs`      | Background jobs: a database backed queue with retries, a dead letter queue and recurring jobs (`henri jobs`), new in 1.1; ships its own module, left core in 1.2                                                 |
-| `packages/graphql`                      | `@usehenri/graphql`   | GraphQL: the models' types and resolvers merged and served by Apollo Server; left core in 1.2                                                                                                                    |
-| `packages/uploads`                      | `@usehenri/uploads`   | File uploads: bounded multipart parsing (busboy), files typed by their bytes and a storage seam; ships its own module, new in 1.2                                                                                |
-| `packages/redis`                        | `@usehenri/redis`     | The shared store of `config.shared`: the rate limit, the sign-in lockout and the idempotency keys counted in Redis instead of one process                                                                        |
-| `packages/testing`                      | `@usehenri/testing`   | Boots an app for Vitest and binds supertest to it                                                                                                                                                                |
-| `packages/mcp`                          | `@usehenri/mcp`       | `henri mcp`: stdio MCP server exposing routes, models, generators, tests and doctor to coding agents                                                                                                             |
-| `packages/websocket`                    | private               | Not published, never wired into core                                                                                                                                                                             |
-| `packages/demo`                         | private               | Demo app used by core's tests (`NODE_ENV=test` chdirs into it)                                                                                                                                                   |
-| `showcase`                              | private               | Lineup, the showcase application (Inertia + Drizzle on PostgreSQL); its own suite, `pnpm test:showcase`                                                                                                          |
-| `website`                               | private               | usehenri.io, deployed by Vercel from `website/`                                                                                                                                                                  |
+| Path                                    | Package               | Role                                                                                                                                                                                                                        |
+| --------------------------------------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/henri`                        | `henri`               | The CLI binary users install; delegates to `@usehenri/cli`.                                                                                                                                                                 |
+| `packages/cli`                          | `@usehenri/cli`       | `new`, `init`, `server`, `console`, `routes`, `openapi`, `generate` (incl. `authentication`), `destroy`, `build`, `test`, `db`, `jobs`, `privacy`, `doctor`, `audit`, `mcp`, `clean`, `about`, `analyze`; the app templates |
+| `packages/core`                         | `@usehenri/core`      | The framework: modules, server, router, models, views, users, policies, mail                                                                                                                                                |
+| `packages/mongoose`                     | `@usehenri/mongoose`  | MongoDB adapter (Mongoose 9)                                                                                                                                                                                                |
+| `packages/disk`                         | `@usehenri/disk`      | Zero-config local MongoDB (mongodb-memory-server) on top of mongoose                                                                                                                                                        |
+| `packages/sequelize`                    | `@usehenri/sequelize` | Shared SQL adapter (Sequelize 6)                                                                                                                                                                                            |
+| `packages/mysql`, `postgresql`, `mssql` | `@usehenri/*`         | Dialect packages on top of `@usehenri/sequelize`                                                                                                                                                                            |
+| `packages/drizzle`                      | `@usehenri/drizzle`   | SQL adapter on Drizzle ORM (sqlite, postgres, mysql) with drizzle-kit migrations (`henri db:*`), new in 1.1                                                                                                                 |
+| `packages/react`                        | `@usehenri/react`     | Next.js 16 view engine (pages router), `withHenri`, `useHenri`, form components; supported and frozen                                                                                                                       |
+| `packages/inertia`                      | `@usehenri/inertia`   | Inertia.js view engine on Vite + React 19; the default renderer of `henri new`                                                                                                                                              |
+| `packages/jobs`                         | `@usehenri/jobs`      | Background jobs: a database backed queue with retries, a dead letter queue and recurring jobs (`henri jobs`), new in 1.1; ships its own module, left core in 1.2                                                            |
+| `packages/graphql`                      | `@usehenri/graphql`   | GraphQL: the models' types and resolvers merged and served by Apollo Server; left core in 1.2                                                                                                                               |
+| `packages/uploads`                      | `@usehenri/uploads`   | File uploads: bounded multipart parsing (busboy), files typed by their bytes and a storage seam; ships its own module, new in 1.2                                                                                           |
+| `packages/redis`                        | `@usehenri/redis`     | The shared store of `config.shared`: the rate limit, the sign-in lockout and the idempotency keys counted in Redis instead of one process                                                                                   |
+| `packages/testing`                      | `@usehenri/testing`   | Boots an app for Vitest and binds supertest to it                                                                                                                                                                           |
+| `packages/mcp`                          | `@usehenri/mcp`       | `henri mcp`: stdio MCP server exposing routes, models, generators, tests and doctor to coding agents                                                                                                                        |
+| `packages/websocket`                    | private               | Not published, never wired into core                                                                                                                                                                                        |
+| `packages/demo`                         | private               | Demo app used by core's tests (`NODE_ENV=test` chdirs into it)                                                                                                                                                              |
+| `showcase`                              | private               | Lineup, the showcase application (Inertia + Drizzle on PostgreSQL); its own suite, `pnpm test:showcase`                                                                                                                     |
+| `website`                               | private               | usehenri.io, deployed by Vercel from `website/`                                                                                                                                                                             |
 
 ## How core works
 
@@ -182,6 +182,26 @@ request-id,redact,headers,pagination,timeout,health}.js`: `res.resource()` and
   that it can serve -- the stores answered, the boot is done and no shutdown
   has started. `resources`/`crud` routes answering JSON without `_links`
   are reported (refused with `config.api.strict`).
+- `henri openapi` (`packages/cli/scripts/openapi.js`, built by
+  `base/openapi.js`) writes the OpenAPI 3.1 description of what an
+  application exposes, from the expanded routes, the model files and the
+  configuration, without booting. It describes what henri itself answers --
+  the HAL resource and collection of a `resources`/`crud` route, the boom
+  envelope of every failure henri owns, the paging, `Idempotency-Key`, the
+  versioned media type, the roles and the policy of each route, and the
+  endpoints the user module and the health probes mount -- and it refuses to
+  describe what a controller writes: such an operation carries the statuses
+  henri produces, `x-henri.known: false` and no success status at all. A
+  response schema requires nothing (an action may present its records) and a
+  request body is the model's writable columns, all optional, with no type on
+  a foreign key. A booted application answers the same document at
+  `GET /_openapi.json` (`5.router.js`, development and loopback only, like
+  `/_routes`), and `henri mcp` exposes it as the `openapi` tool. It is
+  validated against the specification by `src/__tests__/openapi.spec.js`,
+  `packages/cli/__tests__/openapi.spec.js` and `showcase/test/openapi.test.js`,
+  which also calls the application and compares the answers with what the
+  document said. The guide is
+  `website/src/content/docs/guides/openapi.md`.
 - The three counters that only worked with one process -- the rate limit, the
   sign-in lockout (`base/lockout.js`) and the idempotency keys -- share one
   backend through `config.shared` (`base/shared.js`, `henri.shared`). The

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -204,6 +204,18 @@ module.exports = [
     },
   },
   {
+    // The OpenAPI document is written in the order the specification lists
+    // its fields (openapi, info, servers, tags, paths, components, and
+    // inside an operation: operationId, summary, description, parameters,
+    // responses). That order is what the generated file carries, and it is
+    // what a reader of the specification expects to find; alphabetical keys
+    // would make the artifact harder to read for no gain.
+    files: ['packages/core/src/base/openapi.js'],
+    rules: {
+      'sort-keys': 'off',
+    },
+  },
+  {
     // The type-test fixture is a henri application in miniature: type-checked
     // by `pnpm test:types`, never run. Its key order mirrors a routes file and
     // a controller, where the order is load-bearing rather than alphabetical.

--- a/packages/cli/__tests__/openapi.spec.js
+++ b/packages/cli/__tests__/openapi.spec.js
@@ -1,0 +1,103 @@
+const fs = require('fs');
+const path = require('path');
+
+const { cleanup, henri, read, scaffold } = require('./helpers');
+
+describe('henri openapi', () => {
+  let dir;
+  let app;
+  let validate;
+
+  beforeAll(async () => {
+    const { Validator } = await import('@seriousme/openapi-schema-validator');
+
+    validate = (candidate) => new Validator().validate(candidate);
+    ({ app, dir } = scaffold());
+  });
+
+  afterAll(() => {
+    cleanup(dir);
+  });
+
+  test('prints a valid OpenAPI 3.1 document without booting the app', async () => {
+    const { status, stdout } = henri(['openapi'], { cwd: app });
+    const document = JSON.parse(stdout);
+
+    expect(status).toBe(0);
+    expect(document.openapi).toBe('3.1.0');
+    expect(await validate(document)).toEqual({ valid: true });
+    expect(document.info.title).toBe('app');
+    expect(Object.keys(document.paths)).toContain('/tasks');
+    expect(document.components.schemas.Task).toBeDefined();
+  });
+
+  test('describes the scaffolded resource from its model and its routes', () => {
+    const { stdout } = henri(['openapi'], { cwd: app });
+    const document = JSON.parse(stdout);
+    const index = document.paths['/tasks'].get;
+    const create = document.paths['/tasks'].post;
+
+    expect(index['x-henri']).toMatchObject({
+      answer: 'collection',
+      known: true,
+      model: 'Task',
+      source: 'resources',
+    });
+    expect(create.requestBody.content['application/json'].schema).toEqual({
+      $ref: '#/components/schemas/TaskInput',
+    });
+    expect(create.responses['201'].headers.Location).toBeDefined();
+    // The scaffold has no user model, so henri mounts no session endpoints
+    expect(document.paths['/login']).toBeUndefined();
+    expect(document.paths['/livez']).toBeDefined();
+  });
+
+  test('writes the document with --out and reports what it covers', () => {
+    const { status, stdout } = henri(['openapi', '--out', 'openapi.json'], {
+      cwd: app,
+    });
+
+    expect(status).toBe(0);
+    expect(stdout).toContain('openapi.json written');
+    expect(stdout).toContain('whose answer henri cannot know');
+    expect(JSON.parse(read(app, 'openapi.json')).openapi).toBe('3.1.0');
+
+    fs.rmSync(path.join(app, 'openapi.json'));
+  });
+
+  test('prints the coverage alone with --summary', () => {
+    const { status, stdout } = henri(['openapi', '--summary'], { cwd: app });
+
+    expect(status).toBe(0);
+    expect(stdout).toContain('OpenAPI 3.1.0 for app');
+    expect(stdout).toContain('GET /  main#home');
+    expect(stdout).not.toContain('"openapi"');
+  });
+
+  test('refuses to run outside of a project with exit code 3', () => {
+    const { status } = henri(['openapi'], { cwd: dir });
+
+    expect(status).toBe(3);
+  });
+
+  test('names the failure when --out cannot be written', () => {
+    // A file cannot also be a directory: package.json is one
+    const { status, stderr } = henri(
+      ['openapi', '--out', 'package.json/openapi.json', '--json'],
+      { cwd: app }
+    );
+    const { error } = JSON.parse(stderr);
+
+    expect(status).toBe(1);
+    expect(error.code).toBe('HENRI_API_DESCRIPTION_UNWRITABLE');
+    expect(error.command).toBe('openapi');
+    expect(error.hint).toContain('henri openapi > openapi.json');
+  });
+
+  test('--out without a file name is a usage error', () => {
+    const { status, stderr } = henri(['openapi', '--out'], { cwd: app });
+
+    expect(status).toBe(2);
+    expect(stderr).toContain('--out needs a file name');
+  });
+});

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -44,6 +44,7 @@ const BOOLEAN_FLAGS = [
   'skip-install',
   'skip-workers',
   'sql',
+  'summary',
   'version',
   'wait',
   'yes',

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -65,6 +65,7 @@
     "jobs",
     "mcp",
     "new",
+    "openapi",
     "privacy",
     "routes",
     "s",
@@ -72,6 +73,7 @@
     "test"
   ],
   "devDependencies": {
-    "@babel/parser": "^8.0.4"
+    "@babel/parser": "^8.0.4",
+    "@seriousme/openapi-schema-validator": "^2.9.1"
   }
 }

--- a/packages/cli/scripts/help.js
+++ b/packages/cli/scripts/help.js
@@ -898,6 +898,53 @@ const COMMANDS = [
   },
   {
     description: [
+      'Writes the OpenAPI 3.1 description of what the application exposes,',
+      'built from config/routes.js, app/models and the configuration, without',
+      'starting the server or touching a database. JSON on stdout by default.',
+      '',
+      'It describes the answers henri produces itself: the HAL collection and',
+      'resource of every resources/crud route, the error envelope of every',
+      'failure henri answers, the paging, the versioned media type,',
+      'Idempotency-Key, the roles and the policy of each route, and the',
+      'endpoints henri mounts (POST /login, the account flows, the health',
+      'probes). What a controller writes itself it does not describe: those',
+      'operations carry the statuses henri produces and say, in words, that',
+      "the body is the application's. --summary prints which is which.",
+      '',
+      'Out of scope on purpose: a UI, request validation, client generation',
+      'and GraphQL, which has a schema of its own.',
+    ],
+    examples: [
+      {
+        command: 'henri openapi > openapi.json',
+        description: 'The document, on stdout',
+      },
+      {
+        command: 'henri openapi --out openapi.json',
+        description: 'The same, written to a file the application commits',
+      },
+      {
+        command: 'henri openapi --summary',
+        description: 'What it covers, and what henri cannot know',
+      },
+    ],
+    flags: [
+      {
+        description: 'write the document to a file instead of stdout',
+        flag: '--out <file>',
+      },
+      {
+        description:
+          'print what the document covers instead of the document itself',
+        flag: '--summary',
+      },
+    ],
+    name: 'openapi',
+    summary: 'the OpenAPI 3.1 description of what the application exposes',
+    usage: ['henri openapi [--out <file>] [--summary]'],
+  },
+  {
+    description: [
       'Prints the routes expanded from config/routes.js (verb, path,',
       'controller and path helper) without starting the server.',
     ],

--- a/packages/cli/scripts/openapi.js
+++ b/packages/cli/scripts/openapi.js
@@ -1,0 +1,280 @@
+const fs = require('fs');
+const path = require('path');
+
+const { CliError } = require('./errors');
+const { readConfig, readRoutes, validInstall } = require('./utils');
+const { expand } = require('./routing');
+
+/**
+ * `henri openapi`: the OpenAPI 3.1 description of what the application
+ * exposes, built from `config/routes.js`, `app/models` and the
+ * configuration, without booting the server or touching a database.
+ *
+ * The builder is core's (`@usehenri/core/src/base/openapi.js`), so the
+ * document says exactly what the router, the HAL helpers and the guards do.
+ * This file is the part that reads an application off the disk: the routes
+ * expanded the way `henri routes` expands them, the model files, the actions
+ * the controllers actually export, and the policies that exist.
+ */
+
+/**
+ * Prefer the `@usehenri/core` the project depends on and fall back to the
+ * one shipped with this CLI, the way the database commands do
+ *
+ * @param {string} id The module path inside the package
+ * @param {string} cwd The application directory
+ * @returns {*} The module
+ */
+const fromCore = (id, cwd) => {
+  try {
+    return require(require.resolve(`@usehenri/core/${id}`, { paths: [cwd] }));
+  } catch {
+    return require(`@usehenri/core/${id}`);
+  }
+};
+
+/**
+ * The `.js` files of a directory, as posix names without the extension
+ * (`tasks`, `admin/users`)
+ *
+ * @param {string} dir The directory
+ * @returns {Array<string>} The names, sorted
+ */
+const listing = (dir) => {
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+
+  const found = [];
+  const walk = (current, prefix) => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      if (entry.name.startsWith('.') || entry.name === 'node_modules') {
+        continue;
+      }
+
+      if (entry.isDirectory()) {
+        walk(path.join(current, entry.name), `${prefix}${entry.name}/`);
+      } else if (entry.name.endsWith('.js')) {
+        found.push(`${prefix}${entry.name.slice(0, -3)}`);
+      }
+    }
+  };
+
+  walk(dir, '');
+
+  return found.sort();
+};
+
+/**
+ * Action names read from a controller source without loading it, for a file
+ * that cannot be required (it reaches for a model global at load time, say)
+ *
+ * @param {string} source The controller source
+ * @returns {Array<string>} The action names
+ */
+const scanActions = (source) => {
+  const names = new Set();
+  const pattern =
+    /^\s{2}(?:async\s+)?([A-Za-z_$][\w$]*)\s*(?::\s*(?:async\s*)?(?:\(|function)|\()/gm;
+  let match;
+
+  while ((match = pattern.exec(source)) !== null) {
+    names.add(match[1]);
+  }
+
+  return Array.from(names);
+};
+
+/**
+ * Which `controller#action` the application actually exports.
+ *
+ * A route pointing at an action that is not there answers 501 in
+ * development and is never registered in production, and the document says
+ * so rather than describing an endpoint nobody can call. `null` when
+ * `app/controllers` does not exist, which is the honest "unknown".
+ *
+ * @param {string} cwd The application directory
+ * @returns {?object} `{ 'tasks#index': true }`, or null
+ */
+const actionsOf = (cwd) => {
+  const dir = path.join(cwd, 'app', 'controllers');
+
+  if (!fs.existsSync(dir)) {
+    return null;
+  }
+
+  const actions = {};
+
+  for (const name of listing(dir)) {
+    const file = path.join(dir, `${name}.js`);
+    let names;
+
+    try {
+      delete require.cache[require.resolve(file)];
+
+      const loaded = require(file) || {};
+
+      names = Object.keys(loaded).filter(
+        (key) => key !== 'before' && typeof loaded[key] === 'function'
+      );
+    } catch {
+      // A controller that cannot be loaded outside a booted application:
+      // read the actions off the source instead of pretending there are none
+      names = scanActions(fs.readFileSync(file, 'utf8'));
+    }
+
+    for (const action of names) {
+      actions[`${name}#${action}`] = true;
+    }
+  }
+
+  return actions;
+};
+
+/**
+ * The identity of the application, for `info`
+ *
+ * @param {string} cwd The application directory
+ * @returns {{description: ?string, title: string, version: string}} The info
+ */
+const identity = (cwd) => {
+  try {
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(cwd, 'package.json'), 'utf8')
+    );
+
+    return {
+      description: typeof pkg.description === 'string' ? pkg.description : null,
+      title: pkg.name || path.basename(cwd),
+      version: typeof pkg.version === 'string' ? pkg.version : '0.0.0',
+    };
+  } catch {
+    return { description: null, title: path.basename(cwd), version: '0.0.0' };
+  }
+};
+
+/**
+ * Builds the description of the application in the current directory
+ *
+ * @param {string} [cwd=process.cwd()] The application directory
+ * @returns {object} The OpenAPI document
+ */
+const describe = (cwd = process.cwd()) => {
+  const { build } = fromCore('src/base/openapi', cwd);
+  const { loadModules } = fromCore('src/utils', cwd);
+
+  return build({
+    actions: actionsOf(cwd),
+    config: readConfig(cwd, undefined),
+    info: identity(cwd),
+    models: Object.values(loadModules(path.join(cwd, 'app', 'models'))),
+    policies: listing(path.join(cwd, 'app', 'policies')),
+    routes: expand(readRoutes(cwd)),
+  });
+};
+
+/**
+ * What the document covers, and what it could not
+ *
+ * @param {object} document The OpenAPI document
+ * @returns {string} The summary
+ */
+const summary = (document) => {
+  const { coverage, excluded = [] } = document.info['x-henri'];
+  const unknown = [];
+
+  for (const [route, item] of Object.entries(document.paths)) {
+    for (const [verb, operation] of Object.entries(item)) {
+      const marks = operation['x-henri'] || {};
+
+      if (marks.known !== true) {
+        unknown.push(`${verb.toUpperCase()} ${route}  ${operation.summary}`);
+      }
+    }
+  }
+
+  const lines = [
+    '',
+    `OpenAPI ${document.openapi} for ${document.info.title} ${document.info.version}`,
+    '',
+    `  ${coverage.operations} operations, ${Object.keys(document.paths).length} paths`,
+    `  ${coverage.described} described from the routes, the models and henri's own endpoints`,
+    `  ${coverage.unknown} whose answer henri cannot know`,
+    '',
+  ];
+
+  if (unknown.length > 0) {
+    lines.push(
+      '  What henri cannot know (the controller writes the body; only the failures henri answers itself are described):'
+    );
+    lines.push(...unknown.map((line) => `    ${line}`), '');
+  }
+
+  for (const entry of excluded) {
+    lines.push(`  Left out: ${entry.route} (${entry.reason})`);
+  }
+
+  if (excluded.length > 0) {
+    lines.push('');
+  }
+
+  return lines.join('\n');
+};
+
+/**
+ * Print the OpenAPI description of the application (JSON on stdout), or
+ * write it to a file
+ *
+ * @param {object} [args] CLI arguments (`--out <file>`, `--summary`)
+ * @returns {Promise<void>} Resolves when printed
+ * @throws {CliError} USAGE on a bad `--out`, or when the file cannot be written
+ */
+const main = async (args = {}) => {
+  validInstall({ fatal: true });
+
+  const document = describe(process.cwd());
+
+  if (args.summary === true) {
+    console.log(summary(document));
+
+    return;
+  }
+
+  const body = `${JSON.stringify(document, null, 2)}\n`;
+
+  if (typeof args.out === 'undefined') {
+    process.stdout.write(body);
+
+    return;
+  }
+
+  if (typeof args.out !== 'string' || args.out.length === 0) {
+    throw new CliError('USAGE', '--out needs a file name', {
+      hint: 'henri openapi --out openapi.json',
+    });
+  }
+
+  const target = path.resolve(process.cwd(), args.out);
+
+  try {
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, body);
+  } catch (error) {
+    throw new CliError(
+      'HENRI_API_DESCRIPTION_UNWRITABLE',
+      `unable to write ${args.out}: ${error.message}`,
+      {
+        cause: error,
+        hint: 'Check the path and the permissions of the directory, or print the document to stdout instead: henri openapi > openapi.json',
+      }
+    );
+  }
+
+  console.log(`${path.relative(process.cwd(), target)} written`);
+  console.log(summary(document));
+};
+
+module.exports = main;
+module.exports.actionsOf = actionsOf;
+module.exports.describe = describe;
+module.exports.summary = summary;

--- a/packages/core/error-codes.json
+++ b/packages/core/error-codes.json
@@ -7,7 +7,7 @@
     },
     {
       "area": "api",
-      "what": "the JSON API layer: HAL answers, the health endpoint and the optional GraphQL engine"
+      "what": "the JSON API layer: HAL answers, the health endpoints, the OpenAPI description of what an application exposes and the optional GraphQL engine"
     },
     {
       "area": "boot",
@@ -141,6 +141,17 @@
       "code": "HENRI_AGENT_UNREACHABLE",
       "fix": "Check that the development server is still running, and read its output: a boot that failed halfway leaves the port closed.",
       "what": "The running application did not answer."
+    },
+    {
+      "area": "api",
+      "causes": [
+        "the directory of `--out` does not exist and could not be created",
+        "the file or its directory is not writable",
+        "the path names a directory"
+      ],
+      "code": "HENRI_API_DESCRIPTION_UNWRITABLE",
+      "fix": "Check the path and the permissions of the directory, or print the document to stdout instead: `henri openapi > openapi.json`.",
+      "what": "The OpenAPI description of the application could not be written where `henri openapi --out` was told to put it."
     },
     {
       "area": "api",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,6 +65,7 @@
     "validator": "^13.15.35"
   },
   "devDependencies": {
+    "@seriousme/openapi-schema-validator": "^2.9.1",
     "@types/validator": "^13.15.10"
   },
   "engines": {

--- a/packages/core/src/5.router.js
+++ b/packages/core/src/5.router.js
@@ -18,6 +18,7 @@ const { engine: graphqlEngine } = require('./base/graphql');
 const { jsonTypes, noStore, versionGuard } = require('./base/headers');
 const { idempotency } = require('./base/idempotency');
 const { limiter, shutdown } = require('./base/rate-limit');
+const openapi = require('./base/openapi');
 const { table } = require('./base/routes');
 const flash = require('./base/flash');
 const { implicit, track } = require('./base/hooks');
@@ -174,6 +175,14 @@ class Router extends BaseModule {
       this.handler.get('/_controllers', local, (req, res) =>
         res.json(this.henri.controllers.all())
       );
+      // The OpenAPI description of what this application exposes, from the
+      // same table. It is introspection, like the two above: development
+      // only and from this machine only, because it names every route, the
+      // roles that guard it and the policy behind it. An application that
+      // wants to publish it commits the file `henri openapi --out` writes
+      this.handler.get('/_openapi.json', local, (req, res) =>
+        res.json(this.describe())
+      );
 
       // Mailer previews: rendered with the sample data declared next to the
       // mailers, never delivered (see 2.mailers.js)
@@ -217,6 +226,49 @@ class Router extends BaseModule {
     await this.init(true);
 
     return this.name;
+  }
+
+  /**
+   * The OpenAPI 3.1 description of what this application exposes, built
+   * from the table this router registered, the model files and the
+   * configuration (`base/openapi.js`). `henri openapi` builds the same
+   * document from the files, without booting.
+   *
+   * @returns {object} the document
+   * @memberof Router
+   */
+  describe() {
+    const { config, controllers, model, policies } = this.henri;
+    const actions = {};
+    let info = {};
+
+    for (const route of Object.values(this.routes)) {
+      actions[route.controller] =
+        typeof controllers.get(route.controller) === 'function';
+    }
+
+    try {
+      const pkg = JSON.parse(
+        fs.readFileSync(path.join(this.henri.cwd(), 'package.json'), 'utf8')
+      );
+
+      info = {
+        description: pkg.description,
+        title: pkg.name,
+        version: pkg.version,
+      };
+    } catch (error) {
+      debug('no readable package.json: the description keeps its defaults');
+    }
+
+    return openapi.build({
+      actions,
+      config,
+      info,
+      models: (model && model.models) || [],
+      policies: policies ? policies.names() : null,
+      routes: Object.values(this.routes),
+    });
   }
 
   /**

--- a/packages/core/src/__tests__/openapi.spec.js
+++ b/packages/core/src/__tests__/openapi.spec.js
@@ -1,0 +1,432 @@
+/* global Artwork */
+const path = require('path');
+const supertest = require('supertest');
+
+const Henri = require('../henri');
+const { build } = require('../base/openapi');
+const { expand } = require('../base/routes');
+const { loadModules } = require('../utils');
+
+const demo = path.resolve(__dirname, '..', '..', '..', 'demo');
+
+/**
+ * The document of the demo application, built from its files the way
+ * `henri openapi` builds it
+ *
+ * @returns {object} the document
+ */
+const describeDemo = () =>
+  build({
+    actions: Object.fromEntries(
+      Object.entries(
+        loadModules(path.join(demo, 'app', 'controllers'), {
+          keepDirectoryPath: true,
+        })
+      ).flatMap(([, controller]) =>
+        Object.keys(controller)
+          .filter(
+            (key) =>
+              !['before', 'globalId', 'identity'].includes(key) &&
+              typeof controller[key] === 'function'
+          )
+          .map((action) => [`${controller.identity}#${action}`, true])
+      )
+    ),
+    config: require(path.join(demo, 'config', 'default.json')),
+    info: { title: 'demo', version: '1.0.0' },
+    models: Object.values(loadModules(path.join(demo, 'app', 'models'))),
+    policies: Object.keys(loadModules(path.join(demo, 'app', 'policies'))),
+    routes: expand(require(path.join(demo, 'app', 'routes.js'))),
+  });
+
+/**
+ * Every `$ref` of a document, with the path it sits at
+ *
+ * @param {*} value the document (or a part of it)
+ * @param {string} [where=''] where it sits
+ * @param {Array<Array<string>>} [found=[]] the accumulator
+ * @returns {Array<Array<string>>} `[[ref, where], ...]`
+ */
+const refsOf = (value, where = '', found = []) => {
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => refsOf(entry, `${where}/${index}`, found));
+
+    return found;
+  }
+
+  if (!value || typeof value !== 'object') {
+    return found;
+  }
+
+  for (const key of Object.keys(value)) {
+    if (key === '$ref' && typeof value[key] === 'string') {
+      found.push([value[key], where]);
+    } else {
+      refsOf(value[key], `${where}/${key}`, found);
+    }
+  }
+
+  return found;
+};
+
+/**
+ * Follows a `#/a/b` pointer
+ *
+ * @param {object} document the document
+ * @param {string} ref the pointer
+ * @returns {*} what it names, or undefined
+ */
+const resolve = (document, ref) =>
+  ref
+    .replace(/^#\//u, '')
+    .split('/')
+    .reduce(
+      (current, part) =>
+        current ? current[decodeURIComponent(part)] : undefined,
+      document
+    );
+
+/**
+ * Every operation of a document
+ *
+ * @param {object} document the document
+ * @returns {Array<object>} `[{ operation, route, verb }]`
+ */
+const operationsOf = (document) =>
+  Object.entries(document.paths).flatMap(([route, item]) =>
+    Object.entries(item).map(([verb, operation]) => ({
+      operation,
+      route,
+      verb,
+    }))
+  );
+
+describe('the OpenAPI description', () => {
+  let document;
+  let validate;
+
+  beforeAll(async () => {
+    const { Validator } = await import('@seriousme/openapi-schema-validator');
+
+    validate = (candidate) => new Validator().validate(candidate);
+    document = describeDemo();
+  });
+
+  test('the demo application describes as a valid OpenAPI 3.1 document', async () => {
+    expect(document.openapi).toBe('3.1.0');
+    expect(document.jsonSchemaDialect).toBe(
+      'https://json-schema.org/draft/2020-12/schema'
+    );
+    expect(await validate(document)).toEqual({ valid: true });
+  });
+
+  test('every $ref resolves', () => {
+    const dangling = refsOf(document)
+      .filter(([ref]) => typeof resolve(document, ref) === 'undefined')
+      .map(([ref, where]) => `${ref} (${where})`);
+
+    expect(dangling).toEqual([]);
+  });
+
+  test('operation ids are unique', () => {
+    const ids = operationsOf(document).map(
+      ({ operation }) => operation.operationId
+    );
+
+    expect(ids).toHaveLength(new Set(ids).size);
+  });
+
+  test('every path variable is a declared parameter, and the reverse', () => {
+    for (const { operation, route, verb } of operationsOf(document)) {
+      const wanted = [...route.matchAll(/\{([^}]+)\}/gu)].map(
+        (match) => match[1]
+      );
+      const declared = (operation.parameters || [])
+        .map((parameter) =>
+          parameter.$ref ? resolve(document, parameter.$ref) : parameter
+        )
+        .filter((parameter) => parameter.in === 'path')
+        .map((parameter) => parameter.name);
+
+      expect([`${verb} ${route}`, declared.sort()]).toEqual([
+        `${verb} ${route}`,
+        wanted.sort(),
+      ]);
+    }
+  });
+
+  test('every operation says whether henri knows what it answers', () => {
+    for (const { operation, route, verb } of operationsOf(document)) {
+      const marks = operation['x-henri'];
+
+      expect([`${verb} ${route}`, typeof marks]).toEqual([
+        `${verb} ${route}`,
+        'object',
+      ]);
+      expect(typeof marks.known).toBe('boolean');
+      expect(operation.description.length).toBeGreaterThan(40);
+    }
+  });
+
+  describe('what henri knows', () => {
+    test('a resources route answers the HAL envelope of its model', () => {
+      const index = document.paths['/api/v1/artworks'].get;
+
+      expect(index['x-henri']).toMatchObject({
+        answer: 'collection',
+        controller: 'artworks',
+        known: true,
+        model: 'Artwork',
+        source: 'resources',
+        version: 'v1',
+      });
+      // Both shapes a route henri guards can answer, HAL first
+      const [hal, rendered] =
+        index.responses['200'].content['application/hal+json'].schema.anyOf;
+
+      expect(hal.allOf).toEqual([
+        { $ref: '#/components/schemas/ArtworkCollection' },
+      ]);
+      expect(hal.properties._embedded.properties.artworks.items).toEqual({
+        $ref: '#/components/schemas/ArtworkResource',
+      });
+      expect(rendered).toEqual({
+        $ref: '#/components/schemas/RenderedPage',
+      });
+      expect(index.responses['406']).toEqual({
+        $ref: '#/components/responses/NotAcceptable',
+      });
+      expect(index.parameters).toContainEqual({
+        $ref: '#/components/parameters/Page',
+      });
+    });
+
+    test('a model schema carries the columns the adapters add, typed', () => {
+      const { properties } = document.components.schemas.Artwork;
+
+      expect(properties.externalId).toMatchObject({
+        format: 'uuid',
+        type: 'string',
+      });
+      expect(properties.createdAt).toMatchObject({
+        format: 'date-time',
+        type: 'string',
+      });
+      expect(properties.year).toEqual({ type: ['integer', 'null'] });
+    });
+
+    test('a declared foreign key is the public id of the row it names', () => {
+      expect(document.components.schemas.Memo.properties.ownerId).toMatchObject(
+        { format: 'uuid', type: ['string', 'null'] }
+      );
+      // What a request may send for it is the controller's decision
+      expect(
+        document.components.schemas.MemoInput.properties.ownerId.type
+      ).toBeUndefined();
+    });
+
+    test('a field marked personal: { expose: false } is in no schema', () => {
+      const names = JSON.stringify(document.components.schemas);
+
+      // The demo's User marks `gender` expose: false, and the password is
+      // never exposed by any answer henri builds
+      expect(
+        document.components.schemas.User.properties.gender
+      ).toBeUndefined();
+      expect(
+        document.components.schemas.User.properties.password
+      ).toBeUndefined();
+      expect(names).not.toContain('"gender"');
+    });
+
+    test('the guards of a route become the statuses it can answer', () => {
+      const admin = document.paths['/admin'].get;
+
+      expect(admin['x-henri'].roles).toEqual(['admin']);
+      expect(admin.responses['401']).toBeDefined();
+      expect(admin.responses['403']).toBeDefined();
+      expect(admin.security).toEqual([{ session: [] }, { bearer: [] }]);
+
+      // A policy that does not exist refuses every request, and says so
+      expect(document.paths['/ghost'].get.description).toContain(
+        'there is no such file in app/policies'
+      );
+      expect(document.paths['/ghost'].get['x-henri'].policy).toBe(false);
+    });
+
+    test('a mutating route takes Idempotency-Key unless it opted out', () => {
+      const key = { $ref: '#/components/parameters/IdempotencyKey' };
+
+      expect(document.paths['/once'].post.parameters).toContainEqual(key);
+      expect(document.paths['/echo'].post.parameters).not.toContainEqual(key);
+      expect(document.paths['/echo'].post.responses['409']).toBeUndefined();
+    });
+
+    test('the endpoints henri mounts itself are described exactly', () => {
+      const login = document.paths['/login'].post;
+
+      expect(login['x-henri'].source).toBe('built-in');
+      expect(login.responses['200'].content['application/json'].schema).toEqual(
+        {
+          properties: { user: { $ref: '#/components/schemas/PublicUser' } },
+          required: ['user'],
+          type: 'object',
+        }
+      );
+      expect(document.paths['/logout'].get.responses['405']).toBeDefined();
+      expect(document.paths['/signup'].post).toBeDefined();
+      expect(document.paths['/password/reset/{token}'].get).toBeDefined();
+      expect(document.paths['/livez'].get).toBeDefined();
+      expect(document.paths['/readyz'].get.responses['503']).toBeDefined();
+    });
+  });
+
+  describe('what henri does not know', () => {
+    test('a hand-written route declares no success status at all', () => {
+      const version = document.paths['/version'].get;
+
+      expect(version['x-henri'].known).toBe(false);
+      expect(version['x-henri'].answer).toBe('unknown');
+      expect(Object.keys(version.responses)).toEqual(['429', 'default']);
+      expect(version.responses.default.description).toContain('Not described');
+      expect(
+        version.responses.default.content['application/json'].schema
+      ).toEqual({});
+    });
+
+    test('a member route of a resource is not described either', () => {
+      expect(document.paths['/memos/{id}/peek'].get['x-henri']).toMatchObject({
+        answer: 'unknown',
+        known: false,
+      });
+    });
+
+    test('a form page says both shapes rather than choosing one', () => {
+      const form = document.paths['/api/v1/artworks/new'].get;
+
+      expect(form['x-henri']).toMatchObject({
+        answer: 'page',
+        enforced: '_links',
+        known: false,
+      });
+      expect(
+        form.responses['200'].content['application/json'].schema.anyOf
+      ).toEqual([
+        { $ref: '#/components/schemas/RenderedPage' },
+        { $ref: '#/components/schemas/HalResource' },
+      ]);
+      expect(form.responses['200'].content['text/html']).toEqual({});
+    });
+
+    test('nothing is required of a model in an answer', () => {
+      for (const name of ['Artwork', 'Memo', 'User']) {
+        const schema = document.components.schemas[name];
+
+        expect([name, schema.required]).toEqual([name, undefined]);
+        expect([name, schema.additionalProperties]).toEqual([name, true]);
+      }
+    });
+
+    test('a controller with no such action is named as one', () => {
+      const missing = build({
+        actions: { 'tasks#index': true },
+        models: [],
+        routes: expand({ 'get /nope': 'tasks#nope' }),
+      });
+      const operation = missing.paths['/nope'].get;
+
+      expect(operation['x-henri'].known).toBe(false);
+      expect(operation.description).toContain('**No such action.**');
+      expect(operation.responses.default.description).toContain(
+        '501 in development'
+      );
+    });
+
+    test('the coverage says how much of the document was derived', () => {
+      const { coverage } = document.info['x-henri'];
+
+      expect(coverage.described + coverage.unknown).toBe(coverage.operations);
+      expect(coverage.described).toBeGreaterThan(0);
+      expect(coverage.unknown).toBeGreaterThan(0);
+    });
+  });
+
+  describe('against the running application', () => {
+    const skipWorkers = process.env.SKIP_WORKERS;
+    let henri;
+    let request;
+    let live;
+
+    beforeAll(async () => {
+      process.env.SKIP_WORKERS = '1';
+      henri = new Henri();
+      await henri.init();
+      global.henri = henri;
+      request = supertest(henri.server.app);
+      live = henri.router.describe();
+    }, 60000);
+
+    afterAll(async () => {
+      await henri.stop();
+      delete global.henri;
+
+      if (typeof skipWorkers === 'undefined') {
+        delete process.env.SKIP_WORKERS;
+      } else {
+        process.env.SKIP_WORKERS = skipWorkers;
+      }
+    }, 60000);
+
+    test('the booted router describes the same surface as the files', async () => {
+      expect(await validate(live)).toEqual({ valid: true });
+      expect(Object.keys(live.paths).sort()).toEqual(
+        Object.keys(document.paths).sort()
+      );
+    });
+
+    test('a described collection answers what the document says', async () => {
+      await Artwork.create({ title: 'Nighthawks', year: 1942 });
+
+      const answer = await request
+        .get('/api/v1/artworks')
+        .set('Accept', 'application/hal+json');
+      const described = live.paths['/api/v1/artworks'].get;
+
+      expect(described.responses[String(answer.status)]).toBeDefined();
+      expect(answer.headers['content-type']).toContain('application/hal+json');
+      expect(answer.headers['x-request-id']).toBeDefined();
+      expect(answer.headers['x-total-count']).toBeDefined();
+      expect(Object.keys(answer.body)).toEqual(
+        expect.arrayContaining(['_embedded', '_links', 'count'])
+      );
+      expect(answer.body._embedded.artworks[0].externalId).toMatch(
+        /^[0-9a-f-]{36}$/u
+      );
+    });
+
+    test('a described failure answers the envelope the document names', async () => {
+      const answer = await request
+        .get('/admin')
+        .set('Accept', 'application/json');
+      const described = live.paths['/admin'].get;
+
+      expect(answer.status).toBe(401);
+      expect(described.responses['401']).toBeDefined();
+      expect(Object.keys(answer.body).sort()).toEqual([
+        'error',
+        'message',
+        'statusCode',
+      ]);
+    });
+
+    test('a version guard answers the 406 the document declares', async () => {
+      const answer = await request
+        .get('/api/v1/artworks')
+        .set('Accept', 'application/vnd.henri.v2+json');
+
+      expect(answer.status).toBe(406);
+      expect(live.paths['/api/v1/artworks'].get.responses['406']).toBeDefined();
+      expect(answer.body.statusCode).toBe(406);
+    });
+  });
+});

--- a/packages/core/src/base/openapi.js
+++ b/packages/core/src/base/openapi.js
@@ -1,0 +1,2193 @@
+/**
+ * The OpenAPI 3.1 description of what an application exposes, built from
+ * what henri already knows about itself.
+ *
+ * Three things feed it, and nothing else: `config/routes.js` expanded the
+ * way the router expands it (`base/routes.js`), the model files with the
+ * columns the adapters add (`externalId`, the timestamps, the user's
+ * `email`/`password`/`roles`), and the configuration -- which says whether
+ * `_links` are enforced, what a policy refusal answers, how large a page
+ * may be, and which account endpoints henri mounted.
+ *
+ * ## What it describes, and what it refuses to
+ *
+ * A framework can only describe the answers it produces itself. henri
+ * produces a lot of them:
+ *
+ * - the routes expanded from `resources` and `crud` are HAL-guarded
+ *   (`base/hateoas.js`): a successful JSON answer carries `_links`, and
+ *   with `config.api.strict` one that does not is refused with a 500. That
+ *   is what henri enforces, and all it enforces, so such a response names
+ *   the two answers henri itself produces with `_links` -- the HAL envelope
+ *   of `res.resource()` and `res.collection()`, and the page options of
+ *   `res.render()` and of the implicit render -- rather than promising one
+ *   and letting an application answer the other. `_links` is `required`
+ *   exactly when the application turned strict on.
+ * - every failure henri answers itself -- the role guard, the policy gate,
+ *   the version guard, the idempotency replay, the rate limit, the error
+ *   handler -- is the boom envelope of `base/boom.js`, with the henri
+ *   error code when henri raised it on its own behalf.
+ * - `POST /login`, `POST /logout`, the account flows of `base/accounts.js`
+ *   and the health endpoints are henri's own handlers, so their bodies are
+ *   described exactly.
+ *
+ * And it cannot describe:
+ *
+ * - **what an action answers**, unless henri wrapped it. A controller may
+ *   `res.render()` a page, `res.resource()` a record, `res.boom.conflict()`
+ *   or write its own body. A hand-written route (`get /about`), a `member`
+ *   or `collection` route, a namespace root: the operation lists the
+ *   failures henri owns, says so in its description, and declares no
+ *   success status at all. An honest absence beats an invented `object`.
+ * - **which fields an answer carries.** An action may present its records
+ *   before sending them (the showcase does), so a model schema lists the
+ *   columns with their types and marks *nothing* required: what is there is
+ *   right, what is missing is the application's business. Every schema is
+ *   open (`additionalProperties`).
+ * - **what a request body accepts.** `req.permit()` is the controller's
+ *   decision, and a required column may well be set by the server (the
+ *   speaker of a proposal is the session, never the body). The input
+ *   schema is the model's writable columns, all optional, and a foreign
+ *   key gets no type at all: what a form posts for it is the
+ *   application's to say.
+ * - **the status of a success.** `res.resource()` defaults to 200 and takes
+ *   any other; the document enumerates the statuses henri can produce and
+ *   leaves the rest to the `default` response.
+ *
+ * Every operation carries an `x-henri` object saying which of the two it
+ * is (`answer: 'collection' | 'resource' | 'page' | 'unknown'`, `known`)
+ * and what henri actually checks on it (`enforced`), so a reader -- a
+ * person or an agent -- never has to guess how much of the document was
+ * derived and how much was assumed.
+ *
+ * ## Why 3.1 and not 3.0
+ *
+ * 3.1 is JSON Schema 2020-12. A published foreign key is the `externalId`
+ * of the row it names *or* `null` (`base/references.js`), which is
+ * `type: ['string', 'null']` in 2020-12 and `nullable: true` -- a keyword
+ * that is not JSON Schema at all -- in 3.0. The same goes for a schema that
+ * means "anything" (`{}`), which is what an unknown answer has to be.
+ *
+ * GraphQL is out of scope: it has a schema of its own, and
+ * `config.graphql` names where to ask for it.
+ */
+const { singularize } = require('./routes');
+const { accountsConfig } = require('./accounts');
+const { userConfig } = require('./auth');
+const { mapOf, privacyConfig } = require('./privacy');
+const { DEFAULTS: PAGE_DEFAULTS } = require('./pagination');
+
+/** The version of the specification this builder writes */
+const OPENAPI_VERSION = '3.1.0';
+
+/** The JSON Schema dialect 3.1 documents are written in */
+const DIALECT = 'https://json-schema.org/draft/2020-12/schema';
+
+const JSON_MEDIA = 'application/json';
+const HAL_MEDIA = 'application/hal+json';
+const HTML_MEDIA = 'text/html';
+
+/** The verbs that change something: idempotency and CSRF apply to them */
+const MUTATING = new Set(['delete', 'patch', 'post', 'put']);
+
+/**
+ * The verbs a Path Item may hold. henri's routes DSL accepts more of them
+ * than HTTP has methods (`lock`, `mkcol`, `report`, ... come from WebDAV);
+ * OpenAPI has a field for these eight and no others, so a route on another
+ * verb is left out of `paths` and named in `info.x-henri.excluded`.
+ */
+const METHODS = new Set([
+  'delete',
+  'get',
+  'head',
+  'options',
+  'patch',
+  'post',
+  'put',
+  'trace',
+]);
+
+/**
+ * The henri schema types and what they serialize as. `json` is deliberately
+ * `{}`: a JSON column holds whatever the application put in it.
+ */
+const TYPES = {
+  boolean: { type: 'boolean' },
+  date: { format: 'date-time', type: 'string' },
+  float: { type: 'number' },
+  integer: { type: 'integer' },
+  json: {},
+  number: { type: 'number' },
+  string: { type: 'string' },
+  text: { type: 'string' },
+  uuid: { format: 'uuid', type: 'string' },
+};
+
+/** Columns henri writes itself: they never belong in a request body */
+const GENERATED = new Set([
+  'confirmedAt',
+  'createdAt',
+  'deletedAt',
+  'externalId',
+  'id',
+  'passwordChangedAt',
+  'updatedAt',
+]);
+
+/** The seven actions of a resource, and what each one answers */
+const ANSWERS = {
+  create: 'resource',
+  destroy: 'resource',
+  edit: 'page',
+  index: 'collection',
+  new: 'page',
+  show: 'resource',
+  update: 'resource',
+};
+
+/**
+ * A reader for a configuration, whether it is henri's config module or the
+ * plain object a command read from `config/<env>.json`
+ *
+ * @param {*} config the configuration
+ * @returns {function(string, *): *} `(key, fallback) => value`
+ */
+function reader(config) {
+  if (
+    config &&
+    typeof config.has === 'function' &&
+    typeof config.get === 'function'
+  ) {
+    return (key, fallback) => (config.has(key) ? config.get(key) : fallback);
+  }
+
+  return (key, fallback) => {
+    let current = config;
+
+    for (const part of String(key).split('.')) {
+      if (!current || typeof current !== 'object' || !(part in current)) {
+        return fallback;
+      }
+
+      current = current[part];
+    }
+
+    return typeof current === 'undefined' ? fallback : current;
+  };
+}
+
+/**
+ * A `{ has, get }` stand-in for the config module, so the normalizers henri
+ * already owns (`userConfig`, `accountsConfig`, `privacyConfig`) answer the
+ * same way here as they do at boot
+ *
+ * @param {function(string, *): *} read the reader
+ * @returns {{get: function, has: function}} the shim
+ */
+function shim(read) {
+  const missing = Symbol('missing');
+
+  return {
+    get: (key) => read(key, undefined),
+    has: (key) => read(key, missing) !== missing,
+  };
+}
+
+/**
+ * A plain object, or an empty one
+ *
+ * @param {*} value anything
+ * @returns {object} a plain object
+ */
+function objectOf(value) {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value
+    : {};
+}
+
+/**
+ * Everything the document needs from the configuration, normalized once
+ *
+ * @param {*} config henri's config module, or a plain object
+ * @returns {object} the settings
+ */
+function settingsOf(config) {
+  const read = reader(config);
+  const stub = shim(read);
+  const api = objectOf(read('api', {}));
+  const rate = read('rateLimit', {});
+  const policies = objectOf(read('policies', {}));
+  const externalIds = objectOf(read('externalIds', {}));
+
+  return {
+    accounts: accountsConfig(stub),
+    baseRole: read('baseRole', null),
+    csrf: read('csrf', true) !== false,
+    graphql: read('graphql', false),
+    host: read('host', null),
+    idempotency: api.idempotency !== false,
+    lookup: externalIds.lookup === 'any' ? 'any' : 'external',
+    maxPerPage:
+      Number(api.maxPerPage) > 0
+        ? Number(api.maxPerPage)
+        : PAGE_DEFAULTS.maxPerPage,
+    perPage:
+      Number(api.perPage) > 0 ? Number(api.perPage) : PAGE_DEFAULTS.perPage,
+    policyStatus: policies.status === 403 ? 403 : 404,
+    port: Number(read('port', 3000)) || 3000,
+    privacy: privacyConfig(stub),
+    rateLimit: rate !== false,
+    references: externalIds.references !== false,
+    strict: api.strict === true,
+    url: read('url', null),
+    user: userConfig(stub),
+  };
+}
+
+/**
+ * The base url the description is served from
+ *
+ * @param {object} settings the settings
+ * @returns {Array<object>} the `servers` array
+ */
+function serversOf(settings) {
+  if (typeof settings.url === 'string' && settings.url.length > 0) {
+    return [{ description: 'config.url', url: settings.url }];
+  }
+
+  return [
+    {
+      description: 'config.port (the development server)',
+      url: `http://localhost:${settings.port}`,
+    },
+  ];
+}
+
+/**
+ * The model a controller is about, by henri's own convention: the singular
+ * of the last segment of the controller name (`admin/proposals` ->
+ * `proposal`), matched against the identity of a model file. No match means
+ * no schema, which is the honest answer.
+ *
+ * @param {Array<object>} models the model files
+ * @returns {function(string): ?object} `(controller) => model | null`
+ */
+function modelFinder(models) {
+  const byIdentity = new Map();
+
+  for (const model of models) {
+    byIdentity.set(
+      String(model.identity || model.globalId).toLowerCase(),
+      model
+    );
+  }
+
+  return (controller) => {
+    const last = String(controller || '')
+      .split('/')
+      .pop();
+
+    return (
+      byIdentity.get(singularize(last).toLowerCase()) ||
+      byIdentity.get(last.toLowerCase()) ||
+      null
+    );
+  };
+}
+
+/**
+ * The policy a route asks for, resolved the way `3.policies.js` resolves it:
+ * the name as written, then the singular of its last segment. Without the
+ * list of the files that exist, the name as written is the best answer.
+ *
+ * @param {?Array<string>} policies the names of `app/policies`, or null
+ * @returns {function(string): ?string} `(wanted) => name | null`
+ */
+function policyFinder(policies) {
+  if (!Array.isArray(policies)) {
+    return (wanted) => String(wanted).toLowerCase();
+  }
+
+  const known = new Set(policies.map((name) => String(name).toLowerCase()));
+
+  return (wanted) => {
+    const bare = String(wanted).toLowerCase();
+
+    if (known.has(bare)) {
+      return bare;
+    }
+
+    const parts = bare.split('/');
+
+    parts[parts.length - 1] = singularize(parts[parts.length - 1]);
+
+    return known.has(parts.join('/')) ? parts.join('/') : null;
+  };
+}
+
+/**
+ * The columns of a model as they exist once the adapter is done with it:
+ * what the file declares, plus `externalId`, the timestamps, `deletedAt`
+ * and, on the user model, `email`, `password`, `roles`, `confirmedAt` and
+ * `passwordChangedAt`. All three adapters add exactly these.
+ *
+ * @param {object} model a model file
+ * @param {object} settings the settings
+ * @returns {object} the fields, by name
+ */
+function columnsOf(model, settings) {
+  const options = objectOf(model.options);
+  const fields = Object.assign({}, objectOf(model.schema));
+  const isUser =
+    String(model.identity || '').toLowerCase() ===
+    String(settings.user.model || '').toLowerCase();
+
+  if (isUser) {
+    fields.email = fields.email || {
+      required: true,
+      type: 'string',
+      unique: true,
+    };
+    fields.password = fields.password || {
+      required: true,
+      select: false,
+      type: 'string',
+    };
+    fields.roles = fields.roles || { type: 'json' };
+    fields.confirmedAt = fields.confirmedAt || { type: 'date' };
+    fields.passwordChangedAt = fields.passwordChangedAt || { type: 'date' };
+  }
+
+  if (options.externalId !== false) {
+    fields.externalId = fields.externalId || {
+      required: true,
+      type: 'uuid',
+      unique: true,
+    };
+  }
+
+  if (options.timestamps !== false) {
+    fields.createdAt = fields.createdAt || { required: true, type: 'date' };
+    fields.updatedAt = fields.updatedAt || { required: true, type: 'date' };
+  }
+
+  if (options.paranoid === true) {
+    fields.deletedAt = fields.deletedAt || { index: true, type: 'date' };
+  }
+
+  return fields;
+}
+
+/**
+ * The model a field points at, when it says so (`references: { model }` on
+ * the SQL adapters, `ref` on Mongoose). henri never reads a field name for
+ * this: an undeclared column is an opaque value (see base/references.js).
+ *
+ * @param {*} field a field definition
+ * @returns {?string} the model name, or null
+ */
+function referenceOf(field) {
+  if (!field || typeof field !== 'object') {
+    return null;
+  }
+
+  if (typeof field.ref === 'string' && field.ref.length > 0) {
+    return field.ref;
+  }
+
+  const references = objectOf(field.references).model;
+
+  return typeof references === 'string' && references.length > 0
+    ? references
+    : null;
+}
+
+/**
+ * A default worth writing down: a scalar, never a generator function
+ *
+ * @param {*} value what the field declares as its default
+ * @returns {boolean} true when it can be published
+ */
+function publishableDefault(value) {
+  return (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  );
+}
+
+/**
+ * The sentence describing one column: what it is, and what the model asks
+ * of it. It says "required by the model" rather than making the property
+ * required, because a controller may present a record before sending it.
+ *
+ * @param {string} name the field name
+ * @param {*} field the field definition
+ * @param {?string} reference the model it points at, when it declares one
+ * @returns {string} the description
+ */
+function fieldDescription(name, field, reference) {
+  const parts = [];
+
+  if (reference) {
+    parts.push(
+      `A reference to ${reference}: henri publishes it as that row's externalId, and null when there is no such row.`
+    );
+  }
+
+  if (field && field.required === true) {
+    parts.push('Required by the model.');
+  }
+
+  if (field && field.unique === true) {
+    parts.push('Unique.');
+  }
+
+  if (name === 'deletedAt') {
+    parts.push('The soft delete stamp (options.paranoid).');
+  }
+
+  if (name === 'externalId') {
+    parts.push(
+      'The public identifier of the record: the only identifier that leaves the server.'
+    );
+  }
+
+  return parts.join(' ');
+}
+
+/**
+ * One column as a JSON Schema.
+ *
+ * Two shapes, and the split is read against write. **Reading**, the schema
+ * says what the column *is*: its type, whether it can be null, and the
+ * values an enum allows. **Writing**, it also says what the model validates
+ * -- the lengths, the ranges, the pattern, the default -- because that is
+ * what a client can act on before it sends anything.
+ *
+ * A column the model does not require can be null in the database and
+ * therefore null in an answer, so its type carries `null` and its enum
+ * carries `null` with it. Widening is the safe direction here: a response
+ * schema narrower than reality makes a client reject an answer that was
+ * perfectly good.
+ *
+ * @param {string} name the field name
+ * @param {*} field the field definition
+ * @param {object} context `{ resolves, settings, write }`
+ * @returns {object} the schema
+ */
+function fieldSchema(name, field, { resolves, settings, write = false }) {
+  const definition =
+    typeof field === 'string' ? { type: field } : objectOf(field);
+  const reference = referenceOf(definition);
+  const published = reference && settings.references && resolves(reference);
+  const nullable = definition.required !== true;
+  const known = TYPES[definition.type];
+  const schema = {};
+  const description = fieldDescription(
+    name,
+    definition,
+    published ? reference : null
+  );
+
+  if (published) {
+    schema.format = 'uuid';
+    schema.type = ['string', 'null'];
+  } else if (known && known.type) {
+    schema.type = nullable ? [known.type, 'null'] : known.type;
+
+    if (known.format) {
+      schema.format = known.format;
+    }
+  }
+
+  if (
+    !published &&
+    Array.isArray(definition.enum) &&
+    definition.enum.length > 0
+  ) {
+    schema.enum = nullable
+      ? definition.enum.concat(null)
+      : definition.enum.slice();
+  }
+
+  if (!write) {
+    return description.length > 0
+      ? Object.assign(schema, { description })
+      : schema;
+  }
+
+  if (publishableDefault(definition.default) && !published) {
+    schema.default = definition.default;
+  }
+
+  if (
+    !published &&
+    (definition.type === 'string' || definition.type === 'text')
+  ) {
+    if (Number.isFinite(definition.minLength)) {
+      schema.minLength = definition.minLength;
+    }
+
+    if (Number.isFinite(definition.maxLength)) {
+      schema.maxLength = definition.maxLength;
+    }
+
+    const pattern = Array.isArray(definition.match)
+      ? definition.match[0]
+      : definition.match;
+
+    if (pattern instanceof RegExp) {
+      schema.pattern = pattern.source;
+    }
+  }
+
+  if (!published && Number.isFinite(definition.min)) {
+    schema.minimum = definition.min;
+  }
+
+  if (!published && Number.isFinite(definition.max)) {
+    schema.maximum = definition.max;
+  }
+
+  return description.length > 0
+    ? Object.assign(schema, { description })
+    : schema;
+}
+
+/**
+ * The schemas of one model: the record as it leaves, and the columns a
+ * request may carry
+ *
+ * @param {object} model the model file
+ * @param {object} context `{ hidden, resolves, settings }`
+ * @returns {{input: object, record: object}} the two schemas
+ */
+function modelSchemas(model, context) {
+  const { hidden, settings } = context;
+  const fields = columnsOf(model, settings);
+  const isUser =
+    String(model.identity || '').toLowerCase() ===
+    String(settings.user.model || '').toLowerCase();
+  const record = {};
+  const input = {};
+
+  for (const name of Object.keys(fields).sort()) {
+    const field =
+      typeof fields[name] === 'string' ? {} : objectOf(fields[name]);
+
+    if (hidden.has(name) || field.select === false) {
+      continue;
+    }
+
+    record[name] =
+      isUser && name === 'roles'
+        ? {
+            type: ['array', 'null'],
+            description:
+              'The roles of the account. Stripped from a mass assignment: `setRoles()` and `User.setRoles(id, roles)` are what change them.',
+            items: { type: 'string' },
+          }
+        : fieldSchema(name, fields[name], context);
+
+    if (GENERATED.has(name) || name === 'roles' || name === 'password') {
+      continue;
+    }
+
+    const reference = referenceOf(field);
+
+    input[name] = reference
+      ? {
+          description: `A reference to ${reference}. What this endpoint accepts for it -- the row's externalId, its primary key, nothing -- is the controller's decision, so henri states no type.`,
+        }
+      : fieldSchema(name, fields[name], {
+          resolves: () => false,
+          settings,
+          write: true,
+        });
+  }
+
+  return {
+    input: {
+      type: 'object',
+      description: `The columns of ${model.globalId} a request could carry. Every property is optional: what an action accepts is what it passes to req.permit(), which henri does not read, and a column the model requires may well be set by the server. Additional properties are allowed for the same reason.`,
+      properties: input,
+      additionalProperties: true,
+    },
+    record: {
+      type: 'object',
+      description: `${model.globalId} as henri serializes it. Nothing is required: an action may present a record before sending it, so a property that is absent is the application's business. The primary key never leaves${
+        objectOf(model.options).externalId === false
+          ? ''
+          : '; externalId is what identifies the record'
+      }.`,
+      properties: record,
+      additionalProperties: true,
+    },
+  };
+}
+
+/**
+ * The shared schemas of the document
+ *
+ * @param {object} context `{ hidden, models, resolves, settings }`
+ * @returns {object} `components.schemas`
+ */
+function schemasOf(context) {
+  const { models, settings } = context;
+  const schemas = {
+    Link: {
+      type: 'object',
+      description: 'One HAL link.',
+      properties: {
+        href: { type: 'string', description: 'The path to follow.' },
+        method: {
+          type: 'string',
+          description:
+            'The verb to use, when it is not GET (`update` is PATCH, `destroy` is DELETE).',
+        },
+      },
+      required: ['href'],
+    },
+    Links: {
+      type: 'object',
+      description:
+        'The `_links` of a HAL answer, built from the route helpers and filtered by the roles of the caller and then by the policies (base/hateoas.js). A link that is absent is one this caller may not follow. The relations henri builds are `self`, `collection`, `edit`, `update`, `destroy` on a record, and `self`, `first`, `prev`, `next`, `last`, `create`, `new` on a collection; a controller may add its own.',
+      additionalProperties: { $ref: '#/components/schemas/Link' },
+    },
+    Error: {
+      type: 'object',
+      description:
+        'The error envelope of henri (base/boom.js): what `res.boom.*`, the guards and the 404 and 500 handlers answer.',
+      properties: {
+        statusCode: { type: 'integer', description: 'The HTTP status.' },
+        error: {
+          type: 'string',
+          description: 'The reason phrase (`Not Found`, `Forbidden`).',
+        },
+        message: { type: 'string', description: 'What went wrong.' },
+        code: {
+          type: 'string',
+          description:
+            'The henri error code, when henri raised the failure on its own behalf (see the error reference).',
+        },
+        data: {
+          description:
+            'Whatever the failure carries: the missing roles, the fields that did not validate, the retry delay.',
+        },
+      },
+      required: ['statusCode', 'error', 'message'],
+    },
+    HalResource: {
+      type: 'object',
+      description:
+        'A HAL resource whose fields henri cannot name: the controller is not one henri wrote, so only `_links` is described.',
+      properties: { _links: { $ref: '#/components/schemas/Links' } },
+      required: settings.strict ? ['_links'] : undefined,
+      additionalProperties: true,
+    },
+    HalCollection: {
+      type: 'object',
+      description:
+        'A HAL collection whose items henri cannot name. `page`, `perPage` and `total` appear when the controller paginated.',
+      properties: {
+        _links: { $ref: '#/components/schemas/Links' },
+        _embedded: {
+          type: 'object',
+          description:
+            'The items, under the last segment of the controller name.',
+          additionalProperties: { type: 'array' },
+        },
+        count: {
+          type: 'integer',
+          description: 'How many items this page carries.',
+        },
+        page: { type: 'integer' },
+        perPage: { type: 'integer' },
+        total: { type: 'integer' },
+      },
+      required: settings.strict ? ['_links'] : undefined,
+      additionalProperties: true,
+    },
+    RenderedPage: {
+      type: 'object',
+      description:
+        'What `res.render()` answers to a client asking for JSON: the options the view engine renders the page from (5.router.js). `data` is what the controller handed it, published and stripped of the fields marked `personal: { expose: false }`; `paths` are the route helpers this caller may follow.',
+      properties: {
+        _links: { $ref: '#/components/schemas/Links' },
+        csrf: {
+          type: ['string', 'null'],
+          description: 'The CSRF token to send back on a mutating request.',
+        },
+        data: { description: 'The payload of the page.' },
+        errors: {
+          description:
+            'The validation errors of the form, keyed by field, or null.',
+        },
+        flash: {
+          type: 'object',
+          description: 'The one-shot messages of the session.',
+          additionalProperties: true,
+        },
+        localUrl: { type: 'string' },
+        paths: {
+          type: 'object',
+          description:
+            'The route helpers this caller may follow, keyed by `<action>_<controller>_path`.',
+          additionalProperties: true,
+        },
+        query: { type: 'object', additionalProperties: true },
+        user: { $ref: '#/components/schemas/PublicUser' },
+        graphql: { type: 'object', additionalProperties: true },
+        nonce: {
+          type: 'string',
+          description: 'The CSP nonce of this response (`csp.nonce` only).',
+        },
+      },
+      required: [
+        '_links',
+        'csrf',
+        'data',
+        'errors',
+        'flash',
+        'localUrl',
+        'paths',
+        'query',
+        'user',
+      ],
+      additionalProperties: true,
+    },
+    PublicUser: publicUserSchema(context),
+    Health: {
+      type: 'object',
+      description: 'The answer of the health endpoints (base/health.js).',
+      properties: {
+        status: { type: 'string', enum: ['ok', 'unavailable'] },
+        uptime: { type: 'integer', description: 'Seconds since the boot.' },
+        requestId: { type: 'string' },
+        reason: {
+          type: 'string',
+          description: 'Why the process is not ready, when it is not.',
+        },
+        stores: {
+          type: 'object',
+          description:
+            'One entry per store: its adapter, whether it answered and how long it took.',
+          additionalProperties: true,
+        },
+        shared: {
+          type: 'object',
+          description: 'The shared backend, when `config.shared` names one.',
+          additionalProperties: true,
+        },
+        version: {
+          type: 'string',
+          description: 'Absent in production.',
+        },
+      },
+      required: ['status', 'uptime'],
+      additionalProperties: true,
+    },
+  };
+
+  for (const model of models) {
+    const built = modelSchemas(model, context);
+    const name = String(model.globalId);
+
+    schemas[name] = built.record;
+    schemas[`${name}Input`] = built.input;
+    schemas[`${name}Resource`] = {
+      allOf: [{ $ref: `#/components/schemas/${name}` }],
+      type: 'object',
+      description: `${name} as a HAL resource: its columns and the links this caller may follow.`,
+      properties: { _links: { $ref: '#/components/schemas/Links' } },
+      required: settings.strict ? ['_links'] : undefined,
+    };
+    schemas[`${name}Collection`] = {
+      type: 'object',
+      description: `A page of ${name}. \`page\`, \`perPage\`, \`total\` and the links around the page are there only when the action paginated (\`req.pagination()\`).`,
+      properties: {
+        _links: { $ref: '#/components/schemas/Links' },
+        _embedded: {
+          type: 'object',
+          description:
+            'The records, under the last segment of the controller name.',
+          additionalProperties: {
+            type: 'array',
+            items: { $ref: `#/components/schemas/${name}Resource` },
+          },
+        },
+        count: {
+          type: 'integer',
+          description: 'How many records this page carries.',
+        },
+        page: { type: 'integer' },
+        perPage: { type: 'integer' },
+        total: { type: 'integer' },
+      },
+      required: settings.strict ? ['_links'] : undefined,
+      additionalProperties: true,
+    };
+  }
+
+  return prune(schemas);
+}
+
+/**
+ * The user as it leaves the server (`publicUser()`): the identifier, the
+ * address, the roles and whatever `config.user.public` adds
+ *
+ * @param {object} context `{ hidden, models, settings }`
+ * @returns {object} the schema
+ */
+function publicUserSchema({ hidden, models, settings }) {
+  const model = models.find(
+    (entry) =>
+      String(entry.identity || '').toLowerCase() ===
+      String(settings.user.model || '').toLowerCase()
+  );
+  const external = !model || objectOf(model.options).externalId !== false;
+  const columns = model ? columnsOf(model, settings) : {};
+  const properties = {
+    roles: {
+      type: 'array',
+      description: 'The roles of the account.',
+      items: { type: 'string' },
+    },
+  };
+
+  if (external) {
+    properties.externalId = { type: 'string', format: 'uuid' };
+  } else {
+    properties.id = { description: 'The identifier of the account.' };
+  }
+
+  if (!hidden.has('email')) {
+    properties.email = { type: 'string' };
+  }
+
+  for (const field of settings.user.public || []) {
+    if (hidden.has(field) || field === 'password') {
+      continue;
+    }
+
+    properties[field] = columns[field]
+      ? fieldSchema(field, columns[field], { resolves: () => false, settings })
+      : {};
+  }
+
+  const required = [external ? 'externalId' : 'id', 'roles'];
+
+  if (!hidden.has('email')) {
+    required.push('email');
+  }
+
+  return {
+    type: ['object', 'null'],
+    description:
+      'The representation of a user that leaves the server: never the password, never a column the application did not put in `config.user.public`.',
+    properties,
+    required: required.sort(),
+  };
+}
+
+/**
+ * Removes the keys whose value is undefined, at every depth, so the
+ * document never carries a `required: undefined`
+ *
+ * @param {*} value anything
+ * @returns {*} the same value without the undefined keys
+ */
+function prune(value) {
+  if (Array.isArray(value)) {
+    return value.map(prune);
+  }
+
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  const copy = {};
+
+  for (const key of Object.keys(value)) {
+    if (typeof value[key] !== 'undefined') {
+      copy[key] = prune(value[key]);
+    }
+  }
+
+  return copy;
+}
+
+/**
+ * The reusable responses: every failure henri answers itself
+ *
+ * @param {object} settings the settings
+ * @returns {object} `components.responses`
+ */
+function responsesOf(settings) {
+  const body = {
+    content: {
+      [JSON_MEDIA]: { schema: { $ref: '#/components/schemas/Error' } },
+    },
+  };
+  const named = (description) => Object.assign({ description }, body);
+
+  return {
+    BadRequest: named(
+      'The request could not be read. henri answers this for an `Idempotency-Key` longer than 255 characters or not printable ascii, and for an account link that is no longer valid.'
+    ),
+    Conflict: named(
+      'A request with the same `Idempotency-Key` is still running (base/idempotency.js).'
+    ),
+    Error: named(
+      'Any other status. A failure henri answers itself -- a guard, the request timeout, the body limit, the error handler, `res.boom.*` -- uses this envelope, with `code` when henri raised it on its own behalf. A controller may answer something else.'
+    ),
+    Forbidden: named(
+      `The caller is signed in and may not do this: a missing role, a CSRF token that did not check out${
+        settings.policyStatus === 403 ? ', or a policy that said no' : ''
+      }.`
+    ),
+    NotAcceptable: named(
+      'The client asked for an API version this route does not serve (`Accept: application/vnd.henri.vN+json`).'
+    ),
+    NotFound: named(
+      'Nothing here, or nothing this caller may know about: a policy refuses a signed-in caller with a 404 by default, so a record they may not read reads as one that does not exist (`config.policies.status`).'
+    ),
+    TooManyRequests: Object.assign(
+      {
+        description:
+          'The rate limit of `config.rateLimit` (600 requests a minute per user or ip by default, 10 a minute on the authentication paths). Not enforced in development.',
+        headers: {
+          'Retry-After': {
+            description: 'Seconds until the window rolls over.',
+            schema: { type: 'integer' },
+          },
+          RateLimit: {
+            description: 'The limit, the remainder and the reset (draft 7).',
+            schema: { type: 'string' },
+          },
+        },
+      },
+      body
+    ),
+    Unauthorized: named(
+      'Nobody is signed in. A browser asking for HTML is redirected to `config.user.loginPath` instead.'
+    ),
+    UnprocessableEntity: named(
+      'The `Idempotency-Key` was already used for a different method, url or body (base/idempotency.js), or a form could not be accepted.'
+    ),
+  };
+}
+
+/**
+ * The reusable parameters
+ *
+ * @param {object} settings the settings
+ * @returns {object} `components.parameters`
+ */
+function parametersOf(settings) {
+  return {
+    IdempotencyKey: {
+      name: 'Idempotency-Key',
+      in: 'header',
+      required: false,
+      description:
+        'Executes this request once: the first answer is stored for `config.api.idempotency.ttl` (24h) and replayed to any request reusing the key, with `Idempotency-Replayed: true`. Keys are scoped to the caller and tied to a fingerprint of the method, url and body.',
+      schema: { type: 'string', maxLength: 255 },
+    },
+    CsrfToken: {
+      name: 'X-CSRF-Token',
+      in: 'header',
+      required: false,
+      description:
+        'The value of the `henri.csrf` cookie. Required of a mutating request that carries the session cookie; a client authenticating with a bearer token sends neither (base/csrf.js). `_csrf` in the body does as well.',
+      schema: { type: 'string' },
+    },
+    Page: {
+      name: 'page',
+      in: 'query',
+      required: false,
+      description:
+        "The page to read, when the action paginates (`req.pagination()`). henri reads it on every request; whether it reaches the query is the controller's decision.",
+      schema: { type: 'integer', minimum: 1, default: 1 },
+    },
+    PerPage: {
+      name: 'per_page',
+      in: 'query',
+      required: false,
+      description: `How many records a page holds, when the action paginates. Bounded by \`config.api.maxPerPage\` (${settings.maxPerPage}).`,
+      schema: {
+        type: 'integer',
+        minimum: 1,
+        maximum: settings.maxPerPage,
+        default: settings.perPage,
+      },
+    },
+  };
+}
+
+/**
+ * `/tasks/:id` as OpenAPI writes it, and the parameters it declares
+ *
+ * @param {string} route the express path
+ * @returns {{path: string, names: Array<string>}} the template and its names
+ */
+function template(route) {
+  const names = [];
+  const path = String(route)
+    .replace(/:([A-Za-z_][A-Za-z0-9_]*)\??/gu, (match, name) => {
+      names.push(name);
+
+      return `{${name}}`;
+    })
+    .replace(/\*([A-Za-z_][A-Za-z0-9_]*)?/gu, (match, name) => {
+      const wildcard = name || 'wildcard';
+
+      names.push(wildcard);
+
+      return `{${wildcard}}`;
+    });
+
+  return { names, path };
+}
+
+/**
+ * The path parameters of a route. `:id` on a resource route is the public
+ * identifier of the record when the model carries one, because that is the
+ * only identifier `findById()` resolves (`externalIds.lookup`).
+ *
+ * @param {Array<string>} names the parameter names
+ * @param {object} context `{ findModel, route, settings }`
+ * @returns {Array<object>} the parameter objects
+ */
+function pathParameters(names, { findModel, route, settings }) {
+  const controller = String(route.controller || '').split('#')[0];
+
+  return names.map((name) => {
+    const owner =
+      name === 'id'
+        ? findModel(controller)
+        : findModel(name.replace(/_id$/u, ''));
+    const external = owner && objectOf(owner.options).externalId !== false;
+    const schema =
+      external && settings.lookup === 'external'
+        ? { type: 'string', format: 'uuid' }
+        : { type: 'string' };
+
+    return {
+      name,
+      in: 'path',
+      required: true,
+      description: owner
+        ? `The externalId of the ${owner.globalId}${
+            external && settings.lookup === 'external'
+              ? ': the primary key does not resolve (base/references.js)'
+              : ''
+          }.`
+        : 'A path parameter henri knows the name of and nothing else.',
+      schema,
+    };
+  });
+}
+
+/**
+ * What the operation is called. Two routes may share a controller and an
+ * action (PATCH and PUT both reach `update`), so the verb settles a tie.
+ *
+ * @param {object} route the route
+ * @param {Set<string>} taken the identifiers already used
+ * @returns {string} the operation id
+ */
+function operationId(route, taken) {
+  const base = String(route.controller).replace(/[#/]/gu, '.');
+  const name = taken.has(base) ? `${base}.${route.verb}` : base;
+
+  taken.add(name);
+
+  return name;
+}
+
+/**
+ * The failures henri answers on this route, from its own options
+ *
+ * @param {object} route the route
+ * @param {object} settings the settings
+ * @returns {object} the responses, by status
+ */
+function guardResponses(route, settings) {
+  const responses = {};
+  const reference = (name) => ({ $ref: `#/components/responses/${name}` });
+  const roles = route.roles ? [].concat(route.roles) : null;
+  const mutating = MUTATING.has(route.verb);
+
+  if (roles || route.policy) {
+    responses['401'] = reference('Unauthorized');
+  }
+
+  if (roles || (route.policy && settings.policyStatus === 403)) {
+    responses['403'] = reference('Forbidden');
+  }
+
+  if (mutating && settings.csrf) {
+    responses['403'] = reference('Forbidden');
+  }
+
+  if (route.policy && settings.policyStatus === 404) {
+    responses['404'] = reference('NotFound');
+  }
+
+  if (route.version) {
+    responses['406'] = reference('NotAcceptable');
+  }
+
+  if (mutating && settings.idempotency && route.idempotent !== false) {
+    responses['400'] = reference('BadRequest');
+    responses['409'] = reference('Conflict');
+    responses['422'] = reference('UnprocessableEntity');
+  }
+
+  if (settings.rateLimit) {
+    responses['429'] = reference('TooManyRequests');
+  }
+
+  return responses;
+}
+
+/**
+ * The sentences that say what henri knows about this route and what it does
+ * not
+ *
+ * @param {object} route the route
+ * @param {object} context `{ answer, known, model, policy, settings }`
+ * @returns {string} the description
+ */
+function operationDescription(
+  route,
+  { answer, known, model, policy, settings }
+) {
+  const [controller, action] = String(route.controller).split('#');
+  const lines = [
+    `\`${controller}#${action}\`, from the \`${route.verb} ${route.route}\` route of config/routes.js. Path helper: \`${route.path}\`.`,
+  ];
+
+  if (known === false) {
+    lines.push(
+      `**No such action.** \`app/controllers/${controller}.js\` exports no \`${action}\`: in development the route answers 501 Not Implemented, and in production it is never registered, so the path answers 404.`
+    );
+  }
+
+  if (route.roles) {
+    lines.push(
+      `Roles: ${[]
+        .concat(route.roles)
+        .map((role) => `\`${role}\``)
+        .join(
+          ', '
+        )}. Anyone else gets a 401 (anonymous) or a 403 (signed in, missing the role); a browser is redirected to \`${settings.user.loginPath}\`.`
+    );
+  }
+
+  if (route.policy) {
+    lines.push(
+      policy
+        ? `Policy: \`app/policies/${policy}.js\`. A refusal answers ${settings.policyStatus}, or 401 when nobody is signed in; the rules that need the record are answered by the action rather than by the gate.`
+        : `Policy: the route asks for \`${route.policy === true ? controller : route.policy}\`, and there is no such file in app/policies. henri fails closed: every request to this route is refused with a ${settings.policyStatus}.`
+    );
+  }
+
+  if (route.version) {
+    lines.push(
+      `Version: \`${route.version}\`. A client asking for another \`application/vnd.henri.vN+json\` gets a 406; one asking for none is served this version.`
+    );
+  }
+
+  if (answer === 'collection') {
+    lines.push(
+      `Answers a HAL collection${
+        model ? ` of ${model.globalId}` : ''
+      } when the action calls \`res.collection()\`; the paging numbers and the \`first\`/\`prev\`/\`next\`/\`last\` links are there only when it paginated. An action that instead renders a page -- \`res.render()\`, or returning an object without answering -- answers this same route with the options the page is built from (\`RenderedPage\`), which is the other shape below: \`_embedded\` is what tells the two apart. What henri enforces here, and all it enforces, is that a successful JSON answer carries \`_links\`: one that does not is ${
+        settings.strict
+          ? 'refused with a 500 (config.api.strict)'
+          : 'reported in the log'
+      }.`
+    );
+  }
+
+  if (answer === 'resource') {
+    lines.push(
+      `Answers a HAL resource${
+        model ? ` of ${model.globalId}` : ''
+      } when the action calls \`res.resource()\`, and the status is the action's to choose (200 is what \`res.resource()\` sends unless told otherwise). An action that instead renders a page -- \`res.render()\`, or returning an object without answering -- answers this same route with the options the page is built from (\`RenderedPage\`), which is the other shape below. What henri enforces here, and all it enforces, is that a successful JSON answer carries \`_links\`: one that does not is ${
+        settings.strict
+          ? 'refused with a 500 (config.api.strict)'
+          : 'reported in the log'
+      }.`
+    );
+  }
+
+  if (answer === 'page') {
+    lines.push(
+      `A form page, and one of the two answers henri does not write. To a browser it is HTML. To a client asking for JSON it is whatever the action sent -- the options the page is rendered from (\`res.render()\`), or the record (\`res.resource()\`) -- and the only thing henri enforces is that it carries \`_links\`${
+        settings.strict ? ' (config.api.strict refuses one that does not)' : ''
+      }.`
+    );
+  }
+
+  if (answer === 'unknown') {
+    lines.push(
+      'henri does not know what this action answers: it is not one of the seven actions expanded from `resources`, so nothing wraps it and the controller writes the body. The statuses below are the ones henri produces before the action runs, or in place of it.'
+    );
+  }
+
+  lines.push(
+    'JSON is served to a client asking for it (`Accept: application/json`, `application/hal+json`, or the versioned vendor type); anything else gets the page.'
+  );
+
+  return lines.join('\n\n');
+}
+
+/**
+ * The successful answers of a resource route
+ *
+ * @param {string} action the action
+ * @param {object} context `{ model, settings }`
+ * @returns {object} the responses
+ */
+function resourceResponses(action, { embed, model }) {
+  const resource = model
+    ? `#/components/schemas/${model.globalId}Resource`
+    : '#/components/schemas/HalResource';
+  const collection = model
+    ? `#/components/schemas/${model.globalId}Collection`
+    : '#/components/schemas/HalCollection';
+  // The key the items sit under is the last segment of the controller name,
+  // which the component cannot know: it is named here, on top of it
+  const page = model
+    ? {
+        allOf: [{ $ref: collection }],
+        type: 'object',
+        properties: {
+          _embedded: {
+            type: 'object',
+            properties: {
+              [embed]: {
+                type: 'array',
+                items: { $ref: resource },
+              },
+            },
+          },
+        },
+      }
+    : { $ref: collection };
+  // What henri enforces on this route is `_links`, and it produces two
+  // answers that carry them: the HAL envelope of `res.resource()` and
+  // `res.collection()`, and the page options of `res.render()` and of the
+  // implicit render (an action that returns an object without answering).
+  // Both are named, HAL first, rather than the document promising one and
+  // an application answering the other
+  const rendered = { $ref: '#/components/schemas/RenderedPage' };
+  const either = (schema) => ({ anyOf: [schema, rendered] });
+  const media = (schema) => ({
+    [JSON_MEDIA]: { schema: either({ $ref: schema }) },
+    [HAL_MEDIA]: { schema: either({ $ref: schema }) },
+  });
+  const pages = {
+    [JSON_MEDIA]: { schema: either(page) },
+    [HAL_MEDIA]: { schema: either(page) },
+  };
+  const headers = {
+    'X-Request-Id': {
+      description: 'The identifier of this request, in the logs as well.',
+      schema: { type: 'string' },
+    },
+  };
+
+  if (action === 'index') {
+    return {
+      200: {
+        description: `The page of records the action sent, under \`_embedded.${embed}\`.`,
+        content: pages,
+        headers: Object.assign(
+          {
+            Link: {
+              description:
+                'The links around the page (RFC 8288), when the action paginated.',
+              schema: { type: 'string' },
+            },
+            'X-Total-Count': {
+              description: 'The total number of records, when it is known.',
+              schema: { type: 'integer' },
+            },
+          },
+          headers
+        ),
+      },
+    };
+  }
+
+  if (action === 'new' || action === 'edit') {
+    // A form page, and henri does not write its body. What it does enforce
+    // is `_links`, so the two shapes it can be -- the options `res.render()`
+    // sends, or the record itself -- are offered without either being
+    // claimed
+    const either = {
+      anyOf: [
+        { $ref: '#/components/schemas/RenderedPage' },
+        { $ref: '#/components/schemas/HalResource' },
+      ],
+    };
+
+    return {
+      200: {
+        description:
+          'The page for a browser. For a client asking for JSON: the options the page is rendered from when the action called `res.render()`, the record when it called `res.resource()`. henri enforces `_links` on this route and nothing else.',
+        content: {
+          [HTML_MEDIA]: {},
+          [JSON_MEDIA]: { schema: either },
+          [HAL_MEDIA]: { schema: either },
+        },
+        headers,
+      },
+    };
+  }
+
+  const responses = {
+    200: {
+      description: 'The record the action sent.',
+      content: media(resource),
+      headers,
+    },
+  };
+
+  if (action === 'create') {
+    responses[201] = {
+      description:
+        'The record, when the action answered `res.resource(record, { status: 201 })`.',
+      content: media(resource),
+      headers: Object.assign(
+        {
+          Location: {
+            description: 'The `self` link of the new record.',
+            schema: { type: 'string' },
+          },
+        },
+        headers
+      ),
+    };
+  }
+
+  if (action === 'destroy') {
+    responses[204] = {
+      description: 'Nothing, when the action answered without a body.',
+    };
+  }
+
+  return responses;
+}
+
+/**
+ * One operation of the description
+ *
+ * @param {object} route the route
+ * @param {object} context the builder context
+ * @returns {object} the operation object
+ */
+function operationFor(route, context) {
+  const { findModel, findPolicy, ids, settings } = context;
+  const [controller, action] = String(route.controller).split('#');
+  const model = findModel(controller);
+  const policy = route.policy
+    ? findPolicy(route.policy === true ? controller : route.policy)
+    : null;
+  const isResource = route.resource === true;
+  const answer = isResource ? ANSWERS[action] || 'unknown' : 'unknown';
+  const known = context.actionKnown(route.controller);
+  const { names } = template(route.route);
+  const parameters = pathParameters(names, { findModel, route, settings });
+  const responses = {};
+
+  if (answer === 'collection') {
+    parameters.push(
+      { $ref: '#/components/parameters/Page' },
+      { $ref: '#/components/parameters/PerPage' }
+    );
+  }
+
+  if (MUTATING.has(route.verb)) {
+    if (settings.idempotency && route.idempotent !== false) {
+      parameters.push({ $ref: '#/components/parameters/IdempotencyKey' });
+    }
+
+    if (settings.csrf) {
+      parameters.push({ $ref: '#/components/parameters/CsrfToken' });
+    }
+  }
+
+  if (answer !== 'unknown' && known !== false) {
+    Object.assign(
+      responses,
+      resourceResponses(action, {
+        embed: controller.split('/').pop(),
+        model,
+      })
+    );
+  }
+
+  Object.assign(responses, guardResponses(route, settings));
+
+  if (answer === 'unknown' || known === false) {
+    responses.default = {
+      description:
+        known === false
+          ? 'The controller has no such action: 501 in development, 404 in production.'
+          : "Not described: what this action answers is the controller's own. A failure henri answers itself uses the error envelope; anything else is this application's.",
+      content: { [JSON_MEDIA]: { schema: {} } },
+    };
+  } else {
+    responses.default = { $ref: '#/components/responses/Error' };
+  }
+
+  // A form page is a route henri guards and an answer it does not write:
+  // it counts with the ones henri cannot describe
+  const described = answer === 'collection' || answer === 'resource';
+  const operation = {
+    operationId: operationId(route, ids),
+    summary: `${controller}#${action}`,
+    description: operationDescription(route, {
+      answer,
+      known,
+      model,
+      policy,
+      settings,
+    }),
+    tags: [controller],
+    parameters,
+    responses,
+    'x-henri': prune({
+      action,
+      answer: known === false ? 'unknown' : answer,
+      controller,
+      enforced: described || answer === 'page' ? '_links' : undefined,
+      known: known !== false && described,
+      model: answer !== 'unknown' && model ? model.globalId : undefined,
+      pathHelper: route.path,
+      policy: route.policy ? policy || false : undefined,
+      roles: route.roles ? [].concat(route.roles) : undefined,
+      source: isResource ? 'resources' : 'route',
+      version: route.version || undefined,
+    }),
+  };
+
+  if (
+    MUTATING.has(route.verb) &&
+    model &&
+    (action === 'create' || action === 'update')
+  ) {
+    const schema = { $ref: `#/components/schemas/${model.globalId}Input` };
+
+    operation.requestBody = {
+      description: `The attributes to write. henri derives them from the ${model.globalId} model; the action decides which of them it permits.`,
+      content: {
+        [JSON_MEDIA]: { schema },
+        'application/x-www-form-urlencoded': { schema },
+      },
+      required: false,
+    };
+  } else if (MUTATING.has(route.verb)) {
+    operation.requestBody = {
+      description:
+        'henri does not know what this action reads: `req.permit()` names the fields and henri does not see the list.',
+      content: { [JSON_MEDIA]: { schema: {} } },
+      required: false,
+    };
+  }
+
+  if (route.roles) {
+    operation.security = context.securitySchemes
+      ? [{ session: [] }, { bearer: [] }]
+      : [];
+  }
+
+  return operation;
+}
+
+/**
+ * The endpoints henri mounts itself: the session, the account flows of
+ * `config.user` and the health probes. Their bodies are henri's own
+ * handlers, so they are described exactly.
+ *
+ * @param {object} context the builder context
+ * @returns {Array<object>} `[{ verb, route, operation }]`
+ */
+function builtins(context) {
+  const { settings } = context;
+  const { accounts, user } = settings;
+  const found = [];
+  const errors = { $ref: '#/components/responses/Error' };
+  const json = (schema, description) => ({
+    description,
+    content: { [JSON_MEDIA]: { schema } },
+  });
+  const publicUser = { $ref: '#/components/schemas/PublicUser' };
+  const csrf = settings.csrf
+    ? [{ $ref: '#/components/parameters/CsrfToken' }]
+    : [];
+  const add = (verb, route, operation) =>
+    found.push({
+      operation: Object.assign({ tags: ['henri'] }, operation),
+      route,
+      verb,
+    });
+
+  if (!context.hasUserModel) {
+    return healthEndpoints(add, found);
+  }
+
+  add('post', user.loginPath, {
+    operationId: 'henri.login',
+    summary: 'Sign in',
+    description:
+      'Opens a session (passport `local`). A browser is redirected to `config.user.afterLogin`; a client asking for JSON gets the user. Failures are counted per address and the account locks out (`config.user.lockout`).',
+    parameters: csrf,
+    requestBody: {
+      required: true,
+      content: {
+        [JSON_MEDIA]: { schema: { $ref: '#/components/schemas/Credentials' } },
+        'application/x-www-form-urlencoded': {
+          schema: { $ref: '#/components/schemas/Credentials' },
+        },
+      },
+    },
+    responses: {
+      200: json(
+        {
+          type: 'object',
+          properties: { user: publicUser },
+          required: ['user'],
+        },
+        'The session is open.'
+      ),
+      400: { $ref: '#/components/responses/BadRequest' },
+      401: { $ref: '#/components/responses/Unauthorized' },
+      403: json(
+        { $ref: '#/components/schemas/Error' },
+        'The address has not been confirmed (`config.user.confirmation.required`); `data.reason` is `unconfirmed`.'
+      ),
+      429: { $ref: '#/components/responses/TooManyRequests' },
+      default: errors,
+    },
+    'x-henri': { answer: 'session', known: true, source: 'built-in' },
+  });
+
+  add('post', '/logout', {
+    operationId: 'henri.logout',
+    summary: 'Sign out',
+    description:
+      'Destroys the session and clears the cookie. A browser is redirected to `/`.',
+    parameters: csrf,
+    responses: {
+      200: json(
+        {
+          type: 'object',
+          properties: { ok: { const: true } },
+          required: ['ok'],
+        },
+        'The session is gone.'
+      ),
+      default: errors,
+    },
+    'x-henri': { answer: 'session', known: true, source: 'built-in' },
+  });
+
+  add('get', '/logout', {
+    operationId: 'henri.logout.get',
+    summary: 'Sign out (deprecated)',
+    description:
+      'Deprecated and inert: it answers 405 and destroys nothing, because a link, a prefetch or an image tag would otherwise sign a person out. Use `POST /logout`.',
+    responses: {
+      405: Object.assign(
+        json(
+          { $ref: '#/components/schemas/Error' },
+          'Always. The `Allow` header names the method to use.'
+        ),
+        {
+          headers: {
+            Allow: { description: '`POST`.', schema: { type: 'string' } },
+          },
+        }
+      ),
+      default: errors,
+    },
+    'x-henri': { answer: 'error', known: true, source: 'built-in' },
+  });
+
+  if (accounts.signup.enabled) {
+    add('post', accounts.signup.path, {
+      operationId: 'henri.signup',
+      summary: 'Register',
+      description: `Creates an account and, unless \`login\` is off, opens a session. The fields it reads are \`email\`, \`password\` and \`config.user.signup.fields\`${
+        accounts.signup.fields.length > 0
+          ? ` (${accounts.signup.fields.map((field) => `\`${field}\``).join(', ')})`
+          : ''
+      }.`,
+      parameters: csrf,
+      requestBody: {
+        required: true,
+        content: {
+          [JSON_MEDIA]: {
+            schema: { $ref: '#/components/schemas/Registration' },
+          },
+          'application/x-www-form-urlencoded': {
+            schema: { $ref: '#/components/schemas/Registration' },
+          },
+        },
+      },
+      responses: {
+        201: json(
+          {
+            type: 'object',
+            properties: { user: publicUser },
+            required: ['user'],
+          },
+          'The account was created.'
+        ),
+        422: { $ref: '#/components/responses/UnprocessableEntity' },
+        429: { $ref: '#/components/responses/TooManyRequests' },
+        default: errors,
+      },
+      'x-henri': { answer: 'session', known: true, source: 'built-in' },
+    });
+  }
+
+  if (accounts.passwordReset.enabled) {
+    const base = accounts.passwordReset.path;
+
+    add('post', `${base}/forgot`, {
+      operationId: 'henri.password.forgot',
+      summary: 'Ask for a password reset',
+      description:
+        'Always answers the same sentence, whether or not the address has an account, and mails the link afterwards: nothing a client can measure says who is registered.',
+      parameters: csrf,
+      requestBody: {
+        required: true,
+        content: {
+          [JSON_MEDIA]: {
+            schema: {
+              type: 'object',
+              properties: { email: { type: 'string', format: 'email' } },
+              required: ['email'],
+            },
+          },
+        },
+      },
+      responses: {
+        202: json(
+          {
+            type: 'object',
+            properties: { message: { type: 'string' }, ok: { const: true } },
+            required: ['ok', 'message'],
+          },
+          'Accepted, whatever the address was.'
+        ),
+        422: { $ref: '#/components/responses/UnprocessableEntity' },
+        429: { $ref: '#/components/responses/TooManyRequests' },
+        default: errors,
+      },
+      'x-henri': { answer: 'acknowledgement', known: true, source: 'built-in' },
+    });
+
+    add('get', `${base}/reset/:token`, {
+      operationId: 'henri.password.open',
+      summary: 'Open a password reset link',
+      description:
+        'Checks the token and moves it out of the url into the session, so the form posts without it. A browser is redirected to the form.',
+      responses: {
+        200: json(
+          {
+            type: 'object',
+            properties: { ok: { const: true } },
+            required: ['ok'],
+          },
+          'The link is valid.'
+        ),
+        400: { $ref: '#/components/responses/BadRequest' },
+        default: errors,
+      },
+      'x-henri': { answer: 'acknowledgement', known: true, source: 'built-in' },
+    });
+
+    add('post', `${base}/reset`, {
+      operationId: 'henri.password.reset',
+      summary: 'Set a new password',
+      description:
+        'Uses the token of the session, or the one in the body. Every other session of that account is retired.',
+      parameters: csrf,
+      requestBody: {
+        required: true,
+        content: {
+          [JSON_MEDIA]: {
+            schema: {
+              type: 'object',
+              properties: {
+                password: { type: 'string' },
+                token: { type: 'string' },
+              },
+              required: ['password'],
+            },
+          },
+        },
+      },
+      responses: {
+        200: json(
+          {
+            type: 'object',
+            properties: { ok: { const: true }, user: publicUser },
+            required: ['ok'],
+          },
+          'The password was changed.'
+        ),
+        400: { $ref: '#/components/responses/BadRequest' },
+        422: { $ref: '#/components/responses/UnprocessableEntity' },
+        default: errors,
+      },
+      'x-henri': { answer: 'session', known: true, source: 'built-in' },
+    });
+  }
+
+  if (accounts.confirmation.enabled) {
+    const base = accounts.confirmation.path;
+
+    add('get', `${base}/:token`, {
+      operationId: 'henri.confirm',
+      summary: 'Confirm an address',
+      description: 'Consumes the confirmation token of a mail link.',
+      responses: {
+        200: json(
+          {
+            type: 'object',
+            properties: { ok: { const: true }, user: publicUser },
+            required: ['ok'],
+          },
+          'The address is confirmed.'
+        ),
+        400: { $ref: '#/components/responses/BadRequest' },
+        default: errors,
+      },
+      'x-henri': { answer: 'acknowledgement', known: true, source: 'built-in' },
+    });
+
+    add('post', base, {
+      operationId: 'henri.confirm.resend',
+      summary: 'Ask for a confirmation link',
+      description:
+        'The same sentence whatever the address, for the same reason as the password reset.',
+      parameters: csrf,
+      requestBody: {
+        required: false,
+        content: {
+          [JSON_MEDIA]: {
+            schema: {
+              type: 'object',
+              properties: { email: { type: 'string', format: 'email' } },
+            },
+          },
+        },
+      },
+      responses: {
+        202: json(
+          {
+            type: 'object',
+            properties: { message: { type: 'string' }, ok: { const: true } },
+            required: ['ok', 'message'],
+          },
+          'Accepted, whatever the address was.'
+        ),
+        422: { $ref: '#/components/responses/UnprocessableEntity' },
+        default: errors,
+      },
+      'x-henri': { answer: 'acknowledgement', known: true, source: 'built-in' },
+    });
+
+    add('post', accounts.confirmation.emailPath, {
+      operationId: 'henri.account.email',
+      summary: 'Change the address of the account',
+      description:
+        'Sends a confirmation link to the new address; the account keeps the old one until the link is followed. The current password is asked for unless `requirePassword` is off.',
+      parameters: csrf,
+      requestBody: {
+        required: true,
+        content: {
+          [JSON_MEDIA]: {
+            schema: {
+              type: 'object',
+              properties: {
+                email: { type: 'string', format: 'email' },
+                password: { type: 'string' },
+              },
+              required: ['email'],
+            },
+          },
+        },
+      },
+      responses: {
+        202: json(
+          {
+            type: 'object',
+            properties: { message: { type: 'string' }, ok: { const: true } },
+            required: ['ok'],
+          },
+          'The link is on its way to the new address.'
+        ),
+        401: { $ref: '#/components/responses/Unauthorized' },
+        422: { $ref: '#/components/responses/UnprocessableEntity' },
+        default: errors,
+      },
+      security: [{ session: [] }, { bearer: [] }],
+      'x-henri': { answer: 'acknowledgement', known: true, source: 'built-in' },
+    });
+  }
+
+  return healthEndpoints(add, found);
+}
+
+/**
+ * The liveness and readiness probes, which every application answers
+ *
+ * @param {function} add pushes an endpoint
+ * @param {Array<object>} found the endpoints so far
+ * @returns {Array<object>} the endpoints
+ */
+function healthEndpoints(add, found) {
+  const health = { $ref: '#/components/schemas/Health' };
+  const probe = (id, route, summary, description, ready) =>
+    add('get', route, {
+      operationId: id,
+      summary,
+      description,
+      responses: Object.assign(
+        {
+          200: {
+            description: ready
+              ? 'The process can serve traffic.'
+              : 'The process answers.',
+            content: { [JSON_MEDIA]: { schema: health } },
+          },
+        },
+        ready
+          ? {
+              503: {
+                description:
+                  'The boot is not finished, the process is draining, or a store did not answer.',
+                content: { [JSON_MEDIA]: { schema: health } },
+              },
+            }
+          : {},
+        { default: { $ref: '#/components/responses/Error' } }
+      ),
+      'x-henri': { answer: 'health', known: true, source: 'built-in' },
+    });
+
+  probe(
+    'henri.health.live',
+    '/livez',
+    'Liveness',
+    'Answers 200 as long as the process can answer at all. It never touches a store: a failed liveness probe restarts the container, which fixes nothing when the database is what is down.',
+    false
+  );
+  probe(
+    'henri.health.ready',
+    '/readyz',
+    'Readiness',
+    'Pings every store. 503 while the boot is running, while the process drains, and when a store does not answer.',
+    true
+  );
+  probe(
+    'henri.health.healthz',
+    '/healthz',
+    'Readiness (older name)',
+    'The same answer as `/readyz`. The name is the ambiguous one -- it says "health" without saying which of the two questions it answers -- so henri answers readiness here and leaves it to whatever cannot be configured.',
+    true
+  );
+  probe(
+    'henri.health.henri',
+    '/_henri/health',
+    'Readiness (the name henri answered before)',
+    'The same answer as `/readyz`, under the name henri had before it had two, so a deployment already pointing here keeps working.',
+    true
+  );
+
+  return found;
+}
+
+/**
+ * The schemas the built-in endpoints need
+ *
+ * @param {object} context the builder context
+ * @returns {object} the schemas
+ */
+function builtinSchemas(context) {
+  const { settings } = context;
+
+  if (!context.hasUserModel) {
+    return {};
+  }
+
+  const fields = {};
+
+  for (const field of settings.accounts.signup.fields) {
+    fields[field] = {};
+  }
+
+  return {
+    Credentials: {
+      type: 'object',
+      description: 'What `POST /login` reads.',
+      properties: {
+        email: { type: 'string', format: 'email' },
+        password: { type: 'string' },
+      },
+      required: ['email', 'password'],
+    },
+    Registration: {
+      type: 'object',
+      description:
+        'What `POST` on the signup path reads: the address, the password and the fields `config.user.signup.fields` names. Anything else is dropped.',
+      properties: Object.assign(
+        {
+          email: { type: 'string', format: 'email' },
+          password: { type: 'string' },
+        },
+        fields
+      ),
+      required: ['email', 'password'],
+    },
+  };
+}
+
+/**
+ * What the description says about itself, in `info.description`
+ *
+ * @param {object} settings the settings
+ * @returns {string} the text
+ */
+function overview(settings) {
+  return [
+    'Generated by `henri openapi` from the routes, the models and the configuration of this application. It is not hand-written and it is not a contract: it describes the answers henri produces itself and says so, in plain words, wherever it cannot.',
+    'The same routes serve the pages and the JSON API. A client gets JSON by asking for it: `Accept: application/json`, `application/hal+json`, or `application/vnd.henri.v1+json` for a route that declares a version. Anything else -- a browser, `*/*` -- gets the page.',
+    `Every answer carries \`X-Request-Id\`. Every mutating route honours \`Idempotency-Key\` unless it opted out. Requests are rate limited (${
+      settings.rateLimit
+        ? 'on, not enforced in development'
+        : 'off by configuration'
+    }) and time out. A failure henri answers itself uses one envelope, \`Error\`, with a henri error code when henri raised it.`,
+    'Identifiers are public: a record leaves the server with its `externalId` (a uuid), never its primary key, and a declared foreign key leaves as the `externalId` of the row it names (`base/references.js`).',
+    settings.graphql
+      ? `GraphQL is served at \`${settings.graphql}\` and is not described here: it has a schema of its own.`
+      : 'GraphQL is not described here: it has a schema of its own.',
+  ].join('\n\n');
+}
+
+/**
+ * The OpenAPI 3.1 description of an application
+ *
+ * @param {object} input what to describe
+ * @param {*} [input.config={}] henri's config module, or the plain object a
+ *   command read from `config/<env>.json`
+ * @param {Array<object>} [input.models=[]] the model files, with `globalId`
+ *   and `identity` set (what `henri.model.models` holds)
+ * @param {Array<object>} [input.routes=[]] the expanded routes (base/routes.js)
+ * @param {?object} [input.actions=null] which `controller#action` exist, as
+ *   `{ 'tasks#index': true }`; null when the caller could not find out
+ * @param {?Array<string>} [input.policies=null] the names of `app/policies`,
+ *   so a route asking for one that does not exist is reported; null when the
+ *   caller could not find out
+ * @param {object} [input.info={}] `title`, `version` and `description`
+ * @param {Array<object>} [input.servers] the servers, when the caller knows
+ *   better than the configuration
+ * @returns {object} the document
+ */
+function build({
+  actions = null,
+  config = {},
+  info = {},
+  models = [],
+  policies = null,
+  routes = [],
+  servers = null,
+} = {}) {
+  const settings = settingsOf(config);
+  const files = Array.isArray(models) ? models.filter(Boolean) : [];
+  const findModel = modelFinder(files);
+  const userModel = files.find(
+    (model) =>
+      String(model.identity || '').toLowerCase() ===
+      String(settings.user.model || '').toLowerCase()
+  );
+  const findPolicy = policyFinder(policies);
+  const privacy = mapOf(files, {
+    settings: settings.privacy,
+    subject: userModel ? userModel.globalId : null,
+  });
+  const hidden = new Set(privacy.private);
+  const context = {
+    actionKnown: (controller) =>
+      actions === null ? null : Boolean(actions[controller]),
+    findModel,
+    findPolicy,
+    hasUserModel: Boolean(userModel),
+    hidden,
+    ids: new Set(),
+    models: files,
+    resolves: (name) => {
+      const target = files.find(
+        (model) => String(model.globalId) === String(name)
+      );
+
+      return Boolean(target && objectOf(target.options).externalId !== false);
+    },
+    securitySchemes: Boolean(userModel),
+    settings,
+  };
+  const paths = {};
+  const tags = [];
+  const coverage = { described: 0, operations: 0, unknown: 0 };
+  const excluded = [];
+
+  /**
+   * Files one operation under its path
+   *
+   * @param {string} verb the http verb
+   * @param {string} route the express path
+   * @param {object} operation the operation object
+   * @returns {void}
+   */
+  const file = (verb, route, operation) => {
+    const { names, path } = template(route);
+    const declared = new Set(
+      (operation.parameters || [])
+        .filter((parameter) => parameter && parameter.in === 'path')
+        .map((parameter) => parameter.name)
+    );
+
+    // A path template names a variable, so the operation has to declare it:
+    // a built-in endpoint carrying a `:token` gets its parameter here
+    for (const name of names) {
+      if (!declared.has(name)) {
+        operation.parameters = (operation.parameters || []).concat({
+          name,
+          in: 'path',
+          required: true,
+          schema: { type: 'string' },
+        });
+        declared.add(name);
+      }
+    }
+
+    paths[path] = paths[path] || {};
+    paths[path][verb] = operation;
+    coverage.operations += 1;
+
+    if (operation['x-henri'] && operation['x-henri'].known === true) {
+      coverage.described += 1;
+    } else {
+      coverage.unknown += 1;
+    }
+
+    for (const tag of operation.tags || []) {
+      if (!tags.some((entry) => entry.name === tag)) {
+        tags.push({
+          description:
+            tag === 'henri'
+              ? 'The endpoints henri mounts itself: the session, the account flows and the health probes.'
+              : `app/controllers/${tag}.js`,
+          name: tag,
+        });
+      }
+    }
+  };
+
+  for (const route of routes) {
+    if (!route || typeof route.controller !== 'string') {
+      continue;
+    }
+
+    if (!METHODS.has(route.verb)) {
+      excluded.push({
+        reason: 'OpenAPI has no path item field for this verb',
+        route: `${route.verb} ${route.route}`,
+      });
+
+      continue;
+    }
+
+    file(route.verb, route.route, operationFor(route, context));
+  }
+
+  for (const endpoint of builtins(context)) {
+    const { path } = template(endpoint.route);
+
+    if (paths[path] && paths[path][endpoint.verb]) {
+      // The application declared this path itself: what it wrote wins, the
+      // way express takes the first handler that answers
+      continue;
+    }
+
+    file(endpoint.verb, endpoint.route, endpoint.operation);
+  }
+
+  const components = {
+    schemas: Object.assign(schemasOf(context), builtinSchemas(context)),
+    responses: responsesOf(settings),
+    parameters: parametersOf(settings),
+  };
+
+  if (context.securitySchemes) {
+    components.securitySchemes = {
+      session: {
+        type: 'apiKey',
+        in: 'cookie',
+        name: 'henri.sid',
+        description:
+          'The session cookie of `POST /login`. A mutating request carrying it must also send the CSRF token.',
+      },
+      bearer: {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        description:
+          'A token the application signed, read by the passport `jwt` strategy. A request authenticated this way carries no cookie, so the CSRF check does not apply to it.',
+      },
+    };
+  }
+
+  return prune({
+    openapi: OPENAPI_VERSION,
+    jsonSchemaDialect: DIALECT,
+    info: {
+      title: info.title || 'henri application',
+      version: info.version || '0.0.0',
+      description: [info.description, overview(settings)]
+        .filter(Boolean)
+        .join('\n\n'),
+      'x-henri': prune({
+        coverage,
+        excluded: excluded.length > 0 ? excluded : undefined,
+        generator: 'henri openapi',
+        models: files.map((model) => String(model.globalId)).sort(),
+      }),
+    },
+    servers: servers || serversOf(settings),
+    tags,
+    security: [],
+    paths,
+    components,
+  });
+}
+
+module.exports = {
+  DIALECT,
+  OPENAPI_VERSION,
+  build,
+  columnsOf,
+  settingsOf,
+  template,
+};

--- a/packages/mcp/__tests__/server.spec.js
+++ b/packages/mcp/__tests__/server.spec.js
@@ -287,6 +287,7 @@ describe('henri mcp', () => {
       'lint',
       'logs',
       'models',
+      'openapi',
       'query',
       'records',
       'request',
@@ -311,6 +312,25 @@ describe('henri mcp', () => {
       'henri://routes',
       'henri://runtime',
     ]);
+  });
+
+  test('openapi: a valid 3.1 description of what the application exposes', async () => {
+    const { isError, structuredContent } = await call(client, 'openapi');
+    const { Validator } = await import('@seriousme/openapi-schema-validator');
+
+    expect(isError).toBe(false);
+    expect(structuredContent.openapi).toBe('3.1.0');
+    expect(await new Validator().validate(structuredContent)).toEqual({
+      valid: true,
+    });
+    expect(structuredContent.paths['/tasks'].get['x-henri']).toMatchObject({
+      answer: 'collection',
+      controller: 'tasks',
+      known: true,
+      model: 'Task',
+    });
+    // The scaffold has no user model, so henri mounts no session endpoints
+    expect(structuredContent.paths['/livez'].get).toBeDefined();
   });
 
   test('routes: the expanded table of config/routes.js', async () => {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -43,5 +43,8 @@
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@usehenri/cli": "workspace:^",
     "zod": "^4.5.4"
+  },
+  "devDependencies": {
+    "@seriousme/openapi-schema-validator": "^2.9.1"
   }
 }

--- a/packages/mcp/src/app.js
+++ b/packages/mcp/src/app.js
@@ -246,6 +246,7 @@ class App {
       audit: require(path.join(this.cliDir, 'scripts', 'audit')),
       doctor: require(path.join(this.cliDir, 'scripts', 'doctor')),
       help: require(path.join(this.cliDir, 'scripts', 'help')),
+      openapi: require(path.join(this.cliDir, 'scripts', 'openapi')),
       routing: require(path.join(this.cliDir, 'scripts', 'routing')),
       utils: require(path.join(this.cliDir, 'scripts', 'utils')),
       version: require(path.join(this.cliDir, 'package.json')).version,
@@ -335,6 +336,16 @@ class App {
    */
   routes() {
     return this.cli.routing.expand(this.cli.utils.readRoutes(this.cwd));
+  }
+
+  /**
+   * The OpenAPI 3.1 description of what the application exposes, built from
+   * the routes, the models and the configuration without starting anything
+   *
+   * @returns {object} The document
+   */
+  openapi() {
+    return this.cli.openapi.describe(this.cwd);
   }
 
   /**

--- a/packages/mcp/src/server.js
+++ b/packages/mcp/src/server.js
@@ -56,7 +56,7 @@ const TARGETS = [
   'test',
 ];
 
-const INSTRUCTIONS = `henri is a Rails-like MVC framework for Node.js. Read the henri://conventions resource (or AGENTS.md) before changing the application: it states the layout, the naming rules and the commands. Use the generate tool to add models, controllers, routes, views, jobs, workers and tests instead of writing files by hand, then run doctor, audit and test. The guide tool serves the documentation of the henri version installed here: read it instead of guessing from memory. errors, logs, query, records, runtime_routes and request answer against the running application rather than its files: start with errors when something failed, and use request to check a fix without a browser.`;
+const INSTRUCTIONS = `henri is a Rails-like MVC framework for Node.js. Read the henri://conventions resource (or AGENTS.md) before changing the application: it states the layout, the naming rules and the commands. Use the openapi tool to learn the HTTP surface in one call -- every path, its guards, its request body and the answers henri itself produces -- and trust what it marks unknown. Use the generate tool to add models, controllers, routes, views, jobs, workers and tests instead of writing files by hand, then run doctor, audit and test. The guide tool serves the documentation of the henri version installed here: read it instead of guessing from memory. errors, logs, query, records, runtime_routes and request answer against the running application rather than its files: start with errors when something failed, and use request to check a fix without a browser.`;
 
 /** The levels pen writes with */
 const LEVELS = ['error', 'warn', 'info', 'verbose', 'debug', 'silly'];
@@ -223,6 +223,30 @@ const createServer = ({ cwd = process.cwd() } = {}) => {
       const models = app.models(name);
 
       return ok({ count: models.length, models });
+    }
+  );
+
+  server.registerTool(
+    'openapi',
+    {
+      annotations: { readOnlyHint: true },
+      description:
+        'The OpenAPI 3.1 description of what this application exposes, built from config/routes.js, app/models and the configuration without starting anything. It is the fastest way to learn the HTTP surface: every path and verb, the roles and the policy guarding each one, the request body derived from the model, the HAL resource and collection envelopes, the paging, the error envelope and the statuses henri answers itself, plus the endpoints henri mounts (POST /login, the account flows, the health probes). It is deliberately honest about its limits: an operation whose body a controller writes carries `x-henri.known: false` and declares no success status, so do not assume a shape it does not state. GraphQL is not in it (it has a schema of its own).',
+      inputSchema: {},
+      title: 'OpenAPI description',
+    },
+    async () => {
+      try {
+        return ok(app.openapi());
+      } catch (error) {
+        return failed({
+          code: error.code || 'HENRI_CLI_FAILED',
+          hint:
+            error.hint ||
+            'config/routes.js and the files of app/models must load; run doctor for the details',
+          message: error.message,
+        });
+      }
     }
   );
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       '@babel/parser':
         specifier: ^8.0.4
         version: 8.0.4
+      '@seriousme/openapi-schema-validator':
+        specifier: ^2.9.1
+        version: 2.9.1
 
   packages/core:
     dependencies:
@@ -176,6 +179,9 @@ importers:
         specifier: ^13.15.35
         version: 13.15.35
     devDependencies:
+      '@seriousme/openapi-schema-validator':
+        specifier: ^2.9.1
+        version: 2.9.1
       '@types/validator':
         specifier: ^13.15.10
         version: 13.15.10
@@ -344,6 +350,10 @@ importers:
       zod:
         specifier: ^4.5.4
         version: 4.5.4
+    devDependencies:
+      '@seriousme/openapi-schema-validator':
+        specifier: ^2.9.1
+        version: 2.9.1
 
   packages/mongoose:
     dependencies:
@@ -582,9 +592,18 @@ importers:
         specifier: ^8.2.2
         version: 8.2.2(@types/node@26.4.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.104.0)(tsx@4.23.13)(yaml@2.9.0)
     devDependencies:
+      '@seriousme/openapi-schema-validator':
+        specifier: ^2.9.1
+        version: 2.9.1
       '@usehenri/testing':
         specifier: workspace:^
         version: link:../packages/testing
+      ajv:
+        specifier: ^8.20.0
+        version: 8.20.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.20.0)
       vitest:
         specifier: ^5.0.0
         version: 5.0.0(@types/node@26.4.1)(@vitest/coverage-v8@5.0.0)(jsdom@30.0.1(@noble/hashes@1.8.0))(vite@8.2.2(@types/node@26.4.1)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.104.0)(tsx@4.23.13)(yaml@2.9.0))
@@ -3260,6 +3279,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@seriousme/openapi-schema-validator@2.9.1':
+    resolution: {integrity: sha512-EgGqVIP8xiKHmNTHWbrxec+RhD/WPUay7D/erEc7vWoZKxTT9f2aCEu1egKVpxcEbT1z0wdAbWFR9o2Is5FJEw==}
+    hasBin: true
+
   '@shikijs/core@4.4.3':
     resolution: {integrity: sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg==}
     engines: {node: '>=20'}
@@ -3806,6 +3829,14 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ajv-draft-04@1.0.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -9622,6 +9653,13 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.63.1':
     optional: true
 
+  '@seriousme/openapi-schema-validator@2.9.1':
+    dependencies:
+      ajv: 8.20.0
+      ajv-draft-04: 1.0.0(ajv@8.20.0)
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      yaml: 2.9.0
+
   '@shikijs/core@4.4.3':
     dependencies:
       '@shikijs/primitive': 4.4.3
@@ -10115,6 +10153,10 @@ snapshots:
     optional: true
 
   agent-base@7.1.4: {}
+
+  ajv-draft-04@1.0.0(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
 
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -142,6 +142,29 @@ pnpm lint
 log "henri audit"
 pnpm exec henri audit --no-deps --fail-on=low
 
+# The description of what the scaffold exposes, from a real install: the
+# command has to ship, run without a database and produce a document the
+# scaffolded resource is actually in.
+log "henri openapi"
+pnpm exec henri openapi --out openapi.json
+node -e '
+  const doc = require("./openapi.json");
+  const wanted = ["/tasks", "/tasks/{id}", "/livez"];
+  const missing = wanted.filter((route) => !doc.paths[route]);
+
+  if (doc.openapi !== "3.1.0" || missing.length > 0) {
+    console.error("henri openapi wrote no usable document:", doc.openapi, missing);
+    process.exit(1);
+  }
+
+  const { coverage } = doc.info["x-henri"];
+
+  console.log(
+    `  ${coverage.operations} operations, ${coverage.described} described, ${coverage.unknown} not`
+  );
+'
+rm openapi.json
+
 log "henri build"
 pnpm exec henri build
 stop_mongod

--- a/showcase/package.json
+++ b/showcase/package.json
@@ -40,7 +40,10 @@
     "vite": "^8.2.2"
   },
   "devDependencies": {
+    "@seriousme/openapi-schema-validator": "^2.9.1",
     "@usehenri/testing": "workspace:^",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
     "vitest": "^5.0.0"
   }
 }

--- a/showcase/test/openapi.test.js
+++ b/showcase/test/openapi.test.js
@@ -1,0 +1,370 @@
+// The generated description against the running application.
+//
+// `henri openapi` writes a document from the routes, the models and the
+// configuration; this suite builds the same document from the booted router
+// and then calls the application and checks that what came back is what the
+// document said -- the status, the shape and the headers. A document that
+// describes an answer henri does not give is worse than no document, so a
+// disagreement is a failure here, not a note.
+const Ajv = require('ajv/dist/2020');
+const addFormats = require('ajv-formats');
+
+const {
+  createEvent,
+  createProposal,
+  createUser,
+  request,
+  reset,
+  signIn,
+} = require('./helpers');
+
+const HAL = 'application/hal+json';
+const ABSTRACT =
+  'An abstract for the description tests, comfortably longer than the sixty characters the model insists on.';
+
+describe('the OpenAPI description of the showcase', () => {
+  let document;
+  let speaker;
+  let event;
+  let submitted;
+  let compile;
+
+  beforeAll(async () => {
+    document = henri.router.describe();
+
+    const ajv = addFormats(new Ajv({ allErrors: true, strict: false }));
+
+    /**
+     * A validator for one schema of the document, with the components it
+     * refers to in scope
+     *
+     * @param {object} schema A schema, or a `$ref` to one
+     * @returns {function} The ajv validator
+     */
+    compile = (schema) =>
+      ajv.compile({
+        ...schema,
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        components: document.components,
+      });
+
+    await reset();
+    speaker = await createUser({
+      company: 'Fathom',
+      email: 'openapi-speaker@example.test',
+      name: 'Doc Speaker',
+      phone: '555-0100',
+    });
+    ({ event } = await createEvent({ name: 'Doc Conf' }));
+    submitted = await createProposal({
+      eventId: event.id,
+      speakerId: speaker.id,
+      state: 'submitted',
+      submittedAt: new Date(),
+      title: 'A proposal the description describes',
+    });
+  });
+
+  test('is a valid OpenAPI 3.1 document', async () => {
+    const { Validator } = await import('@seriousme/openapi-schema-validator');
+
+    expect(document.openapi).toBe('3.1.0');
+    expect(await new Validator().validate(document)).toEqual({ valid: true });
+  });
+
+  test('says what it could not describe, and how much', () => {
+    const { coverage } = document.info['x-henri'];
+
+    expect(coverage.described + coverage.unknown).toBe(coverage.operations);
+    // The member routes and the pages: henri writes none of those bodies
+    expect(document.paths['/proposals/{id}/submit'].post['x-henri']).toEqual(
+      expect.objectContaining({ answer: 'unknown', known: false })
+    );
+    expect(
+      document.paths['/proposals/{id}/submit'].post.responses['200']
+    ).toBeUndefined();
+  });
+
+  test('never carries a field marked personal: { expose: false }', () => {
+    const { schemas } = document.components;
+    const records = ['Event', 'Proposal', 'Review', 'Track', 'User'];
+
+    // `phone` is marked expose: false on User, and henri strips a hidden
+    // name from every answer at every depth: it is in no schema at all
+    expect(JSON.stringify(schemas)).not.toContain('"phone"');
+
+    for (const name of records) {
+      expect([name, schemas[name].properties.password]).toEqual([
+        name,
+        undefined,
+      ]);
+      expect([name, schemas[`${name}Input`].properties.password]).toEqual([
+        name,
+        undefined,
+      ]);
+    }
+
+    // The password reaches exactly two places, and both are requests henri
+    // reads itself
+    expect(schemas.Credentials.properties.password).toBeDefined();
+    expect(schemas.Registration.properties.password).toBeDefined();
+  });
+
+  describe('GET /proposals', () => {
+    const route = '/proposals';
+
+    test('answers the status, the shape and the headers the document names', async () => {
+      const operation = document.paths[route].get;
+      const answer = await request()
+        .get(`${route}?per_page=5`)
+        .set('Accept', HAL);
+
+      // Status
+      expect(operation.responses[String(answer.status)]).toBeDefined();
+      expect(answer.status).toBe(200);
+
+      // Headers
+      const headers = operation.responses['200'].headers;
+
+      expect(Object.keys(headers)).toEqual(
+        expect.arrayContaining(['Link', 'X-Total-Count', 'X-Request-Id'])
+      );
+      expect(answer.headers['x-total-count']).toBeDefined();
+      expect(answer.headers['x-request-id']).toBeDefined();
+      expect(answer.headers.link).toBeDefined();
+      expect(answer.headers['content-type']).toContain(HAL);
+
+      // Shape: the HAL envelope, which is the first of the two the document
+      // names for a route henri guards (the other is a rendered page)
+      const [hal] = operation.responses['200'].content[HAL].schema.anyOf;
+      const valid = compile(hal);
+
+      expect([valid(answer.body), valid.errors]).toEqual([true, null]);
+      expect(answer.body._embedded.proposals.length).toBeGreaterThan(0);
+    });
+
+    test('honours the page parameters the document declares', () => {
+      const { parameters } = document.paths[route].get;
+      const perPage = parameters
+        .map((parameter) =>
+          parameter.$ref
+            ? document.components.parameters[parameter.$ref.split('/').pop()]
+            : parameter
+        )
+        .find((parameter) => parameter.name === 'per_page');
+
+      expect(perPage.schema.default).toBe(
+        henri.api.settings.pagination.perPage
+      );
+      expect(perPage.schema.maximum).toBe(
+        henri.api.settings.pagination.maxPerPage
+      );
+    });
+  });
+
+  describe('GET /proposals/{id}', () => {
+    test('answers the resource the document describes', async () => {
+      const operation = document.paths['/proposals/{id}'].get;
+      const answer = await request()
+        .get(`/proposals/${submitted.externalId}`)
+        .set('Accept', HAL);
+
+      expect(operation.responses[String(answer.status)]).toBeDefined();
+      expect(answer.status).toBe(200);
+
+      const [hal] = operation.responses['200'].content[HAL].schema.anyOf;
+      const valid = compile(hal);
+
+      expect([valid(answer.body), valid.errors]).toEqual([true, null]);
+      // The path parameter is the public identifier, as the document says
+      expect(
+        operation.parameters.find((parameter) => parameter.name === 'id').schema
+      ).toEqual({ format: 'uuid', type: 'string' });
+      expect(answer.body.externalId).toBe(submitted.externalId);
+      // And a declared foreign key left as the public id of the row it names
+      expect(answer.body.eventId).toBe(event.externalId);
+    });
+
+    test('answers the error envelope the document names for an unknown id', async () => {
+      const operation = document.paths['/proposals/{id}'].get;
+      const answer = await request()
+        .get('/proposals/0199a5c1-1f7e-7a3c-bb0d-2b1a4f6d9c11')
+        .set('Accept', HAL);
+
+      expect(answer.status).toBe(404);
+      expect(operation.responses['404']).toBeDefined();
+
+      const valid = compile({ $ref: '#/components/schemas/Error' });
+
+      expect([valid(answer.body), valid.errors]).toEqual([true, null]);
+    });
+  });
+
+  describe('POST /proposals', () => {
+    test('answers the 201 and the Location header the document declares', async () => {
+      const operation = document.paths['/proposals'].post;
+      const { browser, csrf } = await signIn(speaker);
+      const answer = await browser
+        .post('/proposals')
+        .set('Accept', HAL)
+        .set('X-CSRF-Token', csrf)
+        .send({
+          abstract: ABSTRACT,
+          eventId: event.externalId,
+          title: 'A proposal the document promised',
+        });
+
+      expect(answer.status).toBe(201);
+      expect(operation.responses['201']).toBeDefined();
+      expect(operation.responses['201'].headers.Location).toBeDefined();
+      expect(answer.headers.location).toBe(
+        `/proposals/${answer.body.externalId}`
+      );
+
+      const [hal] = operation.responses['201'].content[HAL].schema.anyOf;
+      const valid = compile(hal);
+
+      expect([valid(answer.body), valid.errors]).toEqual([true, null]);
+
+      // The document declares the two headers this route reads
+      expect(
+        operation.parameters
+          .filter((parameter) => parameter.$ref)
+          .map((parameter) => parameter.$ref.split('/').pop())
+      ).toEqual(expect.arrayContaining(['IdempotencyKey', 'CsrfToken']));
+    });
+
+    test('the request body it declares is what the action accepts', () => {
+      const schema =
+        document.paths['/proposals'].post.requestBody.content[
+          'application/json'
+        ].schema;
+      const input = document.components.schemas.ProposalInput;
+
+      expect(schema).toEqual({ $ref: '#/components/schemas/ProposalInput' });
+      // The FIELDS of app/helpers/proposals.js
+      for (const field of [
+        'abstract',
+        'eventId',
+        'format',
+        'level',
+        'title',
+        'trackId',
+      ]) {
+        expect(Object.keys(input.properties)).toContain(field);
+      }
+      // Nothing is required: the speaker is the session, never the body
+      expect(input.required).toBeUndefined();
+      expect(input.properties.speakerId.type).toBeUndefined();
+    });
+  });
+
+  describe('an action that renders instead of answering HAL', () => {
+    test('answers the other shape the document names', async () => {
+      // The implicit render: events#index returns an object and never
+      // calls res.collection(), so the JSON of this guarded route is the
+      // options the page is built from
+      const operation = document.paths['/events'].get;
+      const [hal, rendered] =
+        operation.responses['200'].content[HAL].schema.anyOf;
+      const answer = await request().get('/events').set('Accept', HAL);
+
+      expect(rendered).toEqual({ $ref: '#/components/schemas/RenderedPage' });
+      expect(answer.status).toBe(200);
+      expect(answer.body._embedded).toBeUndefined();
+
+      const asPage = compile(rendered);
+      const asCollection = compile(hal);
+
+      expect([asPage(answer.body), asPage.errors]).toEqual([true, null]);
+      // And still the envelope henri enforces, which is why both are named
+      expect(asCollection(answer.body)).toBe(true);
+      expect(operation['x-henri'].enforced).toBe('_links');
+    });
+  });
+
+  describe('the guards', () => {
+    test('a role guard answers the 401 the document declares', async () => {
+      const operation = document.paths['/admin/proposals'].get;
+      const answer = await request()
+        .get('/admin/proposals')
+        .set('Accept', 'application/json');
+
+      expect(answer.status).toBe(401);
+      expect(operation.responses['401']).toBeDefined();
+      expect(operation.security).toEqual([{ session: [] }, { bearer: [] }]);
+
+      const valid = compile({ $ref: '#/components/schemas/Error' });
+
+      expect([valid(answer.body), valid.errors]).toEqual([true, null]);
+    });
+
+    test('the version guard answers the 406 the document declares', async () => {
+      const answer = await request()
+        .get('/proposals')
+        .set('Accept', 'application/vnd.henri.v2+json');
+
+      expect(answer.status).toBe(406);
+      expect(document.paths['/proposals'].get.responses['406']).toBeDefined();
+
+      const valid = compile({ $ref: '#/components/schemas/Error' });
+
+      expect([valid(answer.body), valid.errors]).toEqual([true, null]);
+    });
+  });
+
+  describe('the endpoints henri mounts itself', () => {
+    test('POST /login answers the user the document describes', async () => {
+      const operation = document.paths['/login'].post;
+      const first = await request().get('/login').set('Accept', 'text/html');
+      const csrf = decodeURIComponent(
+        (first.headers['set-cookie'] || [])
+          .find((cookie) => cookie.startsWith('henri.csrf='))
+          .split('=')[1]
+          .split(';')[0]
+      );
+      const answer = await request()
+        .post('/login')
+        .set('Accept', 'application/json')
+        .set('Cookie', first.headers['set-cookie'])
+        .send({
+          _csrf: csrf,
+          email: speaker.email,
+          password: 'lineup-showcase',
+        });
+
+      expect(answer.status).toBe(200);
+
+      const valid = compile(
+        operation.responses['200'].content['application/json'].schema
+      );
+
+      expect([valid(answer.body), valid.errors]).toEqual([true, null]);
+      expect(answer.body.user.phone).toBeUndefined();
+    });
+
+    test('GET /readyz answers the health body the document describes', async () => {
+      const operation = document.paths['/readyz'].get;
+      const answer = await request().get('/readyz');
+
+      expect(operation.responses[String(answer.status)]).toBeDefined();
+
+      const valid = compile(
+        operation.responses[String(answer.status)].content['application/json']
+          .schema
+      );
+
+      expect([valid(answer.body), valid.errors]).toEqual([true, null]);
+    });
+
+    test('GET /logout answers the 405 the document declares', async () => {
+      const answer = await request()
+        .get('/logout')
+        .set('Accept', 'application/json');
+
+      expect(answer.status).toBe(405);
+      expect(answer.headers.allow).toBe('POST');
+      expect(document.paths['/logout'].get.responses['405']).toBeDefined();
+    });
+  });
+});

--- a/website/src/content/docs/guides/agents.md
+++ b/website/src/content/docs/guides/agents.md
@@ -109,6 +109,7 @@ Tools that read the files, without starting anything:
 | Tool          | What it does                                                                        |
 | ------------- | ----------------------------------------------------------------------------------- |
 | `routes`      | The expanded routes with their verbs, paths, controllers, helpers and roles.        |
+| `openapi`     | The [OpenAPI 3.1 description](/guides/openapi/) of the HTTP surface, in one call.   |
 | `models`      | The models and their schemas.                                                       |
 | `controllers` | The controllers and their actions.                                                  |
 | `config`      | The configuration of the app, including which adapter and renderer it uses.         |

--- a/website/src/content/docs/guides/api.md
+++ b/website/src/content/docs/guides/api.md
@@ -196,6 +196,10 @@ On `SIGINT` or `SIGTERM` the server drains before the modules stop, so a rolling
 
 `shutdown.signals: false` leaves the signals to your application, which then calls `henri.server.shutdown('SIGTERM')` itself. A `henri jobs` runner never listens on a port and drains its own way: it stops claiming, finishes the jobs it holds and writes their outcomes. See [Shutdown](/configuration/#shutdown).
 
+## The description of it all
+
+`henri openapi` writes the [OpenAPI 3.1 description](/guides/openapi/) of everything on this page for one application: its routes, its HAL envelopes, its error bodies, the statuses each guard answers and the endpoints henri mounts. It is generated from the routes and the models, and it says in the document itself where henri cannot know what a controller answers.
+
 ## Middleware order
 
 Knowing the order helps when adding your own with `henri.addMiddleware()`: request id, timeout, helmet, compression (production), cors, body parsers, cookies, `res.boom`, the API version reader, `req.pagination`, the health endpoints, static files, then the user module (permit, session, passport, CSRF), the authentication and global limiters, the router (per route: version guard, route limiter, role guard, idempotency, HAL guard, the action), the `404` and the error handler.

--- a/website/src/content/docs/guides/openapi.md
+++ b/website/src/content/docs/guides/openapi.md
@@ -1,0 +1,122 @@
+---
+title: OpenAPI
+description: henri openapi writes the OpenAPI 3.1 description of what an application exposes, from its routes, its models and its configuration — and says, in the document, what it cannot know.
+sidebar:
+  order: 8
+---
+
+```bash
+henri openapi                      # the document, on stdout
+henri openapi --out openapi.json   # written to a file the application commits
+henri openapi --summary            # what it covers, and what henri cannot know
+```
+
+`henri openapi` writes the [OpenAPI 3.1](https://spec.openapis.org/oas/v3.1.0.html) description of the HTTP surface an application exposes. It is generated, never hand-written: it reads `config/routes.js` the way the router reads it, `app/models` the way the adapters read it, and `config/<env>.json` the way the boot reads it. It starts no server and opens no database, so it runs in CI and in a container that has neither.
+
+Most frameworks cannot generate a good one, because they know nothing about their own answers: the description ends up being a second, hand-maintained copy of the application that drifts the moment a controller changes. henri is unusually well placed here, because a large part of what an application answers is henri's own doing — the HAL envelopes, the paging, the error body, the guards — and that part can be derived rather than guessed.
+
+The other part cannot, and this page is mostly about that.
+
+## What the document says
+
+Everything below comes from the application, never from a convention henri hopes it follows.
+
+| In the document                   | Read from                                                                                                                                                                 |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| The paths and the verbs           | `config/routes.js`, expanded by [`base/routes.js`](/guides/routes/) — the same table `henri routes` prints                                                                |
+| The path parameters               | The `:id` of the route, typed as the record's `externalId` when the model carries one                                                                                     |
+| The schemas                       | `app/models`, plus the columns the adapters add (`externalId`, `createdAt`/`updatedAt`, `deletedAt`, and the user's `email`, `roles`, `confirmedAt`, `passwordChangedAt`) |
+| The HAL envelopes                 | [`res.resource()` and `res.collection()`](/guides/api/#answering-hal), for the routes expanded from `resources` and `crud`                                                |
+| The error envelope                | [`res.boom.*`](/guides/api/) and the 404/500 handlers, with the `code` of the [error catalogue](/reference/errors/)                                                       |
+| Which statuses a route can answer | Its own guards: `roles`, `policy`, `version`, `Idempotency-Key`, the rate limit                                                                                           |
+| `page` and `per_page`             | `config.api.perPage` and `config.api.maxPerPage`                                                                                                                          |
+| The security schemes              | The session cookie and the bearer token the [user module](/guides/users/) mounts, and the `X-CSRF-Token` a mutating request needs                                         |
+| `POST /login`, the account flows  | `config.user`: they are in the document only when henri actually mounts them                                                                                              |
+| `/livez`, `/readyz`, `/healthz`   | Always: every henri application answers them                                                                                                                              |
+
+Every operation also carries `x-henri.enforced`, which names what henri actually checks on that route (`_links`, on the ones expanded from `resources` and `crud`) as opposed to what it expects.
+
+A field marked `personal: { expose: false }` is in **no** schema, because [privacy](/guides/privacy/) strips that name from every answer henri builds, at every depth. Neither is `password`. A declared foreign key is typed as the `externalId` of the row it names, because that is what [`base/references.js`](/guides/models/#identifiers) publishes — and `null`, because a key that names no row resolves to nothing.
+
+## What it refuses to say
+
+A controller can answer anything. `res.render()` is not JSON. A hand-written route points at an action henri never wrapped. A generated document that describes an answer henri does not give is worse than no document at all, so the rule is: **an honest `unknown` beats a wrong `object`.**
+
+### An operation henri did not wrap
+
+A hand-written route (`get /about`), a `member` or `collection` route of a resource, the root of a namespace: these carry **no success status at all**. What they carry is the failures henri answers before the action runs — a 401 from the role guard, a 404 from the policy, a 406 from the version guard, a 409 from an idempotency replay — plus a `default` response saying so in words:
+
+```json
+"default": {
+  "description": "Not described: what this action answers is the controller's own. A failure henri answers itself uses the error envelope; anything else is this application's.",
+  "content": { "application/json": { "schema": {} } }
+}
+```
+
+`{}` is the JSON Schema for "any value". It is the only correct answer, and the operation's `x-henri.known` is `false` so a reader — a person or an agent — never has to work that out from prose.
+
+### Which of two shapes a guarded route answers
+
+The routes expanded from `resources` and `crud` are the ones henri does guard — but what it guards is `_links`, and nothing else. Two of henri's own answers carry them: the HAL envelope of `res.resource()` and `res.collection()`, and the page options of `res.render()` and of the implicit render (an action that returns an object without answering). A `resources` route that renders a page answers the second one, and it is a perfectly ordinary thing to do — the showcase's `events#index` does it.
+
+So a successful response names both, HAL first (`anyOf`), and the description says which is which: `_embedded` is what tells them apart. Promising one and letting an application answer the other is exactly the drift this document exists not to have.
+
+### A form page
+
+`new` and `edit` are the same story with the odds reversed, so they name both shapes too — and they are counted as unknown, because a form page is a body henri does not write.
+
+### A required field
+
+Nothing in a response schema is `required`, and every schema is open (`additionalProperties: true`). An action may present its records before sending them — the showcase does, and its proposals carry an embedded `speaker`, `event` and `track` that are in no model. A response schema that claimed `title` is always there would be wrong for every application that presents a summary. What the schema does say is: _these columns, with these types, when they are there._ Each property's description says whether the model requires the column.
+
+The one exception is `_links`, and only when `config.api.strict` is on: with it, henri refuses a `resources` JSON answer that has none, so `required` is the truth.
+
+### A request body
+
+`req.permit()` names the fields an action accepts, and henri never sees the list. The input schema is the model's writable columns — no `required`, `additionalProperties: true` — because a column the model requires may well be set by the server (the speaker of a proposal is the session, never the body). A **foreign key gets no type at all**: whether a form posts an `externalId`, a primary key or nothing is the application's decision.
+
+### An action that does not exist
+
+A route pointing at an action the controller does not export answers 501 in development and is never registered in production. The document says exactly that, rather than describing an endpoint nobody can call.
+
+## Reading the coverage
+
+Every operation carries an `x-henri` object, and `info.x-henri.coverage` totals them:
+
+```bash
+$ henri openapi --summary
+
+OpenAPI 3.1.0 for @usehenri/showcase 0.0.0
+
+  47 operations, 36 paths
+  27 described from the routes, the models and henri's own endpoints
+  20 whose answer henri cannot know
+
+  What henri cannot know (the controller writes the body; only the failures henri answers itself are described):
+    GET /  main#home
+    GET /about  main#about
+    ...
+```
+
+Twenty of forty-seven is not a failure of the tool: it is what an application with pages, member routes and form actions actually looks like. Moving an operation from one column to the other is a matter of answering it with `res.resource()` or `res.collection()` from a `resources` route, which is what henri asks for anyway.
+
+## Where the document lives
+
+**As a file.** `henri openapi --out openapi.json` writes it where the application commits it, and the diff of that file in a pull request is the diff of the API. Regenerating it in CI and failing on a change nobody meant is a two-line job.
+
+**As an endpoint, in development only.** A booted application answers `GET /_openapi.json`, next to `/_routes` and `/_controllers` and under the same rule: **development only, and from the loopback interface only.** The document names every route of the application, the roles that guard each one and the policy behind it, which is a map an anonymous visitor has no business reading. An application that wants to publish it puts the generated file in `app/views/public/`, where it is served as a static file, or serves it from a route of its own — a deliberate decision rather than a default.
+
+## For coding agents
+
+The [MCP server](/guides/agents/) exposes it as the `openapi` tool. It is the fastest way for an agent to learn the HTTP surface of an application: one call, every path, its guards, its request body and the answers henri produces — and, where henri cannot know, a mark saying so instead of a shape to be misled by.
+
+## What is out of scope
+
+- **A UI.** No Swagger UI, no Redoc, no bundled viewer. The document is a file; point whatever you like at it.
+- **Request validation.** henri does not validate a request against the document. The model validates a write and `req.permit()` decides what a request may set; a second, generated gate in front of them would be a second source of truth.
+- **Client generation.** The document is standard; the generators for it already exist and are better than anything shipped here would be.
+- **GraphQL.** It has a schema of its own. `config.graphql` names where to ask for it, and the description says so in `info.description` rather than describing the endpoint.
+
+## Exit codes
+
+`henri openapi` exits `0`, `3` outside an application, `2` on `--out` without a file name, and `1` with `HENRI_API_DESCRIPTION_UNWRITABLE` when the file cannot be written. See [Errors](/reference/errors/).

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -18,6 +18,7 @@ henri <command> [options]
 | `server`, `s`                 | Start the application (development mode with hot reload by default).         |
 | `console`                     | Boot the application and open a Node.js REPL.                                |
 | `routes`                      | Print the routes table of `config/routes.js`.                                |
+| `openapi`                     | Write the OpenAPI 3.1 description of what the application exposes.           |
 | `generate <what> <name>`, `g` | Generate code, see below.                                                    |
 | `destroy <what> <name>`, `d`  | Remove what a generator created.                                             |
 | `build`                       | Build the production views without starting the server.                      |
@@ -28,7 +29,7 @@ henri <command> [options]
 | `analyze [module]`            | Boot the application and print the boot chart of its modules.                |
 | `help [command]`              | Print the help.                                                              |
 
-`routes`, `analyze`, `generate`, `destroy`, `build` and `clean` refuse to run outside an application (a `package.json` with a `henri` key and an `app/views/pages` directory). `server`, `console` and `test` need an application too.
+`routes`, `openapi`, `analyze`, `generate`, `destroy`, `build` and `clean` refuse to run outside an application (a `package.json` with a `henri` key and an `app/views/pages` directory). `server`, `console` and `test` need an application too.
 
 ## `new` and `init`
 
@@ -117,6 +118,35 @@ GET     /tasks/:id       tasks#show     show_tasks_path
 
 9 routes
 ```
+
+## `openapi`
+
+```bash
+henri openapi [--out <file>] [--summary]
+```
+
+Writes the [OpenAPI 3.1](/guides/openapi/) description of what the application exposes, built from `config/routes.js`, `app/models` and the configuration. It starts no server and opens no database. JSON on stdout by default; `--out <file>` writes it instead and prints what it covers, `--summary` prints only that.
+
+It describes the answers henri produces itself — the HAL collection and resource of every `resources`/`crud` route, the error envelope, the paging, the versioned media type, `Idempotency-Key`, the roles and the policy of each route, and the endpoints henri mounts (`POST /login`, the account flows, the health probes). What a controller writes itself it does not describe: those operations carry the statuses henri answers, `x-henri.known: false`, and no success status at all.
+
+```text
+$ henri openapi --summary
+
+OpenAPI 3.1.0 for lineup 1.0.0
+
+  47 operations, 36 paths
+  27 described from the routes, the models and henri's own endpoints
+  20 whose answer henri cannot know
+
+  What henri cannot know (the controller writes the body; only the failures henri answers itself are described):
+    GET /  main#home
+    GET /about  main#about
+    POST /proposals/{id}/submit  proposals#submit
+```
+
+A booted application answers the same document at `GET /_openapi.json`, in development and from the loopback interface only, like `/_routes` and `/_controllers`.
+
+Exits `2` on `--out` without a file name and `1` with `HENRI_API_DESCRIPTION_UNWRITABLE` when the file cannot be written.
 
 ## Generators
 

--- a/website/src/content/docs/reference/errors.md
+++ b/website/src/content/docs/reference/errors.md
@@ -159,7 +159,19 @@ Usually:
 
 ## api
 
-The JSON API layer: HAL answers, the health endpoint and the optional GraphQL engine.
+The JSON API layer: HAL answers, the health endpoints, the OpenAPI description of what an application exposes and the optional GraphQL engine.
+
+### `HENRI_API_DESCRIPTION_UNWRITABLE`
+
+The OpenAPI description of the application could not be written where `henri openapi --out` was told to put it.
+
+Usually:
+
+- the directory of `--out` does not exist and could not be created
+- the file or its directory is not writable
+- the path names a directory
+
+**Fix.** Check the path and the permissions of the directory, or print the document to stdout instead: `henri openapi > openapi.json`.
 
 ### `HENRI_API_GRAPHQL_UNAVAILABLE`
 


### PR DESCRIPTION
The agentic section of the backlog asked for a machine-readable description of an application's API surface, generated from the routes. henri is unusually well placed for it, and that is the whole argument: most frameworks cannot generate a good one because they know nothing about their own answers. henri knows the expanded route table, the model schemas, the HAL and boom envelopes, the pagination bounds, the roles and policies on each route, and what leaves after the privacy strip.

`henri openapi` writes OpenAPI 3.1 without booting the application or touching a database. `GET /_openapi.json` serves the same document, and the MCP server exposes it as a tool.

## The interesting half is what it says for what henri cannot know

A controller can answer anything, so an honest document has to admit it:

- **A route henri did not wrap** gets **no success status at all**, only the failures henri answers before the action runs, plus a `default` whose body is described as the controller's. It is marked `x-henri.known: false`, and `--summary` names every such operation.
- **A model in an answer** carries nothing `required` and `additionalProperties: true`, because the controller decides what it sends. `_links` is required only when `config.api.strict` is on, because only then does henri refuse an answer without it.
- **A request body** is the writable columns, all optional, and a foreign key gets no type at all.
- **A guarded route names both shapes** henri can produce there, HAL first.

`info.x-henri.coverage` totals it: on the scaffolded application, 28 operations, 20 described, 8 not.

## Where the document and reality disagreed

One real finding, fixed in the generator rather than papered over. `GET /events` on the showcase answers a rendered-page envelope, not a HAL collection, because that action uses henri's implicit render and never calls `res.collection()`. The first version declared the collection alone: not violated, since every property was optional, but describing an answer that route does not give. A guarded route now names both shapes, and there is a test pinning it.

## What I verified myself

The document describes every route, the roles that guard it and the policy behind it, so it is a map worth not publishing by accident:

| | |
| --- | --- |
| `GET /_openapi.json` in development | 200 |
| the same in production | **404**, like `/_routes` |

It is mounted inside the same development-and-loopback-only guard as the existing introspection routes. An application that wants to publish it commits the file `henri openapi --out` writes.

And what the schemas hold: a field marked `personal: { expose: false }` appears in **no schema at all**, and no response schema has a `password` property. The only two places the word survives are a `PublicUser` description saying it is never sent, and `User.passwordChangedAt`, which is a timestamp. `Credentials` and `Registration` carry it because those are requests henri reads itself.

## Validated against the specification, not eyeballed

A schema validator runs in three suites and fails them on an invalid document, plus semantic checks: unique operation ids, every reference resolves, every path variable is a declared parameter and the reverse.

The author then fetched the document from a booted showcase and validated real answers against the schemas it declares: `GET /proposals` with its `Link`, `X-Total-Count: 34` and `_embedded.proposals`; a single proposal including the presenter's extra keys; a `POST` answering 201 with the declared `Location`; and the guards, anonymous 401, a wrong version 406, `GET /logout` 405 with `Allow: POST`. All matched.

## Out of scope, said in the guide and in the document itself

A UI, request validation from the document, client generation, and GraphQL, which has its own schema.

## Verification

`pnpm test` 2121 passed, the showcase suite 132 passed, `pnpm test:types`, `pnpm lint --max-warnings 0`, `pnpm format:check`, and `scripts/smoke.sh`, which now runs `henri openapi` against a real install of the packed workspace.