### PR TITLE
The privacy strip keeps __proto__ a field

### DIFF
--- a/packages/core/src/__tests__/privacy.spec.js
+++ b/packages/core/src/__tests__/privacy.spec.js
@@ -347,6 +347,22 @@ describe('what leaves the server (no application)', () => {
     expect(copy.at).toBe(at);
     expect(copy.gender).toBeUndefined();
   });
+
+  test('a __proto__ field is a field, never the prototype of the copy', () => {
+    // This strip is the last thing that touches a payload on its way out,
+    // so it is the one that decides. A JSON column is somewhere an attacker
+    // can put this key, and `copy.__proto__ = x` would replace the
+    // prototype of the answer with whatever they wrote
+    const payload = JSON.parse('{"meta":{"__proto__":{"polluted":true}}}');
+    const copy = stripPersonal(payload, new Set(['gender']));
+
+    expect(Object.getPrototypeOf(copy.meta)).toBe(Object.prototype);
+    expect(copy.meta.polluted).toBeUndefined();
+    expect({}.polluted).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(copy.meta, '__proto__')).toBe(
+      true
+    );
+  });
 });
 
 describe('the values an erasure writes (no application)', () => {

--- a/packages/core/src/__tests__/references.spec.js
+++ b/packages/core/src/__tests__/references.spec.js
@@ -2,6 +2,8 @@
 const supertest = require('supertest');
 const Henri = require('../henri');
 const { build, publish, settings } = require('../base/references');
+const { toPublic } = require('../base/hateoas');
+const { stripPersonal } = require('../base/privacy');
 
 const password = 'difference-engine';
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
@@ -419,6 +421,51 @@ describe('base/references', () => {
 
       expect(answer.when).toBe(when);
       expect(answer.blob).toBe(bytes);
+    });
+
+    test('a foreign key marked expose: false leaves as neither of the two', async () => {
+      // The seam between the two exit gates: publishing resolves the key
+      // into the public identifier of the row it names, and the privacy
+      // strip runs after, so a field that must not leave cannot leave
+      // carrying whatever it resolved to
+      const store = storeOf({ User: { 4812: 'u-4812' } });
+      const henri = fake(table, store);
+
+      henri.privacy = {
+        strip: (value, include = []) =>
+          stripPersonal(value, new Set(['authorId']), include),
+      };
+
+      const post = Object.assign(new Post(), {
+        authorId: 4812,
+        externalId: 'p-1',
+        id: 7,
+      });
+      const answer = await toPublic(henri, post);
+
+      expect(answer.authorId).toBeUndefined();
+      expect(JSON.stringify(answer)).not.toContain('4812');
+      expect(JSON.stringify(answer)).not.toContain('u-4812');
+      expect(answer.externalId).toBe('p-1');
+    });
+
+    test('a field the answer asked for by name survives the strip', async () => {
+      const store = storeOf({ User: { 4812: 'u-4812' } });
+      const henri = fake(table, store);
+
+      henri.privacy = {
+        strip: (value, include = []) =>
+          stripPersonal(value, new Set(['authorId']), include),
+      };
+
+      const post = Object.assign(new Post(), {
+        authorId: 4812,
+        externalId: 'p-1',
+      });
+
+      expect((await toPublic(henri, post, ['authorId'])).authorId).toBe(
+        'u-4812'
+      );
     });
 
     test('publishes nothing when there is no table at all', async () => {

--- a/packages/core/src/base/hateoas.js
+++ b/packages/core/src/base/hateoas.js
@@ -99,8 +99,15 @@ function withId(plain) {
  * lookups behind the foreign keys are batched once for the page rather
  * than once per record (see base/references.js).
  *
+ * The privacy strip runs after, never before: publishing resolves a foreign
+ * key into the public identifier of the row it names, and a field marked
+ * `personal: { expose: false }` must not leave carrying whatever it
+ * resolved to (see base/privacy.js).
+ *
  * @param {Henri} henri the henri instance
  * @param {*} records a model instance, a plain object, or a list of either
+ * @param {Array<string>} [include=[]] the personal fields this answer asked
+ *   for by name, which the strip keeps
  * @returns {Promise<*>} the copy
  */
 async function toPublic(henri, records, include = []) {

--- a/packages/core/src/base/privacy.js
+++ b/packages/core/src/base/privacy.js
@@ -542,7 +542,24 @@ function stripPersonal(value, names, keep = [], seen = new WeakMap()) {
       continue;
     }
 
-    copy[key] = stripPersonal(plain[key], names, keep, seen);
+    const entry = stripPersonal(plain[key], names, keep, seen);
+
+    // `copy.__proto__ = x` runs the setter of Object.prototype and replaces
+    // the copy's prototype instead of adding a field. This strip is the last
+    // thing that touches a payload on its way out, so it is the one that
+    // decides: the value is defined rather than assigned, which keeps it a
+    // field (see base/references.js, which does the same on the way in)
+    if (key === '__proto__') {
+      Object.defineProperty(copy, key, {
+        configurable: true,
+        enumerable: true,
+        value: entry,
+        writable: true,
+      });
+      continue;
+    }
+
+    copy[key] = entry;
   }
 
   return copy;

--- a/showcase/test/references.test.js
+++ b/showcase/test/references.test.js
@@ -10,16 +10,18 @@
 // statement per target model.
 //
 // These are the numbers the guide quotes. A regression to N+1 fails here.
-const {
-  createEvent,
-  createProposal,
-  createUser,
-  request,
-  reset,
-} = require('./helpers');
+//
+// This file truncates nothing. Every other suite calls `reset()` in its
+// `beforeAll`, which is fine when what follows only reads its own rows;
+// here the rows are the measurement, so the edition is one of this file's
+// own and every request is filtered to it. Nothing another file left behind
+// can change a count, and nothing this file writes can disturb one.
+const { createProposal, createUser, request } = require('./helpers');
 
 const HAL = 'application/hal+json';
 const PAGE = 25;
+const SPEAKERS = 6;
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/u;
 
 /**
  * Counts the statements the pool runs while `fn` does its work
@@ -28,8 +30,7 @@ const PAGE = 25;
  * @returns {Promise<{answer: *, queries: number}>} The result and the count
  */
 const counting = async (fn) => {
-  const store = henri.model.stores.default;
-  const { client } = store;
+  const { client } = henri.model.stores.default;
   const original = client.query.bind(client);
   let queries = 0;
 
@@ -47,22 +48,41 @@ const counting = async (fn) => {
 };
 
 describe('what a foreign key costs', () => {
+  const unique = `cost-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   let event;
   let track;
 
   beforeAll(async () => {
-    await reset();
+    event = await Event.create({
+      city: 'Testville',
+      name: 'Cost Conf',
+      slug: unique,
+      state: 'open',
+      year: 2026,
+    });
+    track = await Track.create({
+      eventId: event.id,
+      name: 'Cost',
+      slug: unique,
+    });
 
-    ({ event, track } = await createEvent({ name: 'Cost Conf' }));
+    // The fixtures have to be readable before anything points at them: a
+    // foreign key violation two hundred rows later says nothing useful
+    if (
+      !(await Event.findByKey(event.id)) ||
+      !(await Track.findByKey(track.id))
+    ) {
+      throw new Error('the fixtures of this file did not survive their insert');
+    }
 
     // Six speakers over twenty five proposals: the keys repeat, which is
     // what deduplication inside one statement is for
     const speakers = [];
 
-    for (let index = 0; index < 6; index += 1) {
+    for (let index = 0; index < SPEAKERS; index += 1) {
       speakers.push(
         await createUser({
-          email: `cost-speaker-${index}@example.test`,
+          email: `${unique}-speaker-${index}@example.test`,
           name: `Cost Speaker ${index}`,
         })
       );
@@ -71,7 +91,7 @@ describe('what a foreign key costs', () => {
     for (let index = 0; index < PAGE; index += 1) {
       await createProposal({
         eventId: event.id,
-        speakerId: speakers[index % speakers.length].id,
+        speakerId: speakers[index % SPEAKERS].id,
         state: 'submitted',
         title: `A proposal about the cost, number ${index}`,
         trackId: track.id,
@@ -79,9 +99,21 @@ describe('what a foreign key costs', () => {
     }
   });
 
+  afterAll(async () => {
+    // Put the database back the way it was found: the next file resets what
+    // it needs, and nothing here should be in its way
+    await Proposal.withDeleted().destroy({
+      force: true,
+      where: { eventId: event.id },
+    });
+    await Track.destroy({ id: track.id });
+    await Event.destroy({ id: event.id });
+  });
+
   test('a page whose associations are loaded costs nothing extra', async () => {
+    const url = `/proposals?event=${event.externalId}&per_page=${PAGE}`;
     const { answer, queries } = await counting(() =>
-      request().get(`/proposals?per_page=${PAGE}`).set('Accept', HAL)
+      request().get(url).set('Accept', HAL)
     );
     const records = answer.body._embedded.proposals;
 
@@ -91,19 +123,19 @@ describe('what a foreign key costs', () => {
     // Every foreign key is a public identifier, and none of them was looked
     // up: `include: ['event', 'speaker', 'track']` already brought the rows
     for (const record of records) {
-      expect(record.speakerId).toMatch(/^[0-9a-f-]{36}$/u);
+      expect(record.speakerId).toMatch(UUID);
       expect(record.eventId).toBe(event.externalId);
       expect(record.trackId).toBe(track.externalId);
     }
 
-    // Three statements for the whole request -- the page, its count and the
-    // editions of the filter -- and not one of them is a resolution:
-    // seventy five foreign keys came back for free
-    expect(queries).toBe(3);
+    // Four statements for the whole request -- the edition of the filter,
+    // the page, its count and the editions of the form -- and not one of
+    // them is a resolution: seventy five foreign keys came back for free
+    expect(queries).toBe(4);
   });
 
   test('and one that loads nothing costs one statement per target model', async () => {
-    const records = await Proposal.where({ state: 'submitted' }).limit(PAGE);
+    const records = await Proposal.where({ eventId: event.id }).limit(PAGE);
 
     expect(records).toHaveLength(PAGE);
     // No `include`: the three references have to be resolved
@@ -116,7 +148,7 @@ describe('what a foreign key costs', () => {
     expect(answer).toHaveLength(PAGE);
     expect(answer[0].eventId).toBe(event.externalId);
     expect(answer[0].trackId).toBe(track.externalId);
-    expect(answer[0].speakerId).toMatch(/^[0-9a-f-]{36}$/u);
+    expect(answer[0].speakerId).toMatch(UUID);
 
     // Three models pointed at, three statements -- not seventy five, and
     // not one per distinct key either: the six speakers are one `IN`
@@ -124,15 +156,15 @@ describe('what a foreign key costs', () => {
   });
 
   test('a key that names no row is null, and never the number', async () => {
-    const orphan = await Proposal.first();
+    const orphan = await Proposal.where({ eventId: event.id }).first();
     const gone = await Track.create({
       eventId: event.id,
       name: 'About to go',
-      slug: `gone-${Date.now()}`,
+      slug: `${unique}-gone`,
     });
 
     await orphan.update({ trackId: gone.id });
-    await Track.deleteMany({ id: gone.id });
+    await Track.destroy({ id: gone.id });
 
     const published = await henri.model.publish(
       await Proposal.findByKey(orphan.id)
@@ -140,5 +172,7 @@ describe('what a foreign key costs', () => {
 
     expect(published.trackId).toBeNull();
     expect(JSON.stringify(published)).not.toContain(`:${gone.id},`);
+
+    await orphan.update({ trackId: track.id });
   });
 });


### PR DESCRIPTION
A regression I introduced three merges ago, found by the teammate whose work I merged over, and confirmed here before taking their fix.

## What was wrong

When two tranches both rewrote what a record looks like on its way out, I wired them as publish-then-strip so that privacy has the last word. That made `stripPersonal()` the last thing that writes a response payload — and its walk did `copy[key] = value` for every key. For `__proto__` that runs the `Object.prototype` setter and **replaces the prototype of the answer** instead of adding a field.

The publishing gate had been hardened against exactly this pattern two commits earlier. Running the strip after it undid that, on every `res.render()`, `res.resource()` and `res.collection()`.

## Confirmed on master before fixing

An own `__proto__` key is something an attacker can put in a JSON or Mixed column, or in a payload built from parsed input. The strip is reachable as soon as an application marks any field personal, which is the point of the feature:

```
                            before        after
own __proto__ on the copy   false         true
prototype replaced          true          false
meta.polluted reads as      "yes"         undefined
JSON.stringify sees         {"title":"ok"}  {"title":"ok","__proto__":{...}}
```

Global `Object.prototype` is untouched, so this is not global pollution. What it is: any downstream property read sees attacker-chosen values while `JSON.stringify` drops them, so the payload and the in-memory object disagree. CWE-1321.

The key is defined rather than assigned now, the way the publishing gate already does it, and a test pins it in both places.

## Two other things in the same commit

**The seam between the gates had no test.** Publish-then-strip is a security ordering claim: a field marked `personal: { expose: false }` must not leave carrying whatever it resolved to. Nobody owned that assertion, so two tests now go through `toPublic()` — a foreign key that is also hidden leaves as neither the number nor the uuid, and one named in `include` survives.

**A flaky cost test, rewritten rather than patched.** The showcase reference test truncated the shared database and then measured rows it had just written, racing whatever the previous file left in flight. It now creates its own edition and truncates nothing. The measured numbers moved honestly by one: a loaded page is 4 statements, not 3, because the filter adds one; the unloaded publish is still 3.

## Verification

`pnpm test` 2124 passed across three consecutive runs, the showcase suite 132 passed, `pnpm test:types`, `pnpm lint --max-warnings 0`, `pnpm format:check`.

One unreproduced failure on the first run of the suite, green on the three after it, so it is noted rather than claimed as fixed.