### PR TITLE
Skip the website build on every branch but master

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ has to be named per record or per process. An application's own suite keeps
 | `packages/websocket`                    | private               | Not published, never wired into core                                                                                                                                                                                                                  |
 | `packages/demo`                         | private               | Demo app used by core's tests (`NODE_ENV=test` chdirs into it)                                                                                                                                                                                        |
 | `showcase`                              | private               | Lineup, the showcase application (Inertia + Drizzle on PostgreSQL); its own suite, `pnpm test:showcase`                                                                                                                                               |
-| `website`                               | private               | usehenri.io, deployed by Vercel from `website/`                                                                                                                                                                                                       |
+| `website`                               | private               | usehenri.io, deployed by Vercel from `website/`, master only (`vercel.json`)                                                                                                                                                                          |
 
 ## How core works
 

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -4,9 +4,11 @@
   "installCommand": "pnpm install --filter @usehenri/website",
   "buildCommand": "pnpm build",
   "outputDirectory": "dist",
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != master ]",
   "git": {
     "deploymentEnabled": {
       "*": false,
+      "*/*": false,
       "master": true
     }
   }


### PR DESCRIPTION
`git.deploymentEnabled` (#382) did not stop anything: Vercel built a preview for #384 and #385 anyway, exhausted the daily build limit, and put a red check that is not the code on the pull request. The setting is read -- the deployments use this file's install command -- so what failed is the pattern: every branch here carries a slash and the rule was `*`.

Two answers, because the first is cheaper and the second cannot be wrong about globbing:

- `"*/*": false` joins `"*": false`, so no deployment is created for a branch whichever way the matcher treats a slash.
- `ignoreCommand` runs on the build machine with the branch name in `VERCEL_GIT_COMMIT_REF` and exits 0 -- *ignore this build* -- for anything that is not master. No pattern matching involved.

The `Website` job of the CI still builds the site on every pull request, so the docs are still checked before they land. The proof this works is the check list of this pull request itself.