### PR TITLE
Test factories, and a suite that stopped running one file at a time

### DIFF
--- a/.changeset/rich-parrots-search.md
+++ b/.changeset/rich-parrots-search.md
@@ -1,0 +1,28 @@
+---
+'@usehenri/testing': minor
+'@usehenri/uploads': patch
+---
+
+Test factories: a valid record with the fields the test does not care about already filled in.
+
+A factory lives in `test/factories/<name>.js` and is read the first time a test asks for one. It is a plain object -- `{ attributes, traits, model, after }` -- and `@usehenri/testing` now exports `create`, `build`, `createList`, `defineFactory` and `resetFactories`:
+
+```js
+// test/factories/proposal.js
+module.exports = {
+  attributes: {
+    eventId: async ({ create }) => (await create('event')).id,
+    speakerId: async ({ create }) => (await create('user')).id,
+    title: ({ sequence }) => `A proposal ${sequence}`,
+  },
+  traits: { submitted: { state: 'submitted', submittedAt: () => new Date() } },
+};
+
+await create('proposal', 'submitted', { speakerId: me.id });
+```
+
+Three rules hold it together. What the caller gives is never made, so an override of an association creates no second record. A value is a literal or a function of the build context (`attrs`, `build`, `create`, `sequence`, `traits`, `uid`), so there is no separate vocabulary for associations, sequences or computed fields. Fields resolve on demand rather than in the order they are written, so `await attrs.eventId` from another field's function keeps two of them on one parent whatever order the keys sit in. A trait is an override object with a name, kept next to the model because a state is rarely one field.
+
+A factory writes through the model, so the password is still hashed, the timestamps are still stamped and a `paranoid` model still soft-deletes; `after(record, context)` covers what the model refuses to mass assign. Failures carry the new `HENRI_FACTORY_*` codes.
+
+`@usehenri/uploads`: the local storage sweeps only the parts older than an hour when it starts. It could not tell a part a dead process left behind from one another process is streaming into right now, so a second application process -- or a second test file -- booting mid-upload failed that upload.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,8 +54,23 @@ HENRI_TEST_POSTGRES_URL=postgres://henri:henri@127.0.0.1:5432/henri_test pnpm te
 Applications built with henri run their own tests with `henri test`, which
 spawns the app's Vitest with `NODE_ENV=test`; `@usehenri/testing` boots the
 app inside the test worker (`setup`, `teardown`, `request`, `agent`, `henri`,
-plus `@usehenri/testing/setup-file` for `setupFiles`). `packages/demo` is such
-an app and is what core's tests boot.
+plus `@usehenri/testing/setup-file` for `setupFiles`). It also owns the
+factories: `test/factories/<name>.js` exports `{ attributes, traits, model,
+after }`, a value is a literal or a function of the build context
+(`attrs`, `build`, `create`, `sequence`, `traits`, `uid`) resolved on demand,
+and `create`/`build`/`createList`/`defineFactory` are the calls
+(`packages/testing/factory.js`, `guides/testing.md`). An override always wins
+and is never made, which is what keeps `create('proposal', { speakerId })`
+from making a second user. `packages/demo` is such an app and is what core's
+tests boot; `showcase/test/factories` is the worked example.
+
+Every project runs its test files at the same time, core included: each of
+its files boots the demo application on a port the kernel assigns and a
+MongoDB of its own (`packages/disk/port.js`), and `vitest.setup.js` binds
+every host-less `listen()` to `127.0.0.1` so the reservation is exact. What
+those files still share is `packages/demo/.tmp`, so anything written there
+has to be named per record or per process. An application's own suite keeps
+`fileParallelism: false` unless each file gets a database of its own.
 
 ## Layout
 

--- a/packages/cli/__tests__/db.spec.js
+++ b/packages/cli/__tests__/db.spec.js
@@ -3,7 +3,14 @@ const path = require('path');
 
 const { CliError } = require('../scripts/errors');
 const { migrations, seed, sow, status } = require('../scripts/db');
-const { cleanup, exists, henri, scaffold, tmpdir } = require('./helpers');
+const {
+  cleanup,
+  exists,
+  henri,
+  linkAdapter,
+  scaffold,
+  tmpdir,
+} = require('./helpers');
 
 // A minimal application on a drizzle sqlite store: seeding it is a full
 // boot, without a database server to start
@@ -12,26 +19,6 @@ const fixture = path.join(__dirname, 'fixtures', 'seed-app');
 // The demo application of the workspace, on the disk (mongoose) adapter:
 // db:seed must work on every adapter, not only on the drizzle one
 const demo = path.resolve(__dirname, '../../demo');
-
-/**
- * Core resolves `@usehenri/drizzle` from the application directory: link
- * the workspace package into the fixture's node_modules (ignored by git)
- *
- * @returns {void}
- */
-const linkAdapter = () => {
-  const target = path.join(fixture, 'node_modules', '@usehenri', 'drizzle');
-
-  fs.mkdirSync(path.dirname(target), { recursive: true });
-
-  if (!fs.existsSync(target)) {
-    fs.symlinkSync(
-      path.resolve(__dirname, '../../drizzle'),
-      target,
-      'junction'
-    );
-  }
-};
 
 describe('henri db', () => {
   describe('usage', () => {
@@ -292,7 +279,7 @@ describe('henri db', () => {
     let report;
 
     beforeAll(() => {
-      linkAdapter();
+      linkAdapter(fixture, 'drizzle');
       dir = tmpdir('henri-seed-run-');
       report = path.join(dir, 'report.json');
     });

--- a/packages/cli/__tests__/helpers.js
+++ b/packages/cli/__tests__/helpers.js
@@ -84,16 +84,57 @@ const routesOf = (app) => {
 /**
  * Remove a directory
  *
+ * A directory that was never made is nothing to remove: an `afterAll` runs
+ * even when the `beforeAll` that would have made it threw, and a TypeError
+ * there hides the failure that actually happened.
+ *
  * @param {string} dir Directory
  * @returns {void}
  */
-const cleanup = (dir) => fs.rmSync(dir, { force: true, recursive: true });
+const cleanup = (dir) =>
+  dir && fs.rmSync(dir, { force: true, recursive: true });
+
+/**
+ * Link workspace packages into a fixture application's node_modules.
+ *
+ * Core resolves `@usehenri/<name>` from the application directory, and the
+ * fixtures are checked in without one. Several test files share a fixture
+ * and run at the same time, so the link is made without asking first
+ * (`existsSync` then `symlinkSync` is two operations with a gap in between,
+ * and the loser of that race got an `EEXIST` that read like a bug in the
+ * fixture); an existing link, and one another file made a moment ago, are
+ * both the wanted state.
+ *
+ * @param {string} fixture The application directory
+ * @param {...string} names The workspace package names (`drizzle`, `jobs`)
+ * @returns {void}
+ */
+const linkAdapter = (fixture, ...names) => {
+  for (const name of names) {
+    const target = path.join(fixture, 'node_modules', '@usehenri', name);
+
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+
+    try {
+      fs.symlinkSync(
+        path.resolve(__dirname, '../..', name),
+        target,
+        'junction'
+      );
+    } catch (error) {
+      if (error.code !== 'EEXIST') {
+        throw error;
+      }
+    }
+  }
+};
 
 module.exports = {
   bin,
   cleanup,
   exists,
   henri,
+  linkAdapter,
   read,
   routesOf,
   scaffold,

--- a/packages/cli/__tests__/jobs.spec.js
+++ b/packages/cli/__tests__/jobs.spec.js
@@ -2,36 +2,13 @@ const { spawn } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
-const { cleanup, henri, scaffold } = require('./helpers');
+const { cleanup, henri, linkAdapter, scaffold } = require('./helpers');
 
 const bin = path.resolve(__dirname, '../../henri/bin/henri.js');
 
 // A minimal application on a drizzle sqlite file, so the queue survives
 // between two runs of the command line
 const fixture = path.join(__dirname, 'fixtures', 'jobs-app');
-
-/**
- * The fixture depends on the adapter and on @usehenri/jobs, which is what
- * puts the queue in its boot: link the workspace packages into its
- * node_modules (ignored by the repository)
- *
- * @returns {void}
- */
-const link = () => {
-  for (const name of ['drizzle', 'jobs']) {
-    const target = path.join(fixture, 'node_modules', '@usehenri', name);
-
-    fs.mkdirSync(path.dirname(target), { recursive: true });
-
-    if (!fs.existsSync(target)) {
-      fs.symlinkSync(
-        path.resolve(__dirname, '../../', name),
-        target,
-        'junction'
-      );
-    }
-  }
-};
 
 /**
  * Runs a henri command in the fixture and parses its JSON
@@ -117,7 +94,7 @@ describe('henri jobs', () => {
     const report = path.join(fixture, '.henri', 'performed.log');
 
     beforeAll(() => {
-      link();
+      linkAdapter(fixture, 'drizzle', 'jobs');
       fs.rmSync(path.join(fixture, '.henri'), {
         force: true,
         recursive: true,

--- a/packages/cli/__tests__/privacy.spec.js
+++ b/packages/cli/__tests__/privacy.spec.js
@@ -3,31 +3,11 @@ const path = require('path');
 
 const { CliError } = require('../scripts/errors');
 const { erase, exportOne } = require('../scripts/privacy');
-const { cleanup, henri, tmpdir } = require('./helpers');
+const { cleanup, henri, linkAdapter, tmpdir } = require('./helpers');
 
 // The same minimal application `henri db` runs against: a drizzle store, a
 // Task and a User whose fields say what they are
 const fixture = path.join(__dirname, 'fixtures', 'seed-app');
-
-/**
- * Core resolves `@usehenri/drizzle` from the application directory: link
- * the workspace package into the fixture's node_modules (ignored by git)
- *
- * @returns {void}
- */
-const linkAdapter = () => {
-  const target = path.join(fixture, 'node_modules', '@usehenri', 'drizzle');
-
-  fs.mkdirSync(path.dirname(target), { recursive: true });
-
-  if (!fs.existsSync(target)) {
-    fs.symlinkSync(
-      path.resolve(__dirname, '../../drizzle'),
-      target,
-      'junction'
-    );
-  }
-};
 
 describe('henri privacy', () => {
   describe('usage', () => {
@@ -50,7 +30,7 @@ describe('henri privacy', () => {
     let seeded;
 
     beforeAll(() => {
-      linkAdapter();
+      linkAdapter(fixture, 'drizzle');
       dir = tmpdir('henri-privacy-');
       receipts = path.join(dir, 'receipts');
       env = {

--- a/packages/cli/__tests__/retention.spec.js
+++ b/packages/cli/__tests__/retention.spec.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 
 const { CliError } = require('../scripts/errors');
-const { cleanup, henri, tmpdir } = require('./helpers');
+const { cleanup, henri, linkAdapter, tmpdir } = require('./helpers');
 const trail = require('../scripts/trail');
 
 // The same minimal application `henri db` and `henri privacy` run against:
@@ -11,26 +11,6 @@ const fixture = path.join(__dirname, 'fixtures', 'seed-app');
 
 /** The token of the Task rule, which `config.retention.approved` holds */
 const TOKEN = 'Task:default:4c94f8c8576e';
-
-/**
- * Core resolves `@usehenri/drizzle` from the application directory: link
- * the workspace package into the fixture's node_modules (ignored by git)
- *
- * @returns {void}
- */
-const linkAdapter = () => {
-  const target = path.join(fixture, 'node_modules', '@usehenri', 'drizzle');
-
-  fs.mkdirSync(path.dirname(target), { recursive: true });
-
-  if (!fs.existsSync(target)) {
-    fs.symlinkSync(
-      path.resolve(__dirname, '../../drizzle'),
-      target,
-      'junction'
-    );
-  }
-};
 
 describe('henri retention and henri trail', () => {
   describe('usage', () => {
@@ -66,7 +46,7 @@ describe('henri retention and henri trail', () => {
       });
 
     beforeAll(() => {
-      linkAdapter();
+      linkAdapter(fixture, 'drizzle');
       dir = tmpdir('henri-retention-');
       receipts = path.join(dir, 'receipts');
       env = {

--- a/packages/cli/template/default/AGENTS.md
+++ b/packages/cli/template/default/AGENTS.md
@@ -119,29 +119,16 @@ Work that must not block a request goes in `app/jobs`, never in a worker: `henri
 
 ## Users and secrets
 
-Set `"user": "user"` in `config/default.json` and add `app/models/User.js`:
-the store adds `email` (unique), `password` (hashed, never selected) and
-`roles` (default: `baseRole`), plus `POST /login`, `POST /logout`, sessions,
-CSRF and `req.user`. `roles` cannot be mass-assigned: use `user.setRoles()`
-or `User.setRoles(id, roles)`. The secret is `HENRI_SECRET` in `.env`.
+Set `"user": "user"` in `config/default.json` and add `app/models/User.js`: the store adds `email` (unique), `password` (hashed, never selected) and `roles` (default: `baseRole`), plus `POST /login`, `POST /logout`, sessions, CSRF and `req.user`. `roles` cannot be mass-assigned: use `user.setRoles()` or `User.setRoles(id, roles)`. The secret is `HENRI_SECRET` in `.env`.
 
 ## Policies
 
-`roles` says who may reach an endpoint; `app/policies/<model>.js` says who may
-act on one record: one function per action, `(user, record) => boolean`. Ask
-with `req.can('update', post)` or `await req.authorize('update', post)`, and
-put `policy: true` on the routes so henri asks too. It fails closed -- no
-policy, no rule, a rule that threw, anything but the boolean `true`: all no --
-and a rule taking a record is never asked without one, so `index`/`new`/
-`create` are answered at the route. A refusal is a 404. `paths` and `_links`
-lose what it refuses, so a page cannot offer a button the request would deny.
+`roles` says who may reach an endpoint; `app/policies/<model>.js` says who may act on one record: one function per action, `(user, record) => boolean`. Ask with `req.can('update', post)` or `await req.authorize('update', post)`, and put `policy: true` on the routes so henri asks too. It fails closed -- no policy, no rule, a rule that threw, anything but the boolean `true`: all no -- and a rule taking a record is never asked without one, so `index`/`new`/`create` are answered at the route. A refusal is a 404. `paths` and `_links` lose what it refuses, so a page cannot offer a button the request would deny.
 
 ## Tests
 
-`henri test` runs Vitest (`vitest.config.js`, `test/**/*.test.js`) with henri
-booted under `NODE_ENV=test`: `henri` and the models are globals, and
-`request()` from `@usehenri/testing` is a supertest bound to the server
-(`agent()` keeps cookies). `henri generate test posts` writes the skeleton.
+`henri test` runs Vitest (`vitest.config.js`, `test/**/*.test.js`) with henri booted under `NODE_ENV=test`: `henri` and the models are globals, and `request()` from `@usehenri/testing` is a supertest bound to the server (`agent()` keeps cookies). `henri generate test posts` writes the skeleton.
+Records come from `test/factories/<name>.js` (`{ attributes, traits, model, after }`, a value being a literal or a function of `{ attrs, create, sequence, traits, uid }`): `create('post', 'published', { title })` saves one and makes what it references, `build()` answers the attributes, `createList()` several. Whatever the test asserts on goes in the call, everything else in the factory.
 
 ## Commands, exit codes, MCP
 

--- a/packages/core/error-codes.json
+++ b/packages/core/error-codes.json
@@ -26,6 +26,10 @@
       "what": "config/<env>.json, the environment overrides and the credentials file"
     },
     {
+      "area": "factory",
+      "what": "the test factories of `@usehenri/testing`: `test/factories`, the records they make and the traits they apply"
+    },
+    {
       "area": "job",
       "what": "the background job queue of @usehenri/jobs"
     },
@@ -600,6 +604,49 @@
       "what": "No configuration file could be loaded."
     },
     {
+      "area": "factory",
+      "causes": [
+        "two factories that make each other, with nothing to end the chain",
+        "two fields of one factory that read each other through `attrs`"
+      ],
+      "code": "HENRI_FACTORY_DEPTH",
+      "fix": "End the chain by giving the association an id in the overrides: `create(\"proposal\", { speakerId: someone.id })`.",
+      "what": "Factories nested into each other until it had to be called a cycle."
+    },
+    {
+      "area": "factory",
+      "causes": [
+        "the file exports something other than `{ attributes }`",
+        "`model` names a model the application does not have",
+        "the file itself throws when it is loaded"
+      ],
+      "code": "HENRI_FACTORY_INVALID",
+      "fix": "A factory exports `{ attributes }`, optionally with `model`, `traits` and `after`. Name the model with `model:` when the file is not called after it.",
+      "what": "A factory definition cannot be used as one."
+    },
+    {
+      "area": "factory",
+      "causes": [
+        "a typo in the name given to `create()` or `build()`",
+        "the factory file is not in `test/factories`",
+        "the tests run from a directory that is not the application"
+      ],
+      "code": "HENRI_FACTORY_UNKNOWN",
+      "fix": "Add `test/factories/<name>.js`, or declare it in the test file with `defineFactory(name, definition)`. The message lists the factories that were found.",
+      "what": "A test asked for a factory nothing declares."
+    },
+    {
+      "area": "factory",
+      "causes": [
+        "a typo in a trait name",
+        "the trait belongs to another factory",
+        "an override object was passed as a string"
+      ],
+      "code": "HENRI_FACTORY_UNKNOWN_TRAIT",
+      "fix": "Declare the trait in the `traits` of the factory, or pass an override object instead. The message lists the traits it does have.",
+      "what": "A test asked for a trait the factory does not declare."
+    },
+    {
       "area": "job",
       "causes": [
         "an argument that is a function, a class, a bigint or a cycle",
@@ -698,8 +745,8 @@
       "area": "job",
       "causes": ["a job whose `perform()` never returned in time"],
       "code": "HENRI_JOB_TIMEOUT",
-      "fix": "Raise the job\u2019s `timeout`, or split the work: the attempt is failed and retried like any other failure.",
-      "what": "An attempt ran past the job\u2019s timeout."
+      "fix": "Raise the job’s `timeout`, or split the work: the attempt is failed and retried like any other failure.",
+      "what": "An attempt ran past the job’s timeout."
     },
     {
       "area": "job",

--- a/packages/core/src/__tests__/shutdown.spec.js
+++ b/packages/core/src/__tests__/shutdown.spec.js
@@ -301,12 +301,17 @@ describe('a real SIGTERM', () => {
 
     app.child.kill('SIGTERM');
 
-    // The port closes first, so a load balancer stops sending here...
+    // The port closes first, so a load balancer stops sending here. The
+    // probe asks for a path the fixture does not answer: `/slow` would take
+    // its 800ms to come back on a machine that closed the listener a moment
+    // later than this one expected, which is both a slow retry and a second
+    // `received` in the events asserted below
     await vi.waitFor(
       async () =>
-        await expect(get(app.port, '/slow')).rejects.toMatchObject({
+        await expect(get(app.port, '/gone')).rejects.toMatchObject({
           code: 'ECONNREFUSED',
-        })
+        }),
+      { interval: 25, timeout: 10000 }
     );
 
     // ...while what was already being served is answered in full

--- a/packages/demo/test/factories/artwork.js
+++ b/packages/demo/test/factories/artwork.js
@@ -1,0 +1,6 @@
+module.exports = {
+  attributes: {
+    title: ({ sequence }) => `Artwork ${sequence}`,
+    year: 1905,
+  },
+};

--- a/packages/demo/test/factories/memo.js
+++ b/packages/demo/test/factories/memo.js
@@ -1,0 +1,13 @@
+// A memo belongs to whoever wrote it: `ownerId` is a reference, so the
+// factory makes the author unless the test names one.
+module.exports = {
+  attributes: {
+    body: ({ sequence }) => `The body of memo ${sequence}`,
+    ownerId: async ({ create }) => (await create('user')).id,
+    title: ({ sequence }) => `Memo ${sequence}`,
+  },
+
+  traits: {
+    archived: { archivedAt: () => new Date('2020-01-01T00:00:00Z') },
+  },
+};

--- a/packages/demo/test/factories/user.js
+++ b/packages/demo/test/factories/user.js
@@ -1,0 +1,26 @@
+// A user of the demo application. `password` goes through the model, so the
+// row holds a bcrypt hash and nothing here has to know that; `roles` is
+// stripped from mass assignment, so the factory sets it after the write --
+// which is the whole reason `after` exists.
+module.exports = {
+  after: async (user, { attrs }) => {
+    if (!Array.isArray(attrs.roles) || attrs.roles.length === 0) {
+      return user;
+    }
+
+    await user.setRoles(attrs.roles);
+
+    return User.findByKey(user.id);
+  },
+
+  attributes: {
+    age: 42,
+    email: ({ sequence, uid }) => `member-${uid}-${sequence}@usehenri.io`,
+    name: ({ sequence }) => `Member ${sequence}`,
+    password: 'difference-engine',
+  },
+
+  traits: {
+    admin: { roles: ['admin'] },
+  },
+};

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -28,7 +28,9 @@ module.exports = defineConfig({
 The setup file boots henri (`NODE_ENV=test`, `config/test.json`, a free port,
 workers skipped) before each test file and stops it after, inside the test
 worker: `henri` and the models are globals in the tests, exactly like in the
-app. `fileParallelism: false` keeps one server and one database at a time.
+app. `fileParallelism: false` keeps one server and one database at a time --
+drop it only when each file gets a database of its own, which is what the disk
+adapter does under `NODE_ENV=test`.
 
 ## Writing tests
 
@@ -58,6 +60,45 @@ beforeAll(() => setup());
 afterAll(() => teardown());
 ```
 
+## Factories
+
+A factory makes a valid record with the fields the test does not care about
+already filled in. It lives in `test/factories/<name>.js`, is named after its
+file and writes to the model of that name.
+
+```js
+// test/factories/task.js
+module.exports = {
+  attributes: {
+    name: ({ sequence }) => `Task ${sequence}`,
+    ownerId: async ({ create }) => (await create('user')).id,
+  },
+
+  traits: {
+    done: { completedAt: () => new Date(), state: 'done' },
+  },
+};
+```
+
+```js
+const { build, create, createList } = require('@usehenri/testing');
+
+await create('task'); // saved, with an owner
+await create('task', 'done'); // with the trait
+await create('task', { ownerId: me.id }); // no second user is made
+await createList('task', 3, 'done');
+await build('task'); // the attributes, unsaved
+```
+
+A value is a literal or a function of the build context (`attrs`, `build`,
+`create`, `sequence`, `traits`, `uid`), and fields resolve on demand: reading
+`await attrs.eventId` from another field resolves that one first. An override
+always wins, and the definition's value is then not evaluated at all.
+
+`after(record, context)` runs on the saved record and may replace it, which is
+how a factory grants roles the model will not mass assign.
+`defineFactory(name, definition)` declares one from a test file.
+
 ## API
 
 - `setup({ workers = false })` boots henri for the app in `process.cwd()` and
@@ -65,6 +106,11 @@ afterAll(() => teardown());
 - `teardown()` stops it.
 - `request()` a supertest request bound to the running server.
 - `agent()` a supertest agent (keeps cookies between requests).
+- `create(name, ...traits, overrides)` a saved record from a factory.
+- `build(name, ...traits, overrides)` the attributes, without saving.
+- `createList(name, count, ...traits, overrides)` several of them.
+- `defineFactory(name, definition)` a factory without a file.
+- `resetFactories()` forgets the definitions and the sequences.
 - `henri` the running instance (also `global.henri`).
 - `supertest` the underlying module.
 

--- a/packages/testing/__tests__/factory-app.spec.js
+++ b/packages/testing/__tests__/factory-app.spec.js
@@ -1,0 +1,99 @@
+// Factories against a real application and a real store: the demo app on
+// @usehenri/disk (mongoose). What is proved here is the one thing the unit
+// tests cannot: a factory writes through the model, so everything the model
+// does to a record still happens -- the password is hashed, the timestamps
+// are stamped, the roles are not mass assigned. The showcase suite is the
+// same proof against Drizzle and a real PostgreSQL.
+/* global Artwork, User */
+const path = require('node:path');
+
+const {
+  build,
+  create,
+  createList,
+  request,
+  setup,
+  teardown,
+} = require('../index.js');
+
+/** The demo application of this repository */
+const APP = path.resolve(__dirname, '..', '..', 'demo');
+
+describe('factories (demo app, disk store)', () => {
+  const previous = process.cwd();
+
+  beforeAll(async () => {
+    process.chdir(APP);
+    await setup();
+  }, 60000);
+
+  afterAll(async () => {
+    await teardown();
+    process.chdir(previous);
+  });
+
+  test('makes a valid record out of nothing', async () => {
+    const artwork = await create('artwork');
+
+    expect(artwork.title).toMatch(/^Artwork \d+$/u);
+    expect(artwork.year).toBe(1905);
+    // The model's own doing, not the factory's
+    expect(artwork.createdAt).toBeInstanceOf(Date);
+  });
+
+  test('the record goes through the model: the password is hashed', async () => {
+    const user = await create('user');
+    // A factory hands back the record the model made, and `findByKey` is the
+    // primary key lookup: `findById` takes the public identifier only
+    const stored = await User.findByKey(user.id).select('+password');
+
+    expect(stored.password).not.toBe('difference-engine');
+    expect(stored.password).not.toContain('difference-engine');
+    expect(await henri.user.compare('difference-engine', stored)).toBeTruthy();
+  });
+
+  test('roles are not mass assigned, so `after` sets them', async () => {
+    const member = await create('user');
+    const admin = await create('user', 'admin');
+
+    expect(member.roles).not.toContain('admin');
+    expect(admin.roles).toContain('admin');
+  });
+
+  test('an association is made once and shared, and an override replaces it', async () => {
+    const owner = await create('user');
+    const mine = await create('memo', { ownerId: owner.id });
+    const theirs = await create('memo');
+
+    expect(mine.ownerId).toBe(String(owner.id));
+    expect(theirs.ownerId).not.toBe(String(owner.id));
+  });
+
+  test('a trait is a named group of fields, not one', async () => {
+    const archived = await create('memo', 'archived');
+    const draft = await create('memo');
+
+    expect(archived.archivedAt).toBeInstanceOf(Date);
+    expect(draft.archivedAt).toBeFalsy();
+  });
+
+  test('createList makes as many as asked, in sequence', async () => {
+    const artworks = await createList('artwork', 3, { year: 1912 });
+    const titles = artworks.map((artwork) => artwork.title);
+
+    expect(artworks).toHaveLength(3);
+    expect(new Set(titles).size).toBe(3);
+    expect(artworks.every((artwork) => artwork.year === 1912)).toBe(true);
+  });
+
+  test('build() answers the attributes a controller would accept', async () => {
+    const attributes = await build('artwork', { title: 'Le bonheur de vivre' });
+    const answer = await request().post('/artwork').send(attributes);
+    const stored = await Artwork.find({ title: 'Le bonheur de vivre' });
+
+    expect(answer.status).toBe(201);
+    expect(stored).toHaveLength(1);
+    // The year the factory filled in, sent by the test and kept by the model
+    expect(stored[0].year).toBe(1905);
+  });
+});

--- a/packages/testing/__tests__/factory.spec.js
+++ b/packages/testing/__tests__/factory.spec.js
@@ -1,0 +1,297 @@
+const path = require('node:path');
+
+const {
+  build,
+  create,
+  createList,
+  defineFactory,
+  resetFactories,
+} = require('../index.js');
+
+/** A henri application whose models are `test/factories` away */
+const APP = path.join(__dirname, 'fixtures', 'app');
+
+/** What every stub model has written, newest last */
+let written = [];
+
+/**
+ * A model that answers like one of henri's, without a database
+ *
+ * @param {string} name the global name
+ * @returns {object} the model
+ */
+const stubModel = (name) => ({
+  create: async (attrs) => {
+    const record = { ...attrs, id: written.length + 1, model: name };
+
+    written.push(record);
+
+    return record;
+  },
+});
+
+/**
+ * The models of the fixture application, as globals
+ *
+ * @param {Array<string>} names the model names
+ * @returns {void}
+ */
+const withModels = (names) => {
+  global.henri = { model: { ids: names } };
+  names.forEach((name) => (global[name] = stubModel(name)));
+};
+
+describe('factories', () => {
+  const previous = process.cwd();
+
+  beforeEach(() => {
+    process.chdir(APP);
+    written = [];
+    resetFactories();
+    withModels(['Event', 'Proposal', 'Track']);
+  });
+
+  afterEach(() => {
+    process.chdir(previous);
+    delete global.henri;
+    ['Event', 'Proposal', 'Track'].forEach((name) => delete global[name]);
+    resetFactories();
+  });
+
+  describe('the files of test/factories', () => {
+    test('a factory is named after its file and writes to the model of that name', async () => {
+      const event = await create('event');
+
+      expect(event.model).toBe('Event');
+      expect(event.name).toBe('Event 1');
+      expect(event.state).toBe('draft');
+    });
+
+    test('`model` names the model when the file is called something else', async () => {
+      const talk = await create('talk');
+
+      expect(talk.model).toBe('Proposal');
+      expect(talk.title).toBe('Talk 1');
+    });
+
+    test('an unknown factory says so and lists the ones there are', async () => {
+      await expect(create('speaker')).rejects.toMatchObject({
+        code: 'HENRI_FACTORY_UNKNOWN',
+        message: expect.stringContaining('event, talk, track'),
+      });
+    });
+
+    test('a model the application does not have is named in the failure', async () => {
+      withModels(['Event', 'Track']);
+
+      await expect(create('talk')).rejects.toMatchObject({
+        code: 'HENRI_FACTORY_INVALID',
+        message: expect.stringContaining("names the model 'Proposal'"),
+      });
+    });
+  });
+
+  describe('overrides', () => {
+    test('win over the definition', async () => {
+      const event = await create('event', { name: 'Lineup' });
+
+      expect(event.name).toBe('Lineup');
+    });
+
+    test('are never made: the association is not created', async () => {
+      const talk = await create('talk', { eventId: 42, trackId: 7 });
+
+      expect(talk.eventId).toBe(42);
+      expect(written).toHaveLength(1);
+    });
+
+    test('of `undefined` say nothing, so a default survives', async () => {
+      const event = await create('event', { name: undefined });
+
+      expect(event.name).toBe('Event 1');
+    });
+
+    test('may add a field the factory does not declare', async () => {
+      const event = await create('event', { city: 'Montreal' });
+
+      expect(event.city).toBe('Montreal');
+    });
+  });
+
+  describe('traits', () => {
+    test('apply their fields on top of the definition', async () => {
+      const event = await create('event', 'open');
+
+      expect(event.state).toBe('open');
+      expect(event.name).toBe('Event 1');
+    });
+
+    test('compose, and an override still wins over both', async () => {
+      const talk = await create('talk', 'accepted', 'lightning', {
+        state: 'draft',
+      });
+
+      expect(talk.format).toBe('lightning');
+      expect(talk.decidedAt).toEqual(new Date(0));
+      expect(talk.state).toBe('draft');
+    });
+
+    test('reach the hooks through the context', async () => {
+      const seen = [];
+
+      defineFactory('event', {
+        attributes: { name: ({ traits }) => seen.push(...traits) && 'Event' },
+        traits: { open: {} },
+      });
+      await create('event', 'open');
+
+      expect(seen).toEqual(['open']);
+    });
+
+    test('an unknown one says so and lists the ones there are', async () => {
+      await expect(create('talk', 'published')).rejects.toMatchObject({
+        code: 'HENRI_FACTORY_UNKNOWN_TRAIT',
+        message: expect.stringContaining('accepted, lightning'),
+      });
+    });
+  });
+
+  describe('associations', () => {
+    test('are made, and two fields can share one parent', async () => {
+      const talk = await create('talk');
+      const events = written.filter((record) => record.model === 'Event');
+      const track = written.find((record) => record.model === 'Track');
+
+      // The talk asks for an open event and the track reads that same id
+      // rather than making a second one
+      expect(events).toHaveLength(1);
+      expect(events[0].state).toBe('open');
+      expect(track.eventId).toBe(events[0].id);
+      expect(talk.trackId).toBe(track.id);
+    });
+
+    test('are made by build() too: a foreign key has to name a row', async () => {
+      const attributes = await build('talk');
+
+      expect(written.map((record) => record.model)).toEqual(['Event', 'Track']);
+      expect(attributes.eventId).toBe(1);
+      expect(attributes.id).toBeUndefined();
+    });
+
+    test('build() touches nothing when the caller gives the keys', async () => {
+      const attributes = await build('talk', { eventId: 1, trackId: 2 });
+
+      expect(written).toEqual([]);
+      expect(attributes).toEqual({
+        eventId: 1,
+        title: 'Talk 1',
+        trackId: 2,
+      });
+    });
+
+    test('a chain with nothing to end it is reported, not run forever', async () => {
+      defineFactory('event', {
+        attributes: { parentId: async ({ create: nested }) => nested('event') },
+      });
+
+      await expect(create('event')).rejects.toMatchObject({
+        code: 'HENRI_FACTORY_DEPTH',
+        message: expect.stringContaining('event -> event'),
+      });
+    });
+
+    test('two fields that read each other are reported by name', async () => {
+      defineFactory('event', {
+        attributes: {
+          name: async ({ attrs }) => await attrs.slug,
+          slug: async ({ attrs }) => await attrs.name,
+        },
+      });
+
+      await expect(create('event')).rejects.toMatchObject({
+        code: 'HENRI_FACTORY_DEPTH',
+        message: expect.stringContaining('name -> slug -> name'),
+      });
+    });
+  });
+
+  describe('sequences', () => {
+    test('count the records one factory made, from one', async () => {
+      const events = await createList('event', 3);
+
+      expect(events.map((event) => event.name)).toEqual([
+        'Event 1',
+        'Event 2',
+        'Event 3',
+      ]);
+    });
+
+    test('are their own per factory, and build() advances them too', async () => {
+      await build('event');
+      const track = await create('track');
+      const event = await create('event');
+
+      expect(track.name).toBe('Track 1');
+      // The first event was built, the track made a second one
+      expect(event.name).toBe('Event 3');
+    });
+
+    test('uid keeps a unique column apart between processes', async () => {
+      const event = await create('event');
+
+      expect(event.slug).toMatch(/^event-[0-9a-z]{4}-1$/u);
+    });
+  });
+
+  describe('after', () => {
+    test('runs on the saved record, and what it answers replaces it', async () => {
+      const talk = await create('talk');
+
+      expect(talk.seen).toBe(true);
+      expect(written.at(-1).seen).toBeUndefined();
+    });
+
+    test('returning nothing keeps the record', async () => {
+      defineFactory('event', {
+        after: () => undefined,
+        attributes: { name: 'Kept' },
+      });
+
+      expect((await create('event')).name).toBe('Kept');
+    });
+  });
+
+  describe('declaring one from a test file', () => {
+    test('wins over the file of the same name, whatever order they arrive in', async () => {
+      defineFactory('event', { attributes: { name: 'From the test file' } });
+
+      expect((await create('event')).name).toBe('From the test file');
+    });
+
+    test('a definition that cannot be used says what is wrong with it', () => {
+      expect(() => defineFactory('event', { attributes: 'nope' })).toThrow(
+        /has no `attributes` object/u
+      );
+      expect(() =>
+        defineFactory('event', { attributes: {}, model: 42 })
+      ).toThrow(/`model` that is not the name of one/u);
+      expect(() =>
+        defineFactory('event', { attributes: {}, traits: { open: 'yes' } })
+      ).toThrow(/trait 'open' that is not an object/u);
+      expect(() =>
+        defineFactory('event', { after: 1, attributes: {} })
+      ).toThrow(/`after` that is not a function/u);
+      expect(() => defineFactory('', { attributes: {} })).toThrow(
+        /a factory needs a name/u
+      );
+    });
+  });
+
+  test('a factory used before the application booted says how to boot it', async () => {
+    delete global.henri;
+
+    await expect(create('event')).rejects.toMatchObject({
+      code: 'HENRI_BOOT_TESTING_NOT_RUNNING',
+    });
+  });
+});

--- a/packages/testing/__tests__/fixtures/app/test/factories/event.js
+++ b/packages/testing/__tests__/fixtures/app/test/factories/event.js
@@ -1,0 +1,12 @@
+// A factory of the fixture application: read from disk by the registry, the
+// way an application's own factories are.
+module.exports = {
+  attributes: {
+    name: ({ sequence }) => `Event ${sequence}`,
+    slug: ({ sequence, uid }) => `event-${uid}-${sequence}`,
+    state: 'draft',
+  },
+  traits: {
+    open: { state: 'open' },
+  },
+};

--- a/packages/testing/__tests__/fixtures/app/test/factories/talk.js
+++ b/packages/testing/__tests__/fixtures/app/test/factories/talk.js
@@ -1,0 +1,20 @@
+// Named after neither its model nor its associations: `model` says which
+// table it writes to, and the two ids below share one event without the file
+// caring which key `sort-keys` puts first.
+module.exports = {
+  after: (record) => ({ ...record, seen: true }),
+
+  attributes: {
+    eventId: async ({ create }) => (await create('event', 'open')).id,
+    title: ({ sequence }) => `Talk ${sequence}`,
+    trackId: async ({ attrs, create }) =>
+      (await create('track', { eventId: await attrs.eventId })).id,
+  },
+
+  model: 'Proposal',
+
+  traits: {
+    accepted: { decidedAt: () => new Date(0), state: 'accepted' },
+    lightning: { format: 'lightning' },
+  },
+};

--- a/packages/testing/__tests__/fixtures/app/test/factories/track.js
+++ b/packages/testing/__tests__/fixtures/app/test/factories/track.js
@@ -1,0 +1,6 @@
+module.exports = {
+  attributes: {
+    eventId: async ({ create }) => (await create('event')).id,
+    name: ({ sequence }) => `Track ${sequence}`,
+  },
+};

--- a/packages/testing/errors.js
+++ b/packages/testing/errors.js
@@ -1,0 +1,34 @@
+/**
+ * The failures of `@usehenri/testing`, by their henri error code.
+ *
+ * A code is a string and nothing more (`@usehenri/core/error-codes.json` is
+ * the catalogue), so a failure names itself without importing anything --
+ * which matters here, where core is resolved from the application and may
+ * not be loadable at all.
+ *
+ * @module @usehenri/testing/errors
+ */
+
+/**
+ * Put one of henri's error codes on an error
+ *
+ * @param {Error} error The error
+ * @param {string} code The henri error code
+ * @returns {Error} The same error
+ */
+const stamp = (error, code) => Object.assign(error, { code });
+
+/**
+ * The failure raised by anything that needs a running application
+ *
+ * @returns {Error} the error to throw
+ */
+const notRunning = () =>
+  stamp(
+    new Error(
+      'henri is not running: `await setup()` in beforeAll, or add "@usehenri/testing/setup-file" to vitest setupFiles'
+    ),
+    'HENRI_BOOT_TESTING_NOT_RUNNING'
+  );
+
+module.exports = { notRunning, stamp };

--- a/packages/testing/factory.js
+++ b/packages/testing/factory.js
@@ -1,0 +1,579 @@
+/**
+ * Factories: a valid record with the fields the test does not care about
+ * already filled in.
+ *
+ * A factory lives in `test/factories/<name>.js` and is read the first time a
+ * test asks for one. It is a plain object, like a model or a policy:
+ *
+ *   // test/factories/proposal.js
+ *   module.exports = {
+ *     attributes: {
+ *       abstract: () => 'An abstract, comfortably past the sixty characters.',
+ *       eventId: async ({ create }) => (await create('event')).id,
+ *       speakerId: async ({ create }) => (await create('user')).id,
+ *       title: ({ sequence }) => `A proposal long enough to pass (${sequence})`,
+ *       trackId: async ({ attrs, create }) =>
+ *         (await create('track', { eventId: await attrs.eventId })).id,
+ *     },
+ *     traits: {
+ *       accepted: { decidedAt: () => new Date(), state: 'accepted' },
+ *     },
+ *   };
+ *
+ *   await create('proposal');                        // saved
+ *   await create('proposal', 'accepted');            // with the trait
+ *   await create('proposal', { title: 'A talk' });   // the test's own value
+ *   await createList('proposal', 3, 'accepted');
+ *   await build('proposal');                         // the attributes, unsaved
+ *
+ * Three rules hold the design together:
+ *
+ * - **What the caller gives is never made.** An override wins over the
+ *   definition and the definition's value is not evaluated at all, so
+ *   `create('proposal', { speakerId: someone.id })` creates no second user.
+ * - **A value is a literal or a function of the build context.** There is no
+ *   separate vocabulary for associations, sequences or computed fields: an
+ *   association is a function that calls `create`, a sequence is a number on
+ *   the context.
+ * - **Fields resolve on demand, not in the order they are written.** Reading
+ *   `attrs.eventId` from another field's function resolves that field first,
+ *   so two fields can share one parent whatever order the keys sit in --
+ *   which `sort-keys` decides anyway.
+ *
+ * A trait is an override object with a name, kept next to the model instead
+ * of copied into every test. `accepted` versus `draft` is rarely one field
+ * -- an accepted proposal has a `state`, a `submittedAt` and a `decidedAt` --
+ * and that is knowledge about the model, not about the test.
+ *
+ * @module @usehenri/testing/factory
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const { notRunning, stamp } = require('./errors');
+
+/** Where an application keeps its factories, relative to its root */
+const DIRECTORY = path.join('test', 'factories');
+
+/**
+ * How many factories may make one another before it is called a cycle.
+ * Depth is the honest signal, not a repeated name: an `after` that makes
+ * children of the same kind as its parent is a real pattern.
+ */
+const MAX_DEPTH = 10;
+
+/** The definitions, by name */
+const registry = new Map();
+
+/** How many records each factory has made in this process */
+const counters = new Map();
+
+/** The directory the registry was read from, so it is read once */
+let loaded = null;
+
+/**
+ * A short string of this process's own, so a suite whose workers share one
+ * database can keep its unique columns apart:
+ * `` email: ({ sequence, uid }) => `speaker-${uid}-${sequence}@example.test` ``
+ *
+ * @returns {string} four base36 characters
+ */
+const uid = () => `0000${process.pid.toString(36)}`.slice(-4);
+
+/**
+ * The running instance, or a failure naming what is missing
+ *
+ * @returns {object} the henri instance
+ * @throws when nothing booted the application
+ */
+const running = () => {
+  // Lazily, so this module and index.js may require each other
+  const { henri } = require('./index.js');
+
+  if (!henri) {
+    throw notRunning();
+  }
+
+  return henri;
+};
+
+/**
+ * The models henri exposes as globals, by lowercased name
+ *
+ * @param {object} henri the running instance
+ * @returns {Map<string, string>} lowercased name to global name
+ */
+const modelNames = (henri) =>
+  new Map(
+    ((henri.model && henri.model.ids) || []).map((name) => [
+      String(name).toLowerCase(),
+      name,
+    ])
+  );
+
+/**
+ * Check a definition and put it in the registry
+ *
+ * Also how a test file declares a factory without a file, which is what a
+ * one-off shape and the framework's own suites use. A definition made this
+ * way wins over `test/factories/<name>.js`, whatever order they arrive in.
+ *
+ * @param {string} name the factory name (`create('<name>')`)
+ * @param {object} definition `{ after, attributes, model, traits }`
+ * @param {string} [source] where it came from, for the error message
+ * @returns {object} the definition
+ * @throws when the definition cannot be used
+ */
+const defineFactory = (name, definition, source = 'defineFactory()') => {
+  if (typeof name !== 'string' || name.length === 0) {
+    throw stamp(
+      new Error('@usehenri/testing: a factory needs a name'),
+      'HENRI_FACTORY_INVALID'
+    );
+  }
+
+  // The files first, so a factory declared in a test always wins
+  source === 'defineFactory()' && load();
+
+  /**
+   * The failure of this definition
+   *
+   * @param {string} message what is wrong with it
+   * @returns {Error} the error to throw
+   */
+  const invalid = (message) =>
+    stamp(
+      new Error(
+        `@usehenri/testing: the factory '${name}' (${source}) ${message}`
+      ),
+      'HENRI_FACTORY_INVALID'
+    );
+
+  if (!definition || typeof definition !== 'object') {
+    throw invalid('exports no object');
+  }
+
+  const { after, attributes, model, traits } = definition;
+
+  if (!attributes || typeof attributes !== 'object') {
+    throw invalid('has no `attributes` object');
+  }
+
+  if (typeof model !== 'undefined' && typeof model !== 'string') {
+    throw invalid('has a `model` that is not the name of one');
+  }
+
+  if (typeof after !== 'undefined' && typeof after !== 'function') {
+    throw invalid('has an `after` that is not a function');
+  }
+
+  if (typeof traits !== 'undefined') {
+    if (!traits || typeof traits !== 'object') {
+      throw invalid('has a `traits` that is not an object');
+    }
+
+    for (const [trait, values] of Object.entries(traits)) {
+      if (!values || typeof values !== 'object') {
+        throw invalid(`declares a trait '${trait}' that is not an object`);
+      }
+    }
+  }
+
+  registry.set(name, { after, attributes, model, name, source, traits });
+
+  return definition;
+};
+
+/**
+ * Read the factory files of the application
+ *
+ * @param {string} directory where to look
+ * @returns {number} how many were read
+ * @throws when a file cannot be loaded or exports nothing usable
+ */
+const readDirectory = (directory) => {
+  if (!fs.existsSync(directory)) {
+    return 0;
+  }
+
+  const files = fs
+    .readdirSync(directory, { withFileTypes: true })
+    .filter((item) => item.isFile() && item.name.endsWith('.js'))
+    .map((item) => item.name)
+    .sort();
+
+  for (const file of files) {
+    const full = path.join(directory, file);
+    let definition;
+
+    try {
+      // Read from disk rather than from the cache, the way core loads
+      // app/models: a watch run that reloaded the registry wants the file
+      delete require.cache[require.resolve(full)];
+
+      definition = require(full);
+    } catch (error) {
+      throw stamp(
+        new Error(
+          `@usehenri/testing: unable to load the factory ${full} (${error.message})`,
+          { cause: error }
+        ),
+        'HENRI_FACTORY_INVALID'
+      );
+    }
+
+    defineFactory(path.basename(file, '.js'), definition, full);
+  }
+
+  return files.length;
+};
+
+/**
+ * Read `test/factories` once, on the first call that needs it
+ *
+ * @returns {void}
+ */
+const load = () => {
+  const directory = path.resolve(process.cwd(), DIRECTORY);
+
+  if (loaded === directory) {
+    return;
+  }
+
+  // Marked before the read, because `readDirectory` declares what it finds
+  // and would come back here; unmarked again when it fails, so the next
+  // call reports the broken file rather than a factory that is missing
+  loaded = directory;
+
+  try {
+    readDirectory(directory);
+  } catch (error) {
+    loaded = null;
+    throw error;
+  }
+};
+
+/**
+ * The definition of a factory
+ *
+ * @param {string} name the factory name
+ * @returns {object} the definition
+ * @throws when nothing declares it
+ */
+const definitionOf = (name) => {
+  load();
+
+  const found = registry.get(name);
+
+  if (found) {
+    return found;
+  }
+
+  const known = [...registry.keys()].sort();
+  const list =
+    known.length > 0
+      ? `this application has ${known.join(', ')}`
+      : `nothing was found in ${DIRECTORY}`;
+
+  throw stamp(
+    new Error(
+      `@usehenri/testing: there is no factory named '${name}': ${list}`
+    ),
+    'HENRI_FACTORY_UNKNOWN'
+  );
+};
+
+/**
+ * The model a factory writes to: the one it names, or the one its own name
+ * reads as
+ *
+ * @param {object} definition the definition
+ * @param {object} henri the running instance
+ * @returns {object} the model
+ * @throws when the application has no such model
+ */
+const modelOf = (definition, henri) => {
+  const names = modelNames(henri);
+  const wanted = definition.model || definition.name;
+  const found = names.get(String(wanted).toLowerCase());
+  const model = found && globalThis[found];
+
+  if (!model) {
+    const known = [...names.values()].sort().join(', ') || 'none';
+
+    throw stamp(
+      new Error(
+        `@usehenri/testing: the factory '${definition.name}' (${definition.source}) names the model '${wanted}', which this application does not have (it has ${known}). Name the right one with \`model:\`.`
+      ),
+      'HENRI_FACTORY_INVALID'
+    );
+  }
+
+  return model;
+};
+
+/**
+ * Split `create('proposal', 'accepted', { title })` into its parts. A key
+ * whose override is `undefined` says nothing, so an optional value from the
+ * test does not turn a default into a null.
+ *
+ * @param {object} definition the definition
+ * @param {Array} args the trait names and override objects, in any order
+ * @returns {{overrides: object, traits: Array<string>}} what was asked for
+ * @throws when a trait is not declared
+ */
+const parseArguments = (definition, args) => {
+  const overrides = {};
+  const traits = [];
+
+  for (const arg of args) {
+    if (typeof arg === 'string') {
+      const values = definition.traits && definition.traits[arg];
+
+      if (!values) {
+        const known = Object.keys(definition.traits || {})
+          .sort()
+          .join(', ');
+
+        throw stamp(
+          new Error(
+            `@usehenri/testing: the factory '${definition.name}' has no trait '${arg}'${
+              known ? ` (it has ${known})` : ' (it declares none)'
+            }`
+          ),
+          'HENRI_FACTORY_UNKNOWN_TRAIT'
+        );
+      }
+
+      traits.push(arg);
+    } else if (arg && typeof arg === 'object') {
+      for (const [field, value] of Object.entries(arg)) {
+        typeof value === 'undefined' || (overrides[field] = value);
+      }
+    } else if (typeof arg !== 'undefined') {
+      throw stamp(
+        new Error(
+          `@usehenri/testing: create('${definition.name}', ...) takes trait names and override objects, not ${typeof arg}`
+        ),
+        'HENRI_FACTORY_INVALID'
+      );
+    }
+  }
+
+  return { overrides, traits };
+};
+
+/**
+ * The attributes of a record: the overrides, then whatever the definition
+ * and its traits still have to say, each field resolved the first time
+ * something reads it
+ *
+ * @param {string} name the factory name
+ * @param {Array} args trait names and override objects
+ * @param {Array<string>} chain the factories being made, outermost first
+ * @returns {Promise<{context: object, definition: object, values: object}>}
+ *   the definition, the attributes and the context the hooks are given
+ * @throws when the factories nest too deeply, or two fields need each other
+ */
+const attributesOf = async (name, args, chain) => {
+  const definition = definitionOf(name);
+
+  if (chain.length >= MAX_DEPTH) {
+    throw stamp(
+      new Error(
+        `@usehenri/testing: the factories nested ${chain.length} deep and stopped: ${[
+          ...chain,
+          name,
+        ].join(
+          ' -> '
+        )}. Give the association an id in the overrides to end the chain.`
+      ),
+      'HENRI_FACTORY_DEPTH'
+    );
+  }
+
+  const { overrides, traits } = parseArguments(definition, args);
+  const declared = Object.assign(
+    {},
+    definition.attributes,
+    ...traits.map((trait) => definition.traits[trait])
+  );
+  const values = { ...overrides };
+  const resolving = new Set();
+  const nested = [...chain, name];
+  const has = (target, field) =>
+    Object.prototype.hasOwnProperty.call(target, field);
+
+  /**
+   * The value of one field, resolved once
+   *
+   * @param {string} field the field name
+   * @returns {Promise<*>} the value
+   */
+  const resolve = async (field) => {
+    if (has(values, field)) {
+      return values[field];
+    }
+
+    if (resolving.has(field)) {
+      throw stamp(
+        new Error(
+          `@usehenri/testing: the fields of the factory '${name}' need each other: ${[
+            ...resolving,
+            field,
+          ].join(' -> ')}`
+        ),
+        'HENRI_FACTORY_DEPTH'
+      );
+    }
+
+    resolving.add(field);
+
+    try {
+      const declaration = declared[field];
+
+      values[field] =
+        typeof declaration === 'function'
+          ? await declaration(context)
+          : declaration;
+    } finally {
+      resolving.delete(field);
+    }
+
+    return values[field];
+  };
+
+  /**
+   * The attributes resolved so far. Reading a field the definition declares
+   * and nothing has resolved yet answers a promise of it, so
+   * `await attrs.eventId` reads the same either way.
+   */
+  const attrs = new Proxy(values, {
+    /**
+     * @param {object} target the resolved attributes
+     * @param {string|symbol} field what is being read
+     * @returns {*} the value, or a promise of it
+     */
+    get: (target, field) => {
+      if (typeof field !== 'string' || has(target, field)) {
+        return target[field];
+      }
+
+      return has(declared, field) ? resolve(field) : undefined;
+    },
+  });
+  const context = {
+    attrs,
+    build: (child, ...rest) => buildIn(child, rest, nested),
+    create: (child, ...rest) => createIn(child, rest, nested),
+    sequence: (counters.get(name) || 0) + 1,
+    traits,
+    uid: uid(),
+  };
+
+  counters.set(name, context.sequence);
+
+  for (const field of Object.keys(declared)) {
+    await resolve(field);
+  }
+
+  return { context, definition, values };
+};
+
+/**
+ * `build()`, carrying the chain of factories it is nested in
+ *
+ * @param {string} name the factory name
+ * @param {Array} args trait names and override objects
+ * @param {Array<string>} chain the factories being made
+ * @returns {Promise<object>} the attributes
+ */
+const buildIn = async (name, args, chain) =>
+  (await attributesOf(name, args, chain)).values;
+
+/**
+ * `create()`, carrying the chain of factories it is nested in
+ *
+ * @param {string} name the factory name
+ * @param {Array} args trait names and override objects
+ * @param {Array<string>} chain the factories being made
+ * @returns {Promise<object>} the saved record
+ */
+const createIn = async (name, args, chain) => {
+  const henri = running();
+  const { context, definition, values } = await attributesOf(name, args, chain);
+  const record = await modelOf(definition, henri).create(values);
+
+  if (typeof definition.after !== 'function') {
+    return record;
+  }
+
+  const answered = await definition.after(record, context);
+
+  return typeof answered === 'undefined' ? record : answered;
+};
+
+/**
+ * The attributes a valid record would have, without saving one.
+ *
+ * The associations are still made -- a foreign key has to name a row that
+ * exists -- unless the caller gives the field, which is what makes
+ * `build('proposal', { speakerId: someone.id })` touch no database at all.
+ *
+ * @param {string} name the factory name (`test/factories/<name>.js`)
+ * @param {...(string|object)} args trait names and override objects
+ * @returns {Promise<object>} the attributes
+ */
+const build = (name, ...args) => buildIn(name, args, []);
+
+/**
+ * A saved record
+ *
+ * @param {string} name the factory name (`test/factories/<name>.js`)
+ * @param {...(string|object)} args trait names and override objects
+ * @returns {Promise<object>} the record
+ */
+const create = (name, ...args) => createIn(name, args, []);
+
+/**
+ * Several saved records, one after the other so the sequences stay in order
+ *
+ * @param {string} name the factory name
+ * @param {number} count how many
+ * @param {...(string|object)} args trait names and override objects
+ * @returns {Promise<Array<object>>} the records
+ */
+const createList = async (name, count, ...args) => {
+  const records = [];
+
+  for (let made = 0; made < count; made += 1) {
+    records.push(await createIn(name, args, []));
+  }
+
+  return records;
+};
+
+/**
+ * Forget every definition and every sequence.
+ *
+ * A suite never needs this -- each test file is its own process -- but a file
+ * that declares factories of its own starts from a clean slate with it.
+ *
+ * @returns {void}
+ */
+const resetFactories = () => {
+  registry.clear();
+  counters.clear();
+  loaded = null;
+};
+
+module.exports = {
+  DIRECTORY,
+  MAX_DEPTH,
+  build,
+  create,
+  createList,
+  defineFactory,
+  resetFactories,
+};

--- a/packages/testing/index.d.ts
+++ b/packages/testing/index.d.ts
@@ -42,3 +42,82 @@ export const supertest: typeof Supertest;
  * `undefined` before the first boot.
  */
 export const henri: Henri | undefined;
+
+/** What a factory's value function is given. */
+export interface FactoryContext {
+  /**
+   * The attributes resolved so far. A field the definition declares and
+   * nothing has read yet answers a promise of it, so `await attrs.eventId`
+   * reads the same either way.
+   */
+  attrs: Record<string, any>;
+  /** A nested `build()`, counted against the nesting limit. */
+  build(name: string, ...args: FactoryArgument[]): Promise<FactoryAttributes>;
+  /** A nested `create()`, counted against the nesting limit. */
+  create(name: string, ...args: FactoryArgument[]): Promise<any>;
+  /** How many records this factory has made in this process, from 1. */
+  sequence: number;
+  /** The traits this record is being made with. */
+  traits: string[];
+  /** Four characters of this process's own, for a unique column. */
+  uid: string;
+}
+
+/** A field of a factory: a value, or what answers one. */
+export type FactoryValue =
+  unknown | ((context: FactoryContext) => unknown | Promise<unknown>);
+
+/** The fields a factory fills in. */
+export type FactoryAttributes = Record<string, FactoryValue>;
+
+/** `test/factories/<name>.js` exports one of these. */
+export interface FactoryDefinition {
+  /** Runs once the record is saved; what it returns replaces it. */
+  after?(record: any, context: FactoryContext): unknown | Promise<unknown>;
+  /** The fields, each a value or a function of the build context. */
+  attributes: FactoryAttributes;
+  /** The model to write to (the factory's own name by default). */
+  model?: string;
+  /** Named override groups: `create('proposal', 'accepted')`. */
+  traits?: Record<string, FactoryAttributes>;
+}
+
+/** A trait name, or an object of overrides. */
+export type FactoryArgument = string | Record<string, unknown>;
+
+/**
+ * The attributes a valid record would have, without saving one. The
+ * associations are still made unless the caller gives the field.
+ *
+ *     await request().post('/proposals').send(await build('proposal'));
+ */
+export function build(
+  name: string,
+  ...args: FactoryArgument[]
+): Promise<FactoryAttributes>;
+
+/**
+ * A saved record, with the fields the test does not care about filled in.
+ *
+ *     const proposal = await create('proposal', 'accepted', { title: 'A talk' });
+ */
+export function create(name: string, ...args: FactoryArgument[]): Promise<any>;
+
+/** `count` saved records, one after the other. */
+export function createList(
+  name: string,
+  count: number,
+  ...args: FactoryArgument[]
+): Promise<any[]>;
+
+/**
+ * Declares a factory without a file. It wins over
+ * `test/factories/<name>.js`, whatever order they arrive in.
+ */
+export function defineFactory(
+  name: string,
+  definition: FactoryDefinition
+): FactoryDefinition;
+
+/** Forgets every definition and every sequence. */
+export function resetFactories(): void;

--- a/packages/testing/index.js
+++ b/packages/testing/index.js
@@ -1,17 +1,13 @@
 const supertest = require('supertest');
 
-/**
- * Put one of henri's error codes on an error
- *
- * A code is a string and nothing more (`@usehenri/core/error-codes.json` is
- * the catalogue), so a failure names itself without importing anything --
- * which matters here, where core is resolved from the application.
- *
- * @param {Error} error The error
- * @param {string} code The henri error code
- * @returns {Error} The same error
- */
-const stamp = (error, code) => Object.assign(error, { code });
+const { notRunning, stamp } = require('./errors');
+const {
+  build,
+  create,
+  createList,
+  defineFactory,
+  resetFactories,
+} = require('./factory');
 
 const state = {
   instance: null,
@@ -168,12 +164,7 @@ const target = (instance) => {
     return process.env.HENRI_TEST_URL.replace(/\/$/, '');
   }
 
-  throw stamp(
-    new Error(
-      'henri is not running: `await setup()` in beforeAll, or add "@usehenri/testing/setup-file" to vitest setupFiles'
-    ),
-    'HENRI_BOOT_TESTING_NOT_RUNNING'
-  );
+  throw notRunning();
 };
 
 /**
@@ -194,7 +185,12 @@ const agent = (instance = current()) => supertest.agent(target(instance));
 
 module.exports = {
   agent,
+  build,
+  create,
+  createList,
+  defineFactory,
   request,
+  resetFactories,
   setup,
   supertest,
   teardown,

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -35,13 +35,15 @@
     }
   },
   "files": [
+    "README.md",
+    "errors.js",
+    "factory.js",
     "global-setup.d.mts",
     "global-setup.mjs",
     "index.d.ts",
     "index.js",
     "loopback.d.ts",
     "loopback.js",
-    "README.md",
     "setup-file.d.mts",
     "setup-file.mjs"
   ],

--- a/packages/uploads/__tests__/cleanup.spec.js
+++ b/packages/uploads/__tests__/cleanup.spec.js
@@ -195,8 +195,10 @@ describe('what a process that was killed left behind', () => {
   test('is swept when the storage starts', async () => {
     const { uploads } = await application();
     const stale = path.join(uploads.storage.tmp, 'deadbeef.part');
+    const old = new Date(Date.now() - 2 * 60 * 60 * 1000);
 
     fs.writeFileSync(stale, 'left by a SIGKILL');
+    fs.utimesSync(stale, old, old);
     fs.writeFileSync(path.join(uploads.storage.tmp, 'not-a-part.txt'), 'kept');
 
     expect(temporaries(uploads)).toHaveLength(2);
@@ -204,5 +206,19 @@ describe('what a process that was killed left behind', () => {
     await uploads.storage.start();
 
     expect(temporaries(uploads)).toEqual(['not-a-part.txt']);
+  });
+
+  test('a part being written right now is left alone', async () => {
+    const { uploads } = await application();
+    const live = path.join(uploads.storage.tmp, 'inflight.part');
+
+    // The root is shared: another process -- or another test file -- may be
+    // streaming into this directory while this one boots, and its part must
+    // survive the sweep
+    fs.writeFileSync(live, 'a part of a request in flight');
+
+    await uploads.storage.start();
+
+    expect(temporaries(uploads)).toEqual(['inflight.part']);
   });
 });

--- a/packages/uploads/src/storage/local.js
+++ b/packages/uploads/src/storage/local.js
@@ -45,6 +45,18 @@ const FILE_MODE = 0o600;
 const TMP = '.tmp';
 
 /**
+ * How old a part has to be before a boot sweeps it away.
+ *
+ * The root is shared by everything that runs against it -- two application
+ * processes behind a load balancer, a suite whose test files run at the same
+ * time -- and a boot cannot tell a part a dead process left behind from one
+ * another process is streaming into right now. Age can: a part being written
+ * is minutes old at most, so an hour is past every upload the bounds allow
+ * and still short enough that nothing accumulates.
+ */
+const STALE = 60 * 60 * 1000;
+
+/**
  * What is written into the storage root the first time it is created.
  *
  * The root is a directory of an application's repository by default, and an
@@ -126,6 +138,11 @@ class LocalStorage {
    * `SIGKILL` or a power cut left behind. It runs at boot, where a stale
    * file is a leak nobody is watching rather than a bug in the request.
    *
+   * Only parts older than `STALE` are removed: another process may be
+   * streaming into this same directory right now, and unlinking its part
+   * would fail its request with something that reads like a bug in the
+   * upload rather than what it is.
+   *
    * @async
    * @returns {Promise<number>} how many were removed
    * @memberof LocalStorage
@@ -139,6 +156,7 @@ class LocalStorage {
       return 0;
     }
 
+    const before = Date.now() - STALE;
     let removed = 0;
 
     for (const entry of entries) {
@@ -146,8 +164,14 @@ class LocalStorage {
         continue;
       }
 
+      const file = path.join(this.tmp, entry);
+
       try {
-        await fsp.unlink(path.join(this.tmp, entry));
+        if ((await fsp.stat(file)).mtimeMs > before) {
+          continue;
+        }
+
+        await fsp.unlink(file);
         removed++;
       } catch (error) {
         debug('unable to remove the stale part %s: %s', entry, error.message);

--- a/showcase/test/api.test.js
+++ b/showcase/test/api.test.js
@@ -1,13 +1,6 @@
 // The JSON API: HAL, pagination, Idempotency-Key, ETags and the versioned
 // media type. The same routes serve the pages of the application.
-const {
-  createEvent,
-  createProposal,
-  createUser,
-  request,
-  reset,
-  signIn,
-} = require('./helpers');
+const { create, request, reset, signIn } = require('./helpers');
 
 const HAL = 'application/hal+json';
 
@@ -64,22 +57,19 @@ describe('the JSON API', () => {
   beforeAll(async () => {
     await reset();
 
-    speaker = await createUser({
+    speaker = await create('user', {
       company: 'Fathom',
       email: 'api-speaker@example.test',
       name: 'API Speaker',
     });
-    admin = await createUser({
-      email: 'api-admin@example.test',
-      roles: ['speaker', 'admin'],
-    });
-    ({ event, track } = await createEvent({ name: 'API Conf' }));
+    admin = await create('user', 'admin', { email: 'api-admin@example.test' });
+    event = await create('event', { name: 'API Conf' });
+    track = await create('track', { eventId: event.id });
 
     for (let index = 0; index < 14; index += 1) {
-      const proposal = await createProposal({
+      const proposal = await create('proposal', 'submitted', {
         eventId: event.id,
         speakerId: speaker.id,
-        state: 'submitted',
         title: `An API proposal number ${index}`,
         trackId: track.id,
       });
@@ -398,7 +388,7 @@ describe('the JSON API', () => {
       });
 
       test('is scoped to the user, so two of them may use one key', async () => {
-        const other = await createUser({ email: 'api-other@example.test' });
+        const other = await create('user', { email: 'api-other@example.test' });
         const { browser, csrf } = await signIn(other);
         const answer = await browser
           .post('/proposals')

--- a/showcase/test/auth.test.js
+++ b/showcase/test/auth.test.js
@@ -9,7 +9,7 @@
 const {
   PASSWORD,
   agent,
-  createUser,
+  create,
   inertiaVersion,
   page,
   request,
@@ -181,7 +181,7 @@ describe('authentication', () => {
 
   describe('password reset', () => {
     test('answers the same for an address that exists and one that does not', async () => {
-      const user = await createUser({ email: 'forgetful@example.test' });
+      const user = await create('user', { email: 'forgetful@example.test' });
       const known = await request()
         .post('/password/forgot')
         .send({ email: user.email });
@@ -203,7 +203,7 @@ describe('authentication', () => {
     });
 
     test('the link changes the password once and signs the other sessions out', async () => {
-      const user = await createUser({ email: 'reset@example.test' });
+      const user = await create('user', { email: 'reset@example.test' });
       const { browser: elsewhere } = await signIn(user);
 
       expect((await page(elsewhere, '/account')).status).toBe(200);
@@ -286,7 +286,7 @@ describe('authentication', () => {
     });
 
     test('an address change waits for the new address to be confirmed', async () => {
-      const user = await createUser({ email: 'moving@example.test' });
+      const user = await create('user', { email: 'moving@example.test' });
       const { browser, csrf } = await signIn(user);
 
       mails.length = 0;
@@ -315,7 +315,7 @@ describe('authentication', () => {
   });
 
   test('signing in redirects a browser and reaches the pages as req.user', async () => {
-    const user = await createUser({
+    const user = await create('user', {
       email: 'signin@example.test',
       name: 'Signed In',
     });
@@ -336,7 +336,7 @@ describe('authentication', () => {
   });
 
   test('the public user never carries the password hash', async () => {
-    const user = await createUser({ email: 'private@example.test' });
+    const user = await create('user', { email: 'private@example.test' });
     const { browser } = await signIn(user);
     const home = await page(browser, '/');
 
@@ -345,7 +345,7 @@ describe('authentication', () => {
   });
 
   test('signing in with a wrong password sends the browser back', async () => {
-    const user = await createUser({ email: 'wrong@example.test' });
+    const user = await create('user', { email: 'wrong@example.test' });
     const browser = agent();
     const start = await browser.get('/login').set('Accept', 'text/html');
     const answer = await browser
@@ -359,7 +359,7 @@ describe('authentication', () => {
   });
 
   test('an API client gets 401 and the public user, not a redirect', async () => {
-    const user = await createUser({ email: 'api@example.test' });
+    const user = await create('user', { email: 'api@example.test' });
     const bad = await request()
       .post('/login')
       .set('Accept', 'application/json')
@@ -378,7 +378,7 @@ describe('authentication', () => {
   });
 
   test('signing out empties the session', async () => {
-    const user = await createUser({ email: 'bye@example.test' });
+    const user = await create('user', { email: 'bye@example.test' });
     const { browser, csrf } = await signIn(user);
 
     expect((await page(browser, '/')).body.props.user).toBeTruthy();
@@ -400,7 +400,7 @@ describe('authentication', () => {
 
   describe('CSRF', () => {
     test('a request with a session but no token is refused', async () => {
-      const user = await createUser({ email: 'csrf@example.test' });
+      const user = await create('user', { email: 'csrf@example.test' });
       const { browser } = await signIn(user);
       const answer = await browser
         .post('/proposals')
@@ -412,7 +412,7 @@ describe('authentication', () => {
     });
 
     test('the same request with the token gets through to the action', async () => {
-      const user = await createUser({ email: 'csrf-ok@example.test' });
+      const user = await create('user', { email: 'csrf-ok@example.test' });
       const { browser, csrf } = await signIn(user);
       const answer = await browser
         .post('/proposals')
@@ -426,7 +426,7 @@ describe('authentication', () => {
     });
 
     test('a token from another session is refused', async () => {
-      const user = await createUser({ email: 'csrf-other@example.test' });
+      const user = await create('user', { email: 'csrf-other@example.test' });
       const { browser } = await signIn(user);
       const other = await agent().get('/login').set('Accept', 'text/html');
       const answer = await browser

--- a/showcase/test/factories/event.js
+++ b/showcase/test/factories/event.js
@@ -1,0 +1,17 @@
+// One edition of the conference. `open` is the state the call for papers is
+// in, which is what most tests need and not what the model defaults to.
+module.exports = {
+  attributes: {
+    city: 'Testville',
+    name: 'Test Conf',
+    slug: ({ sequence, uid }) => `test-${uid}-${sequence}`,
+    state: 'open',
+    year: 2026,
+  },
+
+  traits: {
+    announced: { state: 'announced' },
+    closed: { state: 'closed' },
+    draft: { state: 'draft' },
+  },
+};

--- a/showcase/test/factories/proposal.js
+++ b/showcase/test/factories/proposal.js
@@ -1,0 +1,45 @@
+// A talk proposal, with the speaker and the edition the schema requires and
+// nothing else: `trackId` is nullable because a draft has no track yet, so
+// the factory leaves it alone and the states that mean "the committee has
+// it" fill it in.
+//
+// That is what the traits are for. A submitted proposal has a `state` *and*
+// a `submittedAt` *and* a track; an accepted one has a `decidedAt` too. None
+// of that is knowledge about a test, so none of it belongs in one.
+//
+// `trackId` reads `attrs.eventId` rather than making a second edition, so
+// `create('proposal', 'submitted', { eventId: event.id })` keeps the track
+// with its edition. The key order below is alphabetical because `sort-keys`
+// says so; the values resolve in the order they are read, not written.
+const track = async ({ attrs, create }) =>
+  (await create('track', { eventId: await attrs.eventId })).id;
+
+module.exports = {
+  attributes: {
+    abstract:
+      'An abstract that is comfortably longer than the sixty characters the model asks for.',
+    eventId: async ({ create }) => (await create('event')).id,
+    speakerId: async ({ create }) => (await create('user')).id,
+    title: 'A proposal with a long enough title',
+  },
+
+  traits: {
+    accepted: {
+      decidedAt: () => new Date(),
+      state: 'accepted',
+      submittedAt: () => new Date(),
+      trackId: track,
+    },
+    rejected: {
+      decidedAt: () => new Date(),
+      state: 'rejected',
+      submittedAt: () => new Date(),
+      trackId: track,
+    },
+    submitted: {
+      state: 'submitted',
+      submittedAt: () => new Date(),
+      trackId: track,
+    },
+  },
+};

--- a/showcase/test/factories/review.js
+++ b/showcase/test/factories/review.js
@@ -1,0 +1,12 @@
+// A committee member's opinion on one proposal. Both associations are made
+// unless the test names them, and the reviewer is an admin because that is
+// who writes reviews.
+module.exports = {
+  attributes: {
+    comment: 'A careful and quite specific opinion about this talk.',
+    proposalId: async ({ create }) =>
+      (await create('proposal', 'submitted')).id,
+    reviewerId: async ({ create }) => (await create('user', 'admin')).id,
+    score: 2,
+  },
+};

--- a/showcase/test/factories/track.js
+++ b/showcase/test/factories/track.js
@@ -1,0 +1,9 @@
+// A track belongs to an edition, so the factory makes one unless the test
+// names it: `create('track', { eventId: event.id })`.
+module.exports = {
+  attributes: {
+    eventId: async ({ create }) => (await create('event')).id,
+    name: 'Backend',
+    slug: 'backend',
+  },
+};

--- a/showcase/test/factories/user.js
+++ b/showcase/test/factories/user.js
@@ -1,0 +1,33 @@
+// A speaker, and with the `admin` trait a member of the program committee.
+//
+// `password` goes through the model, so the row holds a hash and no test has
+// to know that; `roles` is stripped from mass assignment, which is why the
+// factory sets it after the write and reads the row back.
+const { PASSWORD } = require('../helpers');
+
+module.exports = {
+  after: async (user, { attrs }) => {
+    if (!Array.isArray(attrs.roles) || attrs.roles.length === 0) {
+      return user;
+    }
+
+    await User.setRoles(user.externalId, attrs.roles);
+
+    // The row it just wrote: a primary key, so the key lookup
+    return User.findByKey(user.id);
+  },
+
+  attributes: {
+    email: ({ sequence, uid }) => `speaker-${uid}-${sequence}@example.test`,
+    name: 'A Speaker',
+    password: PASSWORD,
+  },
+
+  traits: {
+    // Everything /admin asks for, and nothing else: a trait says what makes
+    // this record that kind of record, so it grants the roles and leaves the
+    // name alone. `speaker` comes along because a chair submits talks too,
+    // which is what the seeds do
+    admin: { roles: ['speaker', 'admin'] },
+  },
+};

--- a/showcase/test/helpers.js
+++ b/showcase/test/helpers.js
@@ -3,7 +3,12 @@
 // Every test file boots the application once (`@usehenri/testing/setup-file`)
 // against the PostgreSQL of config/test.json, so the tables are shared: each
 // file empties them and creates the records it needs.
-const { agent, request } = require('@usehenri/testing');
+//
+// The records themselves come from `test/factories` -- `create('proposal',
+// 'submitted')` makes the speaker, the edition and the track it needs -- so
+// what is left here is the HTTP part: emptying the tables, reading the
+// Inertia asset version, signing in and finding the CSRF token.
+const { agent, create, request } = require('@usehenri/testing');
 
 /** The password every account created here uses */
 const PASSWORD = 'lineup-showcase';
@@ -95,74 +100,10 @@ const token = (response) => {
   return found ? decodeURIComponent(found.split('=')[1].split(';')[0]) : null;
 };
 
-/**
- * Creates a user
- *
- * @param {object} [attributes={}] Overrides
- * @returns {Promise<object>} The user
- */
-const createUser = async (attributes = {}) => {
-  const user = await User.create({
-    email: `speaker-${Math.random().toString(36).slice(2, 10)}@example.test`,
-    name: 'A Speaker',
-    password: PASSWORD,
-    ...attributes,
-  });
-
-  if (attributes.roles) {
-    await User.setRoles(user.externalId, attributes.roles);
-
-    // The row it just wrote: a primary key, so the key lookup
-    return User.findByKey(user.id);
-  }
-
-  return user;
-};
-
-/**
- * Creates an edition with one track
- *
- * @param {object} [attributes={}] Overrides of the edition
- * @returns {Promise<object>} `{ event, track }`
- */
-const createEvent = async (attributes = {}) => {
-  const event = await Event.create({
-    city: 'Testville',
-    name: 'Test Conf',
-    slug: `test-${Math.random().toString(36).slice(2, 8)}`,
-    state: 'open',
-    year: 2026,
-    ...attributes,
-  });
-  const track = await Track.create({
-    eventId: event.id,
-    name: 'Backend',
-    slug: 'backend',
-  });
-
-  return { event, track };
-};
-
-/**
- * Creates a proposal
- *
- * @param {object} attributes The attributes (speakerId and eventId required)
- * @returns {Promise<object>} The proposal
- */
-const createProposal = (attributes) =>
-  Proposal.create({
-    abstract:
-      'An abstract that is comfortably longer than the sixty characters the model asks for.',
-    title: 'A proposal with a long enough title',
-    ...attributes,
-  });
-
 module.exports = {
   PASSWORD,
   agent,
-  createEvent,
-  createProposal,
-  createUser,
+  create,
   inertiaVersion,
   page,
   request,

--- a/showcase/test/openapi.test.js
+++ b/showcase/test/openapi.test.js
@@ -9,14 +9,7 @@
 const Ajv = require('ajv/dist/2020');
 const addFormats = require('ajv-formats');
 
-const {
-  createEvent,
-  createProposal,
-  createUser,
-  request,
-  reset,
-  signIn,
-} = require('./helpers');
+const { create, request, reset, signIn } = require('./helpers');
 
 const HAL = 'application/hal+json';
 const ABSTRACT =
@@ -49,18 +42,16 @@ describe('the OpenAPI description of the showcase', () => {
       });
 
     await reset();
-    speaker = await createUser({
+    speaker = await create('user', {
       company: 'Fathom',
       email: 'openapi-speaker@example.test',
       name: 'Doc Speaker',
       phone: '555-0100',
     });
-    ({ event } = await createEvent({ name: 'Doc Conf' }));
-    submitted = await createProposal({
+    event = await create('event', { name: 'Doc Conf' });
+    submitted = await create('proposal', 'submitted', {
       eventId: event.id,
       speakerId: speaker.id,
-      state: 'submitted',
-      submittedAt: new Date(),
       title: 'A proposal the description describes',
     });
   });

--- a/showcase/test/policies.test.js
+++ b/showcase/test/policies.test.js
@@ -7,9 +7,7 @@
 // policy would refuse; and a policy that does not exist, does not answer, or
 // throws, all mean the same thing.
 const {
-  createEvent,
-  createProposal,
-  createUser,
+  create,
   inertiaVersion,
   page,
   request,
@@ -31,28 +29,28 @@ describe('policies', () => {
     await reset();
     await inertiaVersion();
 
-    speaker = await createUser({
+    speaker = await create('user', {
       email: 'owner@policies.test',
       name: 'Owner',
     });
-    other = await createUser({ email: 'other@policies.test', name: 'Other' });
-    admin = await createUser({
+    other = await create('user', {
+      email: 'other@policies.test',
+      name: 'Other',
+    });
+    admin = await create('user', 'admin', {
       email: 'committee@policies.test',
-      roles: ['speaker', 'admin'],
     });
 
-    ({ event } = await createEvent({ name: 'Policy Conf' }));
+    event = await create('event', { name: 'Policy Conf' });
 
-    draft = await createProposal({
+    draft = await create('proposal', {
       eventId: event.id,
       speakerId: speaker.id,
-      state: 'draft',
       title: 'A draft nobody else may read',
     });
-    submitted = await createProposal({
+    submitted = await create('proposal', 'submitted', {
       eventId: event.id,
       speakerId: speaker.id,
-      state: 'submitted',
       title: 'A submitted proposal anybody may read',
     });
   });

--- a/showcase/test/privacy.test.js
+++ b/showcase/test/privacy.test.js
@@ -6,9 +6,7 @@
 // `personal` is a failure here, and `henri audit` reports it too.
 const {
   PASSWORD,
-  createEvent,
-  createProposal,
-  createUser,
+  create,
   inertiaVersion,
   page,
   request,
@@ -86,7 +84,7 @@ describe('personal data', () => {
 
   describe('what leaves the server', () => {
     test('the account page carries the phone, because it asked for it', async () => {
-      const speaker = await createUser({
+      const speaker = await create('user', {
         name: 'Ada Okonjo',
         phone: '+1-555-0100',
       });
@@ -101,19 +99,13 @@ describe('personal data', () => {
     });
 
     test('no other answer carries it, whoever is asking', async () => {
-      const speaker = await createUser({
+      const speaker = await create('user', {
         name: 'Bruno Sato',
         phone: '+1-555-0101',
       });
-      const admin = await createUser({ roles: ['speaker', 'admin'] });
-      const { event, track } = await createEvent();
+      const admin = await create('user', 'admin');
 
-      await createProposal({
-        eventId: event.id,
-        speakerId: speaker.id,
-        state: 'submitted',
-        trackId: track.id,
-      });
+      await create('proposal', 'submitted', { speakerId: speaker.id });
 
       const { browser } = await signIn(admin);
       const list = await page(browser, '/admin/users');
@@ -135,7 +127,7 @@ describe('personal data', () => {
     });
 
     test('the signed-in user of every page has no phone either', async () => {
-      const speaker = await createUser({ phone: '+1-555-0102' });
+      const speaker = await create('user', { phone: '+1-555-0102' });
       const { browser } = await signIn(speaker);
       const res = await page(browser, '/proposals/mine');
 
@@ -147,26 +139,24 @@ describe('personal data', () => {
 
   describe('henri privacy:export', () => {
     test('hands back everything held about one person', async () => {
-      const speaker = await createUser({
+      const speaker = await create('user', {
         bio: 'Runs the platform team.',
         company: 'Kestrel',
         name: 'Ada Okonjo',
         phone: '+1-555-0100',
       });
-      const reviewer = await createUser({ roles: ['speaker', 'admin'] });
-      const { event, track } = await createEvent();
-      const proposal = await createProposal({
-        eventId: event.id,
+      const reviewer = await create('user', 'admin');
+      const proposal = await create('proposal', {
         speakerId: speaker.id,
         title: 'What a database owes you',
-        trackId: track.id,
       });
 
-      await Review.create({
+      await create('review', {
+        // The words the export is checked for below: what a test asserts on
+        // belongs in the test, and everything else in the factory
         comment: 'A good talk, and the speaker can deliver it.',
         proposalId: proposal.id,
         reviewerId: reviewer.id,
-        score: 2,
       });
 
       const document = await henri.privacy.export(speaker.email);
@@ -203,13 +193,10 @@ describe('personal data', () => {
     });
 
     test("a withdrawn proposal is still the speaker's", async () => {
-      const speaker = await createUser({});
-      const { event, track } = await createEvent();
-      const proposal = await createProposal({
-        eventId: event.id,
+      const speaker = await create('user');
+      const proposal = await create('proposal', {
         speakerId: speaker.id,
         title: 'Withdrawn but written',
-        trackId: track.id,
       });
 
       // Soft deleted: hidden from every query, and still in the database
@@ -226,34 +213,26 @@ describe('personal data', () => {
 
   describe('henri privacy:erase', () => {
     test('anonymizes the speaker and keeps the programme', async () => {
-      const speaker = await createUser({
+      const speaker = await create('user', {
         bio: 'Runs the platform team.',
         company: 'Kestrel',
         name: 'Ada Okonjo',
         phone: '+1-555-0100',
       });
-      const reviewer = await createUser({ roles: ['speaker', 'admin'] });
-      const { event, track } = await createEvent();
-      const accepted = await createProposal({
-        eventId: event.id,
+      const reviewer = await create('user', 'admin');
+      const accepted = await create('proposal', 'accepted', {
         speakerId: speaker.id,
-        state: 'accepted',
         title: 'What a database owes you',
-        trackId: track.id,
       });
-      const withdrawn = await createProposal({
-        eventId: event.id,
+      const withdrawn = await create('proposal', {
         speakerId: speaker.id,
         title: 'A talk that was withdrawn',
-        trackId: track.id,
       });
 
       await withdrawn.destroy();
-      await Review.create({
-        comment: 'A good talk, and the speaker can deliver it.',
+      await create('review', {
         proposalId: accepted.id,
         reviewerId: reviewer.id,
-        score: 2,
       });
 
       const email = speaker.email;
@@ -303,16 +282,10 @@ describe('personal data', () => {
     });
 
     test("erases the reviewer's words with the reviewer", async () => {
-      const speaker = await createUser({});
-      const reviewer = await createUser({ roles: ['speaker', 'admin'] });
-      const { event, track } = await createEvent();
-      const proposal = await createProposal({
-        eventId: event.id,
-        speakerId: speaker.id,
-        trackId: track.id,
-      });
+      const reviewer = await create('user', 'admin');
+      const proposal = await create('proposal');
 
-      await Review.create({
+      await create('review', {
         comment: 'What one committee member thought of it.',
         proposalId: proposal.id,
         reviewerId: reviewer.id,
@@ -332,7 +305,10 @@ describe('personal data', () => {
     });
 
     test('a dry run says what would happen and changes nothing', async () => {
-      const speaker = await createUser({ name: 'Grace', phone: '+1-555-0199' });
+      const speaker = await create('user', {
+        name: 'Grace',
+        phone: '+1-555-0199',
+      });
       const receipt = await henri.privacy.erase(speaker.email, {
         dryRun: true,
       });

--- a/showcase/test/proposals.test.js
+++ b/showcase/test/proposals.test.js
@@ -2,9 +2,7 @@
 // ownership, req.permit, flash messages across a redirect, implicit
 // rendering, and the soft delete behind "withdraw".
 const {
-  createEvent,
-  createProposal,
-  createUser,
+  create,
   inertiaVersion,
   page,
   request,
@@ -27,21 +25,21 @@ describe('proposals', () => {
     await reset();
     await inertiaVersion();
 
-    speaker = await createUser({
+    speaker = await create('user', {
       email: 'author@example.test',
       name: 'Author',
     });
-    other = await createUser({ email: 'other@example.test', name: 'Other' });
-    admin = await createUser({
+    other = await create('user', {
+      email: 'other@example.test',
+      name: 'Other',
+    });
+    admin = await create('user', 'admin', {
       email: 'committee@example.test',
-      roles: ['speaker', 'admin'],
     });
 
-    ({ event, track } = await createEvent({ name: 'Open Conf' }));
-    ({ event: closed } = await createEvent({
-      name: 'Closed Conf',
-      state: 'closed',
-    }));
+    event = await create('event', { name: 'Open Conf' });
+    track = await create('track', { eventId: event.id });
+    closed = await create('event', 'closed', { name: 'Closed Conf' });
   });
 
   describe('the public list', () => {
@@ -49,19 +47,17 @@ describe('proposals', () => {
       await Proposal.withDeleted().destroy({ force: true });
 
       for (let index = 0; index < 15; index += 1) {
-        await createProposal({
+        await create('proposal', 'submitted', {
           eventId: event.id,
           speakerId: speaker.id,
-          state: 'submitted',
           title: `A submitted proposal number ${index}`,
           trackId: track.id,
         });
       }
 
-      await createProposal({
+      await create('proposal', {
         eventId: event.id,
         speakerId: speaker.id,
-        state: 'draft',
         title: 'A draft nobody should see',
       });
     });
@@ -113,10 +109,9 @@ describe('proposals', () => {
     });
 
     test('a draft is a 404 for everyone but its speaker and the committee', async () => {
-      const draft = await createProposal({
+      const draft = await create('proposal', {
         eventId: event.id,
         speakerId: speaker.id,
-        state: 'draft',
         title: 'A draft of my own',
       });
       const anonymous = await request()
@@ -165,10 +160,9 @@ describe('proposals', () => {
     test('editing somebody else’s proposal is a 403', async () => {
       // Submitted, so it is readable: an unreadable one would be a 404 from
       // the hook before, and never reach the ownership check
-      const theirs = await createProposal({
+      const theirs = await create('proposal', 'submitted', {
         eventId: event.id,
         speakerId: speaker.id,
-        state: 'submitted',
         title: 'Not yours to edit',
       });
       const { browser, csrf } = await signIn(other);
@@ -244,7 +238,7 @@ describe('proposals', () => {
 
   describe('the state transitions', () => {
     test('submitting moves the draft on and flashes across the redirect', async () => {
-      const draft = await createProposal({
+      const draft = await create('proposal', {
         eventId: event.id,
         speakerId: speaker.id,
         title: 'A draft ready to go',
@@ -276,7 +270,7 @@ describe('proposals', () => {
     });
 
     test('submitting twice is a 409', async () => {
-      const draft = await createProposal({
+      const draft = await create('proposal', {
         eventId: event.id,
         speakerId: speaker.id,
         title: 'A draft submitted twice',
@@ -297,7 +291,7 @@ describe('proposals', () => {
     });
 
     test('a closed call for papers refuses a submission', async () => {
-      const draft = await createProposal({
+      const draft = await create('proposal', {
         eventId: closed.id,
         speakerId: speaker.id,
         title: 'A draft for a closed edition',
@@ -313,10 +307,9 @@ describe('proposals', () => {
     });
 
     test('a submitted proposal can no longer be edited', async () => {
-      const submitted = await createProposal({
+      const submitted = await create('proposal', 'submitted', {
         eventId: event.id,
         speakerId: speaker.id,
-        state: 'submitted',
         title: 'Already with the committee',
       });
       const { browser, csrf } = await signIn(speaker);
@@ -332,18 +325,16 @@ describe('proposals', () => {
 
   describe('withdrawing (a soft delete)', () => {
     test('hides the row everywhere and keeps its reviews', async () => {
-      const proposal = await createProposal({
+      const proposal = await create('proposal', 'submitted', {
         eventId: event.id,
         speakerId: speaker.id,
-        state: 'submitted',
         title: 'A proposal about to be withdrawn',
       });
 
-      await Review.create({
+      await create('review', {
         comment: 'A review that must survive the withdrawal.',
         proposalId: proposal.id,
         reviewerId: admin.id,
-        score: 1,
       });
 
       const { browser, csrf } = await signIn(speaker);
@@ -375,10 +366,9 @@ describe('proposals', () => {
     });
 
     test('the committee sees it in the trash and puts it back', async () => {
-      const proposal = await createProposal({
+      const proposal = await create('proposal', 'submitted', {
         eventId: event.id,
         speakerId: speaker.id,
-        state: 'submitted',
         title: 'A proposal to restore',
       });
       const owner = await signIn(speaker);
@@ -419,14 +409,18 @@ describe('proposals', () => {
     });
 
     test('a nested resource knows which parent it hangs under', async () => {
-      const answer = await page(
-        request(),
-        `/events/${event.externalId}/tracks`
-      );
+      // An edition of its own, because the count below is the assertion:
+      // reading it off the edition the rest of the file writes to would make
+      // this test depend on how many proposals happened to be made
+      const own = await create('event', { name: 'Nested Conf' });
+
+      await create('track', { eventId: own.id });
+
+      const answer = await page(request(), `/events/${own.externalId}/tracks`);
 
       expect(answer.status).toBe(200);
       expect(answer.body.component).toBe('tracks/index');
-      expect(answer.body.props.data.event.externalId).toBe(event.externalId);
+      expect(answer.body.props.data.event.externalId).toBe(own.externalId);
       expect(answer.body.props.data.event.id).toBeUndefined();
       expect(answer.body.props.data.tracks).toHaveLength(1);
     });
@@ -434,10 +428,9 @@ describe('proposals', () => {
 
   describe('the committee', () => {
     test('reviews a proposal through the nested route and decides on it', async () => {
-      const proposal = await createProposal({
+      const proposal = await create('proposal', 'submitted', {
         eventId: event.id,
         speakerId: speaker.id,
-        state: 'submitted',
         title: 'A proposal to decide on',
       });
       const { browser, csrf } = await signIn(admin);
@@ -473,10 +466,9 @@ describe('proposals', () => {
     });
 
     test('refuses a decision that is not accepted or rejected', async () => {
-      const proposal = await createProposal({
+      const proposal = await create('proposal', 'submitted', {
         eventId: event.id,
         speakerId: speaker.id,
-        state: 'submitted',
         title: 'A proposal with a bad decision',
       });
       const { browser, csrf } = await signIn(admin);

--- a/showcase/test/references.test.js
+++ b/showcase/test/references.test.js
@@ -16,7 +16,7 @@
 // here the rows are the measurement, so the edition is one of this file's
 // own and every request is filtered to it. Nothing another file left behind
 // can change a count, and nothing this file writes can disturb one.
-const { createProposal, createUser, request } = require('./helpers');
+const { create, request } = require('./helpers');
 
 const HAL = 'application/hal+json';
 const PAGE = 25;
@@ -81,7 +81,7 @@ describe('what a foreign key costs', () => {
 
     for (let index = 0; index < SPEAKERS; index += 1) {
       speakers.push(
-        await createUser({
+        await create('user', {
           email: `${unique}-speaker-${index}@example.test`,
           name: `Cost Speaker ${index}`,
         })
@@ -89,10 +89,9 @@ describe('what a foreign key costs', () => {
     }
 
     for (let index = 0; index < PAGE; index += 1) {
-      await createProposal({
+      await create('proposal', 'submitted', {
         eventId: event.id,
         speakerId: speakers[index % SPEAKERS].id,
-        state: 'submitted',
         title: `A proposal about the cost, number ${index}`,
         trackId: track.id,
       });

--- a/showcase/test/retention.test.js
+++ b/showcase/test/retention.test.js
@@ -9,14 +9,7 @@
 // backdating rows: `createdAt` is the adapter's to write, so "two hundred
 // days from now" is the only way to say "later" without lying to the
 // database about when a record was written.
-const {
-  createEvent,
-  createProposal,
-  createUser,
-  request,
-  reset,
-  signIn,
-} = require('./helpers');
+const { create, request, reset, signIn } = require('./helpers');
 
 /** A moment, that many days ago */
 const ago = (days) => new Date(Date.now() - days * 86400000);
@@ -108,36 +101,32 @@ describe('retention', () => {
      * @returns {Promise<object>} What was created
      */
     const conference = async () => {
-      const speaker = await createUser();
-      const reviewer = await createUser({ roles: ['admin'] });
-      const { event, track } = await createEvent();
-      const draft = await createProposal({
+      const speaker = await create('user');
+      const reviewer = await create('user', 'admin');
+      const event = await create('event');
+      const track = await create('track', { eventId: event.id });
+      const draft = await create('proposal', {
         eventId: event.id,
         speakerId: speaker.id,
-        state: 'draft',
         title: 'A draft nobody ever submitted',
       });
-      const decided = await createProposal({
+      const decided = await create('proposal', 'accepted', {
         decidedAt: ago(800),
         eventId: event.id,
         speakerId: speaker.id,
-        state: 'accepted',
         title: 'A talk the committee decided on',
         trackId: track.id,
       });
-      const recent = await createProposal({
+      const recent = await create('proposal', 'accepted', {
         decidedAt: ago(10),
         eventId: event.id,
         speakerId: speaker.id,
-        state: 'accepted',
         title: 'A talk decided on last week',
         trackId: track.id,
       });
-      const review = await Review.create({
-        comment: 'A careful and quite specific opinion about this talk.',
+      const review = await create('review', {
         proposalId: decided.id,
         reviewerId: reviewer.id,
-        score: 2,
       });
 
       return { decided, draft, recent, review, speaker };
@@ -222,14 +211,13 @@ describe('retention', () => {
     });
 
     test('takes what a bounded run left for the next one', async () => {
-      const speaker = await createUser();
-      const { event } = await createEvent();
+      const speaker = await create('user');
+      const event = await create('event');
 
       for (let index = 0; index < 3; index += 1) {
-        await createProposal({
+        await create('proposal', {
           eventId: event.id,
           speakerId: speaker.id,
-          state: 'draft',
           title: `A draft nobody submitted, number ${index}`,
         });
       }
@@ -271,15 +259,9 @@ describe('retention', () => {
     });
 
     test('a record whose clock never started is counted, not swept', async () => {
-      const speaker = await createUser();
-      const { event } = await createEvent();
-
       // Submitted, never decided: `decidedAt` is null, so the two-year
       // clock of the `decided` rule has not started
-      await createProposal({
-        eventId: event.id,
-        speakerId: speaker.id,
-        state: 'submitted',
+      await create('proposal', 'submitted', {
         submittedAt: ago(900),
         title: 'A talk still waiting for an answer',
       });
@@ -313,15 +295,7 @@ describe('the access trail', () => {
   });
 
   test('records a sweep, one entry per rule', async () => {
-    const speaker = await createUser();
-    const { event } = await createEvent();
-
-    await createProposal({
-      eventId: event.id,
-      speakerId: speaker.id,
-      state: 'draft',
-      title: 'A draft nobody ever submitted',
-    });
+    await create('proposal', { title: 'A draft nobody ever submitted' });
 
     const before = await henri.trail.count({ action: 'retention.sweep' });
 
@@ -341,11 +315,9 @@ describe('the access trail', () => {
   });
 
   test('answers "prove the erasure happened" from an address alone', async () => {
-    const speaker = await createUser({ email: 'erased@example.test' });
-    const { event } = await createEvent();
+    const speaker = await create('user', { email: 'erased@example.test' });
 
-    await createProposal({
-      eventId: event.id,
+    await create('proposal', {
       speakerId: speaker.id,
       title: 'A talk that survives its speaker',
     });
@@ -365,13 +337,9 @@ describe('the access trail', () => {
   });
 
   test('records the reads that leave through an answer', async () => {
-    const speaker = await createUser();
-    const { event } = await createEvent();
-    const proposal = await createProposal({
-      eventId: event.id,
+    const speaker = await create('user');
+    const proposal = await create('proposal', 'submitted', {
       speakerId: speaker.id,
-      state: 'submitted',
-      submittedAt: new Date(),
       title: 'A talk somebody will read about',
     });
     const { browser } = await signIn(speaker);

--- a/showcase/test/roles.test.js
+++ b/showcase/test/roles.test.js
@@ -1,9 +1,7 @@
 // The role guard: what a browser gets, what an API client gets, and what the
 // path helpers a page receives hold.
 const {
-  createEvent,
-  createProposal,
-  createUser,
+  create,
   inertiaVersion,
   page,
   request,
@@ -29,21 +27,9 @@ describe('roles', () => {
     await reset();
     await inertiaVersion();
 
-    speaker = await createUser({ email: 'speaker@example.test' });
-    admin = await createUser({
-      email: 'admin@example.test',
-      name: 'An Admin',
-      roles: ['speaker', 'admin'],
-    });
-
-    const { event, track } = await createEvent();
-
-    proposal = await createProposal({
-      eventId: event.id,
-      speakerId: speaker.id,
-      state: 'submitted',
-      trackId: track.id,
-    });
+    speaker = await create('user', { email: 'speaker@example.test' });
+    admin = await create('user', 'admin', { email: 'admin@example.test' });
+    proposal = await create('proposal', 'submitted', { speakerId: speaker.id });
   });
 
   describe('a browser', () => {

--- a/types/packages.test-d.tsx
+++ b/types/packages.test-d.tsx
@@ -38,9 +38,16 @@ import globalSetup from '@usehenri/testing/global-setup';
 import '@usehenri/testing/setup-file';
 import {
   agent,
+  build as buildRecord,
+  create,
+  createList,
+  defineFactory,
   request as testRequest,
+  resetFactories,
   setup,
   teardown,
+  type FactoryAttributes,
+  type FactoryContext,
 } from '@usehenri/testing';
 import type { Henri } from '@usehenri/core';
 
@@ -159,6 +166,31 @@ setup({ port: 3000 });
 
 // @ts-expect-error `teardown()` takes nothing
 teardown(true);
+
+expectType<Promise<FactoryAttributes>>(buildRecord('proposal'));
+expectType<Promise<unknown>>(create('proposal'));
+expectType<Promise<unknown>>(
+  create('proposal', 'accepted', { title: 'A talk' })
+);
+expectType<Promise<unknown[]>>(createList('proposal', 3, 'accepted'));
+expectType<void>(resetFactories());
+defineFactory('proposal', {
+  after: async (record: { id: number }, { traits }: FactoryContext) =>
+    traits.length > 0 ? record : undefined,
+  attributes: {
+    speakerId: async ({ create: nested }: FactoryContext) =>
+      (await nested('user')).id,
+    title: ({ sequence }: FactoryContext) => `A proposal ${sequence}`,
+  },
+  model: 'Proposal',
+  traits: { accepted: { state: 'accepted' } },
+});
+
+// @ts-expect-error a factory needs its `attributes`
+defineFactory('proposal', { model: 'Proposal' });
+
+// @ts-expect-error `createList()` counts with a number
+createList('proposal', 'three');
 
 // --- the subpaths, so that every shipped declaration is compiled -----------
 

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -29,7 +29,29 @@ const testFiles = (pkg) => [
 ];
 
 /**
- * One Vitest project per workspace package that has tests
+ * One Vitest project per workspace package that has tests.
+ *
+ * Every project runs its files at the same time, core included. That was not
+ * always true: core's 46 files each boot the demo application, and when they
+ * ran together the boots fought over ports -- the server's, and the one
+ * mongodb-memory-server picks by probing. Three changes ended that: the
+ * server asks for port 0 instead of probing and then binding (#324), every
+ * host-less `listen()` binds 127.0.0.1 so the reservation is exact
+ * (vitest.setup.js), and @usehenri/disk gives each process a starting port of
+ * its own (packages/disk/port.js). What is left is a mongod and an in-memory
+ * database per file, which is isolation rather than sharing. Measured on 16
+ * cores: the core project went from 58s to 14s, the whole run from 74s to
+ * 25s.
+ *
+ * The one thing these files do share is the demo application's directory
+ * (`packages/demo/.tmp`), so anything written there has to be named per
+ * record or per process: a boot that swept it clean is what made this flaky
+ * at one run in ten, until `@usehenri/uploads` learned to leave a part
+ * younger than an hour alone.
+ *
+ * An application's own suite is the other case, and keeps
+ * `fileParallelism: false`: a store with a url in `config/test.json` is one
+ * database however many files run against it.
  *
  * @returns {object[]} project configurations
  */
@@ -47,8 +69,6 @@ const projects = () =>
     .map((pkg) => ({
       extends: true,
       test: {
-        // Core boots the demo app on one port and one MongoDB per file
-        ...(pkg === 'core' ? { fileParallelism: false } : {}),
         include: testFiles(pkg),
         name: pkg,
       },
@@ -80,6 +100,14 @@ export default defineConfig({
     globals: true,
     // Boots (mongodb-memory-server) happen in beforeAll hooks
     hookTimeout: 60000,
+    // And a test is not a latency assertion either. The slowest here spawns
+    // the henri binary, scaffolds an application and runs two job workers
+    // against it (7s on an idle machine); with every core busy running the
+    // other files, the 5 second default failed a handful of those with a
+    // timeout that said nothing about the code. A test that really hangs
+    // still fails, half a minute later. What needs longer than this says so
+    // itself, as `henri db:seed` and the SIGTERM tests already do
+    testTimeout: 30000,
     // `include` lives in the projects only: with `extends: true` the arrays
     // would be merged and every project would run every file
     // Forks: core tests chdir into packages/demo, impossible in worker threads

--- a/website/src/content/docs/guides/testing.md
+++ b/website/src/content/docs/guides/testing.md
@@ -63,6 +63,88 @@ describe('tasks', () => {
 
 For login flows use `agent()`, which keeps the cookies between requests. Requests made with a session cookie must send the CSRF token back: read the `henri.csrf` cookie from the login answer, or set `"csrf": false` in `config/test.json`.
 
+## Factories
+
+A factory makes a valid record with the fields the test does not care about already filled in. It lives in `test/factories/<name>.js` and is read the first time a test asks for one:
+
+```js
+// test/factories/proposal.js
+module.exports = {
+  attributes: {
+    abstract: () => 'An abstract, comfortably past the sixty characters.',
+    eventId: async ({ create }) => (await create('event')).id,
+    speakerId: async ({ create }) => (await create('user')).id,
+    title: ({ sequence }) => `A proposal long enough to pass (${sequence})`,
+  },
+
+  traits: {
+    submitted: { state: 'submitted', submittedAt: () => new Date() },
+  },
+};
+```
+
+```js
+const { build, create, createList } = require('@usehenri/testing');
+
+const proposal = await create('proposal'); // a saved Proposal
+const accepted = await create('proposal', 'submitted'); // with the trait
+const mine = await create('proposal', { speakerId: me.id }); // and the test's own values
+const page = await createList('proposal', 15, 'submitted');
+const attributes = await build('proposal'); // the attributes, unsaved
+```
+
+Three rules hold the rest together.
+
+**What the caller gives is never made.** An override wins over the definition and the definition's value is not evaluated at all, so `create('proposal', { speakerId: me.id })` creates no second user. An override of `undefined` says nothing, so an optional value from the test does not turn a default into a null.
+
+**A value is a literal or a function of the build context.** There is no separate vocabulary for associations, sequences or computed fields: an association is a function that calls `create`, a sequence is a number on the context. The context carries `attrs` (what is resolved so far), `build` and `create` (nested, and counted against a nesting limit so a cycle is reported rather than run forever), `sequence` (how many records this factory has made in this process, from 1), `traits` (the ones being applied) and `uid` (four characters of this process's own, for a unique column in a suite whose workers share one database).
+
+**Fields resolve on demand, not in the order they are written.** Reading `attrs.eventId` from another field's function resolves that field first, so a track and a proposal can share one edition whatever order the keys sit in:
+
+```js
+trackId: async ({ attrs, create }) =>
+  (await create('track', { eventId: await attrs.eventId })).id,
+```
+
+A **trait** is an override object with a name, kept next to the model instead of copied into every test. It earns that place when a state is more than one field -- a submitted proposal has a `state` _and_ a `submittedAt`, an accepted one a `decidedAt` as well -- because that is knowledge about the model, not about any one test. Traits compose (`create('proposal', 'accepted', 'lightning')`) and an override still wins over all of them.
+
+A factory writes through the model, so everything the model does still happens: the password is hashed, the timestamps are stamped, `personal` still masks, a `paranoid` model still soft-deletes. What the model refuses to mass assign needs an `after` hook, which runs on the saved record and may replace it:
+
+```js
+// test/factories/user.js
+module.exports = {
+  after: async (user, { attrs }) => {
+    if (!attrs.roles) {
+      return user;
+    }
+
+    await User.setRoles(user.externalId, attrs.roles);
+
+    return User.findByKey(user.id);
+  },
+
+  attributes: {
+    email: ({ sequence, uid }) => `speaker-${uid}-${sequence}@example.test`,
+    name: 'A Speaker',
+    password: 'a-password-for-the-tests',
+  },
+
+  traits: { admin: { roles: ['speaker', 'admin'] } },
+};
+```
+
+A factory is named after its file and writes to the model of that name; `model: 'Proposal'` names another one, which is what a factory called after a role rather than a table needs. `build()` still makes the associations -- a foreign key has to name a row that exists -- unless the caller gives the field, which is what makes `build('proposal', { speakerId: me.id })` touch no database at all. `defineFactory(name, definition)` declares one from a test file, and wins over the file of the same name.
+
+Whatever a test asserts on belongs in the test. Everything else belongs in the factory.
+
+## Speed
+
+The setup file boots the application once per test file, and `fileParallelism: false` runs those files one at a time. That is the setting to keep while **the files share one database**, which is the usual case: a store with a `url` in `config/test.json` is one database, whatever runs against it, and two files emptying tables at the same time is not a suite you can read a failure from.
+
+Files may run at the same time when **each file gets a database of its own**, which is what the disk adapter does under `NODE_ENV=test`: `@usehenri/disk` starts a MongoDB of its own per process, in memory, on a port of that process's own. Drop `fileParallelism: false` there and the suite runs on every core. henri's own suite does exactly this and went from 58 to 14 seconds on sixteen cores.
+
+Before turning it on, look for what the files still share. The application's directory is the usual answer: an upload root, a receipt directory, a fixture file written by one test and read by another. Anything written there has to be named per record or per process. Then prove it: run the suite ten times, not once. A suite that is fast and flaky is worse than a slow one.
+
 ## API
 
 `@usehenri/testing` exports:

--- a/website/src/content/docs/reference/errors.md
+++ b/website/src/content/docs/reference/errors.md
@@ -661,6 +661,57 @@ Usually:
 
 **Fix.** The boot prints every path it tried. Create config/default.json, or fix the JSON of the file that is there.
 
+## factory
+
+The test factories of `@usehenri/testing`: `test/factories`, the records they make and the traits they apply.
+
+### `HENRI_FACTORY_DEPTH`
+
+Factories nested into each other until it had to be called a cycle.
+
+Usually:
+
+- two factories that make each other, with nothing to end the chain
+- two fields of one factory that read each other through `attrs`
+
+**Fix.** End the chain by giving the association an id in the overrides: `create("proposal", { speakerId: someone.id })`.
+
+### `HENRI_FACTORY_INVALID`
+
+A factory definition cannot be used as one.
+
+Usually:
+
+- the file exports something other than `{ attributes }`
+- `model` names a model the application does not have
+- the file itself throws when it is loaded
+
+**Fix.** A factory exports `{ attributes }`, optionally with `model`, `traits` and `after`. Name the model with `model:` when the file is not called after it.
+
+### `HENRI_FACTORY_UNKNOWN`
+
+A test asked for a factory nothing declares.
+
+Usually:
+
+- a typo in the name given to `create()` or `build()`
+- the factory file is not in `test/factories`
+- the tests run from a directory that is not the application
+
+**Fix.** Add `test/factories/<name>.js`, or declare it in the test file with `defineFactory(name, definition)`. The message lists the factories that were found.
+
+### `HENRI_FACTORY_UNKNOWN_TRAIT`
+
+A test asked for a trait the factory does not declare.
+
+Usually:
+
+- a typo in a trait name
+- the trait belongs to another factory
+- an override object was passed as a string
+
+**Fix.** Declare the trait in the `traits` of the factory, or pass an override object instead. The message lists the traits it does have.
+
 ## job
 
 The background job queue of @usehenri/jobs.


### PR DESCRIPTION
Two backlog entries that turned out to be one problem: an application has no way to make a record without writing every field by hand, and the suites pay a full boot per file with parallelism switched off.

## Factories

`test/factories/<name>.js`, one file per model, read lazily on the first `create()`. Three rules do the work:

- **What the caller gives is never made.** An override wins and the definition's value is not evaluated, so `create('proposal', { speakerId: me.id })` makes no second user.
- **A value is a literal or a function of the build context**, so associations, sequences and computed fields need no separate vocabulary.
- **Fields resolve on demand, not in declaration order**, because `sort-keys` decides the key order and a field reading another must not depend on where the linter put it. Two fields that need each other are named in the failure instead of recursing.

Traits are first class, and the argument is good: `submitted` is not one field, it is a state, a timestamp and a track. That is knowledge about the model, so it belongs beside the model rather than copied into twelve tests.

**The showcase conversion is the evidence.** Its hand-rolled helpers shrank from 172 lines to 113, the test files went down 282 lines and up 123 for 78 lines of factory, and a typical setup went from 13 lines to 3. Two tests then told the author the design was slightly wrong and he changed the factories rather than the tests, which is the right direction for that argument to run.

## Speed, measured before anything changed

| | before | after |
| --- | --- | --- |
| core project | 57.8 s | 13–15 s |
| whole suite | 74–90 s | 25 s |

The cause was not the boot, it was 46 files times about 540 ms of worker spawn, run serially. `fileParallelism: false` was added during the Vitest migration because parallel boots fought over ports, and the three causes were fixed afterwards: the server asks for port 0, the setup binds every host-less listen to the loopback, and the disk adapter gives each process its own starting port. The setting had outlived its reason.

Vitest's own `isolate: false` hint was declined: it shares the module registry between files, which is a worse kind of isolation loss than running files side by side, and it was worth about a second.

## Fast is only worth having if it is not flaky

Parallelism failed 1 run in 10 at first, and the author fixed causes rather than adding retries. Three of them were real bugs, one in shipped code:

- **`@usehenri/uploads` unlinked every part file at boot**, including one another process was streaming into. That is a production bug too, on any deployment with two processes and a shared volume. It now sweeps only parts older than an hour.
- Four copies of a fixture-linking helper in the CLI tests raced each other. That flake was already in the repository.
- A shutdown test probed a closing port with a path that takes 800 ms to answer.

**I ran the suite eight times back to back on the rebased branch: eight green, no failures.** The author reports 15 of 15 and 12 of 12 on the showcase.

`testTimeout` moved to 30 s because the slowest test scaffolds an application and runs two job workers, and with every core busy Vitest's 5 s default was failing it with a message that said nothing about the code.

## Left out, and said rather than hidden

No `henri generate factory`, because it would touch five CLI surfaces for a ten-line file. No factory in the scaffold. No dedicated Sequelize factory test: Mongoose is covered end to end and Drizzle through the showcase, and `create()` reaches every adapter through the same `Model.create` call, so a third harness was judged not worth its weight — flagged rather than claimed.

## Verification

`pnpm test` 2243 passed in 25 s, eight consecutive green runs, `pnpm test:sql` offline and live, `pnpm test:types`, `pnpm lint --max-warnings 0`, `pnpm format:check`, the showcase suite 150 passed, and `scripts/smoke.sh`.