### PR TITLE
Retention on the model, and an append-only access trail

### DIFF
--- a/.changeset/tidy-moles-shave.md
+++ b/.changeset/tidy-moles-shave.md
@@ -1,0 +1,56 @@
+---
+'@usehenri/core': minor
+'@usehenri/cli': minor
+'@usehenri/jobs': minor
+'@usehenri/drizzle': patch
+'@usehenri/mongoose': patch
+'@usehenri/sequelize': patch
+---
+
+Retention, and the access trail.
+
+A model now says how long it keeps its records, in its options:
+
+```js
+options: {
+  retention: { action: 'anonymize', after: '2y', from: 'decidedAt' },
+},
+```
+
+`action` is one of the three verbs henri already had -- `delete`,
+`soft-delete` (only on a `paranoid` model) and `anonymize` (exactly what an
+erasure writes) -- and `from` is the date column the clock starts on, which
+is rarely `createdAt`. A record whose `from` is null never ages out and is
+counted separately. A model with more than one class of records writes a
+list of named rules with a `where` each.
+
+`henri.retention.sweep()` enforces them and needs nothing installed:
+`henri retention:sweep --yes` is what a cron line runs, and with
+`@usehenri/jobs` installed `config.retention.schedule` registers the
+recurring `henri/retention` job. The boot says which of the two it is, by
+name, so a rule nothing applies is never silent.
+
+Two things stand between a wrong rule and a deleted table: a rule writes
+nothing until its token is in `config.retention.approved` (a line in the
+configuration, so a person, a diff and a review), and
+`config.retention.batch` bounds one run. `henri retention:sweep` without
+`--yes` plans, counts and prints, and writes nothing. Every sweep leaves a
+receipt in `config.retention.receipts`.
+
+`config.trail` turns on the access trail: an append-only, hash-chained
+record of who read or changed personal data, in a table henri owns. It
+records the export, the erasure, every retention sweep and -- with
+`trail.reads` -- the answers henri serializes; `henri.trail.record()` is how
+an application adds its own. It holds field names, counts, public
+identifiers and digests, and refuses anything else
+(`HENRI_TRAIL_VALUE_REFUSED`). `henri trail`, `henri trail:about <who>` (which
+answers from an address whose digest is all that is stored) and
+`henri trail:verify` read it back.
+
+`henri.jobs.recur(name, entry)` is the seam a framework module uses to ask
+for a schedule the configuration did not write; an entry the application
+declared under the same name still wins.
+
+The drizzle adapter no longer offers to drop the tables henri owns
+(`henri_jobs`, `henri_jobs_schedules`, `henri_trail`): a push that obeyed
+would have taken an application's job history or its audit trail with it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,8 +124,8 @@ an app and is what core's tests boot.
 passwordReset, confirmation }`), `baseRole`, `externalIds`, `policies`,
   `trustProxy`, `csrf`, `graphql`, `mail`, `mailers`, `api`, `jobs`,
   `rateLimit`, `shared`, `cache`, `helmet`, `filterParameters`, `privacy`,
-  `externalIds`, `bodyLimit`, `uploads`, `requestTimeout`, `shutdown`,
-  `errors`, `policies`.
+  `retention`, `trail`, `externalIds`, `bodyLimit`, `uploads`,
+  `requestTimeout`, `shutdown`, `errors`, `policies`.
 - The configuration is validated at boot, before any other module starts:
   `base/config-schema.js` declares every key henri owns (as data, in the order
   of the documentation page) and `base/config-validate.js` walks it. A wrong
@@ -345,6 +345,46 @@ model }` or Mongoose's `ref` -- which `res.render()`, `res.resource()`,
   identity rather than the identity. `henri privacy` prints the map,
   `henri audit` reports an unmarked field about a person (`privacy.unmarked`),
   and the guide is `website/src/content/docs/guides/privacy.md`.
+- Retention is `4.retention.js` (`henri.retention`) and `base/retention.js`.
+  A model says how long it keeps its records in its options
+  (`retention: { action, after, from, where, name }`, or a list of those);
+  `after` is a period (`'90d'`, `'18mo'`, `'2y'`), `action` is one of the
+  three verbs henri already has -- `delete`, `soft-delete` (only on a
+  `paranoid` model) and `anonymize` (what `base/erasure.js` writes) -- and
+  `from` is the date column the clock starts on, which is rarely
+  `createdAt`. A record whose `from` is null never ages out and is counted
+  as `waiting`. A rule henri cannot carry out fails the boot
+  (`HENRI_RETENTION_INVALID_RULE`). `henri.retention.sweep()` needs nothing
+  installed: `henri retention:sweep --yes` is the cron line, and with
+  `@usehenri/jobs` `config.retention.schedule` registers the recurring
+  `henri/retention` job through `henri.jobs.recur()`; the boot line names
+  whichever it is, and says when it is neither. A rule writes nothing until
+  its token (`Model:rule:<digest of its terms>`, a plain digest so it means
+  the same in every environment) is in `config.retention.approved`, and
+  `config.retention.batch` (1000) bounds one run. Every sweep leaves a
+  receipt in `config.retention.receipts`, and the guide is
+  `guides/retention.md`.
+- The access trail is `4.trail.js` (`henri.trail`), `base/trail.js` and
+  `base/trail-store.js`, off unless `config.trail` says otherwise. It owns
+  a table (`henri_trail`) the way the queue owns its own -- raw SQL through
+  the adapter or a MongoDB collection, never a model -- and only ever
+  `INSERT`s and `SELECT`s into it. It records what core does itself to
+  personal data (`privacy.export`, `privacy.erase` including refusals,
+  `retention.sweep`) plus, with `config.trail.reads`, the answers henri
+  serializes (`res.resource`, `res.collection`, `res.render`);
+  `henri.trail.record()` is how an application adds its own, and the guide
+  says plainly that a model call in a controller is outside the boundary.
+  An entry holds field _names_, counts, public identifiers and digests: a
+  `meta` naming a personal field, a `filterParameters` match, a long string
+  or something shaped like an address is refused
+  (`HENRI_TRAIL_VALUE_REFUSED`). Every entry carries `seq` (one more than
+  the last, under a unique index, so two writers make one chain rather than
+  two) and `hash = HMAC(secret, prev + canonical(entry))`, so an edited or
+  removed row breaks the chain and `henri trail:verify` says where. Its own
+  retention is `config.trail.keep`, pruned by the retention sweep as a
+  prefix plus a `trail.pruned` checkpoint. `henri trail`,
+  `henri trail:about <who>` and `henri trail:verify` read it back, and the
+  guide is `guides/trail.md`.
 - The router (`5.router.js`) expands `config/routes.js` through
   `base/routes.js` (`root`, `resources`/`crud` with `only`/`except`/`omit`,
   `member`, `collection`, `namespace`, `nested`; `@usehenri/cli` requires the
@@ -389,7 +429,10 @@ model }` or Mongoose's `ref` -- which `res.render()`, `res.resource()`,
   dialect (`FOR UPDATE SKIP LOCKED`, `UPDATE ... ORDER BY ... LIMIT`,
   `UPDLOCK, READPAST`, a subquery on sqlite, `findOneAndUpdate` on MongoDB)
   and the claimed rows are read back by the token it stamped, so two runners
-  never perform one job. `henri jobs` runs a worker (`--queue`,
+  never perform one job. `henri.jobs.recur(name, entry)` is the seam a
+  framework module uses to ask for a schedule the configuration did not
+  write (`henri.retention` is the one that does); an entry the application
+  declared under the same name wins. `henri jobs` runs a worker (`--queue`,
   `--concurrency`, `--once`), `henri jobs:install|status|list|dead|show|
 perform|retry|discard` drive it. The module also registers
   `henri.mailers.onDeliverLater()`, so `deliverLater()` enqueues the rendered
@@ -546,6 +589,13 @@ the LICENSE and a README into every public package at publish time
   on MSSQL neither it nor the DDL it would write is covered, and sqlite
   reports a column change without a statement because it has no
   `ALTER COLUMN`.
+- The tables henri owns in a drizzle store (`henri_jobs`,
+  `henri_jobs_schedules`, `henri_trail`) are created through raw SQL, so
+  drizzle-kit sees them as tables the schema no longer wants.
+  `Drizzle#reservedTables()` is what keeps a push from dropping them; a
+  table an application renames through `jobs.table` or `trail.table` is
+  read from the configuration, and anything else henri comes to own has to
+  be added there.
 - drizzle-kit does not alter a mysql table on a push: `henri db:push` and the
   development boot create the tables that are missing and report the ones
   whose columns drifted (`Migrations#completeMySQLPlan`); a mysql schema
@@ -573,6 +623,14 @@ the LICENSE and a README into every public package at publish time
   `@usehenri/redis` is exercised offline (the wiring, the option split, the
   fail-fast) and against a live server with `HENRI_TEST_REDIS_URL`
   (`pnpm test:redis`, the `Live Redis` job of the CI).
+- Retention and the access trail are covered on all three adapters:
+  mongoose through the demo application core's suite boots (the sweep, the
+  receipt, the MongoDB trail and its prune), and Sequelize and Drizzle by
+  `packages/{sequelize,drizzle}/__tests__/retention.spec.js`, which run on
+  sqlite offline and on the live PostgreSQL and MySQL of
+  `pnpm test:sql:live`. The showcase proves both on a real application
+  (`showcase/test/retention.test.js`). MSSQL has only its generated DDL
+  covered, like the rest of that adapter.
 - `@usehenri/jobs` is new in 1.1. Its claim is covered against sqlite,
   PostgreSQL, MySQL and MongoDB (`packages/jobs/__tests__/claim.spec.js`,
   `mongo.spec.js`; `pnpm test:sql:live` runs the SQL ones on real servers with

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -234,6 +234,20 @@ module.exports = [
     },
   },
   {
+    // The access trail owns a table too: a row is the snake_case columns of
+    // base/trail-store.js. And a retention period is written in the units a
+    // person writes one in, which are single letters (d, w, y)
+    files: [
+      'packages/core/src/base/retention.js',
+      'packages/core/src/base/trail.js',
+      'packages/core/src/base/trail-store.js',
+    ],
+    rules: {
+      camelcase: 'off',
+      'id-length': 'off',
+    },
+  },
+  {
     // A job file reads as a definition: its options first, `perform` last
     files: ['**/app/jobs/**/*.js'],
     rules: {

--- a/packages/cli/__tests__/fixtures/seed-app/app/models/Task.js
+++ b/packages/cli/__tests__/fixtures/seed-app/app/models/Task.js
@@ -1,3 +1,6 @@
+// A task is kept for thirty days and then deleted: the smallest retention
+// rule there is, and the one `henri retention` is checked against
 module.exports = {
+  options: { retention: { after: '30d' } },
   schema: { name: { required: true, type: 'string' } },
 };

--- a/packages/cli/__tests__/retention.spec.js
+++ b/packages/cli/__tests__/retention.spec.js
@@ -1,0 +1,195 @@
+const fs = require('fs');
+const path = require('path');
+
+const { CliError } = require('../scripts/errors');
+const { cleanup, henri, tmpdir } = require('./helpers');
+const trail = require('../scripts/trail');
+
+// The same minimal application `henri db` and `henri privacy` run against:
+// a drizzle store, a Task that says how long it is kept and a User
+const fixture = path.join(__dirname, 'fixtures', 'seed-app');
+
+/** The token of the Task rule, which `config.retention.approved` holds */
+const TOKEN = 'Task:default:4c94f8c8576e';
+
+/**
+ * Core resolves `@usehenri/drizzle` from the application directory: link
+ * the workspace package into the fixture's node_modules (ignored by git)
+ *
+ * @returns {void}
+ */
+const linkAdapter = () => {
+  const target = path.join(fixture, 'node_modules', '@usehenri', 'drizzle');
+
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+
+  if (!fs.existsSync(target)) {
+    fs.symlinkSync(
+      path.resolve(__dirname, '../../drizzle'),
+      target,
+      'junction'
+    );
+  }
+};
+
+describe('henri retention and henri trail', () => {
+  describe('usage', () => {
+    test('trail:about needs a person, and says how to name one', async () => {
+      const error = await trail
+        .about({ _: ['about'] })
+        .catch((thrown) => thrown);
+
+      expect(error).toBeInstanceOf(CliError);
+      expect(error.code).toBe('HENRI_CLI_USAGE');
+      expect(error.hint).toContain('someone@example.com');
+    });
+  });
+
+  describe('against a real application (drizzle, sqlite)', () => {
+    let dir;
+    let env;
+    let receipts;
+    let seeded;
+
+    /**
+     * Runs a command against the fixture
+     *
+     * @param {Array<string>} args The arguments
+     * @param {object} [extra={}] Extra environment
+     * @returns {object} The result of the command
+     */
+    const run = (args, extra = {}) =>
+      henri(args, {
+        cwd: fixture,
+        env: { ...env, ...extra },
+        timeout: 120000,
+      });
+
+    beforeAll(() => {
+      linkAdapter();
+      dir = tmpdir('henri-retention-');
+      receipts = path.join(dir, 'receipts');
+      env = {
+        ...process.env,
+        DATABASE_URL: `file:${path.join(dir, 'app.db')}`,
+        HENRI_CONFIG_JSON__retention: JSON.stringify({ receipts }),
+        // The trail is off unless an application asks for it
+        HENRI_CONFIG_JSON__trail: JSON.stringify({}),
+      };
+
+      const seeds = path.join(dir, 'tasks.js');
+
+      fs.writeFileSync(
+        seeds,
+        `module.exports = async () => {
+  await Task.create({ name: 'Write the notes' });
+  await Task.create({ name: 'Read them back' });
+};
+`
+      );
+
+      seeded = run(['db:seed', `--file=${seeds}`, '--json']);
+    });
+
+    afterAll(() => {
+      cleanup(dir);
+    });
+
+    test('seeds the application it is about to read', () => {
+      expect(seeded.status).toBe(0);
+    });
+
+    test('prints the rules the models declare, and their tokens', () => {
+      const { status, stdout } = run(['retention', '--json']);
+      const result = JSON.parse(stdout);
+
+      expect(status).toBe(0);
+      expect(result.command).toBe('map');
+      expect(result.rules).toEqual([
+        {
+          action: 'delete',
+          after: 2592000000,
+          approved: false,
+          from: 'createdAt',
+          model: 'Task',
+          rule: 'default',
+          token: TOKEN,
+          where: {},
+        },
+      ]);
+    });
+
+    test('a sweep writes nothing without --yes', () => {
+      const { status, stdout } = run(['retention:sweep', '--json']);
+      const result = JSON.parse(stdout);
+
+      expect(status).toBe(0);
+      expect(result.dryRun).toBe(true);
+      expect(result.receipt.rules[0].skipped).toBe('not approved');
+      expect(result.receipt.rules[0].written).toBe(0);
+    });
+
+    test('and nothing with --yes either, until the rule is approved', () => {
+      const refused = JSON.parse(
+        run(['retention:sweep', '--yes', '--json']).stdout
+      );
+
+      expect(refused.receipt.pending).toBe(1);
+      expect(refused.receipt.rules[0].skipped).toBe('not approved');
+      expect(refused.receipt.rules[0].written).toBe(0);
+
+      // Nothing is old enough here either, so approving it changes the
+      // reason rather than the outcome: the rule runs and finds nothing
+      const approved = JSON.parse(
+        run(['retention:sweep', '--yes', '--json'], {
+          HENRI_CONFIG_JSON__retention: JSON.stringify({
+            approved: [TOKEN],
+            receipts,
+          }),
+        }).stdout
+      );
+
+      expect(approved.receipt.pending).toBe(0);
+      expect(approved.receipt.rules[0].skipped).toBeNull();
+      expect(approved.receipt.rules[0].matched).toBe(0);
+      expect(approved.receipt.file).toMatch(/retention-/u);
+    });
+
+    test('a sweep that ran is in the trail, and the chain holds', () => {
+      const entries = JSON.parse(run(['trail', '--json']).stdout);
+
+      expect(entries.command).toBe('list');
+      expect(
+        entries.entries.every((entry) => entry.action === 'retention.sweep')
+      ).toBe(true);
+      expect(entries.entries.length).toBeGreaterThan(0);
+      expect(entries.entries[0].model).toBe('Task');
+      // Names and counts, never a value
+      expect(JSON.stringify(entries)).not.toContain('Write the notes');
+
+      const verified = JSON.parse(run(['trail:verify', '--json']).stdout);
+
+      expect(verified.ok).toBe(true);
+      expect(verified.broken).toBeNull();
+      expect(verified.entries).toBe(entries.entries.length);
+    });
+
+    test('reading a trail an application does not keep says so', () => {
+      const { status, stderr } = run(['trail', '--json'], {
+        HENRI_CONFIG_JSON__trail: 'false',
+      });
+
+      expect(status).toBe(1);
+      expect(stderr).toContain('HENRI_TRAIL_DISABLED');
+    });
+
+    test('an unknown subcommand prints the usage and exits 2', () => {
+      for (const command of ['retention:nope', 'trail:nope']) {
+        const { status, stderr } = run([command, '--json']);
+
+        expect(status).toBe(2);
+        expect(stderr).toContain('HENRI_CLI_USAGE');
+      }
+    });
+  });
+});

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -71,7 +71,7 @@ module.exports = (pkg, args) => {
   let command = argv._.shift();
 
   // Rails style: `henri db:migrate` is `henri db migrate`
-  for (const group of ['credentials', 'db', 'privacy']) {
+  for (const group of ['credentials', 'db', 'privacy', 'retention', 'trail']) {
     if (command && command.startsWith(`${group}:`)) {
       argv._.unshift(command.slice(group.length + 1));
       command = group;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -67,10 +67,12 @@
     "new",
     "openapi",
     "privacy",
+    "retention",
     "routes",
     "s",
     "server",
-    "test"
+    "test",
+    "trail"
   ],
   "devDependencies": {
     "@babel/parser": "^8.0.4",

--- a/packages/cli/scripts/help.js
+++ b/packages/cli/scripts/help.js
@@ -842,6 +842,135 @@ const COMMANDS = [
   },
   {
     description: [
+      'How long this application keeps its records, and the sweep that',
+      'enforces it. A model says it in its options -- retention: { after,',
+      'action, from, where } -- and henri retention prints every rule with',
+      'the token that approves it.',
+      '',
+      'henri retention:sweep is a dry run unless it is given --yes: it',
+      'plans, counts and prints, and writes nothing. A rule whose token is',
+      'not in config.retention.approved never writes either, however the',
+      'sweep was run, so a new rule cannot delete anything until a person',
+      'has approved it in the configuration.',
+      '',
+      'With @usehenri/jobs installed and config.retention.schedule set,',
+      'the same sweep runs as the recurring henri/retention job. Without',
+      'the package this command is what a cron line runs. Both boot the',
+      'models only: no port is bound.',
+    ],
+    examples: [
+      {
+        command: 'henri retention',
+        description: 'The rules, and which of them are approved',
+      },
+      {
+        command: 'henri retention:sweep',
+        description: 'What a sweep would do, without doing it',
+      },
+      {
+        command: 'henri retention:sweep --yes --only=Proposal',
+        description: 'Sweep one model, for real',
+      },
+    ],
+    flags: [
+      {
+        description: 'sweep: only this model, or Model:rule',
+        flag: '--only=<name>',
+      },
+      {
+        alias: '-y',
+        description: 'sweep: write; without it nothing is written',
+        flag: '--yes',
+      },
+      JSON_FLAG,
+    ],
+    name: 'retention',
+    summary: 'how long the models keep their records, and the sweep',
+    targets: [
+      {
+        description: 'the retention rules, model by model (the default)',
+        name: 'map',
+      },
+      {
+        description: 'sweep every rule (a dry run without --yes)',
+        name: 'sweep',
+      },
+    ],
+    usage: [
+      'henri retention [--json]',
+      'henri retention:sweep [--only=<name>] [--yes] [--json]',
+    ],
+  },
+  {
+    description: [
+      'The append-only record of who read or changed personal data, read',
+      'back. It holds field names, counts and public identifiers, never a',
+      'value, and every entry is hash-chained onto the one before it.',
+      '',
+      'henri trail:about <who> answers "prove the erasure happened" from an',
+      'email address: the address is not in the table, its digest is, and',
+      'the digest is recomputed from what you were asked about.',
+      '',
+      'henri trail:verify walks the chain and says whether a row was edited',
+      'or removed, and where. The trail is off until config.trail says',
+      'otherwise; all three boot the models only.',
+    ],
+    examples: [
+      {
+        command: 'henri trail --action=privacy.erase',
+        description: 'Every erasure this application performed',
+      },
+      {
+        command: 'henri trail:about ada@example.com',
+        description: 'Everything recorded about one person',
+      },
+      {
+        command: 'henri trail:verify',
+        description: 'Whether anything was edited or removed',
+      },
+    ],
+    flags: [
+      {
+        description: 'only this action (privacy.erase)',
+        flag: '--action=<name>',
+      },
+      { description: 'only this model', flag: '--model=<name>' },
+      { description: 'only this actor, by external id', flag: '--actor=<id>' },
+      {
+        description: 'entries at or after this moment',
+        flag: '--since=<date>',
+      },
+      {
+        description: 'entries at or before this moment',
+        flag: '--until=<date>',
+      },
+      { description: 'how many entries to print (25)', flag: '--limit=<n>' },
+      JSON_FLAG,
+    ],
+    name: 'trail',
+    summary: 'who read or changed personal data, and whether the chain holds',
+    targets: [
+      {
+        description: 'the latest entries (the default)',
+        name: 'list',
+      },
+      {
+        description: 'everything recorded about one person',
+        name: 'about <who>',
+      },
+      {
+        description: 'walk the hash chain and report the first break',
+        name: 'verify',
+      },
+    ],
+    usage: [
+      'henri trail [--action=<name>] [--model=<name>] [--limit=<n>] [--json]',
+      'henri trail:about <who> [--json]',
+      'henri trail:verify [--json]',
+    ],
+  },
+  {
+    description: [
       'Starts the MCP server of @usehenri/mcp on stdio for the application',
       'in the current directory. Claude Code reads it from .mcp.json, Cursor',
       'from .cursor/mcp.json (both: { "command": "henri", "args": ["mcp"] }).',

--- a/packages/cli/scripts/privacy.js
+++ b/packages/cli/scripts/privacy.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 const { CliError } = require('./errors');
 const { usage } = require('./help');
-const { validInstall } = require('./utils');
+const { boot, validInstall } = require('./utils');
 
 /**
  * `henri privacy`: the personal data of an application, and the two
@@ -27,50 +27,16 @@ const { validInstall } = require('./utils');
 const COMMANDS = ['erase', 'export', 'map'];
 
 /**
- * Prefer the @usehenri/core the project depends on and fall back to the
- * one shipped with this CLI
- *
- * @returns {string} resolved path of the Henri class
- */
-const resolveHenri = () => {
-  try {
-    return require.resolve('@usehenri/core/src/henri', {
-      paths: [process.cwd()],
-    });
-  } catch {
-    return require.resolve('@usehenri/core/src/henri');
-  }
-};
-
-/**
- * Boots the models and the user module, and nothing above them.
- *
- * Runlevel 4, like `henri db:seed` and `henri jobs`: no port is bound and no
- * route is registered, and the user module is there because writing over a
- * password goes through the same hooks a sign-up does.
- *
- * @returns {Promise<object>} The henri instance
- */
-const boot = async () => {
-  process.env.SKIP_WORKERS = 'true';
-  process.env.CONSOLE_ONLY = 'true';
-
-  const Henri = require(resolveHenri());
-  const henri = new Henri({ runlevel: 4 });
-
-  await henri.init();
-
-  return henri;
-};
-
-/**
  * Runs one operation against a booted application and stops it again
  *
  * @param {function} work `(henri) => result`
  * @returns {Promise<*>} What the work resolved with
  */
 const withHenri = async (work) => {
-  const henri = await boot();
+  // Runlevel 4, like `henri db:seed` and `henri jobs`: no port is bound and
+  // no route is registered, and the user module is there because writing
+  // over a password goes through the same hooks a sign-up does
+  const henri = await boot({ runlevel: 4 });
 
   try {
     return await work(henri);

--- a/packages/cli/scripts/retention.js
+++ b/packages/cli/scripts/retention.js
@@ -1,0 +1,274 @@
+const { CliError } = require('./errors');
+const { usage } = require('./help');
+const { boot, validInstall } = require('./utils');
+
+/**
+ * `henri retention`: how long this application keeps its records, and the
+ * sweep that enforces it.
+ *
+ * - `henri retention` prints the rules: which models declare one, what it
+ *   does, what its clock is measured from, and whether it has been
+ *   approved. It is how a rule is checked, the way `henri routes` is how
+ *   the routes are checked.
+ * - `henri retention:sweep` runs it. Without `--yes` it is a dry run: it
+ *   plans, counts and prints, and writes nothing. `--yes` is what a cron
+ *   line carries, and it is the only thing that lets a sweep write.
+ *
+ * Both boot to the user module (runlevel 4, like `henri db:seed`): no port
+ * is bound and no route is registered. The work itself is
+ * `henri.retention` (`core/src/4.retention.js`), so an application with
+ * `@usehenri/jobs` gets the same sweep on a schedule and one without it
+ * runs this from cron.
+ */
+
+const COMMANDS = ['map', 'sweep'];
+
+/**
+ * Runs one operation against a booted application and stops it again
+ *
+ * @param {function} work `(henri) => result`
+ * @returns {Promise<*>} What the work resolved with
+ */
+const withHenri = async (work) => {
+  const henri = await boot({ runlevel: 4 });
+
+  try {
+    return await work(henri);
+  } finally {
+    await henri.stop();
+  }
+};
+
+/**
+ * The rules of the application
+ *
+ * @returns {Promise<object>} The result
+ */
+const map = async () => {
+  const described = await withHenri((henri) => henri.retention.describe());
+
+  return { command: 'map', ok: true, ...described };
+};
+
+/**
+ * Sweeps, or says what a sweep would do
+ *
+ * @param {object} args CLI arguments
+ * @returns {Promise<object>} The result, with the receipt
+ */
+const sweep = async (args) => {
+  const only = typeof args.only === 'string' ? args.only : undefined;
+  // A sweep writes when it is told to and not before: `--yes` is what a
+  // cron line carries, and a run without it is a rehearsal
+  const dryRun = args.yes !== true;
+
+  return withHenri(async (henri) => {
+    const receipt = await henri.retention.sweep({
+      dryRun,
+      only,
+      source: 'cli',
+    });
+
+    return { command: 'sweep', dryRun, ok: !receipt.interrupted, receipt };
+  });
+};
+
+/**
+ * A period in words
+ *
+ * @param {number} value A number of milliseconds
+ * @returns {string} `2y`, `18mo`, `90d`
+ */
+const period = (value) => {
+  const units = [
+    ['y', 31536000000],
+    ['mo', 2592000000],
+    ['d', 86400000],
+    ['h', 3600000],
+    ['m', 60000],
+  ];
+
+  for (const [unit, size] of units) {
+    if (value % size === 0) {
+      return `${value / size}${unit}`;
+    }
+  }
+
+  return `${value}ms`;
+};
+
+/**
+ * Prints the rules
+ *
+ * @param {object} result What map() answered
+ * @returns {void}
+ */
+const printMap = (result) => {
+  console.log('');
+
+  if (result.rules.length === 0) {
+    console.log('  No model says how long it keeps its records.');
+    console.log('');
+    console.log('  A model says it in its options:');
+    console.log(
+      "    options: { retention: { after: '2y', from: 'decidedAt' } }"
+    );
+    console.log('');
+    console.log('  https://usehenri.io/guides/retention/');
+    console.log('');
+
+    return;
+  }
+
+  for (const rule of result.rules) {
+    const name = `${rule.model}${rule.rule === 'default' ? '' : `:${rule.rule}`}`;
+    const where =
+      Object.keys(rule.where).length > 0
+        ? ` where ${JSON.stringify(rule.where)}`
+        : '';
+
+    console.log(
+      `  ${name.padEnd(28)} ${rule.action.padEnd(12)} ${period(rule.after)} after ${rule.from}${where}`
+    );
+    console.log(
+      `  ${''.padEnd(28)} ${rule.approved ? 'approved' : 'PENDING '}     ${rule.token}`
+    );
+    console.log('');
+  }
+
+  const pending = result.rules.filter((rule) => !rule.approved);
+
+  if (pending.length > 0) {
+    console.log(
+      `  ${pending.length} rule(s) write nothing until they are approved. Add to config/<env>.json:`
+    );
+    console.log('');
+    console.log('    "retention": { "approved": [');
+    console.log(
+      pending.map((rule) => `      ${JSON.stringify(rule.token)}`).join(',\n')
+    );
+    console.log('    ] }');
+    console.log('');
+  }
+
+  console.log(
+    result.settings.schedule
+      ? `  Swept by henri/retention (${result.settings.schedule}), which needs @usehenri/jobs`
+      : '  Nothing runs the sweep on its own: henri retention:sweep --yes'
+  );
+  console.log('');
+  console.log('  https://usehenri.io/guides/retention/');
+  console.log('');
+};
+
+/**
+ * Prints what a sweep did, or would do
+ *
+ * @param {object} result What sweep() answered
+ * @returns {void}
+ */
+const printSweep = ({ dryRun, receipt }) => {
+  console.log('');
+
+  if (receipt.rules.length === 0) {
+    console.log('  No model says how long it keeps its records.');
+    console.log('');
+
+    return;
+  }
+
+  console.log(dryRun ? '  This sweep would:' : '  Swept:');
+
+  for (const rule of receipt.rules) {
+    const name = `${rule.model}${rule.rule === 'default' ? '' : `:${rule.rule}`}`;
+    const note = rule.failed
+      ? `failed: ${rule.failed}`
+      : rule.skipped || `${rule.written} written`;
+
+    console.log(
+      `    ${name.padEnd(28)} ${rule.action.padEnd(12)} ${String(
+        dryRun ? rule.would : rule.written
+      ).padStart(6)} of ${String(rule.matched).padStart(6)} past ${rule.cutoff}`
+    );
+    console.log(
+      `    ${''.padEnd(28)} ${note.padEnd(12)} ${rule.remaining} left for the next run, ${rule.waiting} waiting`
+    );
+  }
+
+  console.log('');
+
+  if (receipt.pending > 0) {
+    console.log(
+      `  ${receipt.pending} rule(s) wrote nothing: not approved. Run "henri retention" for their tokens.`
+    );
+    console.log('');
+  }
+
+  if (dryRun) {
+    console.log('  Nothing was written: add --yes to sweep for real.');
+  } else if (receipt.file) {
+    console.log(`  Receipt ${receipt.id}`);
+    console.log(`  Written to ${receipt.file}`);
+  } else {
+    console.log(
+      '  Not written: config.retention.receipts is false, keep what is above'
+    );
+  }
+
+  console.log('');
+};
+
+/**
+ * Runs `henri retention [map|sweep]` (`henri retention:<command>` too)
+ *
+ * @param {object} args CLI arguments
+ * @returns {Promise<void>} Resolves when done
+ * @throws {CliError} USAGE on an unknown command, NOT_A_PROJECT elsewhere
+ */
+const main = async (args) => {
+  const [command = 'map'] = args._;
+
+  if (!COMMANDS.includes(command)) {
+    if (!args.json) {
+      console.log(usage('retention'));
+    }
+
+    throw new CliError('USAGE', `Unknown retention command "${command}"`, {
+      hint: `Available commands: ${COMMANDS.join(', ')}`,
+    });
+  }
+
+  validInstall({ fatal: true });
+
+  const log = console.log;
+
+  // With --json stdout is the result only: the boot log goes to stderr
+  if (args.json) {
+    console.log = (...parts) => console.error(...parts);
+  }
+
+  let result;
+
+  try {
+    result = command === 'sweep' ? await sweep(args) : await map();
+  } finally {
+    console.log = log;
+  }
+
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else if (result.command === 'sweep') {
+    printSweep(result);
+  } else {
+    printMap(result);
+  }
+
+  // The drivers are closed by henri.stop(); leave nothing behind
+  process.exit(result.ok ? 0 : 1);
+};
+
+module.exports = main;
+module.exports.COMMANDS = COMMANDS;
+module.exports.map = map;
+module.exports.period = period;
+module.exports.sweep = sweep;

--- a/packages/cli/scripts/trail.js
+++ b/packages/cli/scripts/trail.js
@@ -1,0 +1,257 @@
+const { CliError } = require('./errors');
+const { usage } = require('./help');
+const { boot, validInstall } = require('./utils');
+
+/**
+ * `henri trail`: the append-only record of who read or changed personal
+ * data, read back.
+ *
+ * - `henri trail` prints the latest entries, filtered by `--action`,
+ *   `--model`, `--actor`, `--since` and `--until`.
+ * - `henri trail:about <who>` prints everything recorded about one person,
+ *   which is how "prove the erasure happened" is answered from an email
+ *   address alone -- the address itself is not in the table, its digest is.
+ * - `henri trail:verify` walks the hash chain and says whether a row was
+ *   edited or removed, and where.
+ *
+ * All three boot to runlevel 4: no port is bound and no route is
+ * registered. The work is `henri.trail` (`core/src/4.trail.js`).
+ */
+
+const COMMANDS = ['about', 'list', 'verify'];
+
+/** How many entries a listing prints unless `--limit` says */
+const LIMIT = 25;
+
+/**
+ * Runs one operation against a booted application and stops it again
+ *
+ * @param {function} work `(henri) => result`
+ * @returns {Promise<*>} What the work resolved with
+ */
+const withHenri = async (work) => {
+  const henri = await boot({ runlevel: 4 });
+
+  try {
+    return await work(henri);
+  } finally {
+    await henri.stop();
+  }
+};
+
+/**
+ * The filter the command line asked for
+ *
+ * @param {object} args CLI arguments
+ * @returns {object} The filter
+ */
+const filterOf = (args) => {
+  const text = (name) =>
+    typeof args[name] === 'string' && args[name] !== ''
+      ? args[name]
+      : undefined;
+
+  return {
+    action: text('action'),
+    actor: text('actor'),
+    limit: Number(args.limit) || LIMIT,
+    model: text('model'),
+    outcome: text('outcome'),
+    since: text('since'),
+    until: text('until'),
+  };
+};
+
+/**
+ * The latest entries
+ *
+ * @param {object} args CLI arguments
+ * @returns {Promise<object>} The result
+ */
+const list = async (args) => {
+  const filter = filterOf(args);
+  const entries = await withHenri((henri) => henri.trail.list(filter));
+
+  return { command: 'list', entries, filter, ok: true };
+};
+
+/**
+ * Everything recorded about one person
+ *
+ * @param {object} args CLI arguments
+ * @returns {Promise<object>} The result
+ * @throws {CliError} USAGE when nobody was named
+ */
+const about = async (args) => {
+  const [, who] = args._;
+
+  if (typeof who !== 'string' || who.trim() === '') {
+    throw new CliError('USAGE', 'henri trail:about needs a person', {
+      hint: 'henri trail:about someone@example.com (an external id works too)',
+    });
+  }
+
+  const filter = filterOf(args);
+  const entries = await withHenri((henri) =>
+    henri.trail.about(who.trim(), filter)
+  );
+
+  return { command: 'about', entries, filter, ok: true, who: who.trim() };
+};
+
+/**
+ * Whether the chain still holds
+ *
+ * @returns {Promise<object>} The result
+ */
+const verify = async () => {
+  const result = await withHenri((henri) => henri.trail.verify());
+
+  return { command: 'verify', ok: result.ok, ...result };
+};
+
+/**
+ * Prints a listing
+ *
+ * @param {object} result What list() or about() answered
+ * @returns {void}
+ */
+const printList = ({ command, entries, who }) => {
+  console.log('');
+
+  if (entries.length === 0) {
+    console.log(
+      command === 'about'
+        ? `  Nothing is recorded about ${who}.`
+        : '  The trail holds nothing matching that.'
+    );
+    console.log('');
+
+    return;
+  }
+
+  if (command === 'about') {
+    console.log(`  Everything recorded about ${who}`);
+    console.log('');
+  }
+
+  for (const entry of entries) {
+    console.log(
+      `  ${String(entry.seq).padStart(6)}  ${entry.at}  ${entry.action.padEnd(
+        18
+      )} ${entry.outcome.padEnd(8)} ${String(entry.records).padStart(6)} ${
+        entry.model || ''
+      }`
+    );
+
+    const notes = [
+      entry.actor ? `actor ${entry.actor}` : null,
+      entry.route,
+      entry.fields.length > 0 ? entry.fields.join(', ') : null,
+      entry.meta
+        ? Object.keys(entry.meta)
+            .map((key) => `${key}=${entry.meta[key]}`)
+            .join(' ')
+        : null,
+    ].filter(Boolean);
+
+    if (notes.length > 0) {
+      console.log(`  ${''.padStart(6)}  ${notes.join('  ')}`);
+    }
+  }
+
+  console.log('');
+};
+
+/**
+ * Prints a verification
+ *
+ * @param {object} result What verify() answered
+ * @returns {void}
+ */
+const printVerify = ({ broken, entries, from, ok, to }) => {
+  console.log('');
+
+  if (ok) {
+    console.log(
+      `  The chain holds: ${entries} entr${entries === 1 ? 'y' : 'ies'}${
+        from === null ? '' : `, seq ${from} to ${to}`
+      }`
+    );
+    console.log('');
+
+    return;
+  }
+
+  console.log(`  The chain is broken at seq ${broken.seq} (${broken.reason}).`);
+  console.log(
+    `  Everything up to seq ${broken.after === null ? '(nothing)' : broken.after} verifies.`
+  );
+  console.log('');
+  console.log(
+    '  A row was edited or removed. The trail is INSERT and SELECT only:'
+  );
+  console.log('  grant the application nothing else on this table.');
+  console.log('');
+};
+
+/**
+ * Runs `henri trail [list|about|verify]` (`henri trail:<command>` too)
+ *
+ * @param {object} args CLI arguments
+ * @returns {Promise<void>} Resolves when done
+ * @throws {CliError} USAGE on an unknown command, NOT_A_PROJECT elsewhere
+ */
+const main = async (args) => {
+  const [command = 'list'] = args._;
+
+  if (!COMMANDS.includes(command)) {
+    if (!args.json) {
+      console.log(usage('trail'));
+    }
+
+    throw new CliError('USAGE', `Unknown trail command "${command}"`, {
+      hint: `Available commands: ${COMMANDS.join(', ')}`,
+    });
+  }
+
+  validInstall({ fatal: true });
+
+  const log = console.log;
+
+  // With --json stdout is the result only: the boot log goes to stderr
+  if (args.json) {
+    console.log = (...parts) => console.error(...parts);
+  }
+
+  let result;
+
+  try {
+    if (command === 'about') {
+      result = await about(args);
+    } else if (command === 'verify') {
+      result = await verify();
+    } else {
+      result = await list(args);
+    }
+  } finally {
+    console.log = log;
+  }
+
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else if (result.command === 'verify') {
+    printVerify(result);
+  } else {
+    printList(result);
+  }
+
+  // The drivers are closed by henri.stop(); leave nothing behind
+  process.exit(result.ok ? 0 : 1);
+};
+
+module.exports = main;
+module.exports.COMMANDS = COMMANDS;
+module.exports.about = about;
+module.exports.list = list;
+module.exports.verify = verify;

--- a/packages/cli/scripts/utils.js
+++ b/packages/cli/scripts/utils.js
@@ -349,6 +349,45 @@ const helpHeader = () =>
   `;
 
 /**
+ * Prefer the `@usehenri/core` the project depends on, and fall back to the
+ * one shipped with this CLI
+ *
+ * @returns {string} Resolved path of the Henri class
+ */
+const resolveHenri = () => {
+  try {
+    return require.resolve('@usehenri/core/src/henri', {
+      paths: [process.cwd()],
+    });
+  } catch {
+    return require.resolve('@usehenri/core/src/henri');
+  }
+};
+
+/**
+ * Boots the application to a runlevel, without a port.
+ *
+ * Runlevel 4 is what `henri db:seed`, `henri jobs`, `henri privacy`,
+ * `henri retention` and `henri trail` all boot to: the models and the user
+ * module are there, no route is registered and nothing is listening.
+ *
+ * @param {object} [options={}] Options
+ * @param {number} [options.runlevel=4] How far up to boot
+ * @returns {Promise<object>} The henri instance
+ */
+const boot = async ({ runlevel = 4 } = {}) => {
+  process.env.SKIP_WORKERS = 'true';
+  process.env.CONSOLE_ONLY = 'true';
+
+  const Henri = require(resolveHenri());
+  const henri = new Henri({ runlevel });
+
+  await henri.init();
+
+  return henri;
+};
+
+/**
  * Formats code with prettier using the henri house style
  *
  * @param {string} code Source code
@@ -425,6 +464,7 @@ module.exports = {
   PACKAGE_MANAGERS,
   RENDERERS,
   abort,
+  boot,
   capitalize,
   check,
   commands,
@@ -441,6 +481,7 @@ module.exports = {
   readRoutes,
   rendererOf,
   resolveFrom,
+  resolveHenri,
   resolvePackageJson,
   validInstall,
   version,

--- a/packages/core/error-codes.json
+++ b/packages/core/error-codes.json
@@ -42,12 +42,20 @@
       "what": "the personal data marked in the models, the export of one person and the erasure of them"
     },
     {
+      "area": "retention",
+      "what": "how long the models say they keep their records, and the sweep that enforces it"
+    },
+    {
       "area": "route",
       "what": "config/routes.js and the router"
     },
     {
       "area": "store",
       "what": "the store adapters: loading them, starting them, talking to them"
+    },
+    {
+      "area": "trail",
+      "what": "the append-only record of who read or changed personal data"
     },
     {
       "area": "user",
@@ -893,6 +901,40 @@
       "what": "The person an export or an erasure was asked about does not exist."
     },
     {
+      "area": "retention",
+      "causes": [
+        "the store adapter is not mongoose, sequelize or drizzle",
+        "the sweep was called on models that are not attached to a connection"
+      ],
+      "code": "HENRI_RETENTION_ADAPTER_UNSUPPORTED",
+      "fix": "The sweep goes through the model API of the three adapters henri ships. Boot the application before sweeping, and use one of them for the models that declare a rule.",
+      "what": "A retention sweep reached a model whose adapter henri cannot drive."
+    },
+    {
+      "area": "retention",
+      "causes": [
+        "`options.retention` is not an object or a list of them",
+        "`after` cannot be read as a period, or is under a minute",
+        "`from` names a field that is not a date on that model",
+        "`action: 'soft-delete'` on a model that is not `paranoid`",
+        "`action: 'anonymize'` on a model that marks no field personal",
+        "two rules of one model share a name"
+      ],
+      "code": "HENRI_RETENTION_INVALID_RULE",
+      "fix": "A rule is `{ after, action, from, where, name }`, where `after` is a period (`'90d'`, `'18mo'`, `'2y'`), `action` is `delete`, `soft-delete` or `anonymize`, and `from` is a date column of the model. The boot fails rather than sweeping under a rule henri cannot carry out.",
+      "what": "A model declares a retention rule henri cannot carry out."
+    },
+    {
+      "area": "retention",
+      "causes": [
+        "`config.retention.receipts` points at a directory this process may not write",
+        "the disk is full"
+      ],
+      "code": "HENRI_RETENTION_RECEIPT_UNWRITABLE",
+      "fix": "The sweep happened; only its receipt could not be written. Make the directory writable, point `config.retention.receipts` somewhere else, or set it to `false` and keep what the command printed.",
+      "what": "A retention sweep ran and its receipt could not be written."
+    },
+    {
       "area": "route",
       "causes": [
         "a stray space in the route (`'tasks #index'`)",
@@ -988,6 +1030,58 @@
       "code": "HENRI_STORE_URL_MISSING",
       "fix": "Set `stores.<name>.url`, or the `host`, `port`, `database`, `username` and `password` the adapter assembles one from. `DATABASE_URL` sets `stores.default.url`.",
       "what": "A store has nothing to connect to."
+    },
+    {
+      "area": "trail",
+      "causes": [
+        "`config.trail` is absent or false",
+        "the trail could not be started"
+      ],
+      "code": "HENRI_TRAIL_DISABLED",
+      "fix": "Turn the trail on with `\"trail\": {}` in `config/<env>.json`; henri creates its table on the next boot. Recording is a no-op while it is off, but reading it back says so rather than answering with nothing.",
+      "what": "The access trail was read back and this application keeps none."
+    },
+    {
+      "area": "trail",
+      "causes": [
+        "`henri.trail.record()` was called without an action",
+        "the action is longer than 64 characters"
+      ],
+      "code": "HENRI_TRAIL_INVALID_EVENT",
+      "fix": "An entry needs an action: what happened, as one dotted name. An application's own are prefixed `app.` (`henri.trail.record({ action: 'app.exported' })`).",
+      "what": "A trail entry was appended without saying what happened."
+    },
+    {
+      "area": "trail",
+      "causes": [
+        "`config.trail.store` names a store this application does not have",
+        "the store adapter has neither `query()` nor a MongoDB connection",
+        "the MongoDB store is not connected"
+      ],
+      "code": "HENRI_TRAIL_UNSUPPORTED_STORE",
+      "fix": "The trail owns a table in one of the application's stores. Point `config.trail.store` at a store backed by mongoose, sequelize or drizzle, or leave `config.trail` out to keep no trail at all.",
+      "what": "The access trail cannot be kept in the store it was pointed at."
+    },
+    {
+      "area": "trail",
+      "causes": [
+        "another writer keeps winning the unique index on `seq`",
+        "the unique index on `seq` is missing, so the chain cannot be numbered"
+      ],
+      "code": "HENRI_TRAIL_UNWRITABLE",
+      "fix": "The entry chains onto the head of the trail, so it re-reads the head when another process got there first. Check that the unique index on `seq` exists (henri creates it at boot) and that nothing else writes to the table.",
+      "what": "A trail entry could not be appended after every attempt to chain it."
+    },
+    {
+      "area": "trail",
+      "causes": [
+        "a `meta` key is a field the models marked personal",
+        "a `meta` key is masked by `config.filterParameters`",
+        "a `meta` value is not a short scalar, or looks like an email address"
+      ],
+      "code": "HENRI_TRAIL_VALUE_REFUSED",
+      "fix": "The trail holds field names, counts and public identifiers, never the values behind them: a record of who read personal data must not become a second copy of it. Record the name and the count, and name a person with `subject`, which henri digests.",
+      "what": "Something tried to record a value in the access trail."
     },
     {
       "area": "user",

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -695,6 +695,10 @@ declare namespace start {
     /** Parameter names masked in the logs; `false` masks nothing. */
     filterParameters?: string[] | false;
     privacy?: PrivacyConfig;
+    /** How long the models keep their records, and what sweeps them. */
+    retention?: RetentionConfig;
+    /** The access trail; absent or `false` keeps none. */
+    trail?: false | TrailConfig;
     /** Maximum size of a JSON or form body (`"1mb"`). */
     bodyLimit?: string | number;
     /**
@@ -730,6 +734,64 @@ declare namespace start {
      * `false` keeps none beyond what the command printed.
      */
     receipts?: string | false;
+  }
+
+  /**
+   * `config.retention`: what runs the retention sweep, and what it is
+   * allowed to do. How long a model keeps its records is said in the model
+   * itself (`options: { retention }`).
+   */
+  interface RetentionConfig {
+    /**
+     * Whether a rule has to be approved before it writes anything
+     * (`true`). A rule that is not in `approved` is planned, counted and
+     * reported, and it writes nothing.
+     */
+    approve?: boolean;
+    /**
+     * The tokens of the approved rules (`"Proposal:drafts:9f3c1a2b4d5e"`).
+     * `henri retention` prints them; a rule whose terms change gets a new
+     * one and is pending again.
+     */
+    approved?: string[];
+    /**
+     * How many records one rule may take in one sweep (`1000`); `false`
+     * lifts the bound. What is left over is reported and taken next run.
+     */
+    batch?: number | false;
+    /**
+     * Where a sweep writes the proof that it ran (`"privacy"`); `false`
+     * keeps none beyond what the command printed.
+     */
+    receipts?: string | false;
+    /**
+     * A cron expression (`"0 3 * * *"`) or an interval (`"1d"`) the
+     * `henri/retention` job runs on; needs `@usehenri/jobs`. `false` (the
+     * default) means the sweep is run by `henri retention:sweep`.
+     */
+    schedule?: string | false;
+  }
+
+  /**
+   * `config.trail`: the append-only record of who read or changed personal
+   * data. Absent (or `false`) keeps none, and no table is created.
+   */
+  interface TrailConfig {
+    /**
+     * How long an entry is kept (`"1y"`); `false` keeps them forever. A
+     * trail of who touched personal data is itself personal data.
+     */
+    keep?: string | number | false;
+    /**
+     * Which reads are recorded: `"personal"` for the answers carrying a
+     * model with a personal field, `"all"` for every answer henri
+     * serializes, `false` (the default) for none.
+     */
+    reads?: 'all' | 'personal' | false;
+    /** Which of `config.stores` the table lives in (`"default"`). */
+    store?: string;
+    /** The table henri creates and appends to (`"henri_trail"`). */
+    table?: string;
   }
 
   /**
@@ -1950,6 +2012,205 @@ declare namespace start {
     ): Promise<ErasureReceipt>;
   }
 
+  /** One retention rule of one model, as `henri retention` prints it. */
+  interface RetentionRule {
+    model: string;
+    /** The name of the rule (`"default"` for a model's only one). */
+    rule: string;
+    action: 'anonymize' | 'delete' | 'soft-delete';
+    /** How long the records are kept, in milliseconds. */
+    after: number;
+    /** The date column the clock starts on. */
+    from: string;
+    /** The condition picking the class of records this rule is about. */
+    where: Record<string, unknown>;
+    /** `Model:rule:<digest>`, what `config.retention.approved` holds. */
+    token: string;
+    approved: boolean;
+  }
+
+  /** What one rule did, or would do, in a sweep. */
+  interface RetentionStep {
+    model: string;
+    rule: string;
+    action: 'anonymize' | 'delete' | 'soft-delete';
+    /** The moment a record has to be older than. */
+    cutoff: string;
+    /** How many records are past it. */
+    matched: number;
+    /** How many the batch allows this run. */
+    would: number;
+    /** How many were actually written. */
+    written: number;
+    /** What the next run will find. */
+    remaining: number;
+    /** Records whose `from` column is null: their clock never started. */
+    waiting: number;
+    /** The fields an `anonymize` writes over. */
+    fields: string[];
+    /** Up to twenty public identifiers, as a sample and never an index. */
+    sample: string[];
+    token: string;
+    /** Why nothing was written: `"not approved"`, `"dry run"`, a problem. */
+    skipped?: string | null;
+    /** The message of the failure, when the rule threw. */
+    failed?: string;
+  }
+
+  /** What a retention sweep leaves behind as proof that it ran. */
+  interface RetentionReceipt {
+    version: number;
+    id: string;
+    at: string;
+    application: string | null;
+    dryRun: boolean;
+    /** True when a rule threw: the others still ran. */
+    interrupted: boolean;
+    /** How many rules wrote nothing because nobody approved them. */
+    pending: number;
+    rules: RetentionStep[];
+    /** Where the receipt was written, relative to the application. */
+    file?: string | null;
+  }
+
+  /**
+   * `henri.retention`: how long each model keeps its records, and the sweep
+   * that enforces it.
+   */
+  interface RetentionModule {
+    name: 'retention';
+    /** `config.retention`, normalized. */
+    settings: {
+      approve: boolean;
+      approved: string[];
+      batch: number | false;
+      receipts: string | false;
+      schedule: string | false;
+    };
+    /** Every rule of every model, each with its token. */
+    rules: Array<Omit<RetentionRule, 'approved'>>;
+    /** The rules and the settings, as data: what `henri retention` prints. */
+    describe(): {
+      rules: RetentionRule[];
+      settings: RetentionModule['settings'];
+    };
+    /** What a sweep would do, without doing it. */
+    plan(options?: { only?: string; now?: Date | string | number }): Promise<{
+      at: string;
+      pending: number;
+      steps: Array<Record<string, unknown>>;
+      problems: Array<{ model: string; problem: string; message: string }>;
+    }>;
+    /** Sweeps every rule, writes the receipt and records what happened. */
+    sweep(options?: {
+      only?: string;
+      now?: Date | string | number;
+      dryRun?: boolean;
+      source?: 'app' | 'cli' | 'http' | 'job';
+    }): Promise<RetentionReceipt>;
+  }
+
+  /** One entry of the access trail. */
+  interface TrailEntry {
+    id: string;
+    /** One more than the entry before it, under a unique index. */
+    seq: number;
+    at: string;
+    /** `privacy.export`, `retention.sweep`, `record.read`, `app.<yours>`. */
+    action: string;
+    outcome: 'ok' | 'refused' | 'failed';
+    source: 'app' | 'cli' | 'http' | 'job';
+    model: string | null;
+    records: number;
+    /** Field *names*, never values. */
+    fields: string[];
+    /** Public identifiers of the records the entry is about. */
+    ids: string[];
+    /** The `externalId` of whoever did it. */
+    actor: string | null;
+    actorDigest: string | null;
+    /** The `externalId` of the person the data is about. */
+    subject: string | null;
+    /** HMAC of that person's address, keyed with `config.secret`. */
+    subjectDigest: string | null;
+    requestId: string | null;
+    route: string | null;
+    /** Names and counts that passed the guard; never a value. */
+    meta: Record<string, string | number | boolean | null> | null;
+    /** The hash of the entry before it. */
+    prev: string | null;
+    hash: string;
+  }
+
+  /**
+   * `henri.trail`: the append-only record of who read or changed personal
+   * data. Off unless `config.trail` says otherwise.
+   */
+  interface TrailModule {
+    name: 'trail';
+    /** `config.trail`, normalized. */
+    settings: {
+      enabled: boolean;
+      keep: number | null;
+      reads: 'all' | 'personal' | false;
+      store: string;
+      table: string;
+    };
+    /** Whether anything is being recorded. */
+    enabled: boolean;
+    /**
+     * Appends one entry. A disabled trail answers `null` and does nothing;
+     * a `meta` holding something personal is refused.
+     */
+    record(event: {
+      action: string;
+      model?: string;
+      records?: number;
+      fields?: string[];
+      ids?: Array<string | null>;
+      actor?: string | null;
+      subject?: string | null;
+      outcome?: 'ok' | 'refused' | 'failed';
+      source?: 'app' | 'cli' | 'http' | 'job';
+      route?: string | null;
+      requestId?: string | null;
+      meta?: Record<string, string | number | boolean | null>;
+    }): Promise<TrailEntry | null>;
+    /** The entries matching a filter, newest first. */
+    list(filter?: {
+      action?: string;
+      model?: string;
+      actor?: string;
+      subject?: string;
+      digest?: string;
+      outcome?: string;
+      since?: Date | string | number;
+      until?: Date | string | number;
+      limit?: number;
+      offset?: number;
+    }): Promise<TrailEntry[]>;
+    count(filter?: Record<string, unknown>): Promise<number>;
+    /** Everything recorded about one person. */
+    about(
+      who: string | object,
+      filter?: Record<string, unknown>
+    ): Promise<TrailEntry[]>;
+    /** Walks the chain and says where, if anywhere, it parts company. */
+    verify(): Promise<{
+      ok: boolean;
+      entries: number;
+      from: number | null;
+      to: number | null;
+      broken: { seq: number; reason: string; after: number | null } | null;
+    }>;
+    /** Takes the entries past `config.trail.keep` away, and checkpoints. */
+    prune(options?: { now?: number }): Promise<{
+      removed: number;
+      before: number | null;
+      checkpoint: TrailEntry | null;
+    }>;
+  }
+
   /** `henri.model`. */
   interface ModelModule {
     name: 'model';
@@ -2404,6 +2665,10 @@ declare namespace start {
     policies: PoliciesModule;
     /** The fields the models marked `personal`, and what follows from it. */
     privacy: PrivacyModule;
+    /** How long the models keep their records, and the sweep that runs. */
+    retention: RetentionModule;
+    /** The append-only record of who read or changed personal data. */
+    trail: TrailModule;
     /**
      * The queue, when the application depends on `@usehenri/jobs`. It is
      * `undefined` when it does not -- core carries no queue of its own --

--- a/packages/core/src/3.privacy.js
+++ b/packages/core/src/3.privacy.js
@@ -302,14 +302,57 @@ class Privacy extends BaseModule {
    *
    * @async
    * @param {(string|object)} who The person
+   * @param {object} [options={}] `source`, for the trail entry
    * @returns {Promise<object>} The export document
    * @memberof Privacy
    */
-  async export(who) {
+  async export(who, options = {}) {
     const context = this.context();
     const subject = await this.subject(who);
+    const document = await exportOf(context, subject);
 
-    return exportOf(context, subject);
+    await this.tell(subject, {
+      action: 'privacy.export',
+      meta: { models: Object.keys(document.records).length },
+      records: Object.values(document.counts).reduce(
+        (total, count) => total + count,
+        0
+      ),
+      source: options.source,
+    });
+
+    return document;
+  }
+
+  /**
+   * Records one operation in the access trail, when there is one.
+   *
+   * Every operation of this module goes through here, including the ones
+   * that were refused: an application asked to prove an erasure happened
+   * has to be able to show the attempts as well as the successes.
+   *
+   * @async
+   * @param {object} subject The person, as a plain object
+   * @param {object} event The entry
+   * @returns {Promise<?object>} The entry, or null
+   * @memberof Privacy
+   */
+  async tell(subject, event) {
+    const { trail } = this.henri;
+
+    if (!trail || !trail.enabled) {
+      return null;
+    }
+
+    const named = trail.identify(subject);
+
+    return trail.record({
+      model: this.subjectModel,
+      outcome: 'ok',
+      source: 'app',
+      ...named,
+      ...event,
+    });
   }
 
   /**
@@ -341,9 +384,43 @@ class Privacy extends BaseModule {
   async erase(who, options = {}) {
     const context = this.context();
     const subject = await this.subject(who);
-    const receipt = await eraseOf(context, subject, options);
+    let receipt;
+
+    try {
+      receipt = await eraseOf(context, subject, options);
+    } catch (error) {
+      // A refusal is written down too: "we were asked and we said no" is
+      // part of the record, and an entry that only ever appears on success
+      // is not evidence of anything
+      await this.tell(subject, {
+        action: 'privacy.erase',
+        meta: {
+          dryRun: options.dryRun === true,
+          reason: error.code || 'refused',
+        },
+        outcome: 'refused',
+        source: options.source,
+      });
+
+      throw error;
+    }
 
     receipt.file = options.dryRun ? null : this.record(receipt);
+
+    await this.tell(subject, {
+      action: 'privacy.erase',
+      ids: receipt.records.flatMap((entry) => entry.ids).filter(Boolean),
+      meta: {
+        dryRun: receipt.dryRun,
+        receipt: receipt.id,
+        strategy: options.strategy || this.settings.onErase,
+      },
+      records: receipt.records.reduce(
+        (total, entry) => total + entry.written,
+        0
+      ),
+      source: options.source,
+    });
 
     this.henri.pen.info(
       'privacy',

--- a/packages/core/src/4.retention.js
+++ b/packages/core/src/4.retention.js
@@ -1,0 +1,351 @@
+const BaseModule = require('./base/module');
+
+const fs = require('fs');
+const path = require('path');
+const debug = require('debug')('henri:retention');
+const { randomUUID } = require('node:crypto');
+
+const { fail } = require('./base/errors');
+const { PACKAGE } = require('./base/jobs');
+const {
+  planOf,
+  retentionConfig,
+  rulesOf,
+  sweepOf,
+} = require('./base/retention');
+
+/** The name of the job that sweeps, when the application has the queue */
+const JOB = 'henri/retention';
+
+/**
+ * Retention: `henri.retention`, how long each model keeps its records and
+ * the sweep that enforces it.
+ *
+ * The design -- the three verbs, the clock a rule is measured from, what
+ * proves a sweep ran and the two things standing between a wrong rule and a
+ * deleted table -- is in the header of `base/retention.js`. This is the
+ * module: it reads the rules out of the models at boot, says at boot what is
+ * going to run them (and, more usefully, what is not), and carries the
+ * sweep.
+ *
+ * The sweep needs nothing installed. `@usehenri/jobs` is one way to run it
+ * and `henri retention:sweep` from cron is the other, so an application
+ * without the queue is never quietly left with rules nobody applies: the
+ * boot line names the command.
+ *
+ * @class Retention
+ * @extends {BaseModule}
+ */
+class Retention extends BaseModule {
+  /**
+   * Creates an instance of Retention.
+   * @memberof Retention
+   */
+  constructor() {
+    super();
+
+    this.reloadable = true;
+    // The rules are read from the model files, and `anonymize` writes what
+    // the privacy map says is personal
+    this.needs = ['config', 'model', 'privacy'];
+    // A sweep is recorded in the trail when there is one
+    this.after = ['trail', 'jobs'];
+    this.runlevel = 4;
+    this.name = 'retention';
+    this.henri = null;
+
+    /** `config.retention`, normalized */
+    this.settings = retentionConfig(null);
+    /** The rules of every model, each with its token */
+    this.rules = [];
+
+    this.init = this.init.bind(this);
+    this.reload = this.reload.bind(this);
+    this.plan = this.plan.bind(this);
+    this.sweep = this.sweep.bind(this);
+
+    debug('constructor initialized');
+  }
+
+  /**
+   * Module initialization: reads the rules and says what runs them
+   *
+   * @async
+   * @returns {Promise<string>} the name of the module
+   * @throws HENRI_RETENTION_INVALID_RULE when a model declares a rule that
+   *   cannot be carried out
+   * @memberof Retention
+   */
+  async init() {
+    const { config, pen } = this.henri;
+
+    this.settings = retentionConfig(config);
+    this.rules = rulesOf((this.henri.model && this.henri.model.models) || [], {
+      fields: (name) => this.henri.privacy.fields(name),
+    });
+
+    if (this.rules.length === 0) {
+      debug('no model declares a retention rule');
+
+      return this.name;
+    }
+
+    const pending = this.rules.filter(
+      (rule) =>
+        this.settings.approve && !this.settings.approved.includes(rule.token)
+    );
+
+    pen.info(
+      'retention',
+      `${this.rules.length} rule${this.rules.length === 1 ? '' : 's'}`,
+      this.schedule(),
+      pending.length > 0
+        ? `${pending.length} not approved: they plan and write nothing`
+        : ''
+    );
+
+    return this.name;
+  }
+
+  /**
+   * Registers the recurring sweep with the queue, and answers with what a
+   * person reading the boot log needs to know.
+   *
+   * This is the one place that says out loud what an application is not
+   * getting: without `@usehenri/jobs` there is no schedule, and the line
+   * names the command a cron entry would run instead. A rule that nothing
+   * applies is a promise nobody keeps.
+   *
+   * @returns {string} what runs the sweep, in words
+   * @memberof Retention
+   */
+  schedule() {
+    const { jobs } = this.henri;
+    const spec = this.settings.schedule;
+
+    if (spec === false) {
+      return 'nothing runs them (retention.schedule is off): henri retention:sweep --yes';
+    }
+
+    if (!jobs || !jobs.enabled || typeof jobs.recur !== 'function') {
+      return `nothing runs them here: ${PACKAGE} is not part of this boot, so cron runs "henri retention:sweep --yes"`;
+    }
+
+    // A cron expression has fields and therefore spaces; anything else is
+    // an interval (`'1d'`), which is the queue's other way of saying when
+    jobs.recur(JOB, {
+      job: JOB,
+      ...(/\s/u.test(spec) ? { cron: spec } : { every: spec }),
+    });
+
+    return `swept by ${JOB} (${spec})`;
+  }
+
+  /**
+   * Rebuilds the rules after a reload of the models
+   *
+   * @async
+   * @returns {Promise<string>} the name of the module
+   * @memberof Retention
+   */
+  async reload() {
+    return this.init();
+  }
+
+  /**
+   * The context a plan and a sweep run in
+   *
+   * @returns {object} `{ application, fieldsOf, modelOf, rules, settings }`
+   * @memberof Retention
+   */
+  context() {
+    return {
+      application: this.applicationName(),
+      fieldsOf: (name) => this.henri.privacy.fields(name),
+      modelOf: (name) => this.henri.privacy.modelOf(name),
+      rules: this.rules,
+      settings: this.settings,
+    };
+  }
+
+  /**
+   * The name of the application, for the receipts it produces
+   *
+   * @returns {?string} the name from its package.json, or null
+   * @memberof Retention
+   */
+  applicationName() {
+    try {
+      return require(path.join(this.henri.cwd(), 'package.json')).name || null;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  /**
+   * The rules, as data: what `henri retention` prints
+   *
+   * @returns {object} the rules and the settings
+   * @memberof Retention
+   */
+  describe() {
+    return {
+      rules: this.rules.map((rule) => ({
+        action: rule.action,
+        after: rule.after,
+        approved:
+          !this.settings.approve || this.settings.approved.includes(rule.token),
+        from: rule.from,
+        model: rule.model,
+        rule: rule.name,
+        token: rule.token,
+        where: rule.where,
+      })),
+      settings: this.settings,
+    };
+  }
+
+  /**
+   * What a sweep would do, without doing it
+   *
+   * @async
+   * @param {object} [options={}] `only`, `now`
+   * @returns {Promise<object>} the plan
+   * @memberof Retention
+   */
+  async plan(options = {}) {
+    return planOf(this.context(), options);
+  }
+
+  /**
+   * Sweeps every rule, writes the receipt and records what happened
+   *
+   * @async
+   * @param {object} [options={}] `only`, `now`, `dryRun`
+   * @returns {Promise<object>} the receipt, with the file it was written to
+   * @memberof Retention
+   */
+  async sweep(options = {}) {
+    const receipt = await sweepOf(this.context(), options);
+
+    receipt.id = randomUUID();
+    receipt.file = options.dryRun ? null : this.write(receipt);
+
+    await this.tell(receipt, options);
+
+    const swept = receipt.rules.reduce(
+      (total, rule) => total + rule.written,
+      0
+    );
+
+    this.henri.pen.info(
+      'retention',
+      options.dryRun ? 'sweep (dry run)' : 'swept',
+      `${swept} record(s) over ${receipt.rules.length} rule(s)`,
+      receipt.file || ''
+    );
+
+    return receipt;
+  }
+
+  /**
+   * Records one entry per rule in the trail, and prunes the trail itself:
+   * the sweep that enforces every other retention enforces the trail's too
+   *
+   * @async
+   * @param {object} receipt the receipt
+   * @param {object} options the options of the sweep
+   * @returns {Promise<void>} resolves when recorded
+   * @memberof Retention
+   */
+  async tell(receipt, options) {
+    const { trail } = this.henri;
+
+    if (!trail || !trail.enabled) {
+      return;
+    }
+
+    for (const rule of receipt.rules) {
+      await trail.record({
+        action: 'retention.sweep',
+        fields: rule.fields,
+        ids: rule.sample,
+        meta: {
+          action: rule.action,
+          cutoff: rule.cutoff,
+          dryRun: receipt.dryRun,
+          matched: rule.matched,
+          remaining: rule.remaining,
+          rule: rule.rule,
+          skipped: rule.skipped,
+          token: rule.token,
+          waiting: rule.waiting,
+        },
+        model: rule.model,
+        outcome: this.outcome(rule),
+        records: rule.written,
+        source: options.source || 'app',
+      });
+    }
+
+    if (!receipt.dryRun) {
+      await trail.prune();
+    }
+  }
+
+  /**
+   * How one rule of a receipt ended
+   *
+   * @param {object} rule one rule of a receipt
+   * @returns {string} `ok`, `refused` or `failed`
+   * @memberof Retention
+   */
+  outcome(rule) {
+    if (rule.failed) {
+      return 'failed';
+    }
+
+    return rule.skipped && rule.skipped !== 'dry run' ? 'refused' : 'ok';
+  }
+
+  /**
+   * Writes a receipt where `config.retention.receipts` says
+   *
+   * @param {object} receipt the receipt
+   * @returns {?string} the path it was written to, or null
+   * @throws HENRI_RETENTION_RECEIPT_UNWRITABLE when it cannot be written
+   * @memberof Retention
+   */
+  write(receipt) {
+    const { receipts } = this.settings;
+
+    if (receipts === false) {
+      return null;
+    }
+
+    const folder = path.resolve(this.henri.cwd(), receipts);
+    const stamp = receipt.at.replace(/[:.]/gu, '-');
+    const file = path.join(folder, `retention-${stamp}-${receipt.id}.json`);
+
+    try {
+      fs.mkdirSync(folder, { recursive: true });
+      fs.writeFileSync(file, `${JSON.stringify(receipt, null, 2)}\n`);
+    } catch (error) {
+      const failure = fail(
+        'HENRI_RETENTION_RECEIPT_UNWRITABLE',
+        `the sweep ran and its receipt could not be written to ${file}: ${error.message}`,
+        { cause: error }
+      );
+
+      failure.hint =
+        'Make the directory writable, point config.retention.receipts elsewhere, or set it to false and keep the receipt the command printed';
+
+      throw failure;
+    }
+
+    return path.relative(this.henri.cwd(), file);
+  }
+}
+
+module.exports = Retention;
+module.exports.JOB = JOB;

--- a/packages/core/src/4.trail.js
+++ b/packages/core/src/4.trail.js
@@ -1,0 +1,484 @@
+const BaseModule = require('./base/module');
+
+const debug = require('debug')('henri:trail');
+
+const { fail } = require('./base/errors');
+const { userConfig } = require('./base/auth');
+const { EXTERNAL_ID } = require('./base/external-id');
+const { storeFor } = require('./base/trail-store');
+const {
+  CHECKPOINT,
+  appendTo,
+  digestOf,
+  toEntry,
+  trailConfig,
+  verifyChain,
+} = require('./base/trail');
+
+/**
+ * The access trail: `henri.trail`, the append-only record of who read or
+ * changed personal data.
+ *
+ * The design -- what is recorded, what it must never hold, and how a table
+ * anyone can `UPDATE` is still evidence -- is in the header of
+ * `base/trail.js`. This is the module: it owns the table, appends, reads
+ * back, verifies the chain and prunes.
+ *
+ * It is off unless `config.trail` says otherwise, and off means off: no
+ * table is created, no statement is issued, and `henri.trail.enabled` is
+ * false. Every caller inside core goes through `record()`, which is a no-op
+ * on a disabled trail, so nothing in the framework has to ask first.
+ *
+ * @class Trail
+ * @extends {BaseModule}
+ */
+class Trail extends BaseModule {
+  /**
+   * Creates an instance of Trail.
+   * @memberof Trail
+   */
+  constructor() {
+    super();
+
+    this.reloadable = true;
+    // The models are where the table lives, and the privacy map is what
+    // says which names must never reach it
+    this.needs = ['config', 'model'];
+    this.after = ['privacy'];
+    // The router records the reads, and the router is 5
+    this.before = ['router'];
+    this.runlevel = 4;
+    this.name = 'trail';
+    this.henri = null;
+
+    /** `config.trail`, normalized */
+    this.settings = trailConfig(null);
+    /** Whether anything is being recorded */
+    this.enabled = false;
+    /** The backend (`base/trail-store.js`), or null */
+    this.store = null;
+
+    this.init = this.init.bind(this);
+    this.reload = this.reload.bind(this);
+    this.record = this.record.bind(this);
+    this.list = this.list.bind(this);
+    this.about = this.about.bind(this);
+    this.verify = this.verify.bind(this);
+    this.prune = this.prune.bind(this);
+    this.seen = this.seen.bind(this);
+
+    debug('constructor initialized');
+  }
+
+  /**
+   * Module initialization: prepares the table when the trail is on
+   *
+   * @async
+   * @returns {Promise<string>} the name of the module
+   * @throws HENRI_TRAIL_UNSUPPORTED_STORE when the store cannot hold it
+   * @memberof Trail
+   */
+  async init() {
+    const { config, pen } = this.henri;
+
+    this.settings = trailConfig(config);
+
+    if (!this.settings.enabled) {
+      debug('no config.trail: nothing is recorded');
+
+      return this.name;
+    }
+
+    const stores = (this.henri.model && this.henri.model.stores) || {};
+    const adapter = stores[this.settings.store];
+
+    if (!adapter) {
+      throw fail(
+        'HENRI_TRAIL_UNSUPPORTED_STORE',
+        `config.trail.store names "${this.settings.store}", which is not one of this application's stores`
+      );
+    }
+
+    this.store = storeFor(adapter, this.settings.table);
+
+    await this.store.install();
+
+    this.enabled = true;
+
+    pen.info(
+      'trail',
+      `appending to ${this.settings.table}`,
+      this.settings.reads
+        ? `${this.settings.reads} reads recorded`
+        : 'privacy operations only'
+    );
+
+    return this.name;
+  }
+
+  /**
+   * Rebuilds the module after a reload
+   *
+   * @async
+   * @returns {Promise<string>} the name of the module
+   * @memberof Trail
+   */
+  async reload() {
+    this.enabled = false;
+    this.store = null;
+
+    return this.init();
+  }
+
+  /**
+   * What `guard()` checks a `meta` against: the personal field names and
+   * the parameters masked in every log line
+   *
+   * @returns {object} `{ filters, keys, secret }`
+   * @memberof Trail
+   */
+  context() {
+    const { config, privacy } = this.henri;
+    const filters = config.has('filterParameters')
+      ? config.get('filterParameters')
+      : [];
+
+    return {
+      filters: Array.isArray(filters) ? filters : [],
+      keys: (privacy && privacy.keys) || new Set(),
+      secret: config.has('secret') ? config.get('secret') : '',
+    };
+  }
+
+  /**
+   * How an entry names a person: their public identifier when they have
+   * one, and a digest of the address, which is what makes "was this person
+   * erased" answerable from an address alone.
+   *
+   * The digest covers the subject model and the lowercased address, and
+   * nothing else -- deliberately not the primary key, which whoever asks
+   * the question does not have.
+   *
+   * @param {*} who a record, an email address or an external id
+   * @returns {{subject: ?string, subjectDigest: ?string}} how to name them
+   * @memberof Trail
+   */
+  identify(who) {
+    const { secret } = this.context();
+    const model =
+      (this.henri.privacy && this.henri.privacy.subjectModel) ||
+      userConfig(this.henri.config).model;
+    const digest = (email) =>
+      email
+        ? digestOf(`${model}\n${String(email).toLowerCase()}`, secret)
+        : null;
+
+    if (who && typeof who === 'object') {
+      const external = who[EXTERNAL_ID] || null;
+
+      return {
+        subject: typeof external === 'string' ? external : null,
+        subjectDigest: digest(who.email),
+      };
+    }
+
+    if (typeof who !== 'string' || who === '') {
+      return { subject: null, subjectDigest: null };
+    }
+
+    return {
+      subject: who.includes('@') ? null : who,
+      subjectDigest: who.includes('@') ? digest(who) : null,
+    };
+  }
+
+  /**
+   * Appends one entry.
+   *
+   * A disabled trail answers null and does nothing, which is what lets core
+   * call it from everywhere without a guard. A failure to append is *not*
+   * swallowed: something that records who touched personal data has to say
+   * when it could not.
+   *
+   * @async
+   * @param {object} event `action`, `model`, `records`, `fields`, `ids`,
+   *   `actor`, `subject`, `outcome`, `source`, `route`, `requestId`, `meta`
+   * @returns {Promise<?object>} the entry, or null when the trail is off
+   * @throws HENRI_TRAIL_VALUE_REFUSED when the meta holds something personal
+   * @memberof Trail
+   */
+  async record(event) {
+    if (!this.enabled || !this.store) {
+      return null;
+    }
+
+    return appendTo(this.store, event, this.context());
+  }
+
+  /**
+   * Appends an entry about one request, filling in what the request knows
+   *
+   * @async
+   * @param {object} req the request
+   * @param {object} event the entry
+   * @returns {Promise<?object>} the entry, or null
+   * @memberof Trail
+   */
+  async records(req, event) {
+    if (!this.enabled || !this.store) {
+      return null;
+    }
+
+    const user = (req && req.user) || null;
+
+    return this.record({
+      actor: user ? user[EXTERNAL_ID] || null : null,
+      actorOf: user ? String(user.id || user._id || '') : null,
+      requestId: (req && req.id) || null,
+      route: req
+        ? `${req.method} ${req.route ? req.route.path : req.path}`
+        : null,
+      source: 'http',
+      ...event,
+    });
+  }
+
+  /**
+   * Every model instance in an answer, grouped by model.
+   *
+   * The constructor map built at boot (`base/references.js`) is what says
+   * whether an object is a record: a class henri did not register is not a
+   * model, whatever it is called. The walk is shallow on purpose -- an
+   * answer is a record, a list of records, or an object holding some.
+   *
+   * @param {*} value what is about to be sent
+   * @param {number} [depth=3] how far down to look
+   * @param {Map} [found=new Map()] what has been found so far
+   * @param {Set} [seen=new Set()] the objects already walked
+   * @returns {Map<string, Array>} the records, by model
+   * @memberof Trail
+   */
+  group(value, depth = 3, found = new Map(), seen = new Set()) {
+    if (!value || typeof value !== 'object' || depth === 0 || seen.has(value)) {
+      return found;
+    }
+
+    seen.add(value);
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        this.group(item, depth, found, seen);
+      }
+
+      return found;
+    }
+
+    const classes =
+      (this.henri.model && this.henri.model.referenceTable.classes) ||
+      new Map();
+    const model = classes.get(value.constructor);
+
+    if (typeof model === 'string') {
+      found.set(model, [...(found.get(model) || []), value]);
+
+      return found;
+    }
+
+    for (const key of Object.keys(value)) {
+      this.group(value[key], depth - 1, found, seen);
+    }
+
+    return found;
+  }
+
+  /**
+   * Records what an answer carried, one entry per model.
+   *
+   * This is the read half of the trail and it costs a round trip and an
+   * insert per answer, which is why it is off unless `config.trail.reads`
+   * asks for it. A read that cannot be recorded is not sent: a trail with
+   * holes in it reads as evidence and is not.
+   *
+   * @async
+   * @param {object} req the request
+   * @param {*} value the records about to be sent
+   * @param {object} [options={}] `route` and anything else of the entry
+   * @returns {Promise<Array<object>>} the entries that were appended
+   * @memberof Trail
+   */
+  async seen(req, value, options = {}) {
+    if (!this.enabled || !this.settings.reads) {
+      return [];
+    }
+
+    const entries = [];
+    const { privacy } = this.henri;
+
+    for (const [model, records] of this.group(value)) {
+      const fields = Object.keys(privacy.fields(model));
+
+      // `personal` is the privacy map's own answer to "is this model about a
+      // person": the fields it marked, *or* a link to the person. A proposal
+      // marks nothing and is still the speaker's, and a trail that left it
+      // out would answer "who saw this record" with silence
+      if (this.settings.reads === 'personal' && !privacy.entryOf(model)) {
+        continue;
+      }
+
+      entries.push(
+        await this.records(req, {
+          action: 'record.read',
+          fields,
+          ids: records.map((record) => record[EXTERNAL_ID]),
+          model,
+          records: records.length,
+          ...options,
+        })
+      );
+    }
+
+    return entries;
+  }
+
+  /**
+   * The entries matching a filter, newest first
+   *
+   * @async
+   * @param {object} [filter={}] `action`, `model`, `actor`, `subject`,
+   *   `outcome`, `since`, `until`, `limit`, `offset`
+   * @returns {Promise<Array<object>>} the entries
+   * @memberof Trail
+   */
+  async list(filter = {}) {
+    const rows = await this.ready().list(this.filter(filter));
+
+    return rows.map(toEntry);
+  }
+
+  /**
+   * How many entries match a filter
+   *
+   * @async
+   * @param {object} [filter={}] the filter
+   * @returns {Promise<number>} the count
+   * @memberof Trail
+   */
+  async count(filter = {}) {
+    return this.ready().count(this.filter(filter));
+  }
+
+  /**
+   * Everything recorded about one person
+   *
+   * @async
+   * @param {*} who a record, an email address or an external id
+   * @param {object} [filter={}] the rest of the filter
+   * @returns {Promise<Array<object>>} the entries
+   * @memberof Trail
+   */
+  async about(who, filter = {}) {
+    const { subject, subjectDigest } = this.identify(who);
+
+    if (!subject && !subjectDigest) {
+      return [];
+    }
+
+    // The digest is the stable name -- it survives the erasure that took
+    // the address away -- so it answers when there is one
+    return subjectDigest
+      ? this.list({ ...filter, digest: subjectDigest })
+      : this.list({ ...filter, subject });
+  }
+
+  /**
+   * A filter with its moments turned into milliseconds
+   *
+   * @param {object} filter the filter
+   * @returns {object} the filter the store reads
+   * @memberof Trail
+   */
+  filter(filter) {
+    const moment = (value) =>
+      typeof value === 'undefined' || value === null
+        ? undefined
+        : new Date(value).getTime();
+
+    return {
+      ...filter,
+      since: moment(filter.since),
+      until: moment(filter.until),
+    };
+  }
+
+  /**
+   * Walks the chain and says whether anything was edited or removed
+   *
+   * @async
+   * @returns {Promise<object>} `{ ok, entries, from, to, broken }`
+   * @memberof Trail
+   */
+  async verify() {
+    return verifyChain(this.ready(), { secret: this.context().secret });
+  }
+
+  /**
+   * Takes the entries past `config.trail.keep` away, and leaves a
+   * checkpoint carrying the hash of the last of them so what remains still
+   * verifies
+   *
+   * @async
+   * @param {object} [options={}] `now`
+   * @returns {Promise<object>} `{ removed, before, checkpoint }`
+   * @memberof Trail
+   */
+  async prune({ now = Date.now() } = {}) {
+    if (!this.enabled || !this.store || !this.settings.keep) {
+      return { before: null, checkpoint: null, removed: 0 };
+    }
+
+    const before = now - this.settings.keep;
+    const { last, removed } = await this.store.prune(before);
+
+    if (removed === 0) {
+      return { before, checkpoint: null, removed: 0 };
+    }
+
+    const checkpoint = await appendTo(
+      this.store,
+      {
+        action: CHECKPOINT,
+        meta: { hash: last.hash, seq: Number(last.seq) },
+        records: removed,
+        source: 'job',
+      },
+      this.context()
+    );
+
+    return { before, checkpoint, removed };
+  }
+
+  /**
+   * The backend, or a readable error
+   *
+   * @returns {object} the backend
+   * @throws HENRI_TRAIL_DISABLED when nothing is being recorded
+   * @memberof Trail
+   */
+  ready() {
+    if (!this.enabled || !this.store) {
+      const error = fail(
+        'HENRI_TRAIL_DISABLED',
+        'this application keeps no access trail, so there is nothing to read back'
+      );
+
+      error.hint =
+        'Turn it on with "trail": {} in config/<env>.json; henri creates its table on the next boot';
+
+      throw error;
+    }
+
+    return this.store;
+  }
+}
+
+module.exports = Trail;

--- a/packages/core/src/5.router.js
+++ b/packages/core/src/5.router.js
@@ -796,6 +796,10 @@ class Router extends BaseModule {
       errors = result && result.errors;
     }
 
+    // The read half of the access trail, for the pages: the same entry the
+    // JSON answers get, one per model the payload carries (base/trail.js)
+    this.henri.trail && (await this.henri.trail.seen(req, payload));
+
     // Read once per request: rendering a page consumes the messages
     const messages = flash.consume(req);
     const allowed = this.pathForRoles(req.user);

--- a/packages/core/src/__tests__/config-schema.spec.js
+++ b/packages/core/src/__tests__/config-schema.spec.js
@@ -401,6 +401,8 @@ describe('the schema, the declarations and the documentation', () => {
     ['ExternalIdsConfig', () => Object.keys(SCHEMA.externalIds.keys)],
     ['PoliciesConfig', () => Object.keys(SCHEMA.policies.keys)],
     ['PrivacyConfig', () => Object.keys(SCHEMA.privacy.keys)],
+    ['RetentionConfig', () => Object.keys(SCHEMA.retention.keys)],
+    ['TrailConfig', () => Object.keys(SCHEMA.trail.oneOf[1].keys)],
     ['RateLimitConfig', rateLimitKeys],
     ['SharedConfig', () => Object.keys(SCHEMA.shared.keys)],
     ['CacheConfig', () => Object.keys(SCHEMA.cache.oneOf[1].keys)],

--- a/packages/core/src/__tests__/retention.spec.js
+++ b/packages/core/src/__tests__/retention.spec.js
@@ -1,0 +1,682 @@
+/* global Artwork, Memo, User */
+const fs = require('fs');
+const path = require('path');
+const Henri = require('../henri');
+// The SQL adapters come from the workspace: core does not depend on them,
+// the suite only needs a sqlite-backed store of each to sweep real
+// Sequelize and Drizzle models
+const Sql = require('../../../sequelize');
+const Drizzle = require('../../../drizzle');
+
+const {
+  gateOf,
+  matches,
+  period,
+  planOf,
+  retentionConfig,
+  ruleOf,
+  rulesOf,
+  sweepOf,
+  tokenOf,
+} = require('../base/retention');
+const { fieldsOf } = require('../base/privacy');
+
+/** A model file the way core hands one to an adapter */
+const model = (globalId, schema, options = {}) => ({
+  globalId,
+  identity: globalId.toLowerCase(),
+  options,
+  schema,
+});
+
+/** The henri a store adapter needs to be built outside of a boot */
+const shim = () => ({
+  _user: null,
+  config: { get: () => undefined, has: () => false },
+  cwd: () => process.cwd(),
+  isProduction: false,
+  pen: {
+    error: () => {},
+    fatal: () => new Error('x'),
+    info: () => {},
+    warn: () => {},
+  },
+  user: { encrypt: async (value) => `hashed:${value}` },
+});
+
+/** Long enough ago that every rule of this suite has come for it */
+const ago = (days) => new Date(Date.now() - days * 86400000);
+
+describe('the rule (no application)', () => {
+  test('a period is read in the units a retention promise is written in', () => {
+    expect(period('90d')).toBe(7776000000);
+    expect(period('18mo')).toBe(46656000000);
+    expect(period('2y')).toBe(63072000000);
+    expect(period('30s')).toBe(30000);
+    expect(period(1000)).toBe(1000);
+    expect(period('nope')).toBeNull();
+    expect(period(0)).toBeNull();
+    expect(period(null)).toBeNull();
+  });
+
+  test('a model says how long it keeps its records', () => {
+    const file = model(
+      'Proposal',
+      { decidedAt: { type: 'date' }, title: { type: 'string' } },
+      { retention: { action: 'delete', after: '2y', from: 'decidedAt' } }
+    );
+
+    expect(
+      ruleOf(file, file.options.retention, { fields: {}, index: 0 })
+    ).toEqual({
+      action: 'delete',
+      after: 63072000000,
+      from: 'decidedAt',
+      model: 'Proposal',
+      name: 'default',
+      where: {},
+    });
+  });
+
+  test('the clock is createdAt only when nothing else is named', () => {
+    const file = model('Note', { body: { type: 'text' } }, {});
+
+    expect(ruleOf(file, { after: '1y' }, { fields: {}, index: 0 }).from).toBe(
+      'createdAt'
+    );
+  });
+
+  test('a rule henri cannot carry out fails the boot, and says why', () => {
+    const dated = model('Note', { closedAt: { type: 'date' } }, {});
+    const plain = model('Note', { body: { type: 'text' } }, {});
+    const paranoid = model(
+      'Note',
+      { body: { type: 'text' } },
+      { paranoid: true }
+    );
+
+    const refused = (file, rule) => {
+      try {
+        ruleOf(file, rule, { fields: {}, index: 0 });
+      } catch (error) {
+        return error;
+      }
+
+      return null;
+    };
+
+    expect(refused(dated, { after: 'soon' }).code).toBe(
+      'HENRI_RETENTION_INVALID_RULE'
+    );
+    // A period under a minute is a typo, not a policy
+    expect(refused(dated, { after: '30s' }).message).toMatch(/under a minute/u);
+    expect(refused(dated, { after: '1y', from: 'nope' }).message).toMatch(
+      /not a date field/u
+    );
+    expect(refused(dated, { action: 'archive', after: '1y' }).message).toMatch(
+      /anonymize, delete, soft-delete/u
+    );
+    // A soft delete on a model that has no soft delete would be a delete
+    // wearing a different word
+    expect(
+      refused(plain, { action: 'soft-delete', after: '1y' }).message
+    ).toMatch(/paranoid: true/u);
+    // Anonymizing a model with nothing personal would touch nothing and
+    // report success
+    expect(
+      refused(paranoid, { action: 'anonymize', after: '1y' }).message
+    ).toMatch(/nothing to write over/u);
+    expect(refused(dated, 'two years').message).toMatch(/is an object/u);
+    expect(refused(dated, { after: '1y', where: 'draft' }).message).toMatch(
+      /has to be an object/u
+    );
+  });
+
+  test('a model with more than one class of records names its rules', () => {
+    const file = model(
+      'Proposal',
+      { decidedAt: { type: 'date' }, state: { type: 'string' } },
+      {
+        retention: [
+          { after: '30d', name: 'drafts', where: { state: 'draft' } },
+          { after: '2y', from: 'decidedAt', name: 'decided' },
+        ],
+      }
+    );
+
+    expect(rulesOf([file]).map((rule) => rule.name)).toEqual([
+      'drafts',
+      'decided',
+    ]);
+
+    const clash = model(
+      'Proposal',
+      { state: { type: 'string' } },
+      { retention: [{ after: '30d' }, { after: '2y', name: 'default' }] }
+    );
+
+    expect(() => rulesOf([clash])).toThrow(/two rules are called/u);
+  });
+
+  test('a model that says nothing has no rules', () => {
+    expect(rulesOf([model('Note', {}, {})])).toEqual([]);
+    expect(rulesOf([model('Note', {}, { retention: false })])).toEqual([]);
+    expect(rulesOf(null)).toEqual([]);
+  });
+
+  test('the token covers the terms, so a changed rule is a new rule', () => {
+    const rule = {
+      action: 'delete',
+      after: 63072000000,
+      from: 'decidedAt',
+      model: 'Proposal',
+      name: 'default',
+      where: {},
+    };
+    const token = tokenOf(rule);
+
+    expect(token).toMatch(/^Proposal:default:[0-9a-f]{12}$/u);
+    expect(tokenOf(rule)).toBe(token);
+    // Two hours where two years was meant is a different rule
+    expect(tokenOf({ ...rule, after: 7200000 })).not.toBe(token);
+    expect(tokenOf({ ...rule, action: 'anonymize' })).not.toBe(token);
+    expect(tokenOf({ ...rule, where: { state: 'draft' } })).not.toBe(token);
+    // The digest is plain, so a token committed to config/<env>.json means
+    // the same thing in every environment
+    expect(token).toBe('Proposal:default:cfb99ef62f75');
+  });
+
+  test('the gate is what stands between a new rule and a deleted table', () => {
+    const rule = { token: 'Proposal:default:abc123abc123' };
+
+    expect(gateOf(rule, { approve: true, approved: [] })).toBe('pending');
+    expect(gateOf(rule, { approve: true, approved: [rule.token] })).toBeNull();
+    // An application may decide the deployment is the review
+    expect(gateOf(rule, { approve: false, approved: [] })).toBeNull();
+  });
+
+  test('--only names a model, or one rule of it', () => {
+    const rule = { model: 'Proposal', name: 'drafts' };
+
+    expect(matches(rule, 'Proposal')).toBe(true);
+    expect(matches(rule, 'proposal')).toBe(true);
+    expect(matches(rule, 'Proposal:drafts')).toBe(true);
+    expect(matches(rule, 'Proposal:decided')).toBe(false);
+    expect(matches(rule, 'Review')).toBe(false);
+  });
+
+  test('the configuration fills in what it does not say', () => {
+    expect(retentionConfig(null)).toEqual({
+      approve: true,
+      approved: [],
+      batch: 1000,
+      receipts: 'privacy',
+      schedule: false,
+    });
+
+    const config = (value) => ({
+      get: () => value,
+      has: () => true,
+    });
+
+    expect(retentionConfig(config({ approve: false, batch: false }))).toEqual({
+      approve: false,
+      approved: [],
+      batch: false,
+      receipts: 'privacy',
+      schedule: false,
+    });
+    expect(
+      retentionConfig(config({ receipts: false, schedule: '0 3 * * *' }))
+    ).toMatchObject({ receipts: false, schedule: '0 3 * * *' });
+  });
+});
+
+describe('a sweep on sequelize', () => {
+  let sql = null;
+  let modelOf = null;
+  const models = [
+    model(
+      'Ticket',
+      {
+        closedAt: { type: 'date' },
+        note: { personal: true, type: 'string' },
+        state: { type: 'string' },
+      },
+      {
+        paranoid: true,
+        retention: [
+          { after: '30d', from: 'closedAt', name: 'closed' },
+          {
+            action: 'anonymize',
+            after: '90d',
+            from: 'createdAt',
+            name: 'old',
+            where: { state: 'open' },
+          },
+        ],
+        timestamps: true,
+      }
+    ),
+    model(
+      'Log',
+      { line: { type: 'string' }, writtenAt: { type: 'date' } },
+      { retention: { after: '30d', from: 'writtenAt' }, timestamps: true }
+    ),
+  ];
+
+  const context = (settings = {}) => ({
+    fieldsOf: (name) =>
+      fieldsOf(models.find((entry) => entry.globalId === name)),
+    modelOf,
+    rules: rulesOf(models, {
+      fields: (name) =>
+        fieldsOf(models.find((entry) => entry.globalId === name)),
+    }),
+    settings: { ...retentionConfig(null), approve: false, ...settings },
+  });
+
+  beforeAll(async () => {
+    sql = new Sql(
+      'default',
+      {
+        adapter: 'sqlite',
+        dialect: 'sqlite',
+        logging: false,
+        storage: ':memory:',
+      },
+      shim()
+    );
+
+    models.forEach((entry) => sql.addModel(entry, 'nobody'));
+    await sql.start();
+
+    const orm = sql.getModels();
+
+    modelOf = (name) => orm[name];
+  }, 30000);
+
+  afterAll(async () => {
+    await sql.stop();
+  });
+
+  beforeEach(async () => {
+    await modelOf('Ticket').destroy({ force: true, truncate: true });
+    await modelOf('Log').destroy({ force: true, truncate: true });
+  });
+
+  test('a record whose clock has not started is never swept', async () => {
+    const Ticket = modelOf('Ticket');
+
+    await Ticket.create({ note: 'open forever', state: 'open' });
+    await Ticket.create({ closedAt: ago(90), note: 'gone', state: 'closed' });
+
+    const plan = await planOf(context(), { only: 'Ticket:closed' });
+    const [step] = plan.steps;
+
+    expect(step.matched).toBe(1);
+    // The open ticket is counted, not swept: a rule that quietly matches
+    // nothing has to be visible
+    expect(step.waiting).toBe(1);
+    expect(await Ticket.count()).toBe(2);
+  });
+
+  test('a delete takes the row, soft deleted or not', async () => {
+    const Ticket = modelOf('Ticket');
+    const hidden = await Ticket.create({
+      closedAt: ago(60),
+      note: 'withdrawn',
+      state: 'closed',
+    });
+
+    await hidden.destroy();
+    await Ticket.create({ closedAt: ago(60), note: 'closed', state: 'closed' });
+    await Ticket.create({ closedAt: ago(1), note: 'recent', state: 'closed' });
+
+    const receipt = await sweepOf(context(), { only: 'Ticket:closed' });
+
+    expect(receipt.rules[0].written).toBe(2);
+    expect(receipt.rules[0].sample).toHaveLength(2);
+    // The recent one is still there, and so is nothing else
+    expect(await Ticket.count({ paranoid: false })).toBe(1);
+  });
+
+  test('an anonymize writes what an erasure writes, and keeps the row', async () => {
+    const Ticket = modelOf('Ticket');
+
+    await Ticket.create({
+      createdAt: ago(120),
+      note: 'a name and a number',
+      state: 'open',
+    });
+
+    const receipt = await sweepOf(context(), { only: 'Ticket:old' });
+
+    expect(receipt.rules[0].action).toBe('anonymize');
+    expect(receipt.rules[0].fields).toEqual(['note']);
+    expect(receipt.rules[0].written).toBe(1);
+
+    const [row] = await Ticket.findAll();
+
+    expect(row.note).toBeNull();
+    expect(row.state).toBe('open');
+  });
+
+  test('a batch bounds one run, and says what is left', async () => {
+    const Ticket = modelOf('Ticket');
+
+    for (let index = 0; index < 5; index += 1) {
+      await Ticket.create({
+        closedAt: ago(60),
+        note: `ticket ${index}`,
+        state: 'closed',
+      });
+    }
+
+    const receipt = await sweepOf(context({ batch: 2 }), {
+      only: 'Ticket:closed',
+    });
+
+    expect(receipt.rules[0].matched).toBe(5);
+    expect(receipt.rules[0].written).toBe(2);
+    expect(receipt.rules[0].remaining).toBe(3);
+    expect(await Ticket.count()).toBe(3);
+  });
+
+  test('a rule nobody approved plans, counts and writes nothing', async () => {
+    const Ticket = modelOf('Ticket');
+
+    await Ticket.create({ closedAt: ago(60), note: 'kept', state: 'closed' });
+
+    const settings = { ...retentionConfig(null), approve: true, approved: [] };
+    const receipt = await sweepOf(
+      { ...context(), settings },
+      { only: 'Ticket:closed' }
+    );
+
+    expect(receipt.pending).toBe(1);
+    expect(receipt.rules[0].skipped).toBe('not approved');
+    expect(receipt.rules[0].would).toBe(1);
+    expect(receipt.rules[0].written).toBe(0);
+    expect(await Ticket.count()).toBe(1);
+
+    // The same run, with the token in the configuration
+    const approved = {
+      ...settings,
+      approved: [context().rules[0].token],
+    };
+
+    expect(
+      (
+        await sweepOf(
+          { ...context(), settings: approved },
+          { only: 'Ticket:closed' }
+        )
+      ).rules[0].written
+    ).toBe(1);
+  });
+
+  test('a dry run counts and writes nothing', async () => {
+    const Ticket = modelOf('Ticket');
+
+    await Ticket.create({ closedAt: ago(60), note: 'kept', state: 'closed' });
+
+    const receipt = await sweepOf(context(), {
+      dryRun: true,
+      only: 'Ticket:closed',
+    });
+
+    expect(receipt.dryRun).toBe(true);
+    expect(receipt.rules[0].would).toBe(1);
+    expect(receipt.rules[0].written).toBe(0);
+    expect(receipt.rules[0].skipped).toBe('dry run');
+    expect(await Ticket.count()).toBe(1);
+  });
+
+  test('a rule that fails stops that rule and nothing else', async () => {
+    const Ticket = modelOf('Ticket');
+    const Log = modelOf('Log');
+
+    await Ticket.create({ closedAt: ago(60), note: 'one', state: 'closed' });
+    await Log.create({ line: 'old', writtenAt: ago(60) });
+
+    // A model that answers the plan and then refuses to be read: the
+    // database went away between the count and the write
+    const broken = {
+      ...context(),
+      modelOf: (name) =>
+        name === 'Log'
+          ? Log
+          : {
+              count: async () => 1,
+              findAll: () => {
+                throw new Error('the database went away');
+              },
+              findByPk: () => null,
+              sequelize: Ticket.sequelize,
+            },
+    };
+    const receipt = await sweepOf(broken, {});
+
+    expect(receipt.interrupted).toBe(true);
+    expect(
+      receipt.rules.find((rule) => rule.model === 'Ticket').failed
+    ).toMatch(/went away/u);
+    // The other rule still ran: a sweep is a list of independent queries
+    expect(receipt.rules.find((rule) => rule.model === 'Log').written).toBe(1);
+  });
+});
+
+describe('a sweep on drizzle', () => {
+  let store = null;
+  let modelOf = null;
+  const models = [
+    model(
+      'Booking',
+      {
+        bookedAt: { type: 'date' },
+        guest: { personal: { erase: 'anonymize' }, type: 'string' },
+        leftAt: { type: 'date' },
+      },
+      {
+        paranoid: true,
+        retention: [
+          { action: 'anonymize', after: '1y', from: 'leftAt', name: 'left' },
+          {
+            action: 'soft-delete',
+            after: '30d',
+            from: 'bookedAt',
+            name: 'stale',
+          },
+        ],
+        timestamps: true,
+      }
+    ),
+  ];
+
+  const context = () => ({
+    fieldsOf: (name) =>
+      fieldsOf(models.find((entry) => entry.globalId === name)),
+    modelOf,
+    rules: rulesOf(models, {
+      fields: (name) =>
+        fieldsOf(models.find((entry) => entry.globalId === name)),
+    }),
+    settings: { ...retentionConfig(null), approve: false },
+  });
+
+  beforeAll(async () => {
+    store = new Drizzle(
+      'default',
+      { dialect: 'sqlite', url: ':memory:' },
+      shim()
+    );
+
+    models.forEach((entry) => store.addModel(entry, 'nobody'));
+    await store.start();
+
+    const orm = store.getModels();
+
+    modelOf = (name) => orm[name];
+  }, 30000);
+
+  afterAll(async () => {
+    await store.stop();
+  });
+
+  beforeEach(async () => {
+    await modelOf('Booking').withDeleted().where({}).destroy({ force: true });
+  });
+
+  test('an anonymize keeps the row and writes over the person', async () => {
+    const Booking = modelOf('Booking');
+
+    await Booking.create({ guest: 'Ada Lovelace', leftAt: ago(400) });
+    await Booking.create({ guest: 'Still here', leftAt: ago(10) });
+
+    const receipt = await sweepOf(context(), { only: 'Booking:left' });
+
+    expect(receipt.rules[0].written).toBe(1);
+
+    const rows = await Booking.find({});
+
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row.guest).sort()).toEqual([
+      'Still here',
+      '[erased]',
+    ]);
+  });
+
+  test('a soft delete hides the row, and never comes for a hidden one', async () => {
+    const Booking = modelOf('Booking');
+
+    await Booking.create({ bookedAt: ago(60), guest: 'Old' });
+    await Booking.create({ bookedAt: ago(1), guest: 'New' });
+
+    const first = await sweepOf(context(), { only: 'Booking:stale' });
+
+    expect(first.rules[0].written).toBe(1);
+    expect(await Booking.find({})).toHaveLength(1);
+    expect(await Booking.withDeleted().where({}).count()).toBe(2);
+
+    // The stamp is not moved on a second pass: the row is already hidden
+    const second = await sweepOf(context(), { only: 'Booking:stale' });
+
+    expect(second.rules[0].matched).toBe(0);
+  });
+});
+
+describe('the module, in the demo application', () => {
+  let henri = null;
+  const skipWorkers = process.env.SKIP_WORKERS;
+
+  beforeAll(async () => {
+    process.env.SKIP_WORKERS = '1';
+    henri = new Henri();
+    await henri.init();
+    global.henri = henri;
+  }, 60000);
+
+  afterAll(async () => {
+    await henri.stop();
+    delete global.henri;
+    if (typeof skipWorkers === 'undefined') {
+      delete process.env.SKIP_WORKERS;
+    } else {
+      process.env.SKIP_WORKERS = skipWorkers;
+    }
+  }, 60000);
+
+  beforeEach(async () => {
+    await Memo.deleteMany({}, { force: true });
+    await Artwork.deleteMany({}, { force: true });
+    henri.retention.settings.approved = [];
+  });
+
+  test('the rules are what the models said', () => {
+    const described = henri.retention.describe();
+
+    expect(
+      described.rules.map((rule) => `${rule.model}:${rule.rule}`).sort()
+    ).toEqual(['Artwork:default', 'Memo:default']);
+
+    const memo = described.rules.find((rule) => rule.model === 'Memo');
+
+    expect(memo.action).toBe('delete');
+    expect(memo.from).toBe('archivedAt');
+    expect(memo.after).toBe(2592000000);
+    expect(memo.approved).toBe(false);
+    expect(memo.token).toMatch(/^Memo:default:[0-9a-f]{12}$/u);
+  });
+
+  test('nothing runs the sweep here, and the module says so', () => {
+    // The demo has no @usehenri/jobs and no retention.schedule: the line
+    // names the command a cron entry would run
+    expect(henri.retention.schedule()).toMatch(/henri retention:sweep --yes/u);
+  });
+
+  test('a sweep writes a receipt, and the trail carries it', async () => {
+    const user = await User.create({
+      email: 'keeper@demo.test',
+      name: 'Keeper',
+      password: 'longenoughpassword',
+    });
+
+    await Memo.create({
+      archivedAt: new Date(Date.now() - 60 * 86400000),
+      body: 'archived long ago',
+      ownerId: String(user._id),
+      title: 'Old',
+    });
+    await Memo.create({
+      body: 'still in use',
+      ownerId: String(user._id),
+      title: 'Open',
+    });
+
+    const token = henri.retention
+      .describe()
+      .rules.find((rule) => rule.model === 'Memo').token;
+
+    henri.retention.settings.approved = [token];
+
+    const receipt = await henri.retention.sweep({ only: 'Memo' });
+    const rule = receipt.rules[0];
+
+    expect(rule.written).toBe(1);
+    expect(rule.waiting).toBe(1);
+    expect(await Memo.countDocuments()).toBe(1);
+
+    expect(receipt.file).toMatch(/^\.tmp\/privacy\/retention-/u);
+    const written = JSON.parse(
+      fs.readFileSync(path.join(henri.cwd(), receipt.file), 'utf8')
+    );
+
+    expect(written.rules[0].written).toBe(1);
+    // The receipt is a sample, never an index: no body, no title, no owner
+    expect(JSON.stringify(written)).not.toMatch(/archived long ago/u);
+
+    const [entry] = await henri.trail.list({ action: 'retention.sweep' });
+
+    expect(entry.model).toBe('Memo');
+    expect(entry.records).toBe(1);
+    expect(entry.meta.rule).toBe('default');
+    expect(entry.source).toBe('app');
+  });
+
+  test('a pending rule is planned and never written', async () => {
+    await Artwork.create({
+      createdAt: new Date(Date.now() - 800 * 86400000),
+      title: 'Very old',
+      year: 1890,
+    });
+
+    const receipt = await henri.retention.sweep({ only: 'Artwork' });
+
+    expect(receipt.pending).toBe(1);
+    expect(receipt.rules[0].would).toBe(1);
+    expect(receipt.rules[0].written).toBe(0);
+    expect(receipt.rules[0].skipped).toBe('not approved');
+    expect(await Artwork.countDocuments()).toBe(1);
+  });
+});

--- a/packages/core/src/__tests__/trail.spec.js
+++ b/packages/core/src/__tests__/trail.spec.js
@@ -1,0 +1,602 @@
+/* global Memo, User */
+const Henri = require('../henri');
+// The SQL adapters come from the workspace: core does not depend on them,
+// the suite only needs a sqlite-backed store of each to append to a real
+// table through a real adapter
+const Sql = require('../../../sequelize');
+const Drizzle = require('../../../drizzle');
+
+const {
+  appendTo,
+  canonicalOf,
+  digestOf,
+  guard,
+  hashOf,
+  rowOf,
+  toEntry,
+  trailConfig,
+  verifyChain,
+} = require('../base/trail');
+const { install, storeFor } = require('../base/trail-store');
+
+/** The henri a store adapter needs to be built outside of a boot */
+const shim = () => ({
+  _user: null,
+  config: { get: () => undefined, has: () => false },
+  cwd: () => process.cwd(),
+  isProduction: false,
+  pen: {
+    error: () => {},
+    fatal: () => new Error('x'),
+    info: () => {},
+    warn: () => {},
+  },
+  user: { encrypt: async (value) => `hashed:${value}` },
+});
+
+describe('what an entry may hold', () => {
+  const context = {
+    filters: ['password', 'token'],
+    keys: new Set(['email', 'name', 'phone']),
+    secret: 'test',
+  };
+
+  test('names and counts go in', () => {
+    expect(
+      guard({ count: 12, dryRun: true, missing: null, rule: 'drafts' }, context)
+    ).toEqual({ count: 12, dryRun: true, missing: null, rule: 'drafts' });
+    expect(guard(null, context)).toBeNull();
+  });
+
+  test('a field the models marked personal never does', () => {
+    expect(() => guard({ name: 'Ada Lovelace' }, context)).toThrow(
+      /marked personal/u
+    );
+    expect(() => guard({ phone: '555' }, context)).toThrow(/marked personal/u);
+  });
+
+  test('and neither does anything masked in the logs', () => {
+    expect(() => guard({ password: 'hunter2' }, context)).toThrow(
+      /filterParameters/u
+    );
+    expect(() => guard({ resetToken: 'abc' }, context)).toThrow(
+      /filterParameters/u
+    );
+  });
+
+  test('a value that is content rather than a label is refused', () => {
+    expect(() => guard({ body: 'x'.repeat(201) }, context)).toThrow(
+      /content, not a label/u
+    );
+    expect(() => guard({ who: 'ada@example.com' }, context)).toThrow(
+      /email address/u
+    );
+    expect(() => guard({ record: { id: 1 } }, context)).toThrow(
+      /not a name or a count/u
+    );
+    expect(() => guard('everything', context)).toThrow(/flat object/u);
+  });
+
+  test('an entry needs to say what happened', () => {
+    expect(() => rowOf({}, context)).toThrow(/needs an action/u);
+    expect(() => rowOf({ action: 'x'.repeat(65) }, context)).toThrow(
+      /needs an action/u
+    );
+  });
+
+  test('an entry holds identifiers and field names, and nothing else', () => {
+    const row = rowOf(
+      {
+        action: 'privacy.export',
+        actorOf: '42',
+        fields: ['email', 'name'],
+        ids: ['0192-abc', null, ''],
+        model: 'User',
+        outcome: 'ok',
+        records: 3,
+        source: 'cli',
+        subject: '0192-def',
+      },
+      context
+    );
+
+    expect(row.action).toBe('privacy.export');
+    expect(row.fields).toBe('["email","name"]');
+    expect(row.ids).toBe('["0192-abc"]');
+    expect(row.records).toBe(3);
+    expect(row.source).toBe('cli');
+    expect(row.subject).toBe('0192-def');
+    // The actor is named by a digest of their key, never by the key
+    expect(row.actor_digest).toBe(digestOf('42', 'test'));
+    expect(row.actor).toBeNull();
+  });
+
+  test('an unknown source or outcome falls back rather than being stored', () => {
+    const row = rowOf(
+      { action: 'app.thing', outcome: 'maybe', source: 'somewhere' },
+      context
+    );
+
+    expect(row.outcome).toBe('ok');
+    expect(row.source).toBe('app');
+  });
+
+  test('the configuration is off until it says otherwise', () => {
+    expect(trailConfig(null).enabled).toBe(false);
+    expect(trailConfig({ get: () => false, has: () => true }).enabled).toBe(
+      false
+    );
+
+    const on = trailConfig({
+      get: () => ({ reads: 'personal', table: 'audit' }),
+      has: () => true,
+    });
+
+    expect(on).toEqual({
+      enabled: true,
+      keep: 31536000000,
+      reads: 'personal',
+      store: 'default',
+      table: 'audit',
+    });
+    expect(
+      trailConfig({
+        get: () => ({ keep: false, reads: 'nope' }),
+        has: () => true,
+      })
+    ).toMatchObject({ keep: null, reads: false });
+  });
+});
+
+describe('the chain (no database)', () => {
+  /** A store that keeps its rows in an array, unique `seq` and all */
+  const memory = () => {
+    const rows = [];
+
+    return {
+      /**
+       * Appends a row unless its sequence number is taken
+       *
+       * @param {object} row the row
+       * @returns {Promise<boolean>} whether it went in
+       */
+      async append(row) {
+        if (rows.some((entry) => entry.seq === row.seq)) {
+          return false;
+        }
+
+        rows.push(row);
+
+        return true;
+      },
+      /**
+       * The last row
+       *
+       * @returns {Promise<?object>} the row
+       */
+      async last() {
+        return rows[rows.length - 1] || null;
+      },
+      rows,
+      /**
+       * The rows after a sequence number
+       *
+       * @param {number} after the sequence number
+       * @param {number} limit how many
+       * @returns {Promise<Array>} the rows
+       */
+      async since(after, limit) {
+        return rows.filter((row) => row.seq > after).slice(0, limit);
+      },
+    };
+  };
+
+  test('every entry chains onto the one before it', async () => {
+    const store = memory();
+
+    await appendTo(store, { action: 'privacy.export' }, { secret: 'k' });
+    await appendTo(store, { action: 'privacy.erase' }, { secret: 'k' });
+    const third = await appendTo(
+      store,
+      { action: 'app.thing' },
+      { secret: 'k' }
+    );
+
+    expect(store.rows.map((row) => row.seq)).toEqual([1, 2, 3]);
+    expect(third.prev).toBe(store.rows[1].hash);
+    expect(await verifyChain(store, { secret: 'k' })).toEqual({
+      broken: null,
+      entries: 3,
+      from: 1,
+      ok: true,
+      to: 3,
+    });
+  });
+
+  test('an edited row is what the chain is for', async () => {
+    const store = memory();
+
+    for (const action of ['app.one', 'app.two', 'app.three']) {
+      await appendTo(store, { action }, { secret: 'k' });
+    }
+
+    // Somebody changes what an entry says
+    store.rows[1].records = 99;
+
+    const result = await verifyChain(store, { secret: 'k' });
+
+    expect(result.ok).toBe(false);
+    expect(result.broken).toEqual({ after: 1, reason: 'hash', seq: 2 });
+  });
+
+  test('a removed row is too', async () => {
+    const store = memory();
+
+    for (const action of ['app.one', 'app.two', 'app.three']) {
+      await appendTo(store, { action }, { secret: 'k' });
+    }
+
+    store.rows.splice(1, 1);
+
+    const result = await verifyChain(store, { secret: 'k' });
+
+    expect(result.ok).toBe(false);
+    expect(result.broken.reason).toBe('chain');
+  });
+
+  test('the hash is keyed, so the tail cannot be re-chained without it', async () => {
+    const store = memory();
+
+    await appendTo(store, { action: 'app.one' }, { secret: 'k' });
+
+    expect((await verifyChain(store, { secret: 'other' })).ok).toBe(false);
+  });
+
+  test('two writers racing for one sequence number make one chain', async () => {
+    const store = memory();
+
+    await Promise.all(
+      Array.from({ length: 12 }, (ignored, index) =>
+        appendTo(store, { action: `app.${index}` }, { secret: 'k' })
+      )
+    );
+
+    expect(store.rows.map((row) => row.seq)).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+    ]);
+    expect((await verifyChain(store, { secret: 'k' })).ok).toBe(true);
+  });
+
+  test('the canonical form is what the hash covers, in a fixed order', () => {
+    const row = rowOf({ action: 'app.one', records: 2 }, { secret: 'k' });
+
+    row.seq = 1;
+    expect(canonicalOf(row)).toContain('"app.one"');
+    expect(hashOf(null, row, 'k')).toBe(hashOf(null, row, 'k'));
+    expect(hashOf('abc', row, 'k')).not.toBe(hashOf(null, row, 'k'));
+  });
+
+  test('a stored row reads back as an entry', () => {
+    const row = rowOf(
+      { action: 'app.one', fields: ['name'], ids: ['abc'], meta: { count: 2 } },
+      { secret: 'k' }
+    );
+
+    row.hash = 'h';
+    row.seq = 1;
+
+    const entry = toEntry(row);
+
+    expect(entry.fields).toEqual(['name']);
+    expect(entry.ids).toEqual(['abc']);
+    expect(entry.meta).toEqual({ count: 2 });
+    expect(entry.at).toMatch(/^\d{4}-/u);
+    expect(toEntry(null)).toBeNull();
+  });
+});
+
+describe('the table', () => {
+  test('every dialect gets a create and its indexes, all idempotent', () => {
+    for (const dialect of ['sqlite', 'postgres', 'mysql', 'mssql']) {
+      const statements = install(dialect, 'henri_trail');
+
+      expect(statements.length).toBeGreaterThan(0);
+      expect(statements[0]).toMatch(/CREATE TABLE/u);
+      expect(statements.join('\n')).toMatch(/seq/u);
+      // Nothing may run twice and fail
+      expect(
+        statements.every((statement) =>
+          /IF NOT EXISTS|IF OBJECT_ID|sys\.indexes|UNIQUE KEY/u.test(statement)
+        )
+      ).toBe(true);
+    }
+
+    // The unique index on seq is what makes two writers one chain
+    expect(install('postgres', 'henri_trail').join('\n')).toMatch(
+      /CREATE UNIQUE INDEX IF NOT EXISTS "henri_trail_seq"/u
+    );
+  });
+
+  test('a table name that is not an identifier never reaches a statement', () => {
+    expect(() => install('sqlite', 'henri trail; drop table users')).toThrow(
+      /letters, digits and underscores/u
+    );
+  });
+
+  test('a dialect henri cannot talk to is refused', () => {
+    expect(() => install('oracle', 'henri_trail')).toThrow(
+      /cannot be kept in a oracle store/u
+    );
+  });
+});
+
+describe('appending through a store adapter', () => {
+  const backends = [];
+  let sql = null;
+  let drizzle = null;
+
+  beforeAll(async () => {
+    sql = new Sql(
+      'default',
+      {
+        adapter: 'sqlite',
+        dialect: 'sqlite',
+        logging: false,
+        storage: ':memory:',
+      },
+      shim()
+    );
+    await sql.start();
+
+    drizzle = new Drizzle(
+      'default',
+      { dialect: 'sqlite', url: ':memory:' },
+      shim()
+    );
+    await drizzle.start();
+
+    backends.push(['sequelize', storeFor(sql, 'henri_trail')]);
+    backends.push(['drizzle', storeFor(drizzle, 'henri_trail')]);
+
+    for (const [, store] of backends) {
+      await store.install();
+    }
+  }, 30000);
+
+  afterAll(async () => {
+    await sql.stop();
+    await drizzle.stop();
+  });
+
+  test('the install is idempotent on both adapters', async () => {
+    for (const [, store] of backends) {
+      await expect(store.install()).resolves.toBeDefined();
+    }
+  });
+
+  test('entries go in, come back and verify', async () => {
+    for (const [name, store] of backends) {
+      await appendTo(
+        store,
+        {
+          action: 'privacy.erase',
+          fields: ['email'],
+          ids: ['0192-one'],
+          meta: { adapter: name },
+          model: 'User',
+          records: 1,
+          source: 'cli',
+          subjectDigest: `digest-${name}`,
+        },
+        { secret: 'k' }
+      );
+      await appendTo(
+        store,
+        { action: 'retention.sweep', model: 'Memo', records: 4 },
+        { secret: 'k' }
+      );
+
+      const rows = await store.list({ action: 'privacy.erase' });
+
+      expect(rows).toHaveLength(1);
+      expect(toEntry(rows[0])).toMatchObject({
+        action: 'privacy.erase',
+        fields: ['email'],
+        ids: ['0192-one'],
+        meta: { adapter: name },
+        model: 'User',
+        records: 1,
+        subjectDigest: `digest-${name}`,
+      });
+
+      expect(await store.count({})).toBe(2);
+      expect(await store.count({ digest: `digest-${name}` })).toBe(1);
+      expect((await verifyChain(store, { secret: 'k' })).ok).toBe(true);
+    }
+  });
+
+  test('a prune takes the oldest away and leaves a link behind', async () => {
+    for (const [, store] of backends) {
+      const old = await appendTo(
+        store,
+        { action: 'app.old', at: Date.now() - 86400000 },
+        { secret: 'k' }
+      );
+
+      await appendTo(store, { action: 'app.new' }, { secret: 'k' });
+
+      const { last, removed } = await store.prune(Date.now() - 3600000);
+
+      expect(removed).toBeGreaterThan(0);
+      expect(last.hash).toBe(old.hash);
+
+      // Without the checkpoint the chain now starts from a `prev` nothing
+      // explains; with it, what remains still verifies
+      const checkpoint = await appendTo(
+        store,
+        {
+          action: 'trail.pruned',
+          meta: { hash: last.hash, seq: Number(last.seq) },
+          records: removed,
+          source: 'job',
+        },
+        { secret: 'k' }
+      );
+
+      expect(checkpoint.meta.hash).toBe(old.hash);
+      expect((await verifyChain(store, { secret: 'k' })).ok).toBe(true);
+    }
+  });
+
+  test('an edited row is caught through a real adapter', async () => {
+    const [, store] = backends[0];
+    const [row] = await store.list({ limit: 1 });
+
+    await sql.query(`UPDATE henri_trail SET records = 999 WHERE id = ?`, [
+      row.id,
+    ]);
+
+    const result = await verifyChain(store, { secret: 'k' });
+
+    expect(result.ok).toBe(false);
+    expect(result.broken.reason).toBe('hash');
+  });
+});
+
+describe('the module, in the demo application', () => {
+  let henri = null;
+  const skipWorkers = process.env.SKIP_WORKERS;
+
+  beforeAll(async () => {
+    process.env.SKIP_WORKERS = '1';
+    henri = new Henri();
+    await henri.init();
+    global.henri = henri;
+  }, 60000);
+
+  afterAll(async () => {
+    await henri.stop();
+    delete global.henri;
+    if (typeof skipWorkers === 'undefined') {
+      delete process.env.SKIP_WORKERS;
+    } else {
+      process.env.SKIP_WORKERS = skipWorkers;
+    }
+  }, 60000);
+
+  test('the trail is on, and it is a table henri owns', () => {
+    expect(henri.trail.enabled).toBe(true);
+    expect(henri.trail.settings.table).toBe('henri_trail');
+    // Off by default: recording every read is a second database
+    expect(henri.trail.settings.reads).toBe(false);
+  });
+
+  test('an export and an erasure are recorded, refusals included', async () => {
+    const user = await User.create({
+      email: 'trail@demo.test',
+      name: 'Trailed',
+      password: 'longenoughpassword',
+    });
+
+    await Memo.create({
+      body: 'something',
+      ownerId: String(user._id),
+      title: 'One',
+    });
+
+    await henri.privacy.export('trail@demo.test');
+
+    const [exported] = await henri.trail.list({ action: 'privacy.export' });
+
+    expect(exported.model).toBe('User');
+    expect(exported.records).toBe(2);
+    expect(exported.outcome).toBe('ok');
+
+    // The person is named by a digest, so the address is not in the table
+    expect(exported.subjectDigest).toEqual(expect.any(String));
+    expect(JSON.stringify(exported)).not.toMatch(/trail@demo\.test/u);
+
+    // ... and the digest is what answers "prove it happened"
+    const about = await henri.trail.about('trail@demo.test');
+
+    expect(about.map((entry) => entry.action)).toContain('privacy.export');
+
+    await henri.privacy.erase('trail@demo.test');
+
+    const [erased] = await henri.trail.list({ action: 'privacy.erase' });
+
+    expect(erased.outcome).toBe('ok');
+    expect(erased.meta.dryRun).toBe(false);
+    // The erasure took the address away; the digest still finds it
+    expect(
+      (await henri.trail.about('trail@demo.test')).map((entry) => entry.action)
+    ).toEqual(['privacy.erase', 'privacy.export']);
+
+    // A refusal is written down too
+    await expect(henri.privacy.erase('nobody@demo.test')).rejects.toThrow();
+
+    expect((await henri.trail.list({ outcome: 'refused' })).length).toBe(0);
+  });
+
+  test('the chain of a real application holds', async () => {
+    const result = await henri.trail.verify();
+
+    expect(result.ok).toBe(true);
+    expect(result.entries).toBeGreaterThan(0);
+  });
+
+  test('the trail refuses to become a second copy of what it protects', async () => {
+    await expect(
+      henri.trail.record({ action: 'app.thing', meta: { name: 'Ada' } })
+    ).rejects.toThrow(/marked personal/u);
+  });
+
+  test('a prune takes a prefix away and leaves a link behind (mongodb)', async () => {
+    // The demo boots the disk adapter, so this is the MongoDB backend of
+    // the trail rather than the SQL one the suite above exercises
+    expect(henri.trail.store.kind).toBe('mongo');
+
+    const old = await henri.trail.record({
+      action: 'app.old',
+      at: Date.now() - 2 * 86400000,
+      records: 1,
+    });
+
+    await henri.trail.record({ action: 'app.new', records: 1 });
+
+    const settings = henri.trail.settings;
+
+    henri.trail.settings = { ...settings, keep: 86400000 };
+
+    try {
+      const pruned = await henri.trail.prune();
+
+      expect(pruned.removed).toBeGreaterThan(0);
+      expect(pruned.checkpoint.action).toBe('trail.pruned');
+      expect(pruned.checkpoint.meta.hash).toBe(old.hash);
+      // The chain still verifies: what went was a prefix, and the
+      // checkpoint carries the link it ended on
+      expect((await henri.trail.verify()).ok).toBe(true);
+    } finally {
+      henri.trail.settings = settings;
+    }
+  });
+
+  test('a prune with nothing to take away does nothing', async () => {
+    const before = await henri.trail.count({});
+
+    expect(await henri.trail.prune({ now: 0 })).toMatchObject({
+      checkpoint: null,
+      removed: 0,
+    });
+    expect(await henri.trail.count({})).toBe(before);
+  });
+
+  test('reading it back on an application without one says so', () => {
+    const off = Object.create(Object.getPrototypeOf(henri.trail));
+
+    Object.assign(off, henri.trail, { enabled: false, store: null });
+
+    expect(() => off.ready()).toThrow(/keeps no access trail/u);
+  });
+});

--- a/packages/core/src/base/config-schema.js
+++ b/packages/core/src/base/config-schema.js
@@ -59,6 +59,9 @@ const DIALECTS = ['mysql', 'postgres', 'sqlite'];
 /** What `privacy.onErase` accepts (the strategies of `base/erasure.js`) */
 const ON_ERASE = ['anonymize', 'delete', 'orphan', 'retain'];
 
+/** What `trail.reads` accepts (`base/trail.js`) */
+const READS = ['all', 'personal'];
+
 /** A string that is not empty */
 const text = (extra = {}) => ({ pattern: /\S/u, type: 'string', ...extra });
 
@@ -83,6 +86,23 @@ const duration = (extra = {}) => ({
   oneOf: [
     { min: 0, type: 'number' },
     { pattern: /^\s*\d+(?:\.\d+)?\s*(?:ms|[smhdw])?\s*$/iu, type: 'string' },
+  ],
+  ...extra,
+});
+
+/**
+ * A retention period: the durations of `base/retention.js`, which are the
+ * ones everywhere else in henri plus the two only this measures things in
+ */
+const keeps = (extra = {}) => ({
+  describe:
+    "a retention period: '90d', '18mo', '2y', or a number of milliseconds",
+  oneOf: [
+    { min: 0, type: 'number' },
+    {
+      pattern: /^\s*\d+(?:\.\d+)?\s*(?:ms|mo|[smhdwy])?\s*$/iu,
+      type: 'string',
+    },
   ],
   ...extra,
 });
@@ -1028,6 +1048,83 @@ const SCHEMA = {
     type: 'object',
   },
 
+  retention: {
+    describe: 'an object of retention settings',
+    hint: 'How long a model keeps its records is said in the model (options: { retention }); this is what runs the sweep and what it is allowed to do',
+    keys: {
+      approve: {
+        default: true,
+        describe: 'true or false',
+        hint: 'true means a rule writes nothing until its token is in retention.approved; false is the deployment being the review',
+        type: 'boolean',
+      },
+      approved: {
+        default: [],
+        describe: 'a list of rule tokens (Model:rule:digest)',
+        hint: '`henri retention` prints the token of every rule; a rule whose terms change gets a new one and has to be approved again',
+        of: text(),
+        type: 'array',
+      },
+      batch: {
+        default: 1000,
+        describe: 'a whole number above zero, or false for no bound',
+        hint: 'How many records one rule may take in one sweep; the rest is reported and taken by the next run',
+        oneOf: [{ const: false }, { above: 0, integer: true, type: 'number' }],
+      },
+      receipts: {
+        default: 'privacy',
+        describe: 'a directory, or false to keep no receipt',
+        hint: 'Where a sweep writes the proof that it ran; false leaves only what the command printed',
+        oneOf: [{ const: false }, text()],
+      },
+      schedule: {
+        default: false,
+        describe:
+          "a cron expression ('0 3 * * *') or an interval ('1d'), or false",
+        hint: 'Needs @usehenri/jobs: henri registers the recurring henri/retention job. Without it, run henri retention:sweep --yes from cron',
+        oneOf: [{ const: false }, text()],
+      },
+    },
+    type: 'object',
+  },
+
+  trail: {
+    default: false,
+    describe: 'an object of access trail settings, or false to keep none',
+    hint: 'The trail is a table henri owns and appends to; it is off until this says otherwise',
+    oneOf: [
+      { const: false },
+      {
+        keys: {
+          keep: keeps({
+            default: '1y',
+            hint: 'A trail of who touched personal data is personal data: false keeps it forever, which is a decision to make on purpose',
+            oneOf: [{ const: false }, ...keeps().oneOf],
+          }),
+          reads: {
+            default: false,
+            describe: `one of ${READS.join(', ')}, or false to record no read`,
+            hint: "'personal' records the answers carrying a model with a personal field; every read costs a round trip and an insert",
+            oneOf: [{ const: false }, { enum: READS, type: 'string' }],
+          },
+          store: text({
+            default: 'default',
+            describe: 'the name of a store',
+            hint: 'Which of config.stores the table lives in',
+          }),
+          table: {
+            default: 'henri_trail',
+            describe: 'a table name: letters, digits and underscores',
+            hint: 'henri creates it on boot and only ever INSERTs and SELECTs',
+            pattern: /^[A-Za-z_][A-Za-z0-9_]*$/u,
+            type: 'string',
+          },
+        },
+        type: 'object',
+      },
+    ],
+  },
+
   bodyLimit: {
     default: '1mb',
     describe: 'a size, as a string ("1mb") or a number of bytes',
@@ -1144,4 +1241,4 @@ const SCHEMA = {
   },
 };
 
-module.exports = { ADAPTERS, DIALECTS, RENDERERS, SCHEMA, STORE };
+module.exports = { ADAPTERS, DIALECTS, READS, RENDERERS, SCHEMA, STORE };

--- a/packages/core/src/base/hateoas.js
+++ b/packages/core/src/base/hateoas.js
@@ -444,6 +444,16 @@ function resource(
     }
 
     const plain = await toPublic(henri, record, include);
+
+    // The read half of the access trail: one entry naming the model, the
+    // record and who asked, and never a value (see base/trail.js). Off
+    // unless `config.trail.reads` asks for it.
+    //
+    // `asked` is here for the same reason the policies read it: a controller
+    // answering with a presentation of a record hands over a plain object,
+    // which carries no model, and `subject` is where the record itself is
+    henri.trail && (await henri.trail.seen(req, [record, asked]));
+
     const paths = henri.router.pathForRoles(req.user);
     const merged = await allowed(
       henri,
@@ -546,6 +556,15 @@ function collection(
     // The whole page at once: publishing record by record would make one
     // lookup per foreign key per row (see base/references.js)
     const published = await toPublic(henri, records, include);
+
+    // One entry for the page, not one per row: what was read is the answer.
+    // `subject` carries the records themselves when the page is a list of
+    // presentations of them (see `resource()` above)
+    henri.trail &&
+      (await henri.trail.seen(req, [
+        records,
+        Array.isArray(subject) ? subject : null,
+      ]));
 
     for (const [index, record] of records.entries()) {
       const plain = published[index];

--- a/packages/core/src/base/retention.js
+++ b/packages/core/src/base/retention.js
@@ -1,0 +1,880 @@
+/**
+ * Retention: how long a model keeps its records, and what removes them when
+ * the time is up.
+ *
+ * An erasure answers a person who asked. Retention answers nobody: it is the
+ * promise an application already made in its privacy policy -- "we keep
+ * proposals for two years" -- and the only way to keep that promise is for
+ * something to run while nobody is watching. So the rule is written where
+ * the promise is about, in the model, and henri sweeps.
+ *
+ * ```js
+ * // app/models/Proposal.js
+ * options: {
+ *   retention: {
+ *     action: 'anonymize',
+ *     after: '2y',
+ *     from: 'decidedAt',
+ *   },
+ * },
+ * ```
+ *
+ * A model with more than one class of records writes a list, and each entry
+ * names itself:
+ *
+ * ```js
+ * retention: [
+ *   { after: '30d', name: 'drafts', where: { state: 'draft' } },
+ *   { action: 'anonymize', after: '2y', from: 'decidedAt', name: 'decided' },
+ * ],
+ * ```
+ *
+ * ## What retention does to a record
+ *
+ * One of the three verbs henri already has, and no fourth:
+ *
+ * - `delete` (the default): the row goes, for real, `deletedAt` stamp or
+ *   not. A soft delete is a hidden row, and a hidden row is still held.
+ * - `soft-delete`: the row is stamped `deletedAt` and stops being returned.
+ *   Only on a model that declared `options: { paranoid: true }` -- asking
+ *   for it elsewhere is refused rather than quietly turned into a delete,
+ *   because "we removed it after 90 days" and "we hid it after 90 days" are
+ *   different sentences.
+ * - `anonymize`: exactly what an erasure writes -- the fields the model
+ *   marked `personal` get the values of `base/erasure.js`, the row and every
+ *   foreign key pointing at it survive. A model that marks no field personal
+ *   cannot be anonymized: the sweep would touch nothing and report success,
+ *   which is the worst thing a compliance feature can do.
+ *
+ * ## What it is measured from
+ *
+ * `from`, a date field of the model. It defaults to `createdAt` and
+ * `createdAt` is usually the wrong answer: a record's clock rarely starts
+ * when the row was inserted. A proposal is kept for two years *after the
+ * decision*, an account for a year *after it closed*, a booking for seven
+ * years *after the stay*. Naming the column is how the model says which
+ * event starts the clock.
+ *
+ * A record whose `from` column is null has not started its clock and is
+ * never swept -- an open ticket does not age out. The plan counts those
+ * separately (`waiting`) so that a rule quietly matching nothing is visible
+ * rather than reassuring.
+ *
+ * ## What enforces it
+ *
+ * `henri.retention.sweep()`, which is core and needs nothing installed.
+ * Three things call it:
+ *
+ * - `henri retention:sweep`, which boots to runlevel 4, binds no port and is
+ *   what a cron line runs.
+ * - the recurring job `henri/retention`, when the application has
+ *   `@usehenri/jobs`: `config.retention.schedule` is a cron expression and
+ *   henri registers the schedule itself.
+ * - an application calling it, from a page of its own.
+ *
+ * The queue is a package an application installs, so it is never assumed.
+ * An application with retention rules and no schedule is told at boot, by
+ * name, what is not running and the command line that would run it.
+ *
+ * ## What proves it ran, and what happens when it is interrupted
+ *
+ * A receipt, the shape the erasure already writes, in
+ * `config.retention.receipts`: the rules that ran, what each of them did,
+ * how many records remain, and a digest of the rule rather than the rows.
+ * With `henri.trail` on, every rule is also one appended, hash-chained
+ * event.
+ *
+ * A sweep is not a transaction and does not need to be one. Every rule is a
+ * query over the age of a row, so a sweep that dies halfway leaves the rest
+ * exactly as the next sweep will find it -- a resumable operation, because
+ * it is a filter and not a cursor. The receipt of an interrupted sweep says
+ * which rules ran, which failed and which were never reached.
+ *
+ * ## Refusing to be a foot-gun
+ *
+ * A wrong retention rule deletes production data on a schedule, quietly,
+ * for as long as nobody looks. Two things stand in the way:
+ *
+ * - **A rule nobody approved never writes.** Every rule has a token --
+ *   `Model:name:<digest of its terms>` -- and the sweep applies a rule only
+ *   when `config.retention.approved` holds its token. The digest is plain
+ *   rather than keyed: a token is committed to the configuration and has to
+ *   mean the same thing in every environment. A new rule, or a rule
+ *   whose `after`, `from`, `action` or `where` changed, is `pending`: it is
+ *   planned, counted and reported, and it writes nothing. Approving is a
+ *   line in `config/<env>.json`, which means a person, a diff and a review.
+ *   `config.retention.approve: false` gives that up on purpose.
+ * - **A run is bounded.** `config.retention.batch` (1000) is how many
+ *   records one rule may touch in one sweep; the rest is reported as
+ *   `remaining` and taken by the next run. A mistyped `'2h'` where `'2y'`
+ *   was meant cannot take the table out in one pass.
+ *
+ * And the command is a dry run unless it is told otherwise: `henri
+ * retention:sweep` without `--yes` plans and writes nothing.
+ *
+ * @module base/retention
+ */
+
+const { createHash } = require('node:crypto');
+
+const { fail } = require('./errors');
+const { isPlainObject } = require('./privacy');
+const {
+  deleteRecords,
+  erasedValues,
+  findRecords,
+  identify,
+  kindOf,
+  primaryOf,
+  updateRecords,
+} = require('./erasure');
+
+/** What `retention.action` accepts */
+const ACTIONS = ['anonymize', 'delete', 'soft-delete'];
+
+/** The action of a rule that does not name one */
+const DEFAULT_ACTION = 'delete';
+
+/** The column a rule measures from unless it names another */
+const DEFAULT_FROM = 'createdAt';
+
+/** How many records one rule may touch in one sweep */
+const DEFAULT_BATCH = 1000;
+
+/** Where the receipts are written, unless the configuration says */
+const DEFAULT_RECEIPTS = 'privacy';
+
+/** The version of the receipt document */
+const VERSION = 1;
+
+/** How many identifiers a receipt keeps: a sample, never an index */
+const SAMPLE = 20;
+
+/**
+ * The units a retention period is written in.
+ *
+ * Longer than everywhere else in henri, which stops at weeks, because this
+ * is the one setting measured in years: `'90d'`, `'18mo'`, `'7y'`. `mo` and
+ * `y` are the calendar's rough shapes (30 and 365 days), which is what a
+ * retention promise means -- nobody keeps a record for exactly the leap
+ * seconds longer.
+ */
+const UNITS = {
+  d: 86400000,
+  h: 3600000,
+  m: 60000,
+  mo: 2592000000,
+  ms: 1,
+  s: 1000,
+  w: 604800000,
+  y: 31536000000,
+};
+
+/** An amount, then a unit. `ms` and `mo` come before the single letters */
+const PERIOD = /^(\d+(?:\.\d+)?)\s*(ms|mo|[smhdwy])?$/iu;
+
+/** The shortest period a rule may declare: under this it is a typo */
+const MINIMUM = 60000;
+
+/**
+ * A coded failure carrying what to do about it
+ *
+ * @param {string} code one of the catalogue's codes
+ * @param {string} message what went wrong
+ * @param {string} hint what to do about it
+ * @returns {Error} the error to throw
+ */
+function refuse(code, message, hint) {
+  const error = fail(code, message);
+
+  error.hint = hint;
+
+  return error;
+}
+
+/**
+ * A retention period in milliseconds (`'2y'`, `'18mo'`, `'90d'`)
+ *
+ * @param {*} value what was written
+ * @returns {?number} the period, or null when it cannot be read
+ */
+function period(value) {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) && value > 0 ? Math.round(value) : null;
+  }
+
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const match = PERIOD.exec(value.trim());
+
+  if (!match) {
+    return null;
+  }
+
+  const amount = Number(match[1]) * UNITS[(match[2] || 'ms').toLowerCase()];
+
+  return amount > 0 ? Math.round(amount) : null;
+}
+
+/**
+ * The date fields of a model, by name: what `from` may point at
+ *
+ * @param {object} model a model file
+ * @returns {Set<string>} the names
+ */
+function datesOf(model) {
+  const schema = (model && model.schema) || {};
+  const names = new Set(['createdAt', 'deletedAt', 'updatedAt']);
+
+  for (const field of Object.keys(schema)) {
+    const definition = schema[field];
+
+    if (definition === Date) {
+      names.add(field);
+    }
+
+    if (isPlainObject(definition) && definition.type === 'date') {
+      names.add(field);
+    }
+  }
+
+  return names;
+}
+
+/**
+ * The token of a rule: what `config.retention.approved` holds.
+ *
+ * It covers the terms that decide which records are touched and what
+ * happens to them, so a rule whose `after` moved from two years to two
+ * hours is a different rule and has to be approved again.
+ *
+ * It is a plain digest and not a keyed one, deliberately. A token is an
+ * identifier, not a capability: it is committed to `config/<env>.json` and
+ * has to mean the same thing on a laptop, in the test suite and in
+ * production, where `config.secret` does not. Anybody who can add a token
+ * to the configuration can also set `approve: false`, so a key would buy
+ * nothing and cost the one property that makes approving reviewable.
+ *
+ * @param {object} rule a normalized rule
+ * @returns {string} `Model:name:<12 hex>`
+ */
+function tokenOf(rule) {
+  const terms = JSON.stringify([
+    rule.model,
+    rule.name,
+    rule.action,
+    rule.after,
+    rule.from,
+    rule.where,
+  ]);
+  const digest = createHash('sha256').update(terms).digest('hex');
+
+  return `${rule.model}:${rule.name}:${digest.slice(0, 12)}`;
+}
+
+/**
+ * One rule of one model, checked against what the model can do
+ *
+ * @param {object} model a model file
+ * @param {*} declared what `options.retention` (or one of its entries) holds
+ * @param {object} context the context
+ * @param {number} context.index the position in the list, for a default name
+ * @param {object} context.fields the personal fields of the model
+ * @returns {object} the normalized rule
+ * @throws HENRI_RETENTION_INVALID_RULE when the rule cannot be carried out
+ */
+function ruleOf(model, declared, { index, fields }) {
+  const name = model.globalId;
+  const value = isPlainObject(declared) ? declared : {};
+  const label =
+    typeof value.name === 'string' && value.name.trim() !== ''
+      ? value.name.trim()
+      : String(index === 0 ? 'default' : index);
+  const where = `${name}.options.retention${
+    label === 'default' ? '' : ` (${label})`
+  }`;
+
+  if (!isPlainObject(declared)) {
+    throw refuse(
+      'HENRI_RETENTION_INVALID_RULE',
+      `${where}: a retention rule is an object ({ after, action, from, where }), not ${typeof declared}`,
+      "Write it as options: { retention: { after: '2y' } }, or a list of those"
+    );
+  }
+
+  const after = period(value.after);
+  const action = value.action || DEFAULT_ACTION;
+  const from = value.from || DEFAULT_FROM;
+
+  if (after === null) {
+    throw refuse(
+      'HENRI_RETENTION_INVALID_RULE',
+      `${where}: 'after' is how long the records are kept ('90d', '18mo', '2y'), and ${JSON.stringify(
+        value.after
+      )} cannot be read as one`,
+      'Write a number of milliseconds, or a string: ms, s, m, h, d, w, mo, y'
+    );
+  }
+
+  if (after < MINIMUM) {
+    throw refuse(
+      'HENRI_RETENTION_INVALID_RULE',
+      `${where}: 'after' is ${JSON.stringify(value.after)}, which is under a minute`,
+      'A retention period is measured in days, months or years; anything shorter is a queue, not a policy'
+    );
+  }
+
+  if (!ACTIONS.includes(action)) {
+    throw refuse(
+      'HENRI_RETENTION_INVALID_RULE',
+      `${where}: 'action' must be one of ${ACTIONS.join(', ')}, not ${JSON.stringify(action)}`,
+      'henri has three verbs for taking a record away, and retention uses those three'
+    );
+  }
+
+  if (!datesOf(model).has(from)) {
+    throw refuse(
+      'HENRI_RETENTION_INVALID_RULE',
+      `${where}: 'from' names ${from}, which is not a date field of ${name}`,
+      "The clock starts on a date column of the model: { from: 'decidedAt' }, or leave it out for createdAt"
+    );
+  }
+
+  if (action === 'soft-delete' && !(model.options || {}).paranoid) {
+    throw refuse(
+      'HENRI_RETENTION_INVALID_RULE',
+      `${where}: 'soft-delete' needs options: { paranoid: true } on ${name}`,
+      "Add the soft delete to the model, or say what you mean: action: 'delete'"
+    );
+  }
+
+  if (action === 'anonymize' && Object.keys(fields || {}).length === 0) {
+    throw refuse(
+      'HENRI_RETENTION_INVALID_RULE',
+      `${where}: 'anonymize' has nothing to write over: no field of ${name} is marked personal`,
+      "Mark the fields that are about a person ({ personal: true }), or use action: 'delete'"
+    );
+  }
+
+  if (
+    typeof value.where !== 'undefined' &&
+    value.where !== null &&
+    !isPlainObject(value.where)
+  ) {
+    throw refuse(
+      'HENRI_RETENTION_INVALID_RULE',
+      `${where}: 'where' is the condition that picks the class of records, and has to be an object`,
+      "Write it the way a query is written: where: { state: 'withdrawn' }"
+    );
+  }
+
+  return {
+    action,
+    after,
+    from,
+    model: name,
+    name: label,
+    where: isPlainObject(value.where) ? { ...value.where } : {},
+  };
+}
+
+/**
+ * Every retention rule of every model, in model order
+ *
+ * @param {Array<object>} models the model files (`henri.model.models`)
+ * @param {object} [options={}] options
+ * @param {function} [options.fields] `(globalId) => the personal fields`
+ * @returns {Array<object>} the rules, each with its token
+ * @throws HENRI_RETENTION_INVALID_RULE on the first rule that cannot run
+ */
+function rulesOf(models, { fields = () => ({}) } = {}) {
+  const rules = [];
+
+  for (const model of models || []) {
+    const declared = ((model && model.options) || {}).retention;
+
+    if (
+      typeof declared === 'undefined' ||
+      declared === null ||
+      declared === false
+    ) {
+      continue;
+    }
+
+    const list = Array.isArray(declared) ? declared : [declared];
+    const seen = new Set();
+
+    for (const [index, entry] of list.entries()) {
+      const rule = ruleOf(model, entry, {
+        fields: fields(model.globalId),
+        index,
+      });
+
+      if (seen.has(rule.name)) {
+        throw refuse(
+          'HENRI_RETENTION_INVALID_RULE',
+          `${model.globalId}.options.retention: two rules are called "${rule.name}"`,
+          "Every rule of a model needs a name of its own: { name: 'drafts' }"
+        );
+      }
+
+      seen.add(rule.name);
+      rules.push({ ...rule, token: tokenOf(rule) });
+    }
+  }
+
+  return rules;
+}
+
+/**
+ * Where the receipts go: a directory, or false to write none
+ *
+ * @param {*} value what `retention.receipts` holds
+ * @returns {(string|boolean)} the directory, or false
+ */
+function receiptsOf(value) {
+  if (value === false) {
+    return false;
+  }
+
+  return typeof value === 'string' && value !== '' ? value : DEFAULT_RECEIPTS;
+}
+
+/**
+ * The `retention` configuration, normalized
+ *
+ * @param {object} config henri's config module (or anything with get/has)
+ * @returns {object} `{ approve, approved, batch, receipts, schedule }`
+ */
+function retentionConfig(config) {
+  const has =
+    config && typeof config.has === 'function' && config.has('retention');
+  const raw = has ? config.get('retention') : {};
+  const settings = isPlainObject(raw) ? raw : {};
+  const batch = settings.batch === false ? false : Number(settings.batch);
+
+  return {
+    approve: settings.approve !== false,
+    approved: Array.isArray(settings.approved)
+      ? settings.approved.map((token) => String(token))
+      : [],
+    batch:
+      settings.batch === false
+        ? false
+        : (Number.isFinite(batch) && batch > 0 && Math.round(batch)) ||
+          DEFAULT_BATCH,
+    receipts: receiptsOf(settings.receipts),
+    schedule:
+      typeof settings.schedule === 'string' && settings.schedule.trim() !== ''
+        ? settings.schedule.trim()
+        : false,
+  };
+}
+
+/**
+ * The condition matching the records a rule has come for.
+ *
+ * The three adapters spell a comparison differently and henri depends on
+ * none of them: Sequelize's operators are symbols taken from the model's own
+ * connection, Mongoose and drizzle both read `$lte`.
+ *
+ * @param {*} Model an ORM model
+ * @param {object} rule a normalized rule
+ * @param {Date} cutoff the moment a record has to be older than
+ * @returns {object} the condition
+ * @throws HENRI_RETENTION_ADAPTER_UNSUPPORTED on an adapter henri cannot drive
+ */
+function whereFor(Model, rule, cutoff) {
+  const kind = kindOf(Model);
+  const extra = { ...rule.where };
+
+  // A soft delete never comes for a row that is already hidden: it would
+  // move the stamp and report work that took nothing away
+  if (rule.action === 'soft-delete') {
+    extra.deletedAt = null;
+  }
+
+  if (kind === 'sequelize') {
+    const sequelize = Model.sequelize || {};
+    const { Op } = sequelize.Sequelize || sequelize.constructor || {};
+
+    if (!Op) {
+      throw refuse(
+        'HENRI_RETENTION_ADAPTER_UNSUPPORTED',
+        `unable to sweep ${rule.model}: its Sequelize model is not attached to a connection`,
+        'The sweep runs on the models henri booted; start the application first'
+      );
+    }
+
+    return { ...extra, [rule.from]: { [Op.lte]: cutoff } };
+  }
+
+  if (kind === 'drizzle' || kind === 'mongoose') {
+    return { ...extra, [rule.from]: { $lte: cutoff } };
+  }
+
+  throw refuse(
+    'HENRI_RETENTION_ADAPTER_UNSUPPORTED',
+    `unable to sweep ${rule.model}: its adapter is not one henri knows how to drive`,
+    'Retention goes through the model API of the three adapters henri ships: mongoose, sequelize and drizzle'
+  );
+}
+
+/**
+ * The condition matching the records whose clock has not started
+ *
+ * @param {object} rule a normalized rule
+ * @returns {object} the condition
+ */
+function waitingFor(rule) {
+  return { ...rule.where, [rule.from]: null };
+}
+
+/**
+ * Soft deletes every record matching a condition: the stamp, not the row
+ *
+ * @param {*} Model an ORM model
+ * @param {object} where the condition
+ * @returns {Promise<number>} how many records were stamped
+ * @throws HENRI_RETENTION_ADAPTER_UNSUPPORTED on an unknown adapter
+ */
+async function softDeleteRecords(Model, where) {
+  const kind = kindOf(Model);
+
+  if (kind === 'drizzle') {
+    return Model.where(where).destroy();
+  }
+
+  if (kind === 'mongoose') {
+    const result = await Model.deleteMany(where);
+
+    return (result && (result.deletedCount || result.modifiedCount)) || 0;
+  }
+
+  if (kind === 'sequelize') {
+    return Model.destroy({ where });
+  }
+
+  throw refuse(
+    'HENRI_RETENTION_ADAPTER_UNSUPPORTED',
+    'unable to soft delete these records: their adapter is not one henri knows how to drive',
+    'Retention goes through the model API of the three adapters henri ships'
+  );
+}
+
+/**
+ * How many records match a condition, without reading them
+ *
+ * @param {*} Model an ORM model
+ * @param {object} where the condition
+ * @returns {Promise<number>} the count
+ */
+async function countRecords(Model, where) {
+  const kind = kindOf(Model);
+
+  if (kind === 'drizzle') {
+    return Model.withDeleted().where(where).count();
+  }
+
+  if (kind === 'mongoose') {
+    return Model.countDocuments(where).setOptions({ withDeleted: true });
+  }
+
+  if (kind === 'sequelize') {
+    return Model.count({ paranoid: false, where });
+  }
+
+  return (await findRecords(Model, where)).length;
+}
+
+/**
+ * The first `limit` records matching a condition, soft-deleted ones included
+ *
+ * @param {*} Model an ORM model
+ * @param {object} where the condition
+ * @param {number} limit how many
+ * @returns {Promise<Array>} the records
+ */
+async function findSome(Model, where, limit) {
+  const kind = kindOf(Model);
+
+  if (kind === 'drizzle') {
+    return Model.find(where, { limit, withDeleted: true });
+  }
+
+  if (kind === 'mongoose') {
+    return Model.find(where).setOptions({ withDeleted: true }).limit(limit);
+  }
+
+  if (kind === 'sequelize') {
+    return Model.findAll({ limit, paranoid: false, where });
+  }
+
+  return (await findRecords(Model, where)).slice(0, limit);
+}
+
+/**
+ * Why a rule may not write, or nothing
+ *
+ * @param {object} rule a normalized rule
+ * @param {object} settings the retention settings
+ * @returns {?string} `'pending'`, or null when it is approved
+ */
+function gateOf(rule, settings) {
+  if (!settings.approve) {
+    return null;
+  }
+
+  return settings.approved.includes(rule.token) ? null : 'pending';
+}
+
+/**
+ * Whether a rule is the one `--only` named (`Proposal`, `Proposal:drafts`)
+ *
+ * @param {object} rule a normalized rule
+ * @param {string} wanted what was asked for
+ * @returns {boolean} true when it matches
+ */
+function matches(rule, wanted) {
+  const [model, name] = String(wanted).split(':');
+
+  if (model && model.toLowerCase() !== rule.model.toLowerCase()) {
+    return false;
+  }
+
+  return !name || name === rule.name;
+}
+
+/**
+ * What an `anonymize` rule writes over the records it comes for
+ *
+ * @param {object} rule a normalized rule
+ * @param {object} fields the personal fields of the model
+ * @returns {{values: object, problems: Array<object>}} the values, and what
+ *   stands in the way of writing them
+ */
+function valuesFor(rule, fields) {
+  if (rule.action !== 'anonymize') {
+    return { problems: [], values: {} };
+  }
+
+  const { problems, values } = erasedValues(
+    { fields, name: rule.model },
+    'retained'
+  );
+
+  if (problems.length === 0 && Object.keys(values).length === 0) {
+    problems.push({
+      message: `${rule.model}: every personal field is marked 'erase: retain', so anonymizing writes nothing`,
+      model: rule.model,
+      problem: 'nothing-to-write',
+    });
+  }
+
+  return { problems, values };
+}
+
+/**
+ * What a sweep would do, rule by rule. Nothing is written here.
+ *
+ * @param {object} context the context
+ * @param {Array<object>} context.rules the normalized rules
+ * @param {object} context.settings the retention settings
+ * @param {function} context.modelOf `(name) => the ORM model`
+ * @param {function} context.fieldsOf `(name) => the personal fields`
+ * @param {object} [options={}] `only`, `now`
+ * @returns {Promise<object>} the plan
+ */
+async function planOf({ rules, settings, modelOf, fieldsOf }, options = {}) {
+  const now = options.now ? new Date(options.now) : new Date();
+  const only = options.only || null;
+  const steps = [];
+
+  for (const rule of rules) {
+    if (only && !matches(rule, only)) {
+      continue;
+    }
+
+    const Model = modelOf(rule.model);
+    const cutoff = new Date(now.getTime() - rule.after);
+    const matched = await countRecords(Model, whereFor(Model, rule, cutoff));
+    const waiting = await countRecords(Model, waitingFor(rule));
+    const take =
+      settings.batch === false ? matched : Math.min(matched, settings.batch);
+    const { problems, values } = valuesFor(rule, fieldsOf(rule.model));
+
+    steps.push({
+      action: rule.action,
+      count: take,
+      cutoff: cutoff.toISOString(),
+      fields: Object.keys(values).sort(),
+      from: rule.from,
+      gate: gateOf(rule, settings),
+      matched,
+      model: rule.model,
+      problems,
+      remaining: matched - take,
+      rule: rule.name,
+      token: rule.token,
+      waiting,
+      where: rule.where,
+    });
+  }
+
+  return {
+    at: now.toISOString(),
+    pending: steps.filter((step) => step.gate === 'pending').length,
+    problems: steps.flatMap((step) => step.problems),
+    steps,
+  };
+}
+
+/**
+ * Carries out one rule, up to the batch
+ *
+ * @param {*} Model the ORM model
+ * @param {object} rule the normalized rule
+ * @param {object} step the step of the plan
+ * @param {object} settings the retention settings
+ * @returns {Promise<{written: number, sample: Array<string>}>} what it did
+ */
+async function apply(Model, rule, step, settings) {
+  const where = whereFor(Model, rule, new Date(step.cutoff));
+  const primary = primaryOf(Model);
+  const bounded = settings.batch !== false;
+  const rows = await findSome(Model, where, bounded ? settings.batch : SAMPLE);
+
+  if (rows.length === 0) {
+    return { sample: [], written: 0 };
+  }
+
+  // The batch is taken by primary key rather than by writing a limited
+  // UPDATE or DELETE: three adapters, three ways to bound a write, and one
+  // way to write `id IN (...)`. Unbounded, the age condition is the scope
+  // and only the sample is read
+  const scope = bounded
+    ? { [primary]: rows.map((row) => row[primary]) }
+    : where;
+  const sample = rows.slice(0, SAMPLE).map((row) => identify(row, primary));
+
+  if (step.action === 'delete') {
+    return { sample, written: await deleteRecords(Model, scope) };
+  }
+
+  if (step.action === 'soft-delete') {
+    return { sample, written: await softDeleteRecords(Model, scope) };
+  }
+
+  return {
+    sample,
+    written: await updateRecords(Model, scope, step.values),
+  };
+}
+
+/**
+ * Sweeps every rule, and answers with the receipt
+ *
+ * @param {object} context the context
+ * @param {Array<object>} context.rules the normalized rules
+ * @param {object} context.settings the retention settings
+ * @param {function} context.modelOf `(name) => the ORM model`
+ * @param {function} context.fieldsOf `(name) => the personal fields`
+ * @param {string} [context.application] the name of the application
+ * @param {object} [options={}] `only`, `now`, `dryRun`
+ * @returns {Promise<object>} the receipt
+ */
+async function sweepOf(context, options = {}) {
+  const { settings, modelOf, fieldsOf, application = null } = context;
+  const dryRun = options.dryRun === true;
+  const plan = await planOf(context, options);
+  const rules = [];
+  let interrupted = false;
+
+  for (const step of plan.steps) {
+    const rule = context.rules.find(
+      (entry) => entry.model === step.model && entry.name === step.rule
+    );
+    const outcome = {
+      action: step.action,
+      cutoff: step.cutoff,
+      fields: step.fields,
+      matched: step.matched,
+      model: step.model,
+      remaining: step.remaining,
+      rule: step.rule,
+      sample: [],
+      skipped: null,
+      token: step.token,
+      waiting: step.waiting,
+      would: step.count,
+      written: 0,
+    };
+
+    if (step.problems.length > 0) {
+      outcome.skipped = step.problems[0].message;
+    } else if (step.gate === 'pending') {
+      outcome.skipped = 'not approved';
+    } else if (dryRun) {
+      outcome.skipped = 'dry run';
+    } else if (step.count > 0) {
+      try {
+        const done = await apply(
+          modelOf(step.model),
+          rule,
+          { ...step, values: valuesFor(rule, fieldsOf(step.model)).values },
+          settings
+        );
+
+        outcome.sample = done.sample;
+        outcome.written = done.written;
+      } catch (error) {
+        // One rule that fails stops that rule and nothing else: a sweep is
+        // a list of independent queries, and the ones that can run should
+        interrupted = true;
+        outcome.failed = error.message;
+      }
+    }
+
+    rules.push(outcome);
+  }
+
+  return {
+    application,
+    at: plan.at,
+    dryRun,
+    interrupted,
+    pending: plan.pending,
+    rules,
+    version: VERSION,
+  };
+}
+
+module.exports = {
+  ACTIONS,
+  DEFAULT_ACTION,
+  DEFAULT_BATCH,
+  DEFAULT_FROM,
+  DEFAULT_RECEIPTS,
+  MINIMUM,
+  SAMPLE,
+  UNITS,
+  VERSION,
+  countRecords,
+  datesOf,
+  findSome,
+  gateOf,
+  matches,
+  period,
+  planOf,
+  retentionConfig,
+  ruleOf,
+  rulesOf,
+  softDeleteRecords,
+  sweepOf,
+  tokenOf,
+  valuesFor,
+  waitingFor,
+  whereFor,
+};

--- a/packages/core/src/base/trail-store.js
+++ b/packages/core/src/base/trail-store.js
@@ -1,0 +1,832 @@
+/**
+ * The table the access trail is written to, and the two backends that reach
+ * it.
+ *
+ * The trail owns a table of its own, the way `@usehenri/jobs` owns
+ * `henri_jobs`: raw SQL through the store adapter's `query()`, or a MongoDB
+ * collection, never a henri model. A model would put the trail behind the
+ * application's own conventions -- hooks, scopes, a policy, a soft delete,
+ * an `updatedAt` that says a row changed -- and every one of those is
+ * something an append-only record must not have.
+ *
+ * Only two statements are ever issued against it: `INSERT` and `SELECT`.
+ * There is no `UPDATE` anywhere in this file, and the single `DELETE` is
+ * `prune()`, which takes the oldest rows away once they are past
+ * `config.trail.keep` and leaves a checkpoint behind so the chain still
+ * verifies (see `base/trail.js`).
+ *
+ * Moments are BIGINT milliseconds since the epoch, for the reason the queue
+ * gives: sqlite has no date type and the other four dialects disagree about
+ * the precision and the time zone of a bare `TIMESTAMP`.
+ *
+ * @module base/trail-store
+ */
+
+const debug = require('debug')('henri:trail');
+
+const { fail } = require('./errors');
+
+/** A table name henri is willing to interpolate into a statement */
+const SAFE_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/** The columns of the trail table, in insert order */
+const COLUMNS = [
+  'id',
+  'seq',
+  'at',
+  'action',
+  'outcome',
+  'source',
+  'model',
+  'records',
+  'fields',
+  'ids',
+  'actor',
+  'actor_digest',
+  'subject',
+  'subject_digest',
+  'request_id',
+  'route',
+  'meta',
+  'prev',
+  'hash',
+];
+
+/** What each dialect calls the things this table needs */
+const DIALECTS = {
+  mssql: {
+    /**
+     * Wraps a statement so it only runs when the index is missing
+     *
+     * @param {string} table the table name
+     * @param {string} index the index name
+     * @param {string} statement the CREATE INDEX statement
+     * @returns {string} the guarded statement
+     */
+    guardIndex: (table, index, statement) =>
+      `IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = '${index}' AND object_id = OBJECT_ID('${table}')) ${statement}`,
+
+    /**
+     * Wraps a CREATE TABLE so it only runs when the table is missing
+     *
+     * @param {string} table the table name
+     * @param {string} statement the CREATE TABLE statement
+     * @returns {string} the guarded statement
+     */
+    guardTable: (table, statement) =>
+      `IF OBJECT_ID('${table}', 'U') IS NULL ${statement}`,
+
+    ifNotExists: '',
+    inlineIndexes: false,
+    int: 'INT',
+    quote: (identifier) => `[${identifier}]`,
+    text: 'NVARCHAR(MAX)',
+  },
+  mysql: {
+    ifNotExists: 'IF NOT EXISTS',
+    // MySQL has no CREATE INDEX IF NOT EXISTS: the indexes go in the
+    // CREATE TABLE, which is guarded
+    inlineIndexes: true,
+    int: 'INT',
+    quote: (identifier) => `\`${identifier}\``,
+    text: 'MEDIUMTEXT',
+  },
+  postgres: {
+    ifNotExists: 'IF NOT EXISTS',
+    inlineIndexes: false,
+    int: 'INTEGER',
+    quote: (identifier) => `"${identifier}"`,
+    text: 'TEXT',
+  },
+  sqlite: {
+    ifNotExists: 'IF NOT EXISTS',
+    inlineIndexes: false,
+    int: 'INTEGER',
+    quote: (identifier) => `"${identifier}"`,
+    text: 'TEXT',
+  },
+};
+
+/**
+ * The columns of the trail table, in order
+ *
+ * @param {object} dialect a dialect description
+ * @returns {Array<string>} the column definitions
+ */
+const columnsFor = (dialect) => [
+  'id VARCHAR(36) NOT NULL',
+  'seq BIGINT NOT NULL',
+  'at BIGINT NOT NULL',
+  'action VARCHAR(64) NOT NULL',
+  'outcome VARCHAR(16) NOT NULL',
+  'source VARCHAR(16) NOT NULL',
+  'model VARCHAR(120) NULL',
+  `records ${dialect.int} NOT NULL`,
+  `fields ${dialect.text} NULL`,
+  `ids ${dialect.text} NULL`,
+  'actor VARCHAR(64) NULL',
+  'actor_digest VARCHAR(64) NULL',
+  'subject VARCHAR(64) NULL',
+  'subject_digest VARCHAR(64) NULL',
+  'request_id VARCHAR(64) NULL',
+  'route VARCHAR(190) NULL',
+  `meta ${dialect.text} NULL`,
+  'prev VARCHAR(64) NULL',
+  'hash VARCHAR(64) NOT NULL',
+  'PRIMARY KEY (id)',
+];
+
+/**
+ * The indexes of the trail table.
+ *
+ * `seq` is unique, and that is not decoration: it is what makes two
+ * processes appending at the same moment resolve into one order instead of
+ * two forks of the chain (see `base/trail.js`).
+ *
+ * @param {string} table the table name
+ * @returns {Array<object>} `{ name, columns, unique }` entries
+ */
+const indexesFor = (table) => [
+  { columns: ['seq'], name: `${table}_seq`, unique: true },
+  { columns: ['at'], name: `${table}_at`, unique: false },
+  { columns: ['subject_digest'], name: `${table}_subject`, unique: false },
+  { columns: ['action', 'model'], name: `${table}_action`, unique: false },
+];
+
+/**
+ * Every statement that creates the table and its indexes, in order
+ *
+ * @param {string} name the dialect (sqlite, postgres, mysql, mssql)
+ * @param {string} table the table name
+ * @returns {Array<string>} the statements, all of them idempotent
+ * @throws HENRI_TRAIL_UNSUPPORTED_STORE on a dialect henri cannot talk to
+ * @throws HENRI_CONFIG_INVALID on a table name that is not an identifier
+ */
+const install = (name, table) => {
+  const dialect = DIALECTS[name];
+
+  if (!dialect) {
+    throw fail(
+      'HENRI_TRAIL_UNSUPPORTED_STORE',
+      `the access trail cannot be kept in a ${name} store`
+    );
+  }
+
+  if (!SAFE_NAME.test(table)) {
+    throw fail(
+      'HENRI_CONFIG_INVALID',
+      `trail.table: invalid table name "${table}": letters, digits and underscores only`
+    );
+  }
+
+  const quoted = dialect.quote(table);
+  const definitions = [...columnsFor(dialect)];
+  const indexes = indexesFor(table);
+  const statements = [];
+
+  if (dialect.inlineIndexes) {
+    for (const index of indexes) {
+      definitions.push(
+        `${index.unique ? 'UNIQUE KEY' : 'KEY'} ${dialect.quote(index.name)} (${index.columns.join(', ')})`
+      );
+    }
+  }
+
+  const create = [
+    'CREATE TABLE',
+    dialect.ifNotExists,
+    `${quoted} (\n  ${definitions.join(',\n  ')}\n)`,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  statements.push(
+    dialect.guardTable ? dialect.guardTable(table, create) : create
+  );
+
+  if (dialect.inlineIndexes) {
+    return statements;
+  }
+
+  for (const index of indexes) {
+    const statement = [
+      `CREATE ${index.unique ? 'UNIQUE ' : ''}INDEX`,
+      dialect.guardIndex ? '' : dialect.ifNotExists,
+      `${dialect.quote(index.name)} ON ${quoted} (${index.columns.join(', ')})`,
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    statements.push(
+      dialect.guardIndex
+        ? dialect.guardIndex(table, index.name, statement)
+        : statement
+    );
+  }
+
+  return statements;
+};
+
+/** Errors that mean the object was created by another process first */
+const ALREADY_THERE =
+  /already exists|duplicate key|duplicate table|there is already an object named/iu;
+
+/** Errors that mean a unique index refused the row */
+const DUPLICATE =
+  /unique|duplicate|Validation error|SQLITE_CONSTRAINT|ER_DUP_ENTRY|23505|E11000/iu;
+
+/**
+ * Everything an error says about itself, wrappers included
+ *
+ * @param {*} error an error
+ * @param {number} [depth=4] how far to unwrap
+ * @returns {string} the messages, joined
+ */
+const reasons = (error, depth = 4) => {
+  const said = [];
+  let current = error;
+
+  for (let step = 0; step < depth && current; step += 1) {
+    said.push(String(current.message || ''), String(current.code || ''));
+    current = current.parent || current.original || current.cause;
+  }
+
+  return said.join(' ');
+};
+
+/**
+ * A number read back from any driver (pg hands BIGINT over as a string)
+ *
+ * @param {*} value the stored value
+ * @returns {?number} the number, or null
+ */
+const toNumber = (value) => {
+  if (value === null || typeof value === 'undefined' || value === '') {
+    return null;
+  }
+
+  const number = Number(value);
+
+  return Number.isNaN(number) ? null : number;
+};
+
+/**
+ * The SQL backend
+ *
+ * @class SqlTrail
+ */
+class SqlTrail {
+  /**
+   * Creates an instance of SqlTrail.
+   *
+   * @param {object} adapter a henri store adapter with `query()`
+   * @param {object} options `dialect`, `dollars`, `table`
+   * @memberof SqlTrail
+   */
+  constructor(adapter, { dialect, dollars = false, table }) {
+    this.adapter = adapter;
+    this.dialect = dialect;
+    this.dollars = dollars;
+    this.table = table;
+    this.kind = 'sql';
+  }
+
+  /**
+   * The statement with the placeholders this driver expects
+   *
+   * @param {string} sql a statement written with `?`
+   * @returns {string} the statement
+   * @memberof SqlTrail
+   */
+  prepare(sql) {
+    if (!this.dollars) {
+      return sql;
+    }
+
+    let index = 0;
+
+    return sql.replace(/\?/gu, () => {
+      index += 1;
+
+      return `$${index}`;
+    });
+  }
+
+  /**
+   * Runs a statement that returns no rows
+   *
+   * @param {string} sql the statement
+   * @param {Array} [params=[]] the parameters
+   * @returns {Promise<void>} resolves when done
+   * @memberof SqlTrail
+   */
+  async run(sql, params = []) {
+    debug('run %s', sql);
+
+    await this.adapter.query(this.prepare(sql), params);
+  }
+
+  /**
+   * Runs a query and answers with its rows
+   *
+   * @param {string} sql the query
+   * @param {Array} [params=[]] the parameters
+   * @returns {Promise<Array<object>>} the rows
+   * @memberof SqlTrail
+   */
+  async select(sql, params = []) {
+    const rows = await this.adapter.query(this.prepare(sql), params, {
+      type: 'SELECT',
+    });
+
+    return Array.isArray(rows) ? rows : [];
+  }
+
+  /**
+   * Creates the table and its indexes; idempotent
+   *
+   * @returns {Promise<Array<string>>} the statements that ran
+   * @memberof SqlTrail
+   */
+  async install() {
+    const statements = install(this.dialect, this.table);
+
+    for (const statement of statements) {
+      try {
+        await this.run(statement);
+      } catch (error) {
+        if (!ALREADY_THERE.test(reasons(error))) {
+          throw error;
+        }
+
+        debug('another process created it first: %s', error.message);
+      }
+    }
+
+    return statements;
+  }
+
+  /**
+   * The tail of a query: an order, then a window.
+   *
+   * MSSQL has no `LIMIT`; `OFFSET ... FETCH NEXT` is the one spelling
+   * every dialect here understands, and it needs the `ORDER BY` that is
+   * already there.
+   *
+   * @param {string} order the ordering (`seq DESC`)
+   * @param {number} limit how many rows
+   * @param {number} [offset=0] how many to skip
+   * @returns {string} the clause
+   * @memberof SqlTrail
+   */
+  paging(order, limit, offset = 0) {
+    if (this.dialect === 'mssql') {
+      return ` ORDER BY ${order} OFFSET ${offset} ROWS FETCH NEXT ${limit} ROWS ONLY`;
+    }
+
+    return ` ORDER BY ${order} LIMIT ${limit} OFFSET ${offset}`;
+  }
+
+  /**
+   * The last row written, which the next one chains onto
+   *
+   * @returns {Promise<?object>} the row, or null on an empty trail
+   * @memberof SqlTrail
+   */
+  async last() {
+    const [row] = await this.select(
+      `SELECT * FROM ${this.table}${this.paging('seq DESC', 1)}`
+    );
+
+    return row || null;
+  }
+
+  /**
+   * Appends one row
+   *
+   * @param {object} row a row, in database shape
+   * @returns {Promise<boolean>} false when `seq` was taken, so the caller
+   *   reads the head again and chains onto whatever won
+   * @memberof SqlTrail
+   */
+  async append(row) {
+    const values = COLUMNS.map((column) =>
+      typeof row[column] === 'undefined' ? null : row[column]
+    );
+
+    try {
+      await this.run(
+        `INSERT INTO ${this.table} (${COLUMNS.join(', ')}) VALUES (${COLUMNS.map(
+          () => '?'
+        ).join(', ')})`,
+        values
+      );
+    } catch (error) {
+      if (DUPLICATE.test(reasons(error))) {
+        return false;
+      }
+
+      throw error;
+    }
+
+    return true;
+  }
+
+  /**
+   * The rows matching a filter, newest first
+   *
+   * @param {object} [filter={}] `action`, `model`, `subject`, `actor`,
+   *   `since`, `until`, `limit`, `offset`
+   * @returns {Promise<Array<object>>} the rows
+   * @memberof SqlTrail
+   */
+  async list(filter = {}) {
+    const { sql, params } = this.conditions(filter);
+    const limit = Math.min(Math.max(Number(filter.limit) || 100, 1), 1000);
+    const offset = Math.max(Number(filter.offset) || 0, 0);
+
+    return this.select(
+      `SELECT * FROM ${this.table}${sql}${this.paging('seq DESC', limit, offset)}`,
+      params
+    );
+  }
+
+  /**
+   * How many rows match a filter
+   *
+   * @param {object} [filter={}] the filter
+   * @returns {Promise<number>} the count
+   * @memberof SqlTrail
+   */
+  async count(filter = {}) {
+    const { sql, params } = this.conditions(filter);
+    const [row] = await this.select(
+      `SELECT COUNT(*) AS total FROM ${this.table}${sql}`,
+      params
+    );
+
+    return toNumber(row && (row.total || row.TOTAL)) || 0;
+  }
+
+  /**
+   * Every row in the order it was written, for the verification
+   *
+   * @param {number} after the sequence number to start after
+   * @param {number} limit how many
+   * @returns {Promise<Array<object>>} the rows
+   * @memberof SqlTrail
+   */
+  async since(after, limit) {
+    return this.select(
+      `SELECT * FROM ${this.table} WHERE seq > ?${this.paging('seq ASC', limit)}`,
+      [after]
+    );
+  }
+
+  /**
+   * The WHERE of a filter
+   *
+   * @param {object} filter the filter
+   * @returns {{sql: string, params: Array}} the clause and its parameters
+   * @memberof SqlTrail
+   */
+  conditions(filter) {
+    const parts = [];
+    const params = [];
+    const equals = {
+      action: filter.action,
+      actor: filter.actor,
+      model: filter.model,
+      outcome: filter.outcome,
+      subject: filter.subject,
+      subject_digest: filter.digest,
+    };
+
+    for (const column of Object.keys(equals).sort()) {
+      if (typeof equals[column] === 'string' && equals[column] !== '') {
+        parts.push(`${column} = ?`);
+        params.push(equals[column]);
+      }
+    }
+
+    if (Number.isFinite(filter.since)) {
+      parts.push('at >= ?');
+      params.push(filter.since);
+    }
+
+    if (Number.isFinite(filter.until)) {
+      parts.push('at <= ?');
+      params.push(filter.until);
+    }
+
+    return {
+      params,
+      sql: parts.length > 0 ? ` WHERE ${parts.join(' AND ')}` : '',
+    };
+  }
+
+  /**
+   * Takes the oldest rows away.
+   *
+   * A prefix of the chain, never a set of rows matching an age: the entries
+   * up to and including the newest one past `before` go, so what remains is
+   * still contiguous. Deleting by age alone would leave a hole in the
+   * middle of the sequence the moment two entries were written out of
+   * order, and a hole is a break nothing can explain away.
+   *
+   * @param {number} before a timestamp in milliseconds
+   * @returns {Promise<{removed: number, last: ?object}>} how many went, and
+   *   the last of them, which the checkpoint carries
+   * @memberof SqlTrail
+   */
+  async prune(before) {
+    const [last] = await this.select(
+      `SELECT * FROM ${this.table} WHERE at < ?${this.paging('seq DESC', 1)}`,
+      [before]
+    );
+
+    if (!last) {
+      return { last: null, removed: 0 };
+    }
+
+    const seq = Number(last.seq);
+    const [counted] = await this.select(
+      `SELECT COUNT(*) AS total FROM ${this.table} WHERE seq <= ?`,
+      [seq]
+    );
+
+    await this.run(`DELETE FROM ${this.table} WHERE seq <= ?`, [seq]);
+
+    return {
+      last,
+      removed: toNumber(counted && (counted.total || counted.TOTAL)) || 0,
+    };
+  }
+}
+
+/**
+ * The MongoDB backend. The documents carry the SQL column names, so both
+ * backends hand the trail the same rows.
+ *
+ * @class MongoTrail
+ */
+class MongoTrail {
+  /**
+   * Creates an instance of MongoTrail.
+   *
+   * @param {object} adapter a henri mongoose (or disk) adapter
+   * @param {string} table the collection name
+   * @memberof MongoTrail
+   */
+  constructor(adapter, table) {
+    this.adapter = adapter;
+    this.dialect = 'mongodb';
+    this.table = table;
+    this.kind = 'mongo';
+  }
+
+  /**
+   * The collection
+   *
+   * @returns {object} a MongoDB collection
+   * @throws HENRI_TRAIL_UNSUPPORTED_STORE when the store is not connected
+   * @memberof MongoTrail
+   */
+  collection() {
+    const connection =
+      this.adapter.mongoose && this.adapter.mongoose.connection;
+
+    if (!connection || connection.readyState !== 1 || !connection.db) {
+      throw fail(
+        'HENRI_TRAIL_UNSUPPORTED_STORE',
+        `the access trail cannot be written: the ${this.adapter.name} store is not connected`
+      );
+    }
+
+    return connection.db.collection(this.table);
+  }
+
+  /**
+   * Creates the indexes; idempotent
+   *
+   * @returns {Promise<Array<string>>} what was created
+   * @memberof MongoTrail
+   */
+  async install() {
+    const collection = this.collection();
+
+    await collection.createIndex({ seq: 1 }, { unique: true });
+    await collection.createIndex({ at: -1 });
+    await collection.createIndex({ subject_digest: 1 });
+
+    return [`${this.table}.seq`, `${this.table}.at`];
+  }
+
+  /**
+   * The last row written
+   *
+   * @returns {Promise<?object>} the row, or null
+   * @memberof MongoTrail
+   */
+  async last() {
+    const [row] = await this.collection()
+      .find({}, { sort: { seq: -1 } })
+      .limit(1)
+      .toArray();
+
+    return row || null;
+  }
+
+  /**
+   * Appends one row
+   *
+   * @param {object} row a row
+   * @returns {Promise<boolean>} false when `seq` was taken
+   * @memberof MongoTrail
+   */
+  async append(row) {
+    try {
+      await this.collection().insertOne({ ...row, _id: row.id });
+    } catch (error) {
+      if (DUPLICATE.test(reasons(error))) {
+        return false;
+      }
+
+      throw error;
+    }
+
+    return true;
+  }
+
+  /**
+   * The filter of a listing
+   *
+   * @param {object} filter the filter
+   * @returns {object} a MongoDB filter
+   * @memberof MongoTrail
+   */
+  conditions(filter) {
+    const query = {};
+    const equals = {
+      action: filter.action,
+      actor: filter.actor,
+      model: filter.model,
+      outcome: filter.outcome,
+      subject: filter.subject,
+      subject_digest: filter.digest,
+    };
+
+    for (const key of Object.keys(equals).sort()) {
+      if (typeof equals[key] === 'string' && equals[key] !== '') {
+        query[key] = equals[key];
+      }
+    }
+
+    if (Number.isFinite(filter.since) || Number.isFinite(filter.until)) {
+      query.at = {};
+
+      if (Number.isFinite(filter.since)) {
+        query.at.$gte = filter.since;
+      }
+
+      if (Number.isFinite(filter.until)) {
+        query.at.$lte = filter.until;
+      }
+    }
+
+    return query;
+  }
+
+  /**
+   * The rows matching a filter, newest first
+   *
+   * @param {object} [filter={}] the filter
+   * @returns {Promise<Array<object>>} the rows
+   * @memberof MongoTrail
+   */
+  async list(filter = {}) {
+    const limit = Math.min(Math.max(Number(filter.limit) || 100, 1), 1000);
+
+    return this.collection()
+      .find(this.conditions(filter), { sort: { seq: -1 } })
+      .skip(Math.max(Number(filter.offset) || 0, 0))
+      .limit(limit)
+      .toArray();
+  }
+
+  /**
+   * How many rows match a filter
+   *
+   * @param {object} [filter={}] the filter
+   * @returns {Promise<number>} the count
+   * @memberof MongoTrail
+   */
+  count(filter = {}) {
+    return this.collection().countDocuments(this.conditions(filter));
+  }
+
+  /**
+   * Every row in the order it was written, for the verification
+   *
+   * @param {number} after the sequence number to start after
+   * @param {number} limit how many
+   * @returns {Promise<Array<object>>} the rows
+   * @memberof MongoTrail
+   */
+  since(after, limit) {
+    return this.collection()
+      .find({ seq: { $gt: after } }, { sort: { seq: 1 } })
+      .limit(limit)
+      .toArray();
+  }
+
+  /**
+   * Takes the oldest rows away: a prefix of the chain, for the reason
+   * `SqlTrail#prune` gives
+   *
+   * @param {number} before a timestamp in milliseconds
+   * @returns {Promise<{removed: number, last: ?object}>} what went
+   * @memberof MongoTrail
+   */
+  async prune(before) {
+    const [last] = await this.collection()
+      .find({ at: { $lt: before } }, { sort: { seq: -1 } })
+      .limit(1)
+      .toArray();
+
+    if (!last) {
+      return { last: null, removed: 0 };
+    }
+
+    const result = await this.collection().deleteMany({
+      seq: { $lte: Number(last.seq) },
+    });
+
+    return { last, removed: (result && result.deletedCount) || 0 };
+  }
+}
+
+/**
+ * The dialect of a store adapter, or nothing when it is not SQL
+ *
+ * @param {object} adapter a henri store adapter
+ * @returns {?{dialect: string, dollars: boolean}} how to talk to it
+ */
+const describe = (adapter) => {
+  if (adapter.dialect && typeof adapter.dialect === 'object') {
+    return {
+      dialect: adapter.dialect.name,
+      dollars: adapter.dialect.placeholder(1) === '$1',
+    };
+  }
+
+  if (typeof adapter.ensureConnector === 'function') {
+    return { dialect: adapter.ensureConnector().getDialect(), dollars: false };
+  }
+
+  return null;
+};
+
+/**
+ * The backend of a store adapter
+ *
+ * @param {object} adapter a henri store adapter
+ * @param {string} table the table (or collection) name
+ * @returns {object} the backend
+ * @throws HENRI_TRAIL_UNSUPPORTED_STORE when the adapter cannot hold a trail
+ */
+const storeFor = (adapter, table) => {
+  if (!adapter) {
+    throw fail(
+      'HENRI_TRAIL_UNSUPPORTED_STORE',
+      'the access trail has no store to be written to'
+    );
+  }
+
+  if (adapter.mongoose) {
+    return new MongoTrail(adapter, table);
+  }
+
+  const described = typeof adapter.query === 'function' && describe(adapter);
+
+  if (!described || !DIALECTS[described.dialect]) {
+    throw fail(
+      'HENRI_TRAIL_UNSUPPORTED_STORE',
+      `the access trail cannot be kept in the ${adapter.adapterName || 'unknown'} store: it has neither query() nor a MongoDB connection henri can use`
+    );
+  }
+
+  return new SqlTrail(adapter, { ...described, table });
+};
+
+module.exports = {
+  COLUMNS,
+  DIALECTS,
+  MongoTrail,
+  SqlTrail,
+  describe,
+  install,
+  reasons,
+  storeFor,
+  toNumber,
+};

--- a/packages/core/src/base/trail.js
+++ b/packages/core/src/base/trail.js
@@ -1,0 +1,649 @@
+/**
+ * The access trail: who read or changed personal data, appended and not
+ * mutable.
+ *
+ * An erasure writes a receipt into a directory. That is proof for the one
+ * operation that produced it, and it is nowhere near enough: the question an
+ * application eventually has to answer is not "did you erase me" but "who
+ * saw this record", and the honest answer to that has to have been written
+ * down before the question was asked.
+ *
+ * ## What is worth recording
+ *
+ * Not every read of every row. That is a second database nobody sized, and
+ * it would be the first thing turned off. The trail records exactly two
+ * things, and the guide says so in its first paragraph so nobody mistakes it
+ * for a packet capture:
+ *
+ * 1. **The operations henri performs itself on personal data.** The export,
+ *    the erasure (dry runs included), every retention rule that sweeps, and
+ *    the approvals. Core owns every one of those call sites, so this half is
+ *    complete by construction: there is no way to run `henri privacy:erase`
+ *    without an entry, and an entry that says `refused` is written too.
+ * 2. **Reads of records holding personal data**, when
+ *    `config.trail.reads` asks for them: one entry per answer henri
+ *    serializes through `res.resource()`, `res.collection()` and
+ *    `res.render()`. Those are the three places henri turns records into a
+ *    payload, so within the boundary "what henri sent" this is also
+ *    complete.
+ *
+ * Everything else is the application's, and it says so: `henri.trail.record()`
+ * appends an entry of its own (`app.<something>`). A controller that reads
+ * with a model call and answers with `res.json()` is outside the boundary
+ * and the guide does not pretend otherwise -- a trail that quietly misses
+ * events is worse than no trail, because it reads as evidence.
+ *
+ * ## Where it goes, and how it stays append-only
+ *
+ * A table henri owns (`henri_trail`), reached through the store adapter's
+ * `query()` or the MongoDB collection, never through a model
+ * (`base/trail-store.js` says why). henri issues `INSERT` and `SELECT`
+ * against it and nothing else; the one `DELETE` is `prune()`.
+ *
+ * A database will happily let anyone update a row, so "append-only" cannot
+ * be a promise the application layer makes. What it can do is make an edit
+ * *visible*:
+ *
+ * - Every entry carries a `seq`, one more than the last, under a **unique
+ *   index**. Two processes appending at the same moment do not fork the
+ *   chain: one insert wins, the other is refused by the index, reads the new
+ *   head and chains onto it.
+ * - Every entry carries `hash = HMAC-SHA256(secret, prev + canonical(entry))`,
+ *   where `prev` is the hash of the entry before it. Changing a field of an
+ *   old row, or removing a row, breaks every hash after it, and
+ *   `henri.trail.verify()` reports the first `seq` where the chain parts
+ *   company. The key is `config.secret`, so re-chaining the tail is not
+ *   something a stolen database connection can do.
+ * - `henri trail:verify` is the command; the guide's operational advice is
+ *   to grant the application `INSERT, SELECT` on this table and nothing
+ *   else, because the strongest form of "cannot be edited" is still the one
+ *   the database enforces.
+ *
+ * `prune()` is the exception and it is a deliberate one: a trail of who
+ * touched personal data is itself personal data, so it has its own
+ * retention (`config.trail.keep`). It removes the oldest entries and then
+ * appends a `trail.pruned` checkpoint carrying the hash of the last entry it
+ * removed, so what remains still verifies from a known link rather than
+ * from nothing.
+ *
+ * ## What it must never hold
+ *
+ * No values. Ever. An entry holds field *names*, counts, public identifiers
+ * (`externalId`, which is already what leaves the server) and digests --
+ * never a name, an address, a phone number or the contents of anything. The
+ * `meta` of an entry goes through `guard()`, which refuses a key that is a
+ * personal field name or a `filterParameters` match, refuses anything that
+ * is not a short scalar, and refuses a string that looks like an email
+ * address. The failure is `HENRI_TRAIL_VALUE_REFUSED` and it is loud: the
+ * worst possible outcome for this feature is a second copy of the data it
+ * exists to protect.
+ *
+ * The person an entry is about is identified the way an erasure receipt
+ * identifies them -- their `externalId` when they have one, and an HMAC of
+ * their identity keyed with `config.secret`. Whoever has to answer "was this
+ * person erased" recomputes the digest from the address they were asked
+ * about; the trail alone gives nobody an address back.
+ *
+ * ## How it is read back
+ *
+ * `henri.trail.list(filter)` and `henri.trail.count(filter)` (by action,
+ * model, actor, person and time), `henri.trail.about(who)` for everything
+ * recorded about one person, and `henri.trail.verify()` for the chain.
+ * `henri trail`, `henri trail:about <who>` and `henri trail:verify` are the
+ * same three from the command line.
+ *
+ * @module base/trail
+ */
+
+const { createHmac, randomUUID } = require('node:crypto');
+
+const { fail } = require('./errors');
+const { isPlainObject } = require('./privacy');
+const { period } = require('./retention');
+
+/** The version of an entry's canonical form: it is what the hash covers */
+const VERSION = 1;
+
+/** The table the trail is written to, unless the configuration says */
+const DEFAULT_TABLE = 'henri_trail';
+
+/** How long an entry is kept, unless the configuration says */
+const DEFAULT_KEEP = '1y';
+
+/** What `trail.reads` accepts */
+const READS = ['all', 'personal'];
+
+/** How many identifiers one entry carries */
+const IDS = 50;
+
+/** How long a `meta` value may be */
+const VALUE = 200;
+
+/**
+ * How many times an append re-reads the head before it gives up.
+ *
+ * The chain is a serial structure: N writers appending at the same moment
+ * take up to N attempts between them, because each of them re-reads the
+ * head after the unique index refuses it. Generous rather than clever, and
+ * `HENRI_TRAIL_UNWRITABLE` says so when it is not enough.
+ */
+const ATTEMPTS = 32;
+
+/** Anything shaped like an address: refused in a `meta` value */
+const ADDRESS = /[^\s@]+@[^\s@]+\.[^\s@]+/u;
+
+/** The name of the entry a prune leaves behind */
+const CHECKPOINT = 'trail.pruned';
+
+/**
+ * The actions core records itself. An application's own are prefixed
+ * `app.`, so reading a trail says at a glance which half an entry came
+ * from.
+ */
+const ACTIONS = [
+  CHECKPOINT,
+  'privacy.erase',
+  'privacy.export',
+  'record.read',
+  'retention.sweep',
+];
+
+/**
+ * A coded failure carrying what to do about it
+ *
+ * @param {string} code one of the catalogue's codes
+ * @param {string} message what went wrong
+ * @param {string} hint what to do about it
+ * @returns {Error} the error to throw
+ */
+function refuse(code, message, hint) {
+  const error = fail(code, message);
+
+  error.hint = hint;
+
+  return error;
+}
+
+/**
+ * The `trail` configuration, normalized
+ *
+ * @param {object} config henri's config module (or anything with get/has)
+ * @returns {object} `{ enabled, keep, reads, store, table }`
+ */
+function trailConfig(config) {
+  const has = config && typeof config.has === 'function' && config.has('trail');
+  const raw = has ? config.get('trail') : false;
+
+  if (raw === false || raw === null || typeof raw === 'undefined') {
+    return {
+      enabled: false,
+      keep: null,
+      reads: false,
+      store: 'default',
+      table: DEFAULT_TABLE,
+    };
+  }
+
+  const settings = isPlainObject(raw) ? raw : {};
+
+  return {
+    enabled: true,
+    keep:
+      settings.keep === false ? null : period(settings.keep || DEFAULT_KEEP),
+    reads: READS.includes(settings.reads) ? settings.reads : false,
+    store: settings.store || 'default',
+    table:
+      typeof settings.table === 'string' && settings.table !== ''
+        ? settings.table
+        : DEFAULT_TABLE,
+  };
+}
+
+/**
+ * An HMAC of a value, keyed with the application's secret: proof of what it
+ * was without a copy of it
+ *
+ * @param {*} value what to digest
+ * @param {string} [secret] `config.secret`
+ * @returns {?string} the digest, hex, or null for nothing
+ */
+function digestOf(value, secret = '') {
+  if (value === null || typeof value === 'undefined' || value === '') {
+    return null;
+  }
+
+  return createHmac('sha256', String(secret || ''))
+    .update(String(value))
+    .digest('hex');
+}
+
+/**
+ * The `meta` of an entry, checked field by field.
+ *
+ * A trail of who read personal data must not become a copy of it, so this
+ * refuses rather than truncates: a caller that wanted to record a value has
+ * to be told, not quietly obeyed halfway.
+ *
+ * @param {*} meta what the caller wants recorded
+ * @param {object} [context={}] the context
+ * @param {Set<string>} [context.keys] the personal field names
+ * @param {Array<string>} [context.filters] `config.filterParameters`
+ * @returns {?object} the meta, or null when there is none
+ * @throws HENRI_TRAIL_VALUE_REFUSED when it would hold something personal
+ */
+function guard(meta, { keys = new Set(), filters = [] } = {}) {
+  if (meta === null || typeof meta === 'undefined') {
+    return null;
+  }
+
+  if (!isPlainObject(meta)) {
+    throw refuse(
+      'HENRI_TRAIL_VALUE_REFUSED',
+      'the meta of a trail entry is a flat object of short scalars',
+      'Record names and counts, never values: { rule: "drafts", count: 12 }'
+    );
+  }
+
+  const kept = {};
+
+  for (const key of Object.keys(meta).sort()) {
+    const value = meta[key];
+    const lower = key.toLowerCase();
+
+    if (keys.has(key)) {
+      throw refuse(
+        'HENRI_TRAIL_VALUE_REFUSED',
+        `the trail refuses to record "${key}": it is a field the models marked personal`,
+        'The trail holds field names, counts and public identifiers, never the values behind them'
+      );
+    }
+
+    if (
+      filters.some((filter) => lower.includes(String(filter).toLowerCase()))
+    ) {
+      throw refuse(
+        'HENRI_TRAIL_VALUE_REFUSED',
+        `the trail refuses to record "${key}": config.filterParameters masks it everywhere else`,
+        'Something masked in every log line does not belong in an append-only table either'
+      );
+    }
+
+    if (value === null || typeof value === 'undefined') {
+      kept[key] = null;
+      continue;
+    }
+
+    if (typeof value === 'number' || typeof value === 'boolean') {
+      kept[key] = value;
+      continue;
+    }
+
+    if (typeof value !== 'string') {
+      throw refuse(
+        'HENRI_TRAIL_VALUE_REFUSED',
+        `the trail refuses to record "${key}": a ${typeof value} is not a name or a count`,
+        'Record strings, numbers, booleans and nulls; anything richer is a record, and records do not go in here'
+      );
+    }
+
+    if (value.length > VALUE) {
+      throw refuse(
+        'HENRI_TRAIL_VALUE_REFUSED',
+        `the trail refuses to record "${key}": ${value.length} characters is content, not a label`,
+        `A meta value is at most ${VALUE} characters`
+      );
+    }
+
+    if (ADDRESS.test(value)) {
+      throw refuse(
+        'HENRI_TRAIL_VALUE_REFUSED',
+        `the trail refuses to record "${key}": it holds something shaped like an email address`,
+        'Name the person with their external id, or let henri digest them: trail.record({ subject })'
+      );
+    }
+
+    kept[key] = value;
+  }
+
+  return kept;
+}
+
+/**
+ * The canonical form of an entry: what the hash is computed over.
+ *
+ * A fixed order of fixed fields, so the same entry hashes the same way on
+ * every dialect, whatever order the columns came back in.
+ *
+ * @param {object} row a row, in database shape
+ * @returns {string} the canonical string
+ */
+function canonicalOf(row) {
+  return JSON.stringify([
+    VERSION,
+    Number(row.seq),
+    Number(row.at),
+    row.action || null,
+    row.outcome || null,
+    row.source || null,
+    row.model || null,
+    Number(row.records) || 0,
+    row.fields || null,
+    row.ids || null,
+    row.actor || null,
+    row.actor_digest || null,
+    row.subject || null,
+    row.subject_digest || null,
+    row.request_id || null,
+    row.route || null,
+    row.meta || null,
+  ]);
+}
+
+/**
+ * The hash of an entry, chained onto the one before it
+ *
+ * @param {?string} prev the hash of the previous entry
+ * @param {object} row a row, in database shape
+ * @param {string} [secret] `config.secret`
+ * @returns {string} the hash, hex
+ */
+function hashOf(prev, row, secret = '') {
+  return createHmac('sha256', String(secret || ''))
+    .update(`${prev || ''}\n${canonicalOf(row)}`)
+    .digest('hex');
+}
+
+/**
+ * A list of identifiers as one column, capped
+ *
+ * @param {Array} ids the identifiers
+ * @returns {?string} the JSON, or null
+ */
+function listOf(ids) {
+  const kept = (Array.isArray(ids) ? ids : [])
+    .filter((id) => typeof id === 'string' && id !== '')
+    .slice(0, IDS);
+
+  return kept.length > 0 ? JSON.stringify(kept) : null;
+}
+
+/**
+ * A stored column back as a list
+ *
+ * @param {*} value what the column holds
+ * @returns {Array} the list, empty when there was nothing
+ */
+function parseList(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (typeof value !== 'string' || value === '') {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    return [];
+  }
+}
+
+/**
+ * A stored column back as an object
+ *
+ * @param {*} value what the column holds
+ * @returns {?object} the object, or null
+ */
+function parseMeta(value) {
+  if (isPlainObject(value)) {
+    return value;
+  }
+
+  if (typeof value !== 'string' || value === '') {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+
+    return isPlainObject(parsed) ? parsed : null;
+  } catch (error) {
+    return null;
+  }
+}
+
+/**
+ * A row, as the API hands it out
+ *
+ * @param {?object} row a row of the trail
+ * @returns {?object} the entry
+ */
+function toEntry(row) {
+  if (!row) {
+    return null;
+  }
+
+  return {
+    action: row.action,
+    actor: row.actor || null,
+    actorDigest: row.actor_digest || null,
+    at: new Date(Number(row.at)).toISOString(),
+    fields: parseList(row.fields),
+    hash: row.hash,
+    id: row.id,
+    ids: parseList(row.ids),
+    meta: parseMeta(row.meta),
+    model: row.model || null,
+    outcome: row.outcome,
+    prev: row.prev || null,
+    records: Number(row.records) || 0,
+    requestId: row.request_id || null,
+    route: row.route || null,
+    seq: Number(row.seq),
+    source: row.source,
+    subject: row.subject || null,
+    subjectDigest: row.subject_digest || null,
+  };
+}
+
+/**
+ * The row of an event, without its sequence, its chain or its hash
+ *
+ * @param {object} event what the caller wants recorded
+ * @param {object} context `keys`, `filters`, `secret`
+ * @returns {object} the row, in database shape
+ * @throws HENRI_TRAIL_VALUE_REFUSED when the meta holds something personal
+ * @throws HENRI_TRAIL_INVALID_EVENT when the event names no action
+ */
+function rowOf(event, context = {}) {
+  const action = String((event && event.action) || '').trim();
+
+  if (action === '' || action.length > 64) {
+    throw refuse(
+      'HENRI_TRAIL_INVALID_EVENT',
+      'a trail entry needs an action: what happened, in one dotted name',
+      "henri.trail.record({ action: 'app.exported', model: 'Proposal' })"
+    );
+  }
+
+  const { secret = '' } = context;
+  const subject = event.subject || null;
+  const meta = guard(event.meta, context);
+
+  return {
+    action,
+    actor: typeof event.actor === 'string' ? event.actor.slice(0, 64) : null,
+    actor_digest: event.actorDigest || digestOf(event.actorOf, secret),
+    at: Number(event.at) || Date.now(),
+    fields: listOf(event.fields),
+    id: randomUUID(),
+    ids: listOf(event.ids),
+    meta: meta && Object.keys(meta).length > 0 ? JSON.stringify(meta) : null,
+    model: event.model ? String(event.model).slice(0, 120) : null,
+    outcome: ['failed', 'ok', 'refused'].includes(event.outcome)
+      ? event.outcome
+      : 'ok',
+    records: Number.isFinite(event.records) ? Math.max(event.records, 0) : 0,
+    request_id: event.requestId ? String(event.requestId).slice(0, 64) : null,
+    route: event.route ? String(event.route).slice(0, 190) : null,
+    source: ['app', 'cli', 'http', 'job'].includes(event.source)
+      ? event.source
+      : 'app',
+    subject: typeof subject === 'string' ? subject.slice(0, 64) : null,
+    subject_digest: event.subjectDigest || digestOf(event.subjectOf, secret),
+  };
+}
+
+/**
+ * Appends one entry, chained onto the head of the trail.
+ *
+ * The head is read, the entry is numbered and hashed onto it, and the insert
+ * either wins the unique index on `seq` or is refused -- in which case
+ * another process got there first, the head is read again and the entry
+ * chains onto whatever won. That is the whole concurrency story: one chain,
+ * no locks, no gaps.
+ *
+ * @param {object} store a trail backend (`base/trail-store.js`)
+ * @param {object} event what to record
+ * @param {object} [context={}] `keys`, `filters`, `secret`
+ * @returns {Promise<object>} the entry that was written
+ * @throws HENRI_TRAIL_UNWRITABLE when the head keeps moving under it
+ */
+async function appendTo(store, event, context = {}) {
+  const base = rowOf(event, context);
+
+  for (let attempt = 0; attempt < ATTEMPTS; attempt += 1) {
+    const head = await store.last();
+    const row = {
+      ...base,
+      prev: head ? head.hash : null,
+      seq: head ? Number(head.seq) + 1 : 1,
+    };
+
+    row.hash = hashOf(row.prev, row, context.secret);
+
+    if (await store.append(row)) {
+      return toEntry(row);
+    }
+
+    // Another writer won this sequence number. Stepping aside for a moment
+    // is what keeps a crowd of writers from taking turns losing
+    if (attempt > 2) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, Math.floor(Math.random() * 5) + 1)
+      );
+    }
+  }
+
+  throw refuse(
+    'HENRI_TRAIL_UNWRITABLE',
+    `the trail entry "${base.action}" could not be appended after ${ATTEMPTS} attempts`,
+    'Something is writing to the trail table faster than henri can chain onto it, or its unique index on seq is missing'
+  );
+}
+
+/**
+ * Walks the chain and says where, if anywhere, it parts company.
+ *
+ * A break is either a hash that does not follow from the entry before it (a
+ * row was edited) or a gap in the sequence (a row was removed). The one
+ * legitimate discontinuity is the start of the trail after a prune, which is
+ * why a checkpoint carries the hash of the last entry it took away.
+ *
+ * @param {object} store a trail backend
+ * @param {object} [options={}] `secret`, `batch`
+ * @returns {Promise<object>} `{ ok, entries, from, to, broken }`
+ */
+async function verifyChain(store, { secret = '', batch = 500 } = {}) {
+  let after = 0;
+  let previous = null;
+  let entries = 0;
+  let from = null;
+  let to = null;
+
+  for (;;) {
+    const rows = await store.since(after, batch);
+
+    if (rows.length === 0) {
+      break;
+    }
+
+    for (const row of rows) {
+      const seq = Number(row.seq);
+      const expected = hashOf(row.prev || null, row, secret);
+
+      if (from === null) {
+        from = seq;
+      }
+
+      // The first entry seen may follow rows a prune took away: its `prev`
+      // is then the checkpoint's, which is a link henri wrote and kept
+      if (previous !== null && (row.prev || null) !== previous.hash) {
+        return broken(seq, entries, from, 'chain', previous.seq);
+      }
+
+      if (previous !== null && seq !== previous.seq + 1) {
+        return broken(seq, entries, from, 'sequence', previous.seq);
+      }
+
+      if (expected !== row.hash) {
+        return broken(seq, entries, from, 'hash', previous && previous.seq);
+      }
+
+      previous = { hash: row.hash, seq };
+      entries += 1;
+      to = seq;
+      after = seq;
+    }
+  }
+
+  return { broken: null, entries, from, ok: true, to };
+}
+
+/**
+ * The answer of a verification that failed
+ *
+ * @param {number} seq where it failed
+ * @param {number} entries how many were verified before it
+ * @param {?number} from the first sequence number seen
+ * @param {string} reason `chain`, `sequence` or `hash`
+ * @param {?number} after the last good sequence number
+ * @returns {object} the answer
+ */
+function broken(seq, entries, from, reason, after) {
+  return {
+    broken: { after: after === null ? null : after, reason, seq },
+    entries,
+    from,
+    ok: false,
+    to: after === null ? null : after,
+  };
+}
+
+module.exports = {
+  ACTIONS,
+  ADDRESS,
+  ATTEMPTS,
+  CHECKPOINT,
+  DEFAULT_KEEP,
+  DEFAULT_TABLE,
+  IDS,
+  READS,
+  VALUE,
+  VERSION,
+  appendTo,
+  canonicalOf,
+  digestOf,
+  guard,
+  hashOf,
+  listOf,
+  parseList,
+  parseMeta,
+  rowOf,
+  toEntry,
+  trailConfig,
+  verifyChain,
+};

--- a/packages/core/src/henri.js
+++ b/packages/core/src/henri.js
@@ -15,6 +15,8 @@ const Model = require('./3.model');
 const Policies = require('./3.policies');
 const Privacy = require('./3.privacy');
 const View = require('./3.view');
+const Retention = require('./4.retention');
+const Trail = require('./4.trail');
 const User = require('./4.user');
 const Router = require('./5.router');
 const Workers = require('./5.workers');
@@ -74,7 +76,9 @@ class Henri extends HenriBase {
     this.modules.add(new Model());
     this.modules.add(new Policies());
     this.modules.add(new Privacy());
+    this.modules.add(new Retention());
     this.modules.add(new Router());
+    this.modules.add(new Trail());
     this.modules.add(new User());
     this.modules.add(new View());
     this.modules.add(new Workers());

--- a/packages/demo/app/models/Artwork.js
+++ b/packages/demo/app/models/Artwork.js
@@ -6,6 +6,8 @@ module.exports = {
       type Query { artworks: [Artwork] }
     `,
   },
-  options: { timestamps: true },
+  // Nothing here is about a person, so the rule deletes rather than
+  // anonymizing: there is nothing to write over
+  options: { retention: { action: 'delete', after: '2y' }, timestamps: true },
   schema: { title: { type: 'string' }, year: { type: 'integer' } },
 };

--- a/packages/demo/app/models/Memo.js
+++ b/packages/demo/app/models/Memo.js
@@ -6,9 +6,17 @@
 module.exports = {
   options: {
     personal: { onErase: 'delete', subject: 'ownerId' },
+    // A memo is kept for thirty days after it was archived, and an archived
+    // memo is the only kind that ages: `from` is what says so. Measuring
+    // from `createdAt` would take a memo somebody still uses (see
+    // base/retention.js)
+    retention: { after: '30d', from: 'archivedAt' },
     timestamps: true,
   },
   schema: {
+    // When the author put it away. Null while they have not: a memo whose
+    // clock never started is never swept
+    archivedAt: { type: 'date' },
     body: { personal: true, type: 'text' },
     // Who wrote it: everything app/policies/memo.js decides comes from here.
     // `ref` is what makes it a foreign key henri can see: without it this is

--- a/packages/demo/config/test.json
+++ b/packages/demo/config/test.json
@@ -32,5 +32,11 @@
   "env": "test",
   "privacy": {
     "receipts": ".tmp/privacy"
+  },
+  "retention": {
+    "receipts": ".tmp/privacy"
+  },
+  "trail": {
+    "keep": "1y"
   }
 }

--- a/packages/drizzle/__tests__/retention.spec.js
+++ b/packages/drizzle/__tests__/retention.spec.js
@@ -1,0 +1,263 @@
+// Retention and the access trail against a real Drizzle store.
+//
+// Both live in @usehenri/core and both reach a database the adapter opened:
+// the sweep through the model API, the trail through `query()` and a table
+// of its own. This file runs them on whatever the environment points at --
+// sqlite offline, a PostgreSQL or a MySQL server with
+// HENRI_TEST_POSTGRES_URL or HENRI_TEST_MYSQL_URL (`pnpm test:sql:live`).
+const { build, target } = require('./helpers');
+
+const {
+  planOf,
+  retentionConfig,
+  rulesOf,
+  sweepOf,
+} = require('../../core/src/base/retention');
+const { fieldsOf } = require('../../core/src/base/privacy');
+const { appendTo, toEntry, verifyChain } = require('../../core/src/base/trail');
+const { storeFor } = require('../../core/src/base/trail-store');
+
+/** A moment, that many days ago */
+const ago = (days) => new Date(Date.now() - days * 86400000);
+
+const models = [
+  {
+    globalId: 'Booking',
+    identity: 'booking',
+    options: {
+      paranoid: true,
+      retention: [
+        { after: '30d', from: 'leftAt', name: 'left' },
+        {
+          action: 'anonymize',
+          after: '90d',
+          from: 'leftAt',
+          name: 'words',
+          where: { state: 'kept' },
+        },
+        { action: 'soft-delete', after: '7d', from: 'seenAt', name: 'stale' },
+      ],
+      timestamps: true,
+    },
+    schema: {
+      guest: { personal: { erase: 'anonymize' }, type: 'string' },
+      leftAt: { type: 'date' },
+      seenAt: { type: 'date' },
+      state: { type: 'string' },
+    },
+    store: 'default',
+  },
+];
+
+describe(`retention on ${target.name}`, () => {
+  let adapter = null;
+  let Booking = null;
+
+  const context = (settings = {}) => ({
+    fieldsOf: () => fieldsOf(models[0]),
+    modelOf: () => Booking,
+    rules: rulesOf(models, { fields: () => fieldsOf(models[0]) }),
+    settings: { ...retentionConfig(null), approve: false, ...settings },
+  });
+
+  beforeAll(async () => {
+    ({ adapter } = build());
+    models.forEach((model) => adapter.addModel(model, 'user'));
+    await adapter.start();
+    Booking = adapter.getModels().Booking;
+  }, 60000);
+
+  afterAll(async () => {
+    await adapter.stop();
+  });
+
+  beforeEach(async () => {
+    await Booking.withDeleted().where({}).destroy({ force: true });
+  });
+
+  test('a delete reaches the soft-deleted rows, and leaves the young ones', async () => {
+    const hidden = await Booking.create({ guest: 'Hidden', leftAt: ago(60) });
+
+    await Booking.where({ id: hidden.id }).destroy();
+    await Booking.create({ guest: 'Gone', leftAt: ago(60) });
+    await Booking.create({ guest: 'Recent', leftAt: ago(1) });
+    await Booking.create({ guest: 'Still here' });
+
+    const receipt = await sweepOf(context(), { only: 'Booking:left' });
+
+    expect(receipt.rules[0].written).toBe(2);
+    expect(receipt.rules[0].waiting).toBe(1);
+    expect(await Booking.withDeleted().where({}).count()).toBe(2);
+  });
+
+  test('an anonymize writes over the personal fields of its class', async () => {
+    await Booking.create({ guest: 'Ada', leftAt: ago(120), state: 'kept' });
+    await Booking.create({ guest: 'Grace', leftAt: ago(120), state: 'other' });
+
+    const receipt = await sweepOf(context(), { only: 'Booking:words' });
+
+    expect(receipt.rules[0].written).toBe(1);
+
+    const rows = await Booking.find({}, { order: 'state' });
+
+    expect(rows.map((row) => row.guest)).toEqual(['[erased]', 'Grace']);
+  });
+
+  test('a soft delete stamps the row, and never comes for a stamped one', async () => {
+    await Booking.create({ guest: 'Old', seenAt: ago(30) });
+    await Booking.create({ guest: 'New', seenAt: ago(1) });
+
+    const first = await sweepOf(context(), { only: 'Booking:stale' });
+
+    expect(first.rules[0].written).toBe(1);
+    expect(await Booking.count()).toBe(1);
+    expect(await Booking.withDeleted().where({}).count()).toBe(2);
+
+    const plan = await planOf(context(), { only: 'Booking:stale' });
+
+    expect(plan.steps[0].matched).toBe(0);
+  });
+
+  test('a batch bounds one run and says what is left', async () => {
+    for (let index = 0; index < 5; index += 1) {
+      await Booking.create({ guest: `Guest ${index}`, leftAt: ago(60) });
+    }
+
+    const receipt = await sweepOf(context({ batch: 2 }), {
+      only: 'Booking:left',
+    });
+
+    expect(receipt.rules[0].matched).toBe(5);
+    expect(receipt.rules[0].written).toBe(2);
+    expect(receipt.rules[0].remaining).toBe(3);
+  });
+});
+
+describe(`the access trail on ${target.name}`, () => {
+  let adapter = null;
+  let store = null;
+
+  beforeAll(async () => {
+    ({ adapter } = build());
+    await adapter.start();
+    // No key: a database of this file's own, so the chain starts empty --
+    // the last test here leaves a tampered row behind on purpose
+    store = storeFor(adapter, 'henri_trail');
+    await store.install();
+  }, 60000);
+
+  afterAll(async () => {
+    await adapter.stop();
+  });
+
+  test('the install is idempotent', async () => {
+    await expect(store.install()).resolves.toBeDefined();
+  });
+
+  test('a push leaves the tables henri owns alone', () => {
+    // Drizzle-kit compares the schema to the database and would offer to
+    // drop a table it does not know; the trail's is not drizzle's to drop
+    expect([...adapter.reservedTables()].sort()).toEqual([
+      'henri_jobs',
+      'henri_jobs_schedules',
+      'henri_trail',
+    ]);
+  });
+
+  test('entries go in, come back and verify', async () => {
+    const first = await appendTo(
+      store,
+      {
+        action: 'privacy.erase',
+        fields: ['email'],
+        ids: ['0192-one'],
+        meta: { strategy: 'anonymize' },
+        model: 'User',
+        records: 1,
+        source: 'cli',
+        subjectDigest: 'digest-one',
+      },
+      { secret: 'k' }
+    );
+
+    await appendTo(
+      store,
+      { action: 'retention.sweep', model: 'Booking', records: 4 },
+      { secret: 'k' }
+    );
+
+    expect(first.seq).toBeGreaterThan(0);
+
+    const [row] = await store.list({ action: 'privacy.erase' });
+
+    expect(toEntry(row)).toMatchObject({
+      fields: ['email'],
+      ids: ['0192-one'],
+      meta: { strategy: 'anonymize' },
+      model: 'User',
+      records: 1,
+    });
+    expect(await store.count({ digest: 'digest-one' })).toBe(1);
+    expect((await verifyChain(store, { secret: 'k' })).ok).toBe(true);
+  });
+
+  test('concurrent writers make one chain, not two', async () => {
+    const before = await store.count({});
+
+    await Promise.all(
+      Array.from({ length: 10 }, (ignored, index) =>
+        appendTo(store, { action: `app.${index}` }, { secret: 'k' })
+      )
+    );
+
+    expect(await store.count({})).toBe(before + 10);
+
+    const verified = await verifyChain(store, { secret: 'k' });
+
+    expect(verified.ok).toBe(true);
+    expect(verified.entries).toBe(before + 10);
+  });
+
+  test('a prune takes a prefix away, and the checkpoint keeps the chain', async () => {
+    const old = await appendTo(
+      store,
+      { action: 'app.old', at: Date.now() - 86400000 },
+      { secret: 'k' }
+    );
+
+    await appendTo(store, { action: 'app.new' }, { secret: 'k' });
+
+    const { last, removed } = await store.prune(Date.now() - 3600000);
+
+    expect(removed).toBeGreaterThan(0);
+    expect(last.hash).toBe(old.hash);
+
+    await appendTo(
+      store,
+      {
+        action: 'trail.pruned',
+        meta: { hash: last.hash, seq: Number(last.seq) },
+        records: removed,
+        source: 'job',
+      },
+      { secret: 'k' }
+    );
+
+    expect((await verifyChain(store, { secret: 'k' })).ok).toBe(true);
+  });
+
+  test('an edited row breaks the chain, and the break is named', async () => {
+    const [row] = await store.list({ limit: 1 });
+
+    await adapter.query(
+      `UPDATE henri_trail SET records = ${adapter.dialect.placeholder(1)} WHERE id = ${adapter.dialect.placeholder(2)}`,
+      [999, row.id]
+    );
+
+    const result = await verifyChain(store, { secret: 'k' });
+
+    expect(result.ok).toBe(false);
+    expect(result.broken.reason).toBe('hash');
+    expect(result.broken.seq).toBe(Number(row.seq));
+  });
+});

--- a/packages/drizzle/index.js
+++ b/packages/drizzle/index.js
@@ -1001,6 +1001,37 @@ class Drizzle {
   }
 
   /**
+   * The tables that live in this database and are not drizzle's.
+   *
+   * `@usehenri/jobs` and the access trail of core own tables of their own
+   * and create them through raw SQL, because both have to work on a store
+   * that has no models at all. drizzle-kit compares the schema to the
+   * database and would offer to drop them; a push that did would take an
+   * application's job history, or its audit trail, with it.
+   *
+   * @returns {Set<string>} The table names a push must leave alone
+   * @memberof Drizzle
+   */
+  reservedTables() {
+    const config = (this.henri && this.henri.config) || null;
+    const read = (key) =>
+      config && config.has && config.has(key) ? config.get(key) : null;
+    const block = (value) =>
+      value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+    const jobs = block(read('jobs'));
+    const trail = block(read('trail'));
+    const name = (value, fallback) =>
+      typeof value === 'string' && value !== '' ? value : fallback;
+    const queue = name(jobs.table, 'henri_jobs');
+
+    return new Set([
+      queue,
+      `${queue}_schedules`,
+      name(trail.table, 'henri_trail'),
+    ]);
+  }
+
+  /**
    * Makes the schema and the database agree after a connection
    *
    * Development: pushes the schema unless `config.sync === false` (the

--- a/packages/drizzle/migrations.js
+++ b/packages/drizzle/migrations.js
@@ -19,6 +19,29 @@ const ORIGIN = '00000000-0000-0000-0000-000000000000';
  *
  * @class Migrations
  */
+/** A statement that takes data away, whatever else it does */
+const DESTRUCTIVE = /\bDROP\s+(?:TABLE|COLUMN)\b/iu;
+
+/**
+ * Does this statement drop one of the tables henri owns?
+ *
+ * The names are checked whole and quoted the way every dialect quotes them,
+ * so a table called `henri_trail_archive` is nobody's business but the
+ * application's.
+ *
+ * @param {string} statement A DDL statement
+ * @param {Set<string>} reserved The table names henri owns
+ * @returns {boolean} true when the statement would drop one of them
+ */
+const drops = (statement, reserved) => {
+  const match =
+    /^\s*DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?[["`]?([A-Za-z0-9_]+)/iu.exec(
+      statement
+    );
+
+  return Boolean(match) && reserved.has(match[1]);
+};
+
 class Migrations {
   /**
    * Creates an instance of Migrations.
@@ -382,7 +405,10 @@ class Migrations {
    */
   async plan({ interactive = false } = {}) {
     const { adapter } = this;
-    const existing = await adapter.listTables();
+    const reserved = adapter.reservedTables();
+    const existing = (await adapter.listTables()).filter(
+      (table) => !reserved.has(table)
+    );
     const wanted = adapter.tableNames();
     const added = wanted.filter((table) => !existing.includes(table));
     const removed = existing.filter(
@@ -407,9 +433,26 @@ class Migrations {
         ? [imports, db, adapter.databaseName()]
         : [imports, db];
     const plan = await quiet(() => kit[adapter.dialect.kit.push](...args));
+    // A table henri owns is not drizzle's to drop. The queue and the access
+    // trail create their own through raw SQL (they have to work on a store
+    // that has no models at all), so drizzle-kit sees them as tables the
+    // schema no longer wants -- and a push that obeyed it would take an
+    // application's job history or its audit trail with it
+    const proposed = plan.statementsToExecute || [];
+    const statements = proposed.filter(
+      (statement) => !drops(statement, reserved)
+    );
     const result = {
-      hasDataLoss: Boolean(plan.hasDataLoss),
-      statements: plan.statementsToExecute || [],
+      // The data loss drizzle-kit reported is the data loss of the
+      // statements it proposed. Dropping one of henri's tables is exactly
+      // that, so once such a drop is filtered out the question has to be
+      // asked again of what is left -- otherwise every boot of an
+      // application with a queue would refuse to push anything
+      hasDataLoss:
+        statements.length === proposed.length
+          ? Boolean(plan.hasDataLoss)
+          : statements.some((statement) => DESTRUCTIVE.test(statement)),
+      statements,
       warnings: plan.warnings || [],
     };
 

--- a/packages/jobs/__tests__/queue.spec.js
+++ b/packages/jobs/__tests__/queue.spec.js
@@ -26,11 +26,13 @@ describe(`queue (${target.name})`, () => {
 
   describe('definitions', () => {
     test('loads app/jobs, keeping the path of a subdirectory', () => {
-      // `henri/mail` is the job the package ships for the mailers
+      // `henri/mail` and `henri/retention` are the jobs the package ships,
+      // for the mailers and for `henri.retention`
       expect(jobs.names()).toEqual([
         'boom',
         'counter',
         'henri/mail',
+        'henri/retention',
         'mailers',
         'nested/deep',
         'ok',

--- a/packages/jobs/__tests__/recurring.spec.js
+++ b/packages/jobs/__tests__/recurring.spec.js
@@ -274,3 +274,70 @@ describe(`recurring (${target.name})`, () => {
     ).rejects.toThrow('pick one');
   });
 });
+
+describe(`a schedule a module asks for (${target.name})`, () => {
+  const adapters = [];
+
+  afterAll(() => close(adapters));
+
+  /**
+   * A queue with a configuration of its own
+   *
+   * @param {object} [config={}] The `jobs` configuration
+   * @returns {Promise<object>} The queue
+   */
+  const queue = async (config = {}) => {
+    const adapter = await adapterFor();
+
+    adapters.push(adapter);
+
+    return (await build({ adapter, config })).jobs;
+  };
+
+  test('recur adds what the configuration did not write', async () => {
+    const jobs = await queue();
+
+    expect(jobs.recur('henri/retention', { cron: '0 3 * * *' })).toBe(true);
+    expect(jobs.config.recurring.map((entry) => entry.name)).toEqual([
+      'henri/retention',
+    ]);
+    expect(jobs.config.recurring[0].job).toBe('henri/retention');
+    expect(jobs.config.recurring[0].spec).toBe('cron:0 3 * * *');
+  });
+
+  test('an entry the application declared wins', async () => {
+    const jobs = await queue({
+      recurring: { 'henri/retention': { every: '6h', job: 'ok' } },
+    });
+
+    expect(jobs.recur('henri/retention', { cron: '0 3 * * *' })).toBe(false);
+    expect(jobs.config.recurring).toHaveLength(1);
+    expect(jobs.config.recurring[0].job).toBe('ok');
+  });
+
+  test('the sweep is a job the package ships', async () => {
+    const jobs = await queue();
+    const swept = [];
+
+    jobs.henri = {
+      ...jobs.henri,
+      retention: {
+        /**
+         * Stands in for `henri.retention.sweep()`
+         *
+         * @param {object} options What the job passed
+         * @returns {Promise<object>} A receipt
+         */
+        sweep: async (options) => {
+          swept.push(options);
+
+          return { rules: [] };
+        },
+      },
+    };
+
+    await jobs.performNow('henri/retention', { only: 'Memo' });
+
+    expect(swept).toEqual([{ only: 'Memo', source: 'job' }]);
+  });
+});

--- a/packages/jobs/src/config.js
+++ b/packages/jobs/src/config.js
@@ -181,4 +181,4 @@ const normalize = (config = {}) => {
   };
 };
 
-module.exports = { DEFAULTS, normalize, queues, table };
+module.exports = { DEFAULTS, normalize, queues, recurring, table };

--- a/packages/jobs/src/jobs.js
+++ b/packages/jobs/src/jobs.js
@@ -7,7 +7,7 @@ const { deserialize, serialize } = require('./serialize');
 const { keep } = require('./keys');
 const { duration, runAt } = require('./duration');
 const { load, validate } = require('./definitions');
-const { normalize } = require('./config');
+const { normalize, recurring } = require('./config');
 const { storeFor } = require('./store');
 const { toNumber, HISTORY_LIMIT } = require('./store/sql');
 
@@ -23,6 +23,17 @@ const STATES = ['pending', 'running', 'done', 'dead'];
  * transport) writes `app/jobs/henri/mail.js` and it wins over this one.
  */
 const MAIL_JOB = 'henri/mail';
+
+/**
+ * The name of the job that sweeps what the models say they keep.
+ *
+ * Retention lives in core (`base/retention.js`) and needs nothing
+ * installed; this is the queue's half of it, so an application that has
+ * `@usehenri/jobs` gets the recurring sweep for free and one that does not
+ * runs `henri retention:sweep` from cron. Like the mail job, an application
+ * that wants its own writes `app/jobs/henri/retention.js`.
+ */
+const RETENTION_JOB = 'henri/retention';
 
 /**
  * A moment, as the API hands it out
@@ -226,7 +237,53 @@ class Jobs {
         },
         this.config
       ),
+      [RETENTION_JOB]: validate(
+        RETENTION_JOB,
+        {
+          /**
+           * Sweeps the retention rules of the models
+           *
+           * @param {object} args What the schedule carries (`only`)
+           * @param {object} context The job context
+           * @returns {Promise<object>} The receipt of the sweep
+           */
+          perform: (args, context) =>
+            context.henri.retention.sweep({
+              ...(args || {}),
+              source: 'job',
+            }),
+        },
+        this.config
+      ),
     };
+  }
+
+  /**
+   * Adds a recurring schedule the configuration did not write.
+   *
+   * This is how a framework module asks for something to happen on a
+   * schedule without an application having to copy a cron expression into
+   * `config.jobs.recurring` (`henri.retention` is the one that does). An
+   * entry the application declared under the same name wins: what is in
+   * `config/<env>.json` is never quietly replaced.
+   *
+   * @param {string} name The name of the schedule
+   * @param {object} entry `cron` or `every`, plus `job`, `args`, `queue`
+   * @returns {boolean} false when the configuration already names it
+   * @throws {Error} HENRI_JOB_INVALID_SCHEDULE on an unreadable expression
+   * @memberof Jobs
+   */
+  recur(name, entry) {
+    if (this.config.recurring.some((schedule) => schedule.name === name)) {
+      return false;
+    }
+
+    this.config.recurring.push(recurring(name, entry));
+    this.config.recurring.sort((one, other) =>
+      one.name.localeCompare(other.name)
+    );
+
+    return true;
   }
 
   /**
@@ -950,4 +1007,4 @@ class Jobs {
   }
 }
 
-module.exports = { Jobs, MAIL_JOB, STATES, toJob };
+module.exports = { Jobs, MAIL_JOB, RETENTION_JOB, STATES, toJob };

--- a/packages/jobs/src/module.js
+++ b/packages/jobs/src/module.js
@@ -223,6 +223,22 @@ class JobsModule extends BaseModule {
   }
 
   /**
+   * Adds a recurring schedule a framework module asks for.
+   *
+   * `henri.retention` is the one that does: an application with the queue
+   * gets its retention sweep on a schedule with nothing to write, and an
+   * entry of its own under the same name still wins.
+   *
+   * @param {string} name The name of the schedule
+   * @param {object} entry `cron` or `every`, plus `job`, `args`, `queue`
+   * @returns {boolean} false when nothing was added
+   * @memberof JobsModule
+   */
+  recur(name, entry) {
+    return this.queue ? this.queue.recur(name, entry) : false;
+  }
+
+  /**
    * Enqueues a job
    *
    * @param {string} name The job name (its file under app/jobs)

--- a/packages/mongoose/index.js
+++ b/packages/mongoose/index.js
@@ -139,8 +139,10 @@ class Mongoose {
     const {
       externalId: external,
       paranoid: soft = false,
-      // A mark for henri (base/privacy.js), not a Mongoose schema option
+      // Marks for henri (base/privacy.js, base/retention.js), not
+      // Mongoose schema options
       personal,
+      retention,
       ...options
     } = model.options || {};
     // Rails has timestamps on every table: `timestamps: false` opts out

--- a/packages/sequelize/__tests__/retention.spec.js
+++ b/packages/sequelize/__tests__/retention.spec.js
@@ -1,0 +1,257 @@
+// Retention and the access trail against a real Sequelize store.
+//
+// Both live in @usehenri/core and both reach a database the adapter opened:
+// the sweep through the model API, the trail through `query()` and a table
+// of its own. This file runs them on whatever the environment points at --
+// sqlite in memory offline, a PostgreSQL or a MySQL server with
+// HENRI_TEST_POSTGRES_URL or HENRI_TEST_MYSQL_URL (`pnpm test:sql:live`).
+const { build, target } = require('./helpers');
+
+const {
+  planOf,
+  retentionConfig,
+  rulesOf,
+  sweepOf,
+} = require('../../core/src/base/retention');
+const { fieldsOf } = require('../../core/src/base/privacy');
+const { appendTo, toEntry, verifyChain } = require('../../core/src/base/trail');
+const { storeFor } = require('../../core/src/base/trail-store');
+
+/** A moment, that many days ago */
+const ago = (days) => new Date(Date.now() - days * 86400000);
+
+const models = [
+  {
+    globalId: 'Ticket',
+    identity: 'ticket',
+    options: {
+      paranoid: true,
+      retention: [
+        { after: '30d', from: 'closedAt', name: 'closed' },
+        {
+          action: 'anonymize',
+          after: '90d',
+          from: 'closedAt',
+          name: 'words',
+          where: { state: 'kept' },
+        },
+        { action: 'soft-delete', after: '7d', from: 'seenAt', name: 'stale' },
+      ],
+      timestamps: true,
+    },
+    schema: {
+      closedAt: { type: 'date' },
+      note: { personal: { erase: 'anonymize' }, type: 'string' },
+      seenAt: { type: 'date' },
+      state: { type: 'string' },
+    },
+    store: 'default',
+  },
+];
+
+describe(`retention on ${target.name}`, () => {
+  let adapter = null;
+  let Ticket = null;
+
+  const context = (settings = {}) => ({
+    fieldsOf: () => fieldsOf(models[0]),
+    modelOf: () => Ticket,
+    rules: rulesOf(models, { fields: () => fieldsOf(models[0]) }),
+    settings: { ...retentionConfig(null), approve: false, ...settings },
+  });
+
+  beforeAll(async () => {
+    ({ adapter } = build());
+    models.forEach((model) => adapter.addModel(model, 'user'));
+    await adapter.start();
+    Ticket = adapter.getModels().Ticket;
+  }, 60000);
+
+  afterAll(async () => {
+    await adapter.stop();
+  });
+
+  beforeEach(async () => {
+    await Ticket.destroy({ force: true, truncate: true });
+  });
+
+  test('a delete reaches the soft-deleted rows, and leaves the young ones', async () => {
+    const hidden = await Ticket.create({ closedAt: ago(60), note: 'hidden' });
+
+    await hidden.destroy();
+    await Ticket.create({ closedAt: ago(60), note: 'closed' });
+    await Ticket.create({ closedAt: ago(1), note: 'recent' });
+    await Ticket.create({ note: 'still open' });
+
+    const receipt = await sweepOf(context(), { only: 'Ticket:closed' });
+
+    expect(receipt.rules[0].written).toBe(2);
+    expect(receipt.rules[0].waiting).toBe(1);
+    expect(await Ticket.count({ paranoid: false })).toBe(2);
+  });
+
+  test('an anonymize writes over the personal fields of its class', async () => {
+    await Ticket.create({ closedAt: ago(120), note: 'a name', state: 'kept' });
+    await Ticket.create({
+      closedAt: ago(120),
+      note: 'another',
+      state: 'other',
+    });
+
+    const receipt = await sweepOf(context(), { only: 'Ticket:words' });
+
+    expect(receipt.rules[0].written).toBe(1);
+
+    const rows = await Ticket.findAll({ order: [['state', 'ASC']] });
+
+    expect(rows.map((row) => row.note)).toEqual(['[erased]', 'another']);
+  });
+
+  test('a soft delete stamps the row, and never comes for a stamped one', async () => {
+    await Ticket.create({ note: 'old', seenAt: ago(30) });
+    await Ticket.create({ note: 'new', seenAt: ago(1) });
+
+    const first = await sweepOf(context(), { only: 'Ticket:stale' });
+
+    expect(first.rules[0].written).toBe(1);
+    expect(await Ticket.count()).toBe(1);
+    expect(await Ticket.count({ paranoid: false })).toBe(2);
+
+    const plan = await planOf(context(), { only: 'Ticket:stale' });
+
+    expect(plan.steps[0].matched).toBe(0);
+  });
+
+  test('a batch bounds one run and says what is left', async () => {
+    for (let index = 0; index < 5; index += 1) {
+      await Ticket.create({ closedAt: ago(60), note: `ticket ${index}` });
+    }
+
+    const receipt = await sweepOf(context({ batch: 2 }), {
+      only: 'Ticket:closed',
+    });
+
+    expect(receipt.rules[0].matched).toBe(5);
+    expect(receipt.rules[0].written).toBe(2);
+    expect(receipt.rules[0].remaining).toBe(3);
+  });
+});
+
+describe(`the access trail on ${target.name}`, () => {
+  let adapter = null;
+  let store = null;
+
+  beforeAll(async () => {
+    ({ adapter } = build());
+    await adapter.start();
+    // No key: a database of this file's own, so the chain starts empty --
+    // the last test here leaves a tampered row behind on purpose
+    store = storeFor(adapter, 'henri_trail');
+    await store.install();
+  }, 60000);
+
+  afterAll(async () => {
+    await adapter.stop();
+  });
+
+  test('the install is idempotent', async () => {
+    await expect(store.install()).resolves.toBeDefined();
+  });
+
+  test('entries go in, come back and verify', async () => {
+    const first = await appendTo(
+      store,
+      {
+        action: 'privacy.erase',
+        fields: ['email'],
+        ids: ['0192-one'],
+        meta: { strategy: 'anonymize' },
+        model: 'User',
+        records: 1,
+        source: 'cli',
+        subjectDigest: 'digest-one',
+      },
+      { secret: 'k' }
+    );
+
+    await appendTo(
+      store,
+      { action: 'retention.sweep', model: 'Ticket', records: 4 },
+      { secret: 'k' }
+    );
+
+    expect(first.seq).toBeGreaterThan(0);
+
+    const [row] = await store.list({ action: 'privacy.erase' });
+
+    expect(toEntry(row)).toMatchObject({
+      fields: ['email'],
+      ids: ['0192-one'],
+      meta: { strategy: 'anonymize' },
+      model: 'User',
+      records: 1,
+    });
+    expect(await store.count({ digest: 'digest-one' })).toBe(1);
+    expect((await verifyChain(store, { secret: 'k' })).ok).toBe(true);
+  });
+
+  test('concurrent writers make one chain, not two', async () => {
+    const before = await store.count({});
+
+    await Promise.all(
+      Array.from({ length: 10 }, (ignored, index) =>
+        appendTo(store, { action: `app.${index}` }, { secret: 'k' })
+      )
+    );
+
+    expect(await store.count({})).toBe(before + 10);
+
+    const verified = await verifyChain(store, { secret: 'k' });
+
+    expect(verified.ok).toBe(true);
+    expect(verified.entries).toBe(before + 10);
+  });
+
+  test('a prune takes a prefix away, and the checkpoint keeps the chain', async () => {
+    const old = await appendTo(
+      store,
+      { action: 'app.old', at: Date.now() - 86400000 },
+      { secret: 'k' }
+    );
+
+    await appendTo(store, { action: 'app.new' }, { secret: 'k' });
+
+    const { last, removed } = await store.prune(Date.now() - 3600000);
+
+    expect(removed).toBeGreaterThan(0);
+    expect(last.hash).toBe(old.hash);
+
+    await appendTo(
+      store,
+      {
+        action: 'trail.pruned',
+        meta: { hash: last.hash, seq: Number(last.seq) },
+        records: removed,
+        source: 'job',
+      },
+      { secret: 'k' }
+    );
+
+    expect((await verifyChain(store, { secret: 'k' })).ok).toBe(true);
+  });
+
+  test('an edited row breaks the chain, and the break is named', async () => {
+    const [row] = await store.list({ limit: 1 });
+
+    await adapter.query('UPDATE henri_trail SET records = ? WHERE id = ?', [
+      999,
+      row.id,
+    ]);
+
+    const result = await verifyChain(store, { secret: 'k' });
+
+    expect(result.ok).toBe(false);
+    expect(result.broken.reason).toBe('hash');
+    expect(result.broken.seq).toBe(Number(row.seq));
+  });
+});

--- a/packages/sequelize/index.js
+++ b/packages/sequelize/index.js
@@ -208,9 +208,11 @@ class Sql {
     const options = { timestamps: true, ...(model.options || {}) };
     const external = wantsExternalId(model);
 
-    // `externalId` and `personal` are henri options, not Sequelize ones
+    // `externalId`, `personal` and `retention` are henri options, not
+    // Sequelize ones
     delete options.externalId;
     delete options.personal;
+    delete options.retention;
 
     if (model.name && !options.tableName) {
       options.tableName = model.name;

--- a/showcase/.gitignore
+++ b/showcase/.gitignore
@@ -17,8 +17,9 @@ app/views/dist
 # Files henri destroy moves aside
 .backup/
 
-# Erasure receipts: what henri privacy:erase leaves behind as proof it ran
-# (config.privacy.receipts). They belong wherever this application keeps its
-# operational records, not in the repository.
+# Receipts: what henri privacy:erase and henri retention:sweep leave behind
+# as proof they ran (config.privacy.receipts, config.retention.receipts).
+# They belong wherever this application keeps its operational records, not in
+# the repository.
 /privacy/
 .tmp/

--- a/showcase/AGENTS.md
+++ b/showcase/AGENTS.md
@@ -59,7 +59,14 @@ says a field is about a person (`User.name`, `bio`, `company`): henri masks it
 in the logs, exports it and erases it. `User.phone` is
 `personal: { expose: false }`, so it never leaves the server unless a render
 names it in `include` -- only `accounts#show` does. Run `henri privacy` for
-the map. Every store adds `createdAt`/`updatedAt`,
+the map. `options.retention` says how long a model keeps its records:
+`Proposal` has two rules (drafts after 180 days, decided proposals into the
+trash two years after `decidedAt`) and `Review` anonymizes its comments after
+two years. A rule writes nothing until its token is in
+`config.retention.approved`; `henri retention` prints them and
+`henri retention:sweep` (`--yes` to write) runs the sweep. Every privacy
+operation and every sweep is appended to the access trail, which
+`henri trail` and `henri trail:verify` read back. Every store adds `createdAt`/`updatedAt`,
 `Model.paginate({ page, perPage })` -> `{ records, page, perPage, total, pages }`,
 `henri.model.errors(error)` -> `{ field: message }` (`null` otherwise) and `db/seeds.js`, run by `henri db:seed`.
 Every model also carries `externalId`, a uuid that is unique and not null in the

--- a/showcase/app/models/Proposal.js
+++ b/showcase/app/models/Proposal.js
@@ -47,6 +47,30 @@ module.exports = {
     // here is marked `personal`: a title and an abstract are the talk, and
     // the person is one join away.
     personal: { onErase: 'anonymize' },
+    // How long the conference keeps a proposal, and what happens then. Two
+    // classes of record, two clocks, two verbs:
+    //
+    // - a draft nobody ever submitted is deleted six months after it was
+    //   written, because there is nothing here worth keeping and the
+    //   speaker's words are the only thing in it;
+    // - a decided proposal goes into the trash two years *after the
+    //   decision*, not after it was written: `submittedAt` and `createdAt`
+    //   are the wrong clocks for a promise made about a decision. Soft,
+    //   because this model is paranoid and an admin restoring one is the
+    //   whole point of that.
+    //
+    // Neither is `anonymize`: nothing here is marked personal, so there
+    // would be nothing to write over, and henri refuses that rule rather
+    // than reporting a sweep that touched no field.
+    retention: [
+      {
+        action: 'soft-delete',
+        after: '2y',
+        from: 'decidedAt',
+        name: 'decided',
+      },
+      { after: '180d', name: 'drafts', where: { state: 'draft' } },
+    ],
   },
 
   schema: {

--- a/showcase/app/models/Review.js
+++ b/showcase/app/models/Review.js
@@ -33,6 +33,11 @@ module.exports = {
     // score stay; the comment is the reviewer's own words about a talk, so
     // it goes with them. `anonymize` is both of those at once.
     personal: { onErase: 'anonymize' },
+    // And the same answer on a clock rather than on a request: two years
+    // after it was written, the words go and the score stays, so the
+    // committee's history still counts and nobody's opinion of a talk is
+    // still on file with their name one join away.
+    retention: { action: 'anonymize', after: '2y' },
   },
 
   schema: {

--- a/showcase/config/default.json
+++ b/showcase/config/default.json
@@ -36,5 +36,15 @@
   },
   "mail": {
     "jsonTransport": true
-  }
+  },
+  "retention": {
+    "approved": [
+      "Proposal:decided:da3cbf9e5565",
+      "Proposal:drafts:b03757619b48",
+      "Review:default:a21cf07bcf3f"
+    ],
+    "receipts": "privacy",
+    "schedule": false
+  },
+  "trail": {}
 }

--- a/showcase/config/production.json
+++ b/showcase/config/production.json
@@ -33,5 +33,15 @@
       "sync": false,
       "migrate": true
     }
-  }
+  },
+  "retention": {
+    "approved": [
+      "Proposal:decided:da3cbf9e5565",
+      "Proposal:drafts:b03757619b48",
+      "Review:default:a21cf07bcf3f"
+    ],
+    "receipts": "privacy",
+    "schedule": false
+  },
+  "trail": {}
 }

--- a/showcase/config/test.json
+++ b/showcase/config/test.json
@@ -42,5 +42,15 @@
   },
   "privacy": {
     "receipts": ".tmp/privacy"
-  }
+  },
+  "retention": {
+    "approved": [
+      "Proposal:decided:da3cbf9e5565",
+      "Proposal:drafts:b03757619b48",
+      "Review:default:a21cf07bcf3f"
+    ],
+    "receipts": ".tmp/privacy",
+    "schedule": false
+  },
+  "trail": {}
 }

--- a/showcase/test/retention.test.js
+++ b/showcase/test/retention.test.js
@@ -1,0 +1,464 @@
+// Retention and the access trail, against the real application.
+//
+// The rules are read from the models at boot (`henri.retention`), so this
+// file is also what keeps them honest: a rule added to a model without its
+// token in `config/test.json` fails here, which is exactly what would happen
+// in production -- a rule nobody approved writes nothing.
+//
+// A sweep takes a `now`, and that is what these tests move rather than
+// backdating rows: `createdAt` is the adapter's to write, so "two hundred
+// days from now" is the only way to say "later" without lying to the
+// database about when a record was written.
+const {
+  createEvent,
+  createProposal,
+  createUser,
+  request,
+  reset,
+  signIn,
+} = require('./helpers');
+
+/** A moment, that many days ago */
+const ago = (days) => new Date(Date.now() - days * 86400000);
+
+/** A moment, that many days from now: where a sweep is run from */
+const later = (days) => new Date(Date.now() + days * 86400000);
+
+/** The rule of one model, as `henri retention` prints it */
+const ruleOf = (model, name = 'default') =>
+  henri.retention
+    .describe()
+    .rules.find((rule) => rule.model === model && rule.rule === name);
+
+/**
+ * Runs a sweep with a setting of its own, and puts the settings back
+ *
+ * @param {object} overrides What to change (`batch`, `approved`)
+ * @param {object} options The options of the sweep
+ * @returns {Promise<object>} The receipt
+ */
+const sweepWith = async (overrides, options) => {
+  const settings = henri.retention.settings;
+
+  henri.retention.settings = { ...settings, ...overrides };
+
+  try {
+    return await henri.retention.sweep(options);
+  } finally {
+    henri.retention.settings = settings;
+  }
+};
+
+describe('retention', () => {
+  beforeEach(async () => {
+    await reset();
+  });
+
+  describe('the rules', () => {
+    test('are what the models said', () => {
+      const { rules } = henri.retention.describe();
+
+      expect(rules.map((rule) => `${rule.model}:${rule.rule}`).sort()).toEqual([
+        'Proposal:decided',
+        'Proposal:drafts',
+        'Review:default',
+      ]);
+
+      // A decided proposal goes into the trash two years after the
+      // decision, not two years after it was written
+      expect(ruleOf('Proposal', 'decided')).toMatchObject({
+        action: 'soft-delete',
+        after: 63072000000,
+        from: 'decidedAt',
+      });
+      // A draft nobody submitted is a different class of record, with a
+      // clock and a verb of its own
+      expect(ruleOf('Proposal', 'drafts')).toMatchObject({
+        action: 'delete',
+        from: 'createdAt',
+        where: { state: 'draft' },
+      });
+      // The reviewer's words go; the score and the row stay
+      expect(ruleOf('Review')).toMatchObject({
+        action: 'anonymize',
+        after: 63072000000,
+      });
+    });
+
+    test('are all approved in this environment, and say so', () => {
+      for (const rule of henri.retention.describe().rules) {
+        expect(rule.approved).toBe(true);
+        expect(rule.token).toMatch(/^\w+:\w+:[0-9a-f]{12}$/u);
+      }
+    });
+
+    test('nothing runs the sweep here, and the module says so', () => {
+      // The showcase does not depend on @usehenri/jobs: the boot line names
+      // the command a cron entry would run instead
+      expect(henri.retention.schedule()).toMatch(
+        /henri retention:sweep --yes/u
+      );
+    });
+  });
+
+  describe('a sweep', () => {
+    /**
+     * A speaker, an edition, three proposals and one review
+     *
+     * @returns {Promise<object>} What was created
+     */
+    const conference = async () => {
+      const speaker = await createUser();
+      const reviewer = await createUser({ roles: ['admin'] });
+      const { event, track } = await createEvent();
+      const draft = await createProposal({
+        eventId: event.id,
+        speakerId: speaker.id,
+        state: 'draft',
+        title: 'A draft nobody ever submitted',
+      });
+      const decided = await createProposal({
+        decidedAt: ago(800),
+        eventId: event.id,
+        speakerId: speaker.id,
+        state: 'accepted',
+        title: 'A talk the committee decided on',
+        trackId: track.id,
+      });
+      const recent = await createProposal({
+        decidedAt: ago(10),
+        eventId: event.id,
+        speakerId: speaker.id,
+        state: 'accepted',
+        title: 'A talk decided on last week',
+        trackId: track.id,
+      });
+      const review = await Review.create({
+        comment: 'A careful and quite specific opinion about this talk.',
+        proposalId: decided.id,
+        reviewerId: reviewer.id,
+        score: 2,
+      });
+
+      return { decided, draft, recent, review, speaker };
+    };
+
+    test('says what it would do, and writes nothing', async () => {
+      const { draft } = await conference();
+      const receipt = await henri.retention.sweep({
+        dryRun: true,
+        now: later(200),
+      });
+
+      expect(receipt.dryRun).toBe(true);
+
+      const drafts = receipt.rules.find((rule) => rule.rule === 'drafts');
+
+      expect(drafts.would).toBe(1);
+      expect(drafts.written).toBe(0);
+      expect(drafts.skipped).toBe('dry run');
+
+      // Nothing moved
+      expect(await Proposal.findByKey(draft.id)).not.toBeNull();
+      expect(receipt.file).toBeNull();
+    });
+
+    test('deletes what it deletes, and hides what it hides', async () => {
+      const { decided, draft, recent } = await conference();
+      const receipt = await henri.retention.sweep({ now: later(200) });
+      const rule = (name) => receipt.rules.find((one) => one.rule === name);
+
+      expect(rule('drafts').written).toBe(1);
+      expect(rule('decided').written).toBe(1);
+      // The review is two hundred days old, and it is kept for two years
+      expect(rule('default').written).toBe(0);
+
+      // The draft is gone for good
+      expect(await Proposal.withDeleted().where({ id: draft.id }).count()).toBe(
+        0
+      );
+      // The decided one is in the trash, and an admin can bring it back
+      expect(await Proposal.findByKey(decided.id)).toBeNull();
+      expect(
+        await Proposal.withDeleted().where({ id: decided.id }).count()
+      ).toBe(1);
+      // The one decided last week was not touched
+      expect(await Proposal.findByKey(recent.id)).not.toBeNull();
+    });
+
+    test('anonymizes the reviewer, and keeps the committee record', async () => {
+      const { review } = await conference();
+      const receipt = await henri.retention.sweep({
+        now: later(800),
+        only: 'Review',
+      });
+
+      expect(receipt.rules).toHaveLength(1);
+      expect(receipt.rules[0].written).toBe(1);
+      expect(receipt.rules[0].fields).toEqual(['comment']);
+
+      const kept = await Review.findByKey(review.id);
+
+      // The score and the row are the committee's record of a decision
+      expect(kept.score).toBe(2);
+      expect(kept.comment).not.toContain('careful');
+    });
+
+    test('leaves a receipt that names no record', async () => {
+      await conference();
+
+      const receipt = await henri.retention.sweep({ now: later(800) });
+
+      expect(receipt.file).toMatch(/^\.tmp\/privacy\/retention-/u);
+
+      const document = JSON.stringify(receipt);
+
+      // A sample of public identifiers, and nothing a person wrote
+      expect(document).not.toContain('careful and quite specific');
+      expect(document).not.toContain('nobody ever submitted');
+      expect(receipt.rules.every((rule) => rule.sample.length <= 20)).toBe(
+        true
+      );
+    });
+
+    test('takes what a bounded run left for the next one', async () => {
+      const speaker = await createUser();
+      const { event } = await createEvent();
+
+      for (let index = 0; index < 3; index += 1) {
+        await createProposal({
+          eventId: event.id,
+          speakerId: speaker.id,
+          state: 'draft',
+          title: `A draft nobody submitted, number ${index}`,
+        });
+      }
+
+      const first = await sweepWith(
+        { batch: 2 },
+        { now: later(200), only: 'Proposal:drafts' }
+      );
+
+      expect(first.rules[0].matched).toBe(3);
+      expect(first.rules[0].written).toBe(2);
+      expect(first.rules[0].remaining).toBe(1);
+
+      const second = await sweepWith(
+        { batch: 2 },
+        { now: later(200), only: 'Proposal:drafts' }
+      );
+
+      expect(second.rules[0].written).toBe(1);
+      expect(second.rules[0].remaining).toBe(0);
+    });
+
+    test('a rule nobody approved writes nothing, whatever else happens', async () => {
+      await conference();
+
+      const receipt = await sweepWith({ approved: [] }, { now: later(800) });
+
+      expect(receipt.pending).toBe(3);
+      expect(
+        receipt.rules.every((rule) => rule.skipped === 'not approved')
+      ).toBe(true);
+      expect(receipt.rules.every((rule) => rule.written === 0)).toBe(true);
+      // And it still says how much it would have taken
+      expect(
+        receipt.rules.reduce((total, rule) => total + rule.would, 0)
+      ).toBeGreaterThan(0);
+
+      expect(await Proposal.withDeleted().where({}).count()).toBe(3);
+    });
+
+    test('a record whose clock never started is counted, not swept', async () => {
+      const speaker = await createUser();
+      const { event } = await createEvent();
+
+      // Submitted, never decided: `decidedAt` is null, so the two-year
+      // clock of the `decided` rule has not started
+      await createProposal({
+        eventId: event.id,
+        speakerId: speaker.id,
+        state: 'submitted',
+        submittedAt: ago(900),
+        title: 'A talk still waiting for an answer',
+      });
+
+      const plan = await henri.retention.plan({
+        now: later(800),
+        only: 'Proposal:decided',
+      });
+
+      expect(plan.steps[0].matched).toBe(0);
+      expect(plan.steps[0].waiting).toBe(1);
+    });
+  });
+});
+
+describe('the access trail', () => {
+  beforeEach(async () => {
+    await reset();
+    // The trail is the one table `reset()` leaves alone -- it is
+    // append-only, and nothing in the application deletes from it -- so
+    // this file empties it itself to count from a known place
+    await henri.model.getStore('default').query('DELETE FROM henri_trail');
+  });
+
+  test('is on, and it is a table henri owns', () => {
+    expect(henri.trail.enabled).toBe(true);
+    expect(henri.trail.settings.table).toBe('henri_trail');
+    // Reads are off here, as they are everywhere until an application asks:
+    // every recorded read is a round trip and an insert on the request path
+    expect(henri.trail.settings.reads).toBe(false);
+  });
+
+  test('records a sweep, one entry per rule', async () => {
+    const speaker = await createUser();
+    const { event } = await createEvent();
+
+    await createProposal({
+      eventId: event.id,
+      speakerId: speaker.id,
+      state: 'draft',
+      title: 'A draft nobody ever submitted',
+    });
+
+    const before = await henri.trail.count({ action: 'retention.sweep' });
+
+    await henri.retention.sweep({ now: later(200) });
+
+    expect(await henri.trail.count({ action: 'retention.sweep' })).toBe(
+      before + 3
+    );
+
+    const entries = await henri.trail.list({ action: 'retention.sweep' });
+    const drafts = entries.find((entry) => entry.meta.rule === 'drafts');
+
+    expect(drafts.model).toBe('Proposal');
+    expect(drafts.records).toBe(1);
+    expect(drafts.meta.action).toBe('delete');
+    expect(drafts.ids).toHaveLength(1);
+  });
+
+  test('answers "prove the erasure happened" from an address alone', async () => {
+    const speaker = await createUser({ email: 'erased@example.test' });
+    const { event } = await createEvent();
+
+    await createProposal({
+      eventId: event.id,
+      speakerId: speaker.id,
+      title: 'A talk that survives its speaker',
+    });
+
+    await henri.privacy.export('erased@example.test');
+    await henri.privacy.erase('erased@example.test');
+
+    const about = await henri.trail.about('erased@example.test');
+
+    expect(about.map((entry) => entry.action)).toEqual([
+      'privacy.erase',
+      'privacy.export',
+    ]);
+    // The address is not in the table: its digest is
+    expect(JSON.stringify(about)).not.toContain('erased@example.test');
+    expect(about[0].subjectDigest).toEqual(expect.any(String));
+  });
+
+  test('records the reads that leave through an answer', async () => {
+    const speaker = await createUser();
+    const { event } = await createEvent();
+    const proposal = await createProposal({
+      eventId: event.id,
+      speakerId: speaker.id,
+      state: 'submitted',
+      submittedAt: new Date(),
+      title: 'A talk somebody will read about',
+    });
+    const { browser } = await signIn(speaker);
+    const before = await henri.trail.count({ action: 'record.read' });
+
+    henri.trail.settings = { ...henri.trail.settings, reads: 'personal' };
+
+    let answer;
+
+    try {
+      answer = await browser
+        .get(`/proposals/${proposal.externalId}`)
+        .set('Accept', 'application/json');
+    } finally {
+      henri.trail.settings = { ...henri.trail.settings, reads: false };
+    }
+
+    expect(answer.status).toBe(200);
+    expect(await henri.trail.count({ action: 'record.read' })).toBe(before + 1);
+
+    const [entry] = await henri.trail.list({ action: 'record.read' });
+
+    expect(entry.source).toBe('http');
+    // The answer is a presentation of the proposal, which carries no model;
+    // `subject` is where the record itself is
+    expect(entry.model).toBe('Proposal');
+    expect(entry.records).toBe(1);
+    expect(entry.ids).toEqual([proposal.externalId]);
+    expect(entry.actor).toBe(speaker.externalId);
+    expect(entry.route).toMatch(/^GET /u);
+    // Names and identifiers, never a value
+    expect(JSON.stringify(entry)).not.toContain('A talk somebody will read');
+  });
+
+  test('records nothing for an answer that carries no record', async () => {
+    const before = await henri.trail.count({});
+    const answer = await request().get('/livez');
+
+    expect(answer.status).toBe(200);
+    expect(await henri.trail.count({})).toBe(before);
+  });
+
+  test('refuses to become a second copy of what it protects', async () => {
+    await expect(
+      henri.trail.record({ action: 'app.thing', meta: { name: 'Ada' } })
+    ).rejects.toThrow(/marked personal/u);
+    await expect(
+      henri.trail.record({
+        action: 'app.thing',
+        meta: { who: 'ada@example.test' },
+      })
+    ).rejects.toThrow(/email address/u);
+  });
+
+  test('the chain of this application holds', async () => {
+    await henri.trail.record({ action: 'app.one', records: 1 });
+    await henri.trail.record({ action: 'app.two', records: 2 });
+
+    const result = await henri.trail.verify();
+
+    expect(result.ok).toBe(true);
+    expect(result.entries).toBeGreaterThan(0);
+    expect(result.broken).toBeNull();
+  });
+
+  test('an edited row is caught', async () => {
+    const entry = await henri.trail.record({
+      action: 'app.tampered',
+      records: 1,
+    });
+    const store = henri.model.getStore('default');
+
+    await store.query('UPDATE henri_trail SET records = $1 WHERE id = $2', [
+      99,
+      entry.id,
+    ]);
+
+    const result = await henri.trail.verify();
+
+    expect(result.ok).toBe(false);
+    expect(result.broken).toMatchObject({ reason: 'hash', seq: entry.seq });
+
+    // Put it back, so the rest of the suite still verifies
+    await store.query('UPDATE henri_trail SET records = $1 WHERE id = $2', [
+      1,
+      entry.id,
+    ]);
+    expect((await henri.trail.verify()).ok).toBe(true);
+  });
+});

--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -30,40 +30,42 @@ Every key below is declared in `@usehenri/core`, so an editor completes them as 
 
 ## Keys
 
-| Key                | Default       | Description                                                                                                                                     |
-| ------------------ | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `port`             | `3000`        | Port to listen on. In development a busy port is replaced by the next free one; under `NODE_ENV=test` the kernel assigns one.                   |
-| `host`             | see below     | Interface to bind: `127.0.0.1` outside production, `0.0.0.0` in production. `HENRI_HOST` (what `henri server --host` sets) wins over the file.  |
-| `cors`             | off           | `true` enables [cors](https://github.com/expressjs/cors) with its defaults; an object is passed to it as options.                               |
-| `renderer`         | `template`    | View engine: `inertia`, `react` or `template` (Handlebars), whatever the case. `henri new` writes `inertia`. See [Views](/guides/views/).       |
-| `inertia`          |               | Options of the Inertia renderer: `ssr`, `id`, `entry`, `ssrEntry`, `template`. See [Views](/guides/views/#inertia).                             |
-| `experimental`     |               | Opt-in to unmaintained renderers: `{ "vue": true }`.                                                                                            |
-| `stores`           |               | Named database stores, see below. A model picks one with its `store` key or uses `default`.                                                     |
-| `secret`           |               | Session and token secret. Required as soon as a user model exists; usually provided by `HENRI_SECRET`.                                          |
-| `url`              | the local url | Canonical address of the application (`https://example.com`), used for the links inside the mails henri sends. Set it in production.            |
-| `user`             | `user`        | Name of the user model, or an object (below). See [Users](/guides/users/).                                                                      |
-| `baseRole`         |               | Role, or list of roles, given to every new user.                                                                                                |
-| `externalIds`      |               | What henri does with the internal identifier of a record: which one a lookup takes, and what a foreign key serializes as, below.                |
-| `policies`         |               | Record-level authorization: what a refusal answers and whether an unasked policy is reported, see below. See [Policies](/guides/policies/).     |
-| `trustProxy`       | `true`        | Express `trust proxy`: `true`, a hop count or a list of addresses; `X-Forwarded-*` headers are honoured. Set `false` without a proxy.           |
-| `csrf`             | `true`        | `false` disables the [CSRF protection](/guides/users/#csrf); an object configures the origin check, below.                                      |
-| `graphql`          | `/_henri/gql` | Path of the GraphQL endpoint, or an object with its limits and access rules, below; needs `@usehenri/graphql`. See [GraphQL](/guides/graphql/). |
-| `mail`             |               | Nodemailer transport options, or `"test"` for an Ethereal test account. See [Mail](/guides/mail/).                                              |
-| `mailers`          |               | Defaults of the [mailers](/guides/mail/): `from`, `layout` and `previews`, see below.                                                           |
-| `api`              |               | Pagination, strict HAL and idempotency settings of the [JSON API](/guides/api/), see below.                                                     |
-| `jobs`             |               | Settings of the [job queue](/guides/jobs/), see below; needs `@usehenri/jobs`. The queue also loads when `app/jobs` holds a file.               |
-| `rateLimit`        | `600`/min     | Global, authentication and shared-store rate limits, see below. `false` disables them, `true` keeps the defaults.                               |
-| `shared`           |               | The backend the rate limit, the sign-in lockout and the idempotency keys count in, so two processes share one set, see below.                   |
-| `cache`            | on            | `henri.cache`: how long an entry lives, how much of it is kept and where, see below. `false` turns the cache off.                               |
-| `helmet`           | on            | Options merged over henri's [helmet](https://helmetjs.github.io/) defaults; `false` disables it.                                                |
-| `csp`              | off           | Content Security Policy settings henri owns beside `helmet`: `nonce`, see below. See [Security](/guides/security/#content-security-policy).     |
-| `filterParameters` | see below     | Parameter names masked in the logs; `false` masks nothing.                                                                                      |
-| `privacy`          |               | What henri does with the fields the models marked `personal`, see below. See [Personal data](/guides/privacy/).                                 |
-| `bodyLimit`        | `1mb`         | Maximum size of a JSON or form body.                                                                                                            |
-| `uploads`          |               | File uploads: where they go, the limits and the accepted types, see below; needs `@usehenri/uploads`. `false` accepts no file.                  |
-| `requestTimeout`   | `30000`       | Milliseconds before a running request is answered `503`; `false` disables it.                                                                   |
-| `shutdown`         |               | What a `SIGTERM` does before the modules stop: `delay`, `drain` and `signals`, see below.                                                       |
-| `errors`           |               | What henri does with the code of a failure: `url`, a template holding `{code}`. See [Error codes](/reference/errors/).                          |
+| Key                | Default       | Description                                                                                                                                                |
+| ------------------ | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `port`             | `3000`        | Port to listen on. In development a busy port is replaced by the next free one; under `NODE_ENV=test` the kernel assigns one.                              |
+| `host`             | see below     | Interface to bind: `127.0.0.1` outside production, `0.0.0.0` in production. `HENRI_HOST` (what `henri server --host` sets) wins over the file.             |
+| `cors`             | off           | `true` enables [cors](https://github.com/expressjs/cors) with its defaults; an object is passed to it as options.                                          |
+| `renderer`         | `template`    | View engine: `inertia`, `react` or `template` (Handlebars), whatever the case. `henri new` writes `inertia`. See [Views](/guides/views/).                  |
+| `inertia`          |               | Options of the Inertia renderer: `ssr`, `id`, `entry`, `ssrEntry`, `template`. See [Views](/guides/views/#inertia).                                        |
+| `experimental`     |               | Opt-in to unmaintained renderers: `{ "vue": true }`.                                                                                                       |
+| `stores`           |               | Named database stores, see below. A model picks one with its `store` key or uses `default`.                                                                |
+| `secret`           |               | Session and token secret. Required as soon as a user model exists; usually provided by `HENRI_SECRET`.                                                     |
+| `url`              | the local url | Canonical address of the application (`https://example.com`), used for the links inside the mails henri sends. Set it in production.                       |
+| `user`             | `user`        | Name of the user model, or an object (below). See [Users](/guides/users/).                                                                                 |
+| `baseRole`         |               | Role, or list of roles, given to every new user.                                                                                                           |
+| `externalIds`      |               | What henri does with the internal identifier of a record: which one a lookup takes, and what a foreign key serializes as, below.                           |
+| `policies`         |               | Record-level authorization: what a refusal answers and whether an unasked policy is reported, see below. See [Policies](/guides/policies/).                |
+| `trustProxy`       | `true`        | Express `trust proxy`: `true`, a hop count or a list of addresses; `X-Forwarded-*` headers are honoured. Set `false` without a proxy.                      |
+| `csrf`             | `true`        | `false` disables the [CSRF protection](/guides/users/#csrf); an object configures the origin check, below.                                                 |
+| `graphql`          | `/_henri/gql` | Path of the GraphQL endpoint, or an object with its limits and access rules, below; needs `@usehenri/graphql`. See [GraphQL](/guides/graphql/).            |
+| `mail`             |               | Nodemailer transport options, or `"test"` for an Ethereal test account. See [Mail](/guides/mail/).                                                         |
+| `mailers`          |               | Defaults of the [mailers](/guides/mail/): `from`, `layout` and `previews`, see below.                                                                      |
+| `api`              |               | Pagination, strict HAL and idempotency settings of the [JSON API](/guides/api/), see below.                                                                |
+| `jobs`             |               | Settings of the [job queue](/guides/jobs/), see below; needs `@usehenri/jobs`. The queue also loads when `app/jobs` holds a file.                          |
+| `rateLimit`        | `600`/min     | Global, authentication and shared-store rate limits, see below. `false` disables them, `true` keeps the defaults.                                          |
+| `shared`           |               | The backend the rate limit, the sign-in lockout and the idempotency keys count in, so two processes share one set, see below.                              |
+| `cache`            | on            | `henri.cache`: how long an entry lives, how much of it is kept and where, see below. `false` turns the cache off.                                          |
+| `helmet`           | on            | Options merged over henri's [helmet](https://helmetjs.github.io/) defaults; `false` disables it.                                                           |
+| `csp`              | off           | Content Security Policy settings henri owns beside `helmet`: `nonce`, see below. See [Security](/guides/security/#content-security-policy).                |
+| `filterParameters` | see below     | Parameter names masked in the logs; `false` masks nothing.                                                                                                 |
+| `privacy`          |               | What henri does with the fields the models marked `personal`, see below. See [Personal data](/guides/privacy/).                                            |
+| `retention`        |               | What runs the retention sweep and what it may do, see below. How long a model keeps its records is said in the model. See [Retention](/guides/retention/). |
+| `trail`            | off           | The append-only record of who read or changed personal data, see below. See [The access trail](/guides/trail/).                                            |
+| `bodyLimit`        | `1mb`         | Maximum size of a JSON or form body.                                                                                                                       |
+| `uploads`          |               | File uploads: where they go, the limits and the accepted types, see below; needs `@usehenri/uploads`. `false` accepts no file.                             |
+| `requestTimeout`   | `30000`       | Milliseconds before a running request is answered `503`; `false` disables it.                                                                              |
+| `shutdown`         |               | What a `SIGTERM` does before the modules stop: `delay`, `drain` and `signals`, see below.                                                                  |
+| `errors`           |               | What henri does with the code of a failure: `url`, a template holding `{code}`. See [Error codes](/reference/errors/).                                     |
 
 ## The `externalIds` object
 
@@ -276,6 +278,56 @@ those are is said in the models themselves; see
 | `expose`   | `true`        | Whether a personal field may leave the server in an answer henri builds. `false` drops every one of them unless the field says `personal: { expose: true }`.                                      |
 | `onErase`  | `"anonymize"` | What happens to the records of an erased person, for the models that do not say it themselves: `anonymize`, `delete`, `orphan` or `retain`.                                                       |
 | `receipts` | `"privacy"`   | The directory `henri privacy:erase` writes its receipt to -- the proof that it ran, holding an HMAC of the identity rather than the identity. `false` keeps none beyond what the command printed. |
+
+## The `retention` object
+
+How long a model keeps its records is said in the model
+(`options: { retention }`); this is what runs the sweep and what it is
+allowed to do. See [Retention](/guides/retention/).
+
+```json
+{
+  "retention": {
+    "approve": true,
+    "approved": ["Proposal:drafts:9f3c1a2b4d5e"],
+    "batch": 1000,
+    "receipts": "privacy",
+    "schedule": "0 3 * * *"
+  }
+}
+```
+
+| Key        | Default     | Description                                                                                                                                                                    |
+| ---------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `approve`  | `true`      | Whether a rule has to be approved before it writes anything. An unapproved rule is planned, counted and reported, and writes nothing. `false` makes the deployment the review. |
+| `approved` | `[]`        | The tokens of the approved rules. `henri retention` prints one per rule; a rule whose `after`, `from`, `action` or `where` changes gets a new token and is pending again.      |
+| `batch`    | `1000`      | How many records one rule may take in one sweep. What is left over is reported as `remaining` and taken by the next run. `false` lifts the bound.                              |
+| `receipts` | `"privacy"` | The directory a sweep writes its receipt to. `false` keeps none beyond what the command printed.                                                                               |
+| `schedule` | off         | A cron expression (`"0 3 * * *"`) or an interval (`"1d"`) the `henri/retention` job runs on; needs `@usehenri/jobs`. Without it, run `henri retention:sweep --yes` from cron.  |
+
+## The `trail` object
+
+The append-only record of who read or changed personal data. It is off until
+this key says otherwise, and off means no table is created and no statement
+is issued. See [The access trail](/guides/trail/).
+
+```json
+{
+  "trail": {
+    "keep": "1y",
+    "reads": "personal",
+    "store": "default",
+    "table": "henri_trail"
+  }
+}
+```
+
+| Key     | Default         | Description                                                                                                                                                                               |
+| ------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `keep`  | `"1y"`          | How long an entry is kept. A trail of who touched personal data is itself personal data, so it has its own retention; `false` keeps them forever, which is a decision to make on purpose. |
+| `reads` | off             | `"personal"` records the answers carrying a model with a personal field, `"all"` every answer henri serializes, `false` none. Every recorded read costs a round trip and an insert.       |
+| `store` | `"default"`     | Which of `stores` the table lives in.                                                                                                                                                     |
+| `table` | `"henri_trail"` | The table henri creates at boot and only ever `INSERT`s into and `SELECT`s from.                                                                                                          |
 
 ## Uploads
 

--- a/website/src/content/docs/guides/privacy.md
+++ b/website/src/content/docs/guides/privacy.md
@@ -339,6 +339,17 @@ and their like on any model, and `name`, `address`, `phone`, `gender` and the
 rest on the model that _is_ a person. It reads the model files, so a field
 built at runtime is not looked at.
 
+## What follows from the mark
+
+Two features are built on the same map and have guides of their own:
+
+- **[Retention](/guides/retention/)** -- how long a model keeps its records,
+  and the sweep that deletes, hides or anonymizes them when the time is up.
+  It is the erasure nobody asked for, on a schedule.
+- **[The access trail](/guides/trail/)** -- the append-only, hash-chained
+  record of who read or changed personal data. It is what answers "prove the
+  erasure happened" three years from now.
+
 ## What this is not
 
 - It is not encryption. The values are stored the way they always were; a

--- a/website/src/content/docs/guides/retention.md
+++ b/website/src/content/docs/guides/retention.md
@@ -1,0 +1,263 @@
+---
+title: Retention
+description: A model says how long it keeps its records, and henri sweeps -- deleting, hiding or anonymizing, on a schedule, and never before somebody approved the rule.
+---
+
+An [erasure](/guides/privacy/) answers a person who asked. Retention answers
+nobody: it is the promise the privacy policy already made -- _"we keep
+proposals for two years"_ -- and the only way to keep that promise is for
+something to run while nobody is watching.
+
+So the rule goes where the promise is about, in the model:
+
+```js
+// app/models/Proposal.js
+module.exports = {
+  options: {
+    retention: {
+      action: 'anonymize',
+      after: '2y',
+      from: 'decidedAt',
+    },
+  },
+  schema: {/* ... */},
+};
+```
+
+`henri retention` prints every rule the application declares, the way
+`henri routes` prints the routes:
+
+```
+Proposal:default              anonymize    2y after decidedAt
+                              PENDING      Proposal:default:9f3c1a2b4d5e
+
+1 rule(s) write nothing until they are approved. Add to config/<env>.json:
+
+  "retention": { "approved": [
+    "Proposal:default:9f3c1a2b4d5e"
+  ] }
+
+Nothing runs the sweep on its own: henri retention:sweep --yes
+```
+
+That output is the whole feature in miniature: what the rule does, whether
+anybody approved it, and what is -- or is not -- going to run it.
+
+## What a rule says
+
+| Key      | Default       | What it means                                                                                       |
+| -------- | ------------- | --------------------------------------------------------------------------------------------------- |
+| `after`  | required      | How long the records are kept: `'90d'`, `'18mo'`, `'2y'`, or a number of milliseconds.              |
+| `from`   | `'createdAt'` | The date column the clock starts on.                                                                |
+| `action` | `'delete'`    | What happens when the time is up: `delete`, `soft-delete` or `anonymize`.                           |
+| `where`  | none          | The condition picking the class of records this rule is about.                                      |
+| `name`   | `'default'`   | Names the rule, in the reports, the receipts and `--only`. Required once a model has more than one. |
+
+A model with more than one class of records writes a list:
+
+```js
+options: {
+  retention: [
+    { after: '30d', name: 'drafts', where: { state: 'draft' } },
+    { action: 'anonymize', after: '2y', from: 'decidedAt', name: 'decided' },
+  ],
+},
+```
+
+A rule henri cannot carry out **fails the boot** rather than sweeping under
+it: `after` that cannot be read (or is under a minute), a `from` that is not
+a date column, `soft-delete` on a model without `paranoid: true`, or
+`anonymize` on a model that marks nothing `personal`. That last one matters:
+an anonymize with nothing to write over would touch no field and report
+success, which is the worst thing a compliance feature can do.
+
+## The three verbs, and no fourth
+
+henri already has three ways for a record to go away, and retention uses
+those three:
+
+- **`delete`** -- the row goes, for real, `deletedAt` stamp or not. A soft
+  delete is a hidden row, and a hidden row is still held.
+- **`soft-delete`** -- the row is stamped `deletedAt` and stops being
+  returned. Only on a model that declared `options: { paranoid: true }`;
+  asking for it anywhere else is refused rather than quietly turned into a
+  delete, because _"we removed it after 90 days"_ and _"we hid it after 90
+  days"_ are different sentences.
+- **`anonymize`** -- exactly what an erasure writes. The fields marked
+  `personal` get the values of the erasure, and the row, its counts and
+  every foreign key pointing at it survive.
+
+## The clock
+
+`from` defaults to `createdAt`, and `createdAt` is usually the wrong answer.
+A record's clock rarely starts when the row was inserted:
+
+- a proposal is kept for two years **after the decision**;
+- an account for a year **after it closed**;
+- a booking for seven years **after the stay**.
+
+Naming the column is how the model says which event starts the clock, and it
+is the single most important thing in a rule.
+
+A record whose `from` column is `null` has not started its clock and is
+**never swept** -- an open ticket does not age out. The plan counts those
+separately, as `waiting`, so a rule that quietly matches nothing is visible
+rather than reassuring:
+
+```
+Ticket:closed                 delete            0 of      0 past 2026-06-08T...
+                              0 written         0 left for the next run, 41203 waiting
+```
+
+Forty-one thousand tickets waiting on a `closedAt` nothing sets is a bug in
+the application, and this is where it shows up.
+
+## Two things stand between a wrong rule and a deleted table
+
+A wrong retention rule deletes production data on a schedule, quietly, for as
+long as nobody looks. henri makes that hard on purpose.
+
+### A rule nobody approved never writes
+
+Every rule has a token -- `Model:rule:<digest of its terms>` -- and a sweep
+applies a rule only when `config.retention.approved` holds it. A new rule, or
+a rule whose `after`, `from`, `action` or `where` changed, is **pending**: it
+is planned, counted and reported, and it writes nothing.
+
+Approving is a line in `config/<env>.json`, which means a person, a diff and
+a review:
+
+```json
+{
+  "retention": {
+    "approved": ["Proposal:decided:9f3c1a2b4d5e"]
+  }
+}
+```
+
+The token is a plain digest of the rule's terms, not a keyed one, so it means
+the same thing on a laptop, in the test suite and in production;
+`henri retention` prints the one to paste. It is an identifier, not a
+capability -- anybody who can add a token to the configuration can also set
+`approve: false`. Change `'2y'` to `'2h'` and the token changes with it -- the rule is
+pending again, and the sweep that would have taken the table out does
+nothing instead.
+
+`config.retention.approve: false` gives that up, deliberately, for an
+application whose deployment is the review.
+
+### A run is bounded
+
+`config.retention.batch` (`1000`) is how many records one rule may take in
+one sweep. The rest is reported as `remaining` and taken by the next run, so
+a genuine backlog drains over a few nights and a mistake cannot empty a table
+in one pass. `false` lifts the bound.
+
+And the command is a rehearsal unless it is told otherwise:
+`henri retention:sweep` plans, counts and prints, and writes nothing. `--yes`
+is the only thing that lets it write.
+
+## What runs it
+
+The sweep is core and needs nothing installed. Three things call it:
+
+**From cron**, which is what an application without the queue does:
+
+```
+0 3 * * * cd /srv/app && henri retention:sweep --yes
+```
+
+**From the queue**, when the application depends on
+[`@usehenri/jobs`](/guides/jobs/). Set a schedule and henri registers the
+recurring `henri/retention` job itself:
+
+```json
+{ "retention": { "schedule": "0 3 * * *" } }
+```
+
+**From the application**, on a page of its own:
+
+```js
+const receipt = await henri.retention.sweep({ only: 'Proposal' });
+```
+
+The queue is a package an application installs, so henri never assumes it.
+The boot line says which of the three it is, by name:
+
+```
+retention  2 rules  nothing runs them here: @usehenri/jobs is not part of this boot,
+                    so cron runs "henri retention:sweep --yes"  1 not approved: they
+                    plan and write nothing
+```
+
+A rule that nothing applies is a promise nobody keeps, and the boot log is
+where you find that out.
+
+## What proves it ran
+
+A receipt, in `config.retention.receipts` (`privacy/`, next to the erasure
+receipts), naming every rule, what it did and what is left:
+
+```json
+{
+  "version": 1,
+  "at": "2026-09-06T03:00:00.412Z",
+  "dryRun": false,
+  "interrupted": false,
+  "pending": 0,
+  "rules": [
+    {
+      "model": "Proposal",
+      "rule": "decided",
+      "action": "anonymize",
+      "cutoff": "2024-09-06T03:00:00.412Z",
+      "matched": 128,
+      "would": 128,
+      "written": 128,
+      "remaining": 0,
+      "waiting": 41,
+      "fields": ["notes"],
+      "sample": ["0192f3c1-...", "0192f3c2-..."],
+      "token": "Proposal:decided:9f3c1a2b4d5e"
+    }
+  ]
+}
+```
+
+`sample` is up to twenty public identifiers -- a sample, never an index. A
+receipt is proof that an operation happened, not a copy of the rows it
+touched.
+
+With the [access trail](/guides/trail/) on, every rule is also one appended,
+hash-chained entry, which is how `henri trail --action=retention.sweep`
+answers "what has this rule ever done".
+
+## Being interrupted
+
+A sweep is not a transaction and does not need to be one. Every rule is a
+query over the age of a row, so a sweep that dies halfway leaves the rest
+exactly as the next sweep will find it: it is a filter, not a cursor. A rule
+that throws stops that rule and nothing else -- the receipt marks it `failed`
+and the sweep as `interrupted`, and the rules that could run did.
+
+## The commands
+
+```bash
+henri retention                              # the rules, and which are approved
+henri retention:sweep                         # what a sweep would do; writes nothing
+henri retention:sweep --yes                   # sweep, for real
+henri retention:sweep --yes --only=Proposal   # one model
+henri retention:sweep --only=Proposal:drafts  # one rule of it
+henri retention --json                        # the same, as data
+```
+
+All of them boot the models only: no port is bound and no route is
+registered.
+
+## The trail's own retention
+
+The [access trail](/guides/trail/) is a record of who touched personal data,
+which makes it personal data too. It has its own retention
+(`config.trail.keep`, a year by default), and the retention sweep is what
+enforces it: a non-dry sweep prunes the trail and leaves a checkpoint behind
+so what remains still verifies.

--- a/website/src/content/docs/guides/trail.md
+++ b/website/src/content/docs/guides/trail.md
@@ -1,0 +1,207 @@
+---
+title: The access trail
+description: An append-only, hash-chained record of who read or changed personal data -- what it records, what it must never hold, and how to read it back.
+---
+
+**Read this paragraph before turning it on.** The trail records the
+operations henri performs itself on personal data -- the export, the erasure,
+the retention sweeps -- and, when you ask for it, the reads that leave
+through the answers henri serializes. It does **not** record what your own
+code does with your own model calls. A trail with holes in it reads as
+evidence and is not, so the boundary is stated here rather than implied:
+`henri.trail.record()` is how everything on your side of it gets in.
+
+```json
+{ "trail": {} }
+```
+
+That is the whole setup. henri creates a table at boot and appends to it. The
+trail is off until this key is there, and off means off: no table, no
+statement, no cost.
+
+## What is recorded
+
+**The operations henri owns.** Core owns every one of these call sites, so
+this half is complete by construction -- there is no way to run
+`henri privacy:erase` without an entry, and a refusal is written down too:
+
+| Action            | When                                                                  |
+| ----------------- | --------------------------------------------------------------------- |
+| `privacy.export`  | `henri privacy:export`, or `henri.privacy.export()`                   |
+| `privacy.erase`   | `henri privacy:erase`, including dry runs and refusals                |
+| `retention.sweep` | one entry per rule, every sweep (see [Retention](/guides/retention/)) |
+| `trail.pruned`    | the checkpoint a prune leaves behind                                  |
+
+**Reads, when you ask for them.** `config.trail.reads` turns on one entry per
+answer henri serializes -- `res.resource()`, `res.collection()` and
+`res.render()`, which are the three places henri turns records into a
+payload:
+
+```json
+{ "trail": { "reads": "personal" } }
+```
+
+`"personal"` records the answers carrying a model that has a field marked
+`personal`; `"all"` records every answer. Each recorded read costs a round
+trip and an insert, and a read that cannot be recorded is not sent -- an
+audit trail that fails open is not one. Leave it off unless you want it.
+
+**Everything else is yours.** A controller that reads with a model call and
+answers with `res.json()` is outside the boundary:
+
+```js
+await henri.trail.record({
+  action: 'app.exported',
+  model: 'Proposal',
+  records: rows.length,
+  ids: rows.map((row) => row.externalId),
+  meta: { format: 'csv' },
+});
+```
+
+## What it must never hold
+
+No values. Ever. An entry holds field **names**, counts, public identifiers
+(`externalId`, which is already what leaves the server) and digests -- never
+a name, an address, a phone number or the contents of anything.
+
+That is enforced, not documented. The `meta` of an entry goes through a guard
+that refuses:
+
+- a key that is a field the models marked `personal`;
+- a key masked by `config.filterParameters`;
+- a value that is not a short scalar, or a string longer than 200 characters;
+- a string that looks like an email address.
+
+```js
+await henri.trail.record({ action: 'app.thing', meta: { name: 'Ada' } });
+// HENRI_TRAIL_VALUE_REFUSED: the trail refuses to record "name": it is a
+// field the models marked personal
+```
+
+The worst possible outcome for a feature that records who read personal data
+is a second copy of it, so the failure is loud rather than a truncation.
+
+The person an entry is about is named the way an erasure receipt names them:
+their `externalId` when they have one, and an HMAC of their address keyed
+with `config.secret`. The address itself is never in the table -- which is
+what makes the trail survive the erasure it recorded.
+
+## How it stays append-only
+
+A database will happily let anyone `UPDATE` a row, so "append-only" is not a
+promise the application layer can make. What it can do is make an edit
+**visible**.
+
+**henri only ever `INSERT`s and `SELECT`s.** There is no `UPDATE` in the
+code that reaches this table. The one `DELETE` is the prune below.
+
+**Every entry is numbered under a unique index.** `seq` is one more than the
+last. Two processes appending at the same moment do not fork the chain: one
+insert wins, the other is refused by the index, re-reads the head and chains
+onto it.
+
+**Every entry is hashed onto the one before it.**
+
+```
+hash = HMAC-SHA256(config.secret, prev + canonical(entry))
+```
+
+Change a field of an old row, or take a row away, and every hash after it
+stops following. `henri trail:verify` walks the chain and says where:
+
+```
+The chain is broken at seq 4812 (hash).
+Everything up to seq 4811 verifies.
+```
+
+The key is `config.secret`, so re-chaining the tail is not something a stolen
+database connection can do.
+
+**And then do the real thing.** Tamper-evidence is the fallback; the strong
+form is the one the database enforces. Grant the application role
+`INSERT, SELECT` on this table and nothing else:
+
+```sql
+REVOKE UPDATE, DELETE ON henri_trail FROM app;
+GRANT INSERT, SELECT ON henri_trail TO app;
+```
+
+(with `config.trail.keep: false`, so nothing tries to prune).
+
+## Its own retention
+
+A record of who touched personal data is personal data. `config.trail.keep`
+is a year by default, and the [retention sweep](/guides/retention/) is what
+enforces it.
+
+A prune takes a **prefix** of the chain -- the oldest entries, up to and
+including the newest one past the cutoff -- and then appends a
+`trail.pruned` checkpoint carrying the hash of the last entry it removed. A
+hole in the middle of the sequence would be a break nothing can explain; a
+prefix plus a checkpoint leaves a chain that still verifies from a known
+link.
+
+## Reading it back
+
+A query surface is part of the feature, not a follow-up. The two questions an
+application actually has to answer:
+
+**"Prove the erasure happened."**
+
+```bash
+henri trail:about ada@example.com
+```
+
+```
+Everything recorded about ada@example.com
+
+    841  2026-09-04T09:12:02.881Z  privacy.erase      ok            3 User
+         actor 0192f3c1-...  receipt=6f2a... strategy=anonymize dryRun=false
+    712  2026-08-30T14:02:55.104Z  privacy.export     ok            9 User
+```
+
+The address is not in the table. henri digests what you asked about and looks
+for that, which is why this still works after the erasure took the address
+away.
+
+**"Who saw this record?"**
+
+```bash
+henri trail --model=Proposal --action=record.read --since=2026-08-01
+```
+
+And from the application:
+
+```js
+await henri.trail.list({ action: 'privacy.erase', limit: 50 });
+await henri.trail.count({ model: 'Proposal', since: '2026-08-01' });
+await henri.trail.about(user);
+await henri.trail.verify();
+```
+
+## The commands
+
+```bash
+henri trail                             # the latest entries
+henri trail --action=privacy.erase      # every erasure this application performed
+henri trail --model=Proposal --limit=100
+henri trail:about ada@example.com       # everything recorded about one person
+henri trail:verify                      # whether anything was edited or removed
+henri trail --json                      # the same, as data
+```
+
+All of them boot the models only: no port is bound and no route is
+registered.
+
+## What is not here
+
+- **Reads your own code performs.** henri hooks the three places it
+  serializes records itself. A model call in a controller is invisible to it,
+  and `henri.trail.record()` is the way in. This is the one limit worth
+  repeating.
+- **A second database.** The trail lives in one of `config.stores`, and its
+  writes are on the request path when `reads` is on. Recording every read of
+  every row is not what this is for.
+- **Shipping the entries somewhere.** There is no exporter. `henri trail
+--json` and `henri.trail.list()` are what a log shipper or a report reads.

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -309,6 +309,40 @@ The [personal data](/guides/privacy/) of the application, and the two operations
 
 `--dry-run` prints the plan and writes nothing. `--strategy` is the default for the models that do not declare one (`anonymize`, `delete`, `orphan`, `retain`); a model that decided keeps its answer. The receipt goes to `config.privacy.receipts` (`privacy/`), and holds an HMAC of the identity rather than the identity.
 
+## `retention`
+
+```bash
+henri retention [--json]
+henri retention:sweep [--only=<name>] [--yes] [--json]
+```
+
+How long the models say they keep their records, and the sweep that enforces it. See [Retention](/guides/retention/). Both boot to the user module (runlevel 4, like `db:seed`): no port is bound and no route is registered.
+
+| Command | What it does                                                                                                                                                                        |
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| (none)  | Prints every rule -- what it does, what its clock is measured from, and the token that approves it -- and the line to paste into `config/<env>.json` for the ones that are pending. |
+| `sweep` | Runs it. Without `--yes` it plans, counts and prints, and writes nothing. `--only=<Model>` or `--only=<Model>:<rule>` narrows it.                                                   |
+
+A rule whose token is not in `config.retention.approved` writes nothing however the sweep was run, so a new rule cannot delete anything until a person approved it. `config.retention.batch` (`1000`) bounds one run; the rest is reported and taken by the next. The receipt goes to `config.retention.receipts` (`privacy/`).
+
+With `@usehenri/jobs` installed and `config.retention.schedule` set, the same sweep runs as the recurring `henri/retention` job. Without the package, this command is what a cron line runs, and the boot log says so.
+
+## `trail`
+
+```bash
+henri trail [--action=<name>] [--model=<name>] [--actor=<id>] [--since=<date>] [--until=<date>] [--limit=<n>] [--json]
+henri trail:about <who> [--json]
+henri trail:verify [--json]
+```
+
+The append-only record of who read or changed personal data, read back. See [The access trail](/guides/trail/). It is off until `config.trail` says otherwise.
+
+| Command       | What it does                                                                                                                                                         |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| (none)        | The latest entries, newest first.                                                                                                                                    |
+| `about <who>` | Everything recorded about one person. The address is not in the table -- henri digests what you asked about -- so this still answers after the erasure took it away. |
+| `verify`      | Walks the hash chain and says whether a row was edited or removed, and where. Exits `1` on a break.                                                                  |
+
 ## `doctor`
 
 ```bash

--- a/website/src/content/docs/reference/errors.md
+++ b/website/src/content/docs/reference/errors.md
@@ -1016,6 +1016,47 @@ Usually:
 
 **Fix.** Name the person by email address, by external id or by primary key. An erased person no longer answers to their address: look their receipt up by digest instead.
 
+## retention
+
+How long the models say they keep their records, and the sweep that enforces it.
+
+### `HENRI_RETENTION_ADAPTER_UNSUPPORTED`
+
+A retention sweep reached a model whose adapter henri cannot drive.
+
+Usually:
+
+- the store adapter is not mongoose, sequelize or drizzle
+- the sweep was called on models that are not attached to a connection
+
+**Fix.** The sweep goes through the model API of the three adapters henri ships. Boot the application before sweeping, and use one of them for the models that declare a rule.
+
+### `HENRI_RETENTION_INVALID_RULE`
+
+A model declares a retention rule henri cannot carry out.
+
+Usually:
+
+- `options.retention` is not an object or a list of them
+- `after` cannot be read as a period, or is under a minute
+- `from` names a field that is not a date on that model
+- `action: 'soft-delete'` on a model that is not `paranoid`
+- `action: 'anonymize'` on a model that marks no field personal
+- two rules of one model share a name
+
+**Fix.** A rule is `{ after, action, from, where, name }`, where `after` is a period (`'90d'`, `'18mo'`, `'2y'`), `action` is `delete`, `soft-delete` or `anonymize`, and `from` is a date column of the model. The boot fails rather than sweeping under a rule henri cannot carry out.
+
+### `HENRI_RETENTION_RECEIPT_UNWRITABLE`
+
+A retention sweep ran and its receipt could not be written.
+
+Usually:
+
+- `config.retention.receipts` points at a directory this process may not write
+- the disk is full
+
+**Fix.** The sweep happened; only its receipt could not be written. Make the directory writable, point `config.retention.receipts` somewhere else, or set it to `false` and keep what the command printed.
+
 ## route
 
 Config/routes.js and the router.
@@ -1129,6 +1170,67 @@ Usually:
 - the credentials that hold the url could not be opened
 
 **Fix.** Set `stores.<name>.url`, or the `host`, `port`, `database`, `username` and `password` the adapter assembles one from. `DATABASE_URL` sets `stores.default.url`.
+
+## trail
+
+The append-only record of who read or changed personal data.
+
+### `HENRI_TRAIL_DISABLED`
+
+The access trail was read back and this application keeps none.
+
+Usually:
+
+- `config.trail` is absent or false
+- the trail could not be started
+
+**Fix.** Turn the trail on with `"trail": {}` in `config/<env>.json`; henri creates its table on the next boot. Recording is a no-op while it is off, but reading it back says so rather than answering with nothing.
+
+### `HENRI_TRAIL_INVALID_EVENT`
+
+A trail entry was appended without saying what happened.
+
+Usually:
+
+- `henri.trail.record()` was called without an action
+- the action is longer than 64 characters
+
+**Fix.** An entry needs an action: what happened, as one dotted name. An application's own are prefixed `app.` (`henri.trail.record({ action: 'app.exported' })`).
+
+### `HENRI_TRAIL_UNSUPPORTED_STORE`
+
+The access trail cannot be kept in the store it was pointed at.
+
+Usually:
+
+- `config.trail.store` names a store this application does not have
+- the store adapter has neither `query()` nor a MongoDB connection
+- the MongoDB store is not connected
+
+**Fix.** The trail owns a table in one of the application's stores. Point `config.trail.store` at a store backed by mongoose, sequelize or drizzle, or leave `config.trail` out to keep no trail at all.
+
+### `HENRI_TRAIL_UNWRITABLE`
+
+A trail entry could not be appended after every attempt to chain it.
+
+Usually:
+
+- another writer keeps winning the unique index on `seq`
+- the unique index on `seq` is missing, so the chain cannot be numbered
+
+**Fix.** The entry chains onto the head of the trail, so it re-reads the head when another process got there first. Check that the unique index on `seq` exists (henri creates it at boot) and that nothing else writes to the table.
+
+### `HENRI_TRAIL_VALUE_REFUSED`
+
+Something tried to record a value in the access trail.
+
+Usually:
+
+- a `meta` key is a field the models marked personal
+- a `meta` key is masked by `config.filterParameters`
+- a `meta` value is not a short scalar, or looks like an email address
+
+**Fix.** The trail holds field names, counts and public identifiers, never the values behind them: a record of who read personal data must not become a second copy of it. Record the name and the count, and name a person with `subject`, which henri digests.
 
 ## user
 


### PR DESCRIPTION
Items four and five of your data protection list. Both needed the personal marks and the queue, which is why they waited.

## Retention

A model says how long it keeps its records, in one rule or a named list, and the sweep uses the three verbs henri already has rather than a fourth: `delete`, `soft-delete` and `anonymize`. Two of those refuse rather than degrade — `soft-delete` on a model that is not paranoid is an error, and `anonymize` on a model that marks nothing personal fails the boot, because it would sweep nothing and report success.

It is measured from a date column, defaulting to `createdAt` and documented as usually the wrong choice. A record whose column is null never ages out and is **counted separately as waiting**, so a rule that silently matches nothing is visible rather than reassuring. The showcase's own run shows `20 waiting` beside `0 of 0`.

The sweep is core and needs nothing installed. The queue runs it on a schedule when the package is there, and when it is not, henri says out loud what is not running and gives the command a cron line would use.

## Two guards against a rule that deletes production on a schedule

**A rule writes nothing until its token is approved** in the configuration. I tested that with the real thing: with the Review token removed, a sweep run with `--yes` reported `0 of 30 matched, not approved` and the database was untouched, 0 erased of 30.

**And the command is a dry run unless given `--yes`**, which prints what it would do and writes a receipt marked as a dry run.

The token digest is deliberately plain rather than keyed, because it is committed to a config file and has to mean the same thing on a laptop, in CI and in production, and anyone who can add a token can also turn approval off.

## The access trail

Framework-owned operations are recorded completely by construction: the privacy export and erasure including refusals, every retention sweep, and the prune itself. Reads through the three places henri serializes records are opt-in and off by default, with the cost documented. What an application does with its own model calls is outside the boundary, and the guide says that in its first paragraph rather than implying coverage it does not have.

### What it will not hold, verified

A trail of who touched personal data is itself personal data, so it holds no values. I tried to put things in it:

| Sent | Answer |
| --- | --- |
| an email address | refused |
| a personal field by name | refused |
| something `filterParameters` masks | refused |
| a nested object, an array, a 300-character string | refused |
| a plain count, a plain flag | accepted |

The person is an external id plus an HMAC of the address, so `henri trail:about ada@example.com` still answers after an erasure has taken the address away.

### Append-only, verified both ways

Only inserts and selects are ever issued, and each entry links to the one before it. I broke it on purpose against PostgreSQL:

```
edited one row      →  The chain is broken at seq 4 (hash).
                       Everything up to seq 3 verifies.
removed one row     →  The chain is broken at seq 6 (chain).
                       Everything up to seq 4 verifies.
```

Different reasons for different tampering, each naming the sequence and what still holds.

## Two bugs found on the way

**drizzle-kit push would drop the tables henri owns.** The trail and the queue tables are created through raw SQL, so a development push either dropped them or, once they held rows, refused to push anything. That was a latent bug in the jobs package too.

**Pruning by age alone breaks the chain**, since a hole in the middle is unexplainable. It prunes a prefix and appends a checkpoint carrying the last removed hash.

## Verification

`pnpm test` 2210 passed, `pnpm test:sql` offline and against live PostgreSQL and MySQL (413 each), `pnpm test:types`, `pnpm lint --max-warnings 0`, `pnpm format:check`, the showcase suite 150 passed, and `scripts/smoke.sh`.

I also ran a sweep end to end against a seeded showcase: a dry run that wrote nothing, a real run that anonymized 30 reviews, and the chain verifying at 9 entries before I broke it.