### PR TITLE
Deploy the website from master only

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -3,5 +3,11 @@
   "framework": "astro",
   "installCommand": "pnpm install --filter @usehenri/website",
   "buildCommand": "pnpm build",
-  "outputDirectory": "dist"
+  "outputDirectory": "dist",
+  "git": {
+    "deploymentEnabled": {
+      "*": false,
+      "master": true
+    }
+  }
 }


### PR DESCRIPTION
Vercel built a preview for every branch and every pull request, which exhausted the daily build limit this morning and has been putting a red check that is not the code on every pull request since.

`git.deploymentEnabled` in `website/vercel.json` is per branch: everything off, `master` on.

The `Website` job in CI still builds the site on every pull request, so a broken docs page is caught before it lands. What stops is publishing a throwaway deployment for each one.