### PR TITLE
The public API surface checks what it is called with

### DIFF
--- a/.changeset/checked-arguments.md
+++ b/.changeset/checked-arguments.md
@@ -1,0 +1,39 @@
+---
+'@usehenri/core': minor
+---
+
+Every entry point an application calls checks what it is called with.
+
+JavaScript is not strongly typed and TypeScript erases at runtime, so henri validates exhaustively at its boundaries and trusts what is inside. The configuration was the first boundary and the request a controller answers was the second. This is the third and the last one an application can reach: the roughly fifty methods on `henri.*`, on `req` and on `res`.
+
+Until now some of them threw something a person could act on, some threw a `TypeError` three frames down naming a variable of henri's rather than the mistake, and some did nothing at all — so the application found out later, or never.
+
+**A call henri cannot honour raises `HENRI_ARGUMENT_INVALID`**, naming the method, the argument, what was expected and what arrived, with every problem reported rather than the first:
+
+```
+henri.cache.fetch(fn) must be a function, but it is the number 42
+req.pagination(overrides.perPage) must be a whole number above zero, but it is the string "abc"
+res.render(options) must be an object, but it is the string "oops"
+henri.privacy.erase(options.stratgy) is not one of its options: did you mean "options.strategy"?
+```
+
+The signatures are data (`src/base/arguments.js`) in the node vocabulary `config-schema.js` already established — no dependency, and no second schema language: `config-validate.js` gained `problems(node, value, key)`, so one walker serves both, and it learned the two kinds a call can pass and a JSON file cannot, `function` and `date`.
+
+**Eight of these were answering something wrong rather than refusing**, and those are the changes worth reading:
+
+- `res.negotiate({})` answered `406 Not Acceptable`, which blames the client's `Accept` header for a mistake in the controller; a non-function handler threw from inside express with no henri frame in the stack.
+- `res.render(route, 'oops')` read the string as a GraphQL query — and said so only in development. `data` and `graphql` together silently discarded the data.
+- `req.pagination({ perPage: 'abc' })` produced `NaN` and handed it to the ORM as `.limit(NaN)` and to the HAL paging links.
+- `res.resource(record, null)` threw a destructuring `TypeError` from the parameter list, over the good message just below it; a non-array `include` reached a substring match where it **un-hides a field marked `personal: { expose: false }`**.
+- `henri.privacy.erase(record)` took any object as the person it named, so a record carrying no primary key reached the erasure as `{ id: undefined }` — every row, on some adapters.
+- `henri.mail.send(message)` with no recipient succeeded under `NODE_ENV=test`, where the transport is nodemailer's json one, and failed only in production.
+- `deliverLater({ delay: 60 })` ignored the misspelled key, which is a mail that leaves immediately.
+- `henri.cache.fetch()` refused a bad `ttl` only _after_ the function had run, so it rejected the call and threw away the value it had just computed.
+
+**A selector that names nothing is its own refusal**, `HENRI_ARGUMENT_UNKNOWN_TARGET`: `henri.retention.sweep({ only: 'Propsal' })` and `henri.encryption.rotate({ model: 'Usr' })` used to report a clean, successful, empty run, which is exactly what somebody reads as the work being done — an operator dropping the old key after a rotation that rotated nothing.
+
+Three rules decide where a check goes, and each is in the module header. **An argument is checked once, at the method an application names**: `henri.can()` and `req.can()` both funnel into `henri.policies.can()`, so that is the one that checks, and the loops in `links()`/`paths()` ask an unchecked body they share. **`null` is not the same as absent for an argument** — `options = {}` only fills in for `undefined` — and _is_ the same for a selector inside an options bag, though not for a key whose absence has a default. **A check never goes inside a loop of henri's own**: `res.collection(records)` checks the list and not the rows, and `henri.encryption.encrypt`/`decrypt` guard by hand with three `typeof`s and no allocation, because the adapters call them once per row per encrypted column. The checks run in production too: there is no build step to compile them out, and a check missing from the one place a wrong call is expensive is not worth having.
+
+**What already refuses well was left alone, and saying so is part of it.** A bad cache key, an unstorable cache value, a trail entry with no action, an unknown mailer and a model's own declarations all keep their own codes and messages. `henri.model.errors()`, `henri.policies.get()` and `henri.config.has()` stay total and answer `null` or `false`. `henri.reporter.report()` stays deliberately lenient — it runs on a failure path, so refusing a wrong call there would lose the failure it was called about — and its `null` options no longer read as "the error handler threw".
+
+**None of it can fall behind.** `src/__tests__/arguments.spec.js` walks the surface the way the configuration's own test does: every method `index.d.ts` declares is checked or listed with the reason it is not, every declared signature is checked somewhere in the source, and every entry point is called with garbage derived from its own declaration. A new public method that forgets its check fails it. The declarations moved with the code — `res.negotiate()` now takes an html handler, a json one, or both and never neither, `RenderOptions` is `data` or `graphql` and never both, an erasure strategy is one of the four henri has — and `types/core.test-d.ts` makes eleven of the wrong calls part of the type test.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -643,6 +643,33 @@ perform|retry|discard` drive it. The module also registers
   answers 422 with `{ field: message }` and `HENRI_PARAMS_INVALID`, negotiated
   like everything else (a browser that posted a form goes back to it with the
   messages in the flash). An action with no declaration is untouched.
+- The third boundary is every entry point an application calls
+  (`base/arguments.js`), after the configuration and the request: the
+  signature of roughly fifty of them, as data, in the same node vocabulary
+  `config-schema.js` uses -- `config-validate.js` exports `problems()` so
+  there is one walker and no second schema language, and it
+  learned `function` and `date`, the two kinds a call can pass and a JSON
+  file cannot. `check(where, args)` raises `HENRI_ARGUMENT_INVALID` naming
+  the method, the argument, what was expected and what arrived, and reports
+  every problem rather than the first. Three rules: an argument is checked
+  once, at the method an application names (`henri.can` and `req.can` both
+  funnel into `policies.can`, which is where the check is, and `links`/
+  `paths` ask the unchecked `policies.answer` because they loop); `null` is
+  not the same as absent for an argument, and _is_ the same for a selector
+  inside an options bag but not for a key whose absence has a default; and a
+  check never goes inside a loop of henri's own -- `res.collection` checks
+  the list and not the rows, and `encryption.encrypt`/`decrypt` guard by
+  hand with three `typeof`s because the adapters call them per row. The
+  checks always run: there is no build step to compile them out and no
+  reason to want one. `HENRI_ARGUMENT_UNKNOWN_TARGET` is the second code, for
+  a selector that names nothing (`retention.sweep({ only })`,
+  `encryption.rotate({ model })`) rather than a clean, empty, successful run.
+  What already refuses well is listed in `UNCHECKED` with the reason, and
+  `src/__tests__/arguments.spec.js` is what keeps both true: every method
+  `index.d.ts` declares is in one table or the other, every declared
+  signature is checked somewhere in the source, and every entry point is
+  called with garbage derived from its own nodes. The page is
+  `website/src/content/docs/reference/api.md` (`#wrong-calls`).
 - Mailers (`2.mailers.js`) are `app/mailers/*.js` loaded like controllers:
   every exported function is an action returning the message it wants sent
   (`to`, `subject`, `data`, and anything else nodemailer takes), `defaults`

--- a/packages/core/error-codes.json
+++ b/packages/core/error-codes.json
@@ -10,6 +10,10 @@
       "what": "the JSON API layer: HAL answers, the health endpoints, the OpenAPI description of what an application exposes and the optional GraphQL engine"
     },
     {
+      "area": "argument",
+      "what": "the arguments a public method of henri was called with"
+    },
+    {
       "area": "boot",
       "what": "the module graph and the boot sequence: registration, ordering, dependencies"
     },
@@ -207,6 +211,29 @@
       "code": "HENRI_API_INVALID_RESOURCE",
       "fix": "Pass one record (a model instance or a plain object) and use `res.collection()` for lists; outside a `resources` route name the type: `res.resource(record, { type: 'tasks' })`.",
       "what": "res.resource() was called with something it cannot turn into a HAL resource."
+    },
+    {
+      "area": "argument",
+      "causes": [
+        "an argument of the wrong type, or one that is missing",
+        "null where an options object was meant, which no default fills in",
+        "a misspelled key in an options object (`stratgy` for `strategy`)",
+        "a value out of the bounds the method accepts"
+      ],
+      "code": "HENRI_ARGUMENT_INVALID",
+      "fix": "The message names the method, the argument, what was expected and what arrived. Fix the call; the signature of every entry point is in packages/core/src/base/arguments.js and on the API reference page.",
+      "what": "A public method of henri was called with something it cannot honour."
+    },
+    {
+      "area": "argument",
+      "causes": [
+        "a typo in `retention.plan({ only })` or `retention.sweep({ only })`",
+        "a typo in `encryption.rotate({ model, field })`",
+        "a model or a rule that was renamed and not renamed here"
+      ],
+      "code": "HENRI_ARGUMENT_UNKNOWN_TARGET",
+      "fix": "The hint lists what the option could have named. henri refuses rather than reporting a clean run over nothing, because an empty success is what makes somebody believe the work is done.",
+      "what": "A call named something to work on and this application has nothing by that name."
     },
     {
       "area": "boot",
@@ -850,8 +877,8 @@
       "area": "job",
       "causes": ["a job whose `perform()` never returned in time"],
       "code": "HENRI_JOB_TIMEOUT",
-      "fix": "Raise the job\u2019s `timeout`, or split the work: the attempt is failed and retried like any other failure.",
-      "what": "An attempt ran past the job\u2019s timeout."
+      "fix": "Raise the job’s `timeout`, or split the work: the attempt is failed and retried like any other failure.",
+      "what": "An attempt ran past the job’s timeout."
     },
     {
       "area": "job",
@@ -1433,7 +1460,7 @@
         "a receiver answering 410 Gone, which also disables the endpoint"
       ],
       "code": "HENRI_WEBHOOK_DELIVERY_FAILED",
-      "fix": "The delivery is a job: it is retried with the queue\u2019s backoff and lands in the dead letter queue when it runs out of attempts. `henri jobs:dead --queue webhooks` shows them, `henri jobs:retry <id>` sends one again.",
+      "fix": "The delivery is a job: it is retried with the queue’s backoff and lands in the dead letter queue when it runs out of attempts. `henri jobs:dead --queue webhooks` shows them, `henri jobs:retry <id>` sends one again.",
       "what": "A receiver refused a delivery."
     },
     {

--- a/packages/core/error-codes.json
+++ b/packages/core/error-codes.json
@@ -920,6 +920,17 @@
     {
       "area": "mail",
       "causes": [
+        "a mailer action that built its message without a `to`",
+        "a `to` read from a record that turned out to be null",
+        "a message assembled by hand and handed to henri.mail.send()"
+      ],
+      "code": "HENRI_MAIL_NO_RECIPIENT",
+      "fix": "Give the message a `to`, a `cc` or a `bcc`. Under NODE_ENV=test the transport is nodemailer's json one, which accepts a message nobody will ever receive, so this is refused before it gets there.",
+      "what": "A message was sent to nobody."
+    },
+    {
+      "area": "mail",
+      "causes": [
         "`mail` is missing from the configuration",
         "the mail module never started, or its transport failed to verify"
       ],

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -1203,18 +1203,29 @@ declare namespace start {
   }
 
   /** The second argument of `res.render()` and `res.hbs()`. */
-  interface RenderOptions {
-    /** What the page receives as `data`. */
-    data?: Record<string, unknown>;
-    /** A GraphQL query run for the page; its result becomes `data`. */
-    graphql?: string;
-    /**
-     * The fields marked `personal: { expose: false }` this page may carry.
-     * They are dropped from every answer henri builds; naming one here is
-     * how the person's own page gets it back.
-     */
-    include?: string[];
-  }
+  /**
+   * Options of `res.render()`: `data` or `graphql`, never both -- the query
+   * answers the page and the data would be thrown away, so the call is
+   * refused (`HENRI_ARGUMENT_INVALID`).
+   */
+  type RenderOptions =
+    | {
+        /** What the page receives as `data`. */
+        data?: Record<string, unknown>;
+        graphql?: never;
+        /**
+         * The fields marked `personal: { expose: false }` this page may
+         * carry. They are dropped from every answer henri builds; naming
+         * one here is how the person's own page gets it back.
+         */
+        include?: string[];
+      }
+    | {
+        data?: never;
+        /** A GraphQL query run for the page; its result becomes `data`. */
+        graphql: string | Record<string, string>;
+        include?: string[];
+      };
 
   /** Options of `res.resource()`. */
   interface ResourceOptions {
@@ -1405,11 +1416,16 @@ declare namespace start {
     /**
      * Runs `html` for browsers and `json` for API clients. The handler is not
      * awaited: what comes back is the response, not what the handler returned.
+     *
+     * One of the two is required: with neither, express answers `406` and
+     * blames the client's `Accept` header for a mistake in the controller,
+     * so henri refuses the call instead (`HENRI_ARGUMENT_INVALID`).
      */
-    negotiate(handlers: {
-      html?: () => unknown;
-      json?: () => unknown;
-    }): ExpressResponse;
+    negotiate(
+      handlers:
+        | { html: () => unknown; json?: () => unknown }
+        | { html?: () => unknown; json: () => unknown }
+    ): ExpressResponse;
     /** With the Inertia renderer. */
     inertia?: {
       errors(errors: Record<string, string>): ExpressResponse;
@@ -2304,6 +2320,9 @@ declare namespace start {
     }>;
   }
 
+  /** What an erasure does with the records that reference the person. */
+  type ErasureStrategy = 'anonymize' | 'delete' | 'orphan' | 'retain';
+
   /**
    * `henri.privacy`: which fields of which models are about a person, and
    * the two operations that follow from the mark.
@@ -2331,11 +2350,14 @@ declare namespace start {
     };
     /** The person, by email address, external id or primary key. */
     subject(who: string | object): Promise<Record<string, unknown>>;
-    export(who: string | object): Promise<PersonalExport>;
+    export(
+      who: string | object,
+      options?: { source?: 'app' | 'cli' | 'http' | 'job' }
+    ): Promise<PersonalExport>;
     /** What an erasure would do, and what stands in its way. */
     plan(
       who: string | object,
-      options?: { strategy?: string }
+      options?: { strategy?: ErasureStrategy }
     ): Promise<{
       steps: Array<Record<string, unknown>>;
       problems: Array<{ model: string; problem: string; message: string }>;
@@ -2345,7 +2367,11 @@ declare namespace start {
     }>;
     erase(
       who: string | object,
-      options?: { strategy?: string; dryRun?: boolean }
+      options?: {
+        strategy?: ErasureStrategy;
+        dryRun?: boolean;
+        source?: 'app' | 'cli' | 'http' | 'job';
+      }
     ): Promise<ErasureReceipt>;
   }
 

--- a/packages/core/src/1.encryption.js
+++ b/packages/core/src/1.encryption.js
@@ -3,6 +3,7 @@ const BaseModule = require('./base/module');
 const debug = require('debug')('henri:encryption');
 const { AsyncLocalStorage } = require('node:async_hooks');
 
+const { check, unknown } = require('./base/arguments');
 const {
   Keyring,
   decrypt,
@@ -289,7 +290,58 @@ class Encryption extends BaseModule {
    * @memberof Encryption
    */
   markOf(model, field) {
+    check('henri.encryption.markOf', [model, field]);
+
     return this.fields.get(`${model}.${field}`) || null;
+  }
+
+  /**
+   * The check `encrypt()` and `decrypt()` make, by hand.
+   *
+   * These two are the one place `base/arguments.js` says not to put its
+   * table: the three adapters call them once per row per encrypted column,
+   * and a walk that allocates per call is not worth it there. So the two
+   * things that actually go wrong are checked with three `typeof`s and no
+   * allocation -- a missing `context`, which writes an envelope whose AAD
+   * no read path can ever match, and a value that is not a string, which
+   * used to be encrypted as `String(value)` and to come back as one.
+   *
+   * @param {string} where The entry point, for the message
+   * @param {*} value The value
+   * @param {object} options The options
+   * @returns {void}
+   * @throws HENRI_ARGUMENT_INVALID
+   * @memberof Encryption
+   */
+  static guard(where, value, options) {
+    if (!options || typeof options !== 'object') {
+      throw fail(
+        'HENRI_ARGUMENT_INVALID',
+        `${where}(options) must be an object holding the context, but it is ${
+          typeof options === 'undefined' ? 'missing' : `a ${typeof options}`
+        }`
+      );
+    }
+
+    if (typeof options.context !== 'string' || options.context === '') {
+      throw fail(
+        'HENRI_ARGUMENT_INVALID',
+        `${where}(options.context) must be the "<Model>.<field>" the value belongs to, and it is missing: the envelope is bound to it, so one written without it never opens again`
+      );
+    }
+
+    // Null and undefined are the documented pass-through: a column that
+    // holds nothing stays holding nothing
+    if (
+      value !== null &&
+      typeof value !== 'undefined' &&
+      typeof value !== 'string'
+    ) {
+      throw fail(
+        'HENRI_ARGUMENT_INVALID',
+        `${where}(value) must be a string, but it is a ${typeof value}`
+      );
+    }
   }
 
   /**
@@ -302,6 +354,8 @@ class Encryption extends BaseModule {
    * @memberof Encryption
    */
   encrypt(value, options) {
+    Encryption.guard('henri.encryption.encrypt', value, options);
+
     if (value === null || typeof value === 'undefined') {
       return value;
     }
@@ -320,6 +374,8 @@ class Encryption extends BaseModule {
    * @memberof Encryption
    */
   decrypt(value, options) {
+    Encryption.guard('henri.encryption.decrypt', value, options);
+
     if (value === null || typeof value === 'undefined') {
       return value;
     }
@@ -391,6 +447,8 @@ class Encryption extends BaseModule {
    * @memberof Encryption
    */
   async tolerate(work) {
+    check('henri.encryption.tolerate', [work]);
+
     const scope = { failures: [] };
     const value = await this.lenient.run(scope, async () => work());
     const seen = new Set();
@@ -428,6 +486,8 @@ class Encryption extends BaseModule {
    * @memberof Encryption
    */
   candidates(value, options) {
+    check('henri.encryption.candidates', [value, options]);
+
     return this.keyring.entries.map((key) =>
       encrypt(value, {
         ...options,
@@ -534,6 +594,26 @@ class Encryption extends BaseModule {
    * @memberof Encryption
    */
   async rotate(options = {}) {
+    check('henri.encryption.rotate', [options]);
+
+    // A rotation over nothing reports `scanned: 0, rotated: 0` and a clean
+    // exit, which is exactly what an operator reads before dropping the old
+    // key. A `model` or a `field` that names no encrypted column is refused
+    const marks = [...this.fields.values()];
+    const wanted = (name, of) =>
+      typeof options[name] === 'string' &&
+      !marks.some((mark) => mark[name] === options[name]) &&
+      unknown('henri.encryption.rotate', `options.${name}`, options[name], [
+        ...new Set(marks.map(of)),
+      ]);
+    const refusal =
+      wanted('model', (mark) => mark.model) ||
+      wanted('field', (mark) => `${mark.model}.${mark.field}`);
+
+    if (refusal) {
+      throw refusal;
+    }
+
     return rotateOf(this.walk, options);
   }
 

--- a/packages/core/src/1.encryption.js
+++ b/packages/core/src/1.encryption.js
@@ -608,7 +608,7 @@ class Encryption extends BaseModule {
       ]);
     const refusal =
       wanted('model', (mark) => mark.model) ||
-      wanted('field', (mark) => `${mark.model}.${mark.field}`);
+      wanted('field', (mark) => mark.field);
 
     if (refusal) {
       throw refusal;

--- a/packages/core/src/1.mailer.js
+++ b/packages/core/src/1.mailer.js
@@ -1,3 +1,4 @@
+const { check } = require('./base/arguments');
 const { fail } = require('./base/errors');
 const BaseModule = require('./base/module');
 
@@ -130,6 +131,18 @@ class Mailer extends BaseModule {
    * @memberof Mailer
    */
   async send(opts) {
+    check('henri.mail.send', [opts]);
+
+    // Under NODE_ENV=test the transport is nodemailer's json one, which
+    // happily "sends" a message nobody will ever receive; in production the
+    // same call is an SMTP EENVELOPE three deploys later
+    if (!opts.to && !opts.cc && !opts.bcc) {
+      throw fail(
+        'HENRI_MAIL_NO_RECIPIENT',
+        'henri.mail.send(message) needs a recipient: give it a to, a cc or a bcc'
+      );
+    }
+
     if (!this.transporter) {
       this.henri.pen.error('mail', 'transport not initialized');
 

--- a/packages/core/src/3.model.js
+++ b/packages/core/src/3.model.js
@@ -1,3 +1,4 @@
+const { check } = require('./base/arguments');
 const { fail, stamp } = require('./base/errors');
 const BaseModule = require('./base/module');
 const path = require('path');
@@ -210,11 +211,28 @@ class Model extends BaseModule {
   getStore(name) {
     const { config, pen } = this.henri;
 
+    check('henri.model.getStore', [name]);
+
     if (this.stores[name]) {
       debug('store %s is already loaded, returning from cache', name);
 
       return this.stores[name];
     }
+
+    // `config.get` would answer HENRI_CONFIG_UNKNOWN_KEY here, which reads
+    // as a problem with the configuration file rather than with the name
+    // that was asked for
+    if (!config.has(`stores.${name}`)) {
+      throw fail(
+        'HENRI_MODEL_UNKNOWN_STORE',
+        `there is no store named "${name}": the configuration holds ${
+          Object.keys(config.has('stores') ? config.get('stores') : {}).join(
+            ', '
+          ) || 'none'
+        }`
+      );
+    }
+
     const store = config.get(`stores.${name}`);
 
     const valid = {

--- a/packages/core/src/3.policies.js
+++ b/packages/core/src/3.policies.js
@@ -4,6 +4,7 @@ const path = require('path');
 const debug = require('debug')('henri:policies');
 
 const { loadModules } = require('./utils');
+const { check, unknown } = require('./base/arguments');
 const { singularize } = require('./base/routes');
 const { userConfig } = require('./base/auth');
 const {
@@ -286,6 +287,29 @@ class Policies extends BaseModule {
    * @memberof Policies
    */
   async can(user, action, record = null, options = {}) {
+    check('henri.policies.can', [user, action, record, options]);
+
+    return this.answer(user, action, record, options);
+  }
+
+  /**
+   * The same question, unchecked: what henri asks itself.
+   *
+   * `links()` and `paths()` ask it once per link, with an action they read
+   * out of a route helper and options they built themselves. Checking a
+   * value henri produced, inside a loop henri wrote, is the one trade
+   * `base/arguments.js` says not to make -- so the check lives on `can()`,
+   * which is what an application calls, and this is the body they share.
+   *
+   * @async
+   * @param {*} user the user (`req.user`), or null
+   * @param {string} action the action (`update`)
+   * @param {*} [record=null] the record, when there is one
+   * @param {(object|string)} [options={}] `{ policy, type, req }`, or a name
+   * @returns {Promise<boolean>} allowed or not
+   * @memberof Policies
+   */
+  async answer(user, action, record = null, options = {}) {
     const opts = typeof options === 'string' ? { policy: options } : options;
     const name = this.nameFor(record, opts || {});
     const target = record === undefined ? null : record;
@@ -370,7 +394,9 @@ class Policies extends BaseModule {
    * @memberof Policies
    */
   async authorize(user, action, record = null, options = {}) {
-    if (await this.can(user, action, record, options)) {
+    check('henri.policies.authorize', [user, action, record, options]);
+
+    if (await this.answer(user, action, record, options)) {
       return record;
     }
 
@@ -393,7 +419,8 @@ class Policies extends BaseModule {
    * @memberof Policies
    */
   refusal(user, action, record, options = {}) {
-    const name = this.nameFor(record, options || {});
+    const opts = typeof options === 'string' ? { policy: options } : options;
+    const name = this.nameFor(record, opts || {});
     const anonymous = !user;
     const status =
       (options && options.status) || (anonymous ? 401 : this.settings.status);
@@ -425,12 +452,12 @@ class Policies extends BaseModule {
    * @memberof Policies
    */
   async scope(user, name, context = {}) {
+    check('henri.policies.scope', [user, name, context]);
+
     const found = this.resolve(name);
 
     if (!found) {
-      throw new TypeError(
-        `no policy for "${name}": write app/policies/${String(name).toLowerCase()}.js`
-      );
+      throw unknown('henri.policies.scope', 'name', name, this.names());
     }
 
     const policy = this._policies.get(found);
@@ -471,6 +498,8 @@ class Policies extends BaseModule {
    * @memberof Policies
    */
   async links(user, links, record, options = {}) {
+    check('henri.policies.links', [user, links, record, options]);
+
     const name = this.nameFor(record, options);
 
     if (!name || !links) {
@@ -494,7 +523,7 @@ class Policies extends BaseModule {
       if (!known.record && cache && cache.has(key)) {
         allowed = cache.get(key);
       } else {
-        allowed = await this.can(
+        allowed = await this.answer(
           user,
           known.action,
           known.record ? record : null,
@@ -531,6 +560,8 @@ class Policies extends BaseModule {
    * @memberof Policies
    */
   async paths(user, paths, options = {}) {
+    check('henri.policies.paths', [user, paths, options]);
+
     if (this._policies.size === 0 || !paths) {
       return paths;
     }
@@ -560,7 +591,7 @@ class Policies extends BaseModule {
       if (!cache.has(key)) {
         cache.set(
           key,
-          await this.can(user, parsed.action, null, {
+          await this.answer(user, parsed.action, null, {
             policy: name,
             req: options.req || null,
           })

--- a/packages/core/src/3.privacy.js
+++ b/packages/core/src/3.privacy.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const debug = require('debug')('henri:privacy');
 
+const { check } = require('./base/arguments');
 const { fail } = require('./base/errors');
 const { userConfig } = require('./base/auth');
 const { mapOf, privacyConfig, stripPersonal } = require('./base/privacy');
@@ -13,6 +14,7 @@ const {
   findSubject,
   planOf,
   plainOf,
+  primaryOf,
 } = require('./base/erasure');
 
 /**
@@ -186,6 +188,11 @@ class Privacy extends BaseModule {
    * @memberof Privacy
    */
   fields(name) {
+    // Only the name is checked: a model that holds nothing personal is not
+    // a mistake, and `{}` is the honest answer for it. An unknown-target
+    // refusal belongs where an empty answer would be a false success
+    check('henri.privacy.fields', [name]);
+
     const entry = this.entryOf(name);
 
     return entry ? entry.fields : {};
@@ -201,6 +208,11 @@ class Privacy extends BaseModule {
    * @memberof Privacy
    */
   strip(value, include = []) {
+    // `include` is the one way back for a field marked `expose: false`, and
+    // it is matched with `Array#includes`: a string there is a *substring*
+    // test, which un-hides every private field whose name it contains
+    check('henri.privacy.strip', [value, include]);
+
     return stripPersonal(value, this.private, include);
   }
 
@@ -283,10 +295,26 @@ class Privacy extends BaseModule {
    * @memberof Privacy
    */
   async subject(who) {
+    check('henri.privacy.subject', [who]);
+
     const context = this.context();
 
     if (who && typeof who === 'object') {
-      return plainOf(who);
+      const plain = plainOf(who);
+      const primary = primaryOf(context.modelOf(this.subjectModel));
+
+      // A record is taken as the person it is, without a lookup -- so a
+      // record that does not say which row it is names everybody. The
+      // erasure downstream builds `where: { [primary]: plain[primary] }`,
+      // and `{ id: undefined }` is every row on some adapters
+      if (plain[primary] === null || typeof plain[primary] === 'undefined') {
+        throw fail(
+          'HENRI_PRIVACY_UNKNOWN_SUBJECT',
+          `the record given to henri.privacy is not one: it carries no "${primary}", so it names nobody`
+        );
+      }
+
+      return plain;
     }
 
     const found = await findSubject(
@@ -307,6 +335,8 @@ class Privacy extends BaseModule {
    * @memberof Privacy
    */
   async export(who, options = {}) {
+    check('henri.privacy.export', [who, options]);
+
     const context = this.context();
     let subject;
     // Tolerant, because a person asking for their data is entitled to an
@@ -419,6 +449,8 @@ class Privacy extends BaseModule {
    * @memberof Privacy
    */
   async plan(who, options = {}) {
+    check('henri.privacy.plan', [who, options]);
+
     const context = this.context();
 
     return this.tolerantly(async () =>
@@ -437,6 +469,8 @@ class Privacy extends BaseModule {
    * @memberof Privacy
    */
   async erase(who, options = {}) {
+    check('henri.privacy.erase', [who, options]);
+
     const context = this.context();
     let receipt;
     let subject;

--- a/packages/core/src/4.retention.js
+++ b/packages/core/src/4.retention.js
@@ -5,6 +5,7 @@ const path = require('path');
 const debug = require('debug')('henri:retention');
 const { randomUUID } = require('node:crypto');
 
+const { check, unknown } = require('./base/arguments');
 const { fail } = require('./base/errors');
 const { PACKAGE } = require('./base/jobs');
 const {
@@ -214,7 +215,47 @@ class Retention extends BaseModule {
    * @memberof Retention
    */
   async plan(options = {}) {
+    check('henri.retention.plan', [options]);
+    this.only(options, 'henri.retention.plan');
+
     return planOf(this.context(), options);
+  }
+
+  /**
+   * Refuse an `only` that matches no rule
+   *
+   * A sweep over nothing answers the way a sweep over everything does --
+   * `0 record(s) over 0 rule(s)`, a receipt, an exit status of zero -- so a
+   * typo in a cron line reads as a job that is doing its work.
+   *
+   * @param {object} options the options of the call
+   * @param {string} where the entry point, for the message
+   * @returns {void}
+   * @throws {Error} `HENRI_ARGUMENT_UNKNOWN_TARGET` when nothing matches
+   * @memberof Retention
+   */
+  only(options, where) {
+    const wanted = options && options.only;
+
+    if (typeof wanted !== 'string') {
+      return;
+    }
+
+    const [model, name] = wanted.split(':');
+    const found = this.rules.some(
+      (rule) =>
+        (!model || model.toLowerCase() === rule.model.toLowerCase()) &&
+        (!name || name === rule.name)
+    );
+
+    if (!found) {
+      throw unknown(
+        where,
+        'options.only',
+        wanted,
+        this.rules.map((rule) => `${rule.model}:${rule.name}`)
+      );
+    }
   }
 
   /**
@@ -226,6 +267,9 @@ class Retention extends BaseModule {
    * @memberof Retention
    */
   async sweep(options = {}) {
+    check('henri.retention.sweep', [options]);
+    this.only(options, 'henri.retention.sweep');
+
     const receipt = await sweepOf(this.context(), options);
 
     receipt.id = randomUUID();

--- a/packages/core/src/4.trail.js
+++ b/packages/core/src/4.trail.js
@@ -2,6 +2,7 @@ const BaseModule = require('./base/module');
 
 const debug = require('debug')('henri:trail');
 
+const { check } = require('./base/arguments');
 const { fail } = require('./base/errors');
 const { userConfig } = require('./base/auth');
 const { EXTERNAL_ID } = require('./base/external-id');
@@ -350,6 +351,11 @@ class Trail extends BaseModule {
    * @memberof Trail
    */
   async list(filter = {}) {
+    // A filter value the store cannot use is dropped rather than matched,
+    // so `list({ action: 42 })` used to answer the whole trail -- the
+    // opposite of what it asked for, and no way to tell
+    check('henri.trail.list', [filter]);
+
     const rows = await this.ready().list(this.filter(filter));
 
     return rows.map(toEntry);
@@ -364,6 +370,8 @@ class Trail extends BaseModule {
    * @memberof Trail
    */
   async count(filter = {}) {
+    check('henri.trail.count', [filter]);
+
     return this.ready().count(this.filter(filter));
   }
 
@@ -377,6 +385,8 @@ class Trail extends BaseModule {
    * @memberof Trail
    */
   async about(who, filter = {}) {
+    check('henri.trail.about', [who, filter]);
+
     const { subject, subjectDigest } = this.identify(who);
 
     if (!subject && !subjectDigest) {
@@ -431,7 +441,11 @@ class Trail extends BaseModule {
    * @returns {Promise<object>} `{ removed, before, checkpoint }`
    * @memberof Trail
    */
-  async prune({ now = Date.now() } = {}) {
+  async prune(options = {}) {
+    check('henri.trail.prune', [options]);
+
+    const { now = Date.now() } = options;
+
     if (!this.enabled || !this.store || !this.settings.keep) {
       return { before: null, checkpoint: null, removed: 0 };
     }

--- a/packages/core/src/5.router.js
+++ b/packages/core/src/5.router.js
@@ -1139,6 +1139,9 @@ class Router extends BaseModule {
       };
 
       res.hbs = async (route, extras = {}) => {
+        // The same arguments as res.render, and a body of its own
+        check('res.render', [route, extras], 'res.hbs');
+
         const { data = {}, graphql = null } = extras;
         const opts = await this.viewOptions(req, res, { data, graphql });
 

--- a/packages/core/src/5.router.js
+++ b/packages/core/src/5.router.js
@@ -3,8 +3,10 @@ const BaseModule = require('./base/module');
 const path = require('path');
 const fs = require('fs');
 const debug = require('debug')('henri:router');
+const { check } = require('./base/arguments');
 const { loopbackOnly, negotiate: answer } = require('./base/http');
 const runtime = require('./base/runtime');
+const { fail } = require('./base/errors');
 const { respond, userConfig } = require('./base/auth');
 const {
   collection,
@@ -1005,8 +1007,22 @@ class Router extends BaseModule {
       req._henri = flash.expose(req, exposed);
 
       res.render = async (route, extras = {}) => {
+        check('res.render', [route, extras]);
+
         let { data = {}, graphql = null } = extras;
         const include = Array.isArray(extras.include) ? extras.include : [];
+
+        if (
+          typeof extras.data !== 'undefined' &&
+          typeof extras.graphql !== 'undefined'
+        ) {
+          // The query wins and the data is discarded, so asking for both is
+          // a page rendered with something other than what it was given
+          throw fail(
+            'HENRI_ARGUMENT_INVALID',
+            'res.render(options) takes data or graphql, not both: the query answers the page and the data would be thrown away'
+          );
+        }
 
         if (
           Object.keys(extras).length > 0 &&
@@ -1099,7 +1115,28 @@ class Router extends BaseModule {
         resource(this.henri, req, res, record, options);
       res.collection = (records, options) =>
         collection(this.henri, req, res, records, options);
-      res.negotiate = (handlers) => this.negotiate(req, res, handlers);
+      res.negotiate = (handlers) => {
+        check('res.negotiate', [handlers]);
+
+        if (
+          typeof handlers.html !== 'function' &&
+          typeof handlers.json !== 'function'
+        ) {
+          const error = fail(
+            'HENRI_ARGUMENT_INVALID',
+            'res.negotiate(handlers) must hold an html handler, a json handler, or both, and it holds neither'
+          );
+
+          // Without this it answered 406, which blames the Accept header of
+          // a client for a mistake in the controller
+          error.hint =
+            'res.negotiate({ html: () => res.render(...), json: () => res.resource(...) })';
+
+          throw error;
+        }
+
+        return this.negotiate(req, res, handlers);
+      };
 
       res.hbs = async (route, extras = {}) => {
         const { data = {}, graphql = null } = extras;

--- a/packages/core/src/__tests__/arguments.spec.js
+++ b/packages/core/src/__tests__/arguments.spec.js
@@ -1,0 +1,544 @@
+const fs = require('fs');
+const path = require('path');
+const supertest = require('supertest');
+
+const Henri = require('../henri');
+const { problems } = require('../base/config-validate');
+const { isCode } = require('../base/errors');
+const {
+  CODE,
+  SIGNATURES,
+  UNCHECKED,
+  UNKNOWN,
+  check,
+} = require('../base/arguments');
+
+/**
+ * The convention test of the public surface.
+ *
+ * `base/arguments.js` is only worth having if it cannot fall behind, so
+ * this is the half that keeps it true, the way `config-schema.spec.js`
+ * compares the schema with the types and the documentation:
+ *
+ * 1. every method the type declarations expose is in one of the two tables
+ *    -- checked, or left alone with a reason;
+ * 2. every declared signature is checked somewhere in the source, so a
+ *    declaration nothing calls fails;
+ * 3. every entry point genuinely refuses garbage, by calling it with
+ *    garbage on a booted application.
+ *
+ * (3) is the one with teeth, and it is generic: the poison for an argument
+ * is derived from the node that declares it, so a signature added tomorrow
+ * is exercised without a line being written here.
+ */
+
+const ROOT = path.resolve(__dirname, '..');
+
+/**
+ * The interfaces of `index.d.ts` this table covers, and the name a method
+ * of each gets. What is missing from this list is missing on purpose and
+ * is named in `NOT_WALKED` below.
+ */
+const INTERFACES = {
+  Cache: 'henri.cache',
+  ConfigModule: 'henri.config',
+  EncryptionModule: 'henri.encryption',
+  Henri: 'henri',
+  MailModule: 'henri.mail',
+  ModelModule: 'henri.model',
+  Pen: 'henri.pen',
+  PoliciesModule: 'henri.policies',
+  PrivacyModule: 'henri.privacy',
+  Reporter: 'henri.reporter',
+  Request: 'req',
+  Response: 'res',
+  RetentionModule: 'henri.retention',
+  TrailModule: 'henri.trail',
+  Utils: 'henri.utils',
+};
+
+/**
+ * The rest of the surface, and why it is not walked yet. Each of these is
+ * a module of its own with its own guards; adding one here is adding its
+ * methods to `SIGNATURES` or to `UNCHECKED`, and that is the next pass.
+ */
+const NOT_WALKED = {
+  AccountsService:
+    'reached through a route, where base/params-schema.js is the boundary. Four of its calls do refuse badly on their own -- register(null) throws one frame down, urlFor(42) builds https://host42, tokenFor mints a token for a purpose nothing consumes -- and that is the next pass',
+  ControllersModule:
+    'reads what 2.controllers.js loaded and answers null for anything else',
+  GraphqlModule:
+    '@usehenri/graphql ships it, and a package checks its own surface',
+  JobsModule: '@usehenri/jobs ships it',
+  RouterModule: 'the expanded route table, read-only',
+  ServerModule: 'the express application and the listener',
+  SharedStore:
+    'the backend of config.shared, reached by the three counters and never by an application directly',
+  StoreAdapter:
+    'the adapter contract, implemented by the adapters and called by core',
+  UploadsModule: '@usehenri/uploads ships it',
+  UserModule:
+    'the password helpers, which mostly refuse on their own terms (a policy failure, a mismatch) rather than on a shape. Two do not and are the next pass: compare(password, user) answers a bad user with the same bare error a wrong password gets, and publicUser(42) answers a user-shaped object',
+  ViewEngine:
+    'the engine contract, implemented by the renderers and called by core',
+  ViewModule: 'the engine, the renderer name and the handlebars instance',
+  WebhooksModule: '@usehenri/webhooks ships it',
+  WorkersModule: 'the loaded workers, read-only',
+};
+
+/**
+ * Every method an interface of `index.d.ts` declares at its own level, with
+ * whether it takes an argument at all
+ *
+ * @param {string} source the content of index.d.ts
+ * @param {string} name the interface name
+ * @returns {Map<string, boolean>} the method names, true when it takes one
+ */
+function methods(source, name) {
+  // `interface Response extends Omit<ExpressResponse, 'render'> {`
+  const declaration = new RegExp(
+    `^\\s*interface ${name}(?:\\s+extends[^{]*)?\\s*\\{`,
+    'mu'
+  );
+  const found_at = declaration.exec(source);
+
+  expect(found_at).not.toBeNull();
+
+  const start = found_at.index;
+
+  const found = new Map();
+  let depth = 0;
+
+  for (const line of source.slice(start).split('\n').slice(1)) {
+    if (depth === 0) {
+      // `fetch<T>(key: CacheKey, ...)`, `file?(field: string)`, `stats()`
+      const match = /^\s{4}(?:readonly\s+)?(\w+)\??(?:<[^>]*>)?\(([^)]*)/u.exec(
+        line
+      );
+
+      if (match) {
+        const takes = match[2].trim() !== '';
+
+        found.set(match[1], found.get(match[1]) || takes);
+      }
+    }
+
+    depth += (line.match(/\{/gu) || []).length;
+    depth -= (line.match(/\}/gu) || []).length;
+
+    if (depth < 0) {
+      break;
+    }
+  }
+
+  return found;
+}
+
+/** Every `.js` of core's source, the tests aside */
+function sources(dir, found = []) {
+  for (const item of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (item.name === '__tests__') {
+      continue;
+    }
+
+    const full = path.join(dir, item.name);
+
+    if (item.isDirectory()) {
+      sources(full, found);
+    } else if (item.name.endsWith('.js')) {
+      found.push(full);
+    }
+  }
+
+  return found;
+}
+
+/** The names `check('<name>', ...)` is called with, anywhere in the source */
+const called = new Set(
+  sources(ROOT).flatMap((file) =>
+    [...fs.readFileSync(file, 'utf8').matchAll(/\bcheck\('([^']+)'/gu)].map(
+      (match) => match[1]
+    )
+  )
+);
+
+/** Is there anything for `check()` to do in this signature? */
+const enforced = (signature) =>
+  signature.some((argument) => !argument.by && argument.type !== 'any');
+
+/** The values a sample and a poison are picked from, in order */
+const VALUES = [
+  'x',
+  1,
+  200,
+  true,
+  {},
+  [],
+  () => 1,
+  new Date('2024-01-02T03:04:05Z'),
+  null,
+];
+
+/** A value the node accepts, or undefined when it accepts none of them */
+const sample = (node) =>
+  VALUES.find((value) => problems(node, value, 'x').length === 0);
+
+/**
+ * ... and one it does not.
+ *
+ * A list is poisoned with a bad item rather than with something that is not
+ * a list, because `req.permit(...fields)` is variadic: the list *is* the
+ * call, and a string there is one perfectly good field name.
+ *
+ * @param {object} node the node
+ * @returns {*} a value the node refuses
+ */
+const poison = (node) =>
+  node.type === 'array' && node.of
+    ? [poison(node.of)]
+    : VALUES.find((value) => problems(node, value, 'x').length > 0);
+
+/**
+ * What to pass for an argument another guard owns (`by`), by its name.
+ * Small on purpose: the point is a call that is right everywhere except
+ * where the test poisoned it.
+ */
+const OWNED = {
+  event: { action: 'test.called' },
+  key: 'a-key',
+  message: { to: 'someone@example.test' },
+  name: 'a-name',
+  record: { externalId: '018f0000-0000-7000-8000-000000000000' },
+  records: [],
+  value: 1,
+};
+
+describe('the public surface and the two tables', () => {
+  const types = () =>
+    fs.readFileSync(path.join(ROOT, '..', 'index.d.ts'), 'utf8');
+
+  test('every method the types declare is checked, or left alone with a reason', () => {
+    const source = types();
+    const missing = [];
+
+    for (const [name, prefix] of Object.entries(INTERFACES)) {
+      for (const [method, takes] of methods(source, name)) {
+        const full = `${prefix}.${method}`;
+
+        // A method that takes no argument has nothing to check, and a
+        // whole module may be left alone at once (`henri.pen`)
+        if (
+          !takes ||
+          SIGNATURES[full] ||
+          UNCHECKED[full] ||
+          UNCHECKED[prefix]
+        ) {
+          continue;
+        }
+
+        missing.push(full);
+      }
+    }
+
+    expect(missing).toEqual([]);
+  });
+
+  test('the interfaces that are not walked yet say so', () => {
+    const source = types();
+
+    for (const [name, reason] of Object.entries(NOT_WALKED)) {
+      expect(source).toContain(`interface ${name} {`);
+      expect(reason.length).toBeGreaterThan(20);
+    }
+
+    expect(
+      Object.keys(NOT_WALKED).filter((name) => name in INTERFACES)
+    ).toEqual([]);
+  });
+
+  test('no name is in both tables, and every reason reads like one', () => {
+    const both = Object.keys(SIGNATURES).filter((name) => name in UNCHECKED);
+
+    expect(both).toEqual([]);
+
+    for (const [name, reason] of Object.entries(UNCHECKED)) {
+      expect(typeof reason).toBe('string');
+      // Long enough to be a reason rather than a shrug
+      expect(reason.length).toBeGreaterThan(20);
+      expect(name).toMatch(/^(?:henri|req|res|message)(?:\.\w+)*$/u);
+    }
+  });
+
+  test('an argument another guard owns names a code the catalogue holds', () => {
+    const declared = Object.values(SIGNATURES).flat();
+
+    expect(declared.map((argument) => typeof argument.name)).toEqual(
+      declared.map(() => 'string')
+    );
+    expect(
+      declared
+        .map((argument) => argument.by)
+        .filter(Boolean)
+        .filter((code) => !isCode(code))
+    ).toEqual([]);
+  });
+
+  test('every declared signature is checked somewhere in the source', () => {
+    const never = Object.entries(SIGNATURES)
+      .filter(([name, signature]) => enforced(signature) && !called.has(name))
+      .map(([name]) => name);
+
+    expect(never).toEqual([]);
+  });
+
+  test('check() refuses a name it does not declare', () => {
+    expect(() => check('henri.nothing.here', [])).toThrow(
+      /has no declared signature/u
+    );
+  });
+});
+
+describe('every entry point refuses what it cannot honour', () => {
+  let henri;
+  let request;
+  let response;
+
+  beforeAll(async () => {
+    process.env.SKIP_WORKERS = '1';
+    henri = new Henri();
+    await henri.init();
+    global.henri = henri;
+
+    // A real request, so `res.render`, `res.negotiate`, `res.boom` and
+    // `req.permit` are the ones the router installs rather than a fake
+    henri.router.handler.use((req, res) => {
+      request = req;
+      response = res;
+      res.status(204).end();
+    });
+
+    await supertest(henri.server.app).get('/__arguments_spec__');
+  }, 60000);
+
+  afterAll(async () => {
+    await henri.stop();
+    delete global.henri;
+  });
+
+  /**
+   * The function a name stands for, already bound, or null when this test
+   * cannot reach it
+   *
+   * @param {string} name the entry point
+   * @returns {?function} the function
+   */
+  const entry = (name) => {
+    if (name === 'res.boom') {
+      return response.boom.badRequest;
+    }
+
+    if (name === 'message.deliverLater') {
+      const message = henri.mailers.auth.confirm(
+        { email: 'someone@example.test' },
+        'https://example.test/confirm/x'
+      );
+
+      return (...args) => message.deliverLater(...args);
+    }
+
+    // The one variadic entry point: the list is the call
+    if (name === 'req.permit') {
+      return (fields) => request.permit(...fields);
+    }
+
+    const [head, ...rest] = name.split('.');
+    const last = rest.pop();
+    const owner = rest.reduce(
+      (held, step) => (held ? held[step] : null),
+      { henri, req: request, res: response }[head]
+    );
+
+    return owner && typeof owner[last] === 'function'
+      ? (...args) => owner[last](...args)
+      : null;
+  };
+
+  /**
+   * The arguments of a call that is right everywhere except at `index`
+   *
+   * @param {Array<object>} signature the signature
+   * @param {number} index the argument to poison
+   * @returns {Array<*>} the arguments
+   */
+  const call = (signature, index) =>
+    signature.map((argument, at) => {
+      if (at === index) {
+        return poison(argument);
+      }
+
+      if (argument.by) {
+        return OWNED[argument.name];
+      }
+
+      return argument.type === 'any' ? 1 : sample(argument);
+    });
+
+  // What a shape cannot say, and what a clean empty run hides
+  test('a selector that names nothing is its own refusal', async () => {
+    let error = null;
+
+    try {
+      await henri.retention.plan({ only: 'Nothing' });
+    } catch (thrown) {
+      error = thrown;
+    }
+
+    expect(error && error.code).toBe(UNKNOWN);
+    expect(error.hint).toMatch(/^(?:It is one of: |This application)/u);
+
+    try {
+      error = null;
+      await henri.encryption.rotate({ model: 'Nothing' });
+    } catch (thrown) {
+      error = thrown;
+    }
+
+    expect(error && error.code).toBe(UNKNOWN);
+  });
+
+  // The record that names nobody, which used to reach an unsafe mass
+  // update as `{ [primary]: undefined }`
+  test('a record that says which row it is not names nobody', async () => {
+    let error = null;
+
+    try {
+      await henri.privacy.subject({ email: 'someone@example.test' });
+    } catch (thrown) {
+      error = thrown;
+    }
+
+    expect(error && error.code).toBe('HENRI_PRIVACY_UNKNOWN_SUBJECT');
+    expect(error.message).toContain('names nobody');
+  });
+
+  for (const [name, signature] of Object.entries(SIGNATURES)) {
+    if (!enforced(signature)) {
+      continue;
+    }
+
+    signature.forEach((argument, index) => {
+      if (argument.by || argument.type === 'any') {
+        return;
+      }
+
+      test(`${name}(${argument.name})`, async () => {
+        const fn = entry(name);
+
+        expect(typeof fn).toBe('function');
+
+        // Every argument this test can express is expressible: a signature
+        // whose node nothing in VALUES matches would silently not be tested
+        expect(poison(argument)).toBeDefined();
+
+        let error = null;
+
+        try {
+          await fn(...call(signature, index));
+        } catch (thrown) {
+          error = thrown;
+        }
+
+        expect(error).not.toBeNull();
+        expect(error.code).toBe(CODE);
+        // The message names the method and the argument that is wrong
+        expect(error.message).toContain(name.split('.').slice(-2).join('.'));
+        expect(error.message).toContain(`${argument.name}`);
+      });
+
+      if (argument.optional) {
+        return;
+      }
+
+      test(`${name}(${argument.name}) left out`, async () => {
+        const fn = entry(name);
+        const args = call(signature, -1);
+
+        args[index] = undefined;
+
+        let error = null;
+
+        try {
+          await fn(...args);
+        } catch (thrown) {
+          error = thrown;
+        }
+
+        // A required argument that is absent is refused too, whether it
+        // reads as missing or as the default the method fills in for it
+        expect(error && error.code).toBe(CODE);
+        expect(error.message).toContain(argument.name);
+      });
+    });
+  }
+});
+
+describe('what a refusal says', () => {
+  test('it names the method, the argument, the expectation and the value', () => {
+    expect(() => check('henri.cache.fetch', ['k', {}, 42])).toThrow(
+      'henri.cache.fetch(fn) must be a function, but it is the number 42'
+    );
+    expect(() => check('res.render', ['/tasks', 'oops'])).toThrow(
+      'res.render(options) must be an object, but it is the string "oops"'
+    );
+    expect(() => check('req.pagination', [{ perPage: 'abc' }])).toThrow(
+      'req.pagination(overrides.perPage) must be a whole number above zero, but it is the string "abc"'
+    );
+  });
+
+  test('a near miss of a declared option is named', () => {
+    expect(() =>
+      check('henri.privacy.erase', ['someone@example.test', { stratgy: 'x' }])
+    ).toThrow('did you mean "options.strategy"?');
+
+    // ... and a key that is nothing like one is left alone, the way the
+    // configuration leaves an application's own keys alone
+    expect(() =>
+      check('henri.privacy.erase', ['someone@example.test', { mine: 'x' }])
+    ).not.toThrow();
+  });
+
+  test('one signature may stand for a family of methods', () => {
+    expect(() => check('res.boom', [42], 'res.boom.notFound')).toThrow(
+      'res.boom.notFound(message) must be a string, but it is the number 42'
+    );
+  });
+
+  test('every problem is reported, not the first one', () => {
+    let error;
+
+    try {
+      check('henri.policies.can', [null, 42, null, { policy: 1 }]);
+    } catch (thrown) {
+      error = thrown;
+    }
+
+    expect(error.problems).toHaveLength(2);
+    expect(error.message).toContain('2 arguments henri cannot honour');
+    expect(error.message).toContain('(action)');
+    expect(error.message).toContain('(options.policy)');
+  });
+
+  test('null is not the same as absent for an argument', () => {
+    // The whole of the `options = {}` default that never applied to null
+    expect(() => check('henri.cache.set', ['k', 1, null])).toThrow(
+      'henri.cache.set(options) must be an object, but it is null'
+    );
+    expect(() => check('henri.cache.set', ['k', 1])).not.toThrow();
+  });
+
+  test('... and it is the same as absent for a selector inside a bag', () => {
+    expect(() =>
+      check('henri.encryption.rotate', [{ field: 'phone', model: null }])
+    ).not.toThrow();
+  });
+});

--- a/packages/core/src/__tests__/cache.spec.js
+++ b/packages/core/src/__tests__/cache.spec.js
@@ -734,7 +734,9 @@ describe('the cache', () => {
     test('needs a function', async () => {
       const cache = cacheWith();
 
-      await expect(cache.fetch('memo')).rejects.toThrow(/needs a function/u);
+      await expect(cache.fetch('memo')).rejects.toThrow(
+        /henri\.cache\.fetch\(fn\) must be a function/u
+      );
     });
   });
 

--- a/packages/core/src/__tests__/policies.spec.js
+++ b/packages/core/src/__tests__/policies.spec.js
@@ -457,7 +457,7 @@ describe('policies (demo app, disk store)', () => {
         /declares no scope/u
       );
       await expect(henri.policies.scope(null, 'ghost')).rejects.toThrow(
-        /no policy for "ghost"/u
+        /scope\(name\) names the string "ghost"/u
       );
 
       henri.policies._policies.delete('scopeless');

--- a/packages/core/src/base/arguments.js
+++ b/packages/core/src/base/arguments.js
@@ -560,7 +560,9 @@ const SIGNATURES = {
     },
   ],
 
-  'req.permit': [{ name: 'fields', of: NAME, type: 'array' }],
+  // `permit()` with no field at all answers everything the action declared,
+  // so the list may be empty -- and `params.js` always hands one over
+  'req.permit': [{ name: 'fields', of: NAME, optional: true, type: 'array' }],
 
   'res.boom': [
     {
@@ -616,7 +618,9 @@ const SIGNATURES = {
 /**
  * The public methods that are checked somewhere else, or that are right as
  * they are -- and why. `src/__tests__/arguments.spec.js` reads this, so a
- * new public method has to land in one table or the other.
+ * new public method has to land in one table or the other -- unless it
+ * takes no argument at all, which that test exempts on its own rather than
+ * making a list of methods with nothing to check.
  */
 const UNCHECKED = {
   'henri.addMiddleware':
@@ -628,11 +632,9 @@ const UNCHECKED = {
   'henri.config.has': 'answers false for anything that is not a key',
   'henri.encryption.decrypt':
     'checked by hand in 1.encryption.js, with three typeofs and no allocation: the three adapters call it once per row per encrypted column, which is the one place a walk is not worth it',
-  'henri.encryption.describe': 'takes no argument',
   'henri.encryption.encrypt': 'the same, on the write path',
   'henri.encryption.isEnvelope': 'a total function of unknown',
   'henri.encryption.keyIdIn': 'a total function of unknown',
-  'henri.encryption.status': 'takes no argument',
   'henri.gql': 'a tagged template that answers a string, whatever it is given',
   'henri.mailers.onDeliverLater':
     'says so and answers false, which is its documented contract',
@@ -640,26 +642,26 @@ const UNCHECKED = {
     'answers null for anything that is not a validation failure, which is its documented contract',
   'henri.model.publish':
     'its contract is anything: it is what res.render hands whatever a controller returned',
+  'henri.params':
+    'the helper behind req.permit(), whose fields are checked there; what it is given a request for is read with optional chaining and answers {}',
   'henri.pen': 'a logger that throws is worse than a wrong log line',
   'henri.policies.get': 'documented to answer null',
   'henri.policies.has': 'documented to answer false',
-  'henri.policies.names': 'takes no argument',
   'henri.policies.resolve': 'documented to answer null',
   'henri.policies.rule': 'documented to answer null',
-  'henri.policies.size': 'takes no argument',
-  'henri.privacy.describe': 'takes no argument',
   'henri.reporter.onError':
     'says so and answers false, which is its documented contract',
   'henri.reporter.report':
     'the one entry point that must not refuse: it runs on a failure path, so throwing would lose the failure it was called about. A wrong source is coerced and a wrong options is read as none, deliberately',
-  'henri.retention.describe': 'takes no argument',
   'henri.trail.record':
     'HENRI_TRAIL_INVALID_EVENT and the meta refusals already say what is wrong',
-  'henri.trail.verify': 'takes no argument',
   'henri.utils': 'node resolution answers for itself',
   'req.authorize': 'the one implementation is henri.policies.authorize',
   'req.can': 'the one implementation is henri.policies.can',
   'req.file': 'answers null for anything that is not a field name',
+  'req.logIn': "passport's, not henri's",
+  'req.logOut': "passport's, not henri's",
+  'req.logout': "passport's, not henri's",
   'req.permitFiles': 'the same list req.permit takes, checked there',
   'req.scope': 'the one implementation is henri.policies.scope',
   'res.hbs': 'the same arguments as res.render, checked there',

--- a/packages/core/src/base/arguments.js
+++ b/packages/core/src/base/arguments.js
@@ -1,0 +1,785 @@
+/**
+ * What a public method may be called with.
+ *
+ * JavaScript is not strongly typed and TypeScript erases at runtime, so
+ * henri checks its own inputs -- exhaustively at the boundaries, and it
+ * trusts what is inside. Two of those boundaries were done first: the
+ * configuration at boot (`config-schema.js`, `config-validate.js`) and the
+ * request a controller answers (`params-schema.js`). This is the third and
+ * the last one an application can reach: **every entry point it calls**.
+ *
+ * `henri.cache.fetch(42)`, `henri.jobs.perform(null)`, `res.collection('nope')`,
+ * `henri.privacy.export()` with nobody named. Some of those already threw
+ * something a person could act on; some threw a `TypeError` three frames
+ * down, naming a variable of henri's rather than the mistake; and some did
+ * nothing at all, so the application found out later, or never.
+ *
+ * ## The vocabulary, which is not a new one
+ *
+ * An argument is declared with the nodes of `config-schema.js`: `type`,
+ * `oneOf`, `const`, `enum`, `pattern`, `min`/`max`, `integer`, `of`, `keys`,
+ * `required`, `unknown`, `describe`, `hint`. `config-validate.js` walks
+ * them, and `problems(node, value, key)` there is the same walk over a
+ * single value -- one walker, two callers, and no second schema language.
+ * The walker learned two kinds for this: `function` and `date`, which a
+ * call can pass and a JSON file cannot.
+ *
+ * A signature is the arguments in order:
+ *
+ * ```js
+ * 'henri.cache.set': [
+ *   { by: 'HENRI_CACHE_KEY_INVALID', name: 'key' },
+ *   { name: 'value', ...ANY },
+ *   { name: 'options', optional: true, ...CACHE_OPTIONS },
+ * ],
+ * ```
+ *
+ * - a plain node is checked here;
+ * - `optional: true` means the argument may be absent -- and `null` is not
+ *   absent, which is the whole of the `options = {}` default that never
+ *   applied to `null` and threw one line later;
+ * - `by` names the code that already refuses it precisely, so the table
+ *   stays a complete inventory of the surface without checking anything
+ *   twice. `cacheKey()` says more about a bad cache key than this could.
+ *
+ * An options bag is declared `unknown: 'near'`: a key that is a near miss
+ * of a declared one is refused and named (`{ stratgy }` -> `strategy`),
+ * and anything else is left alone. That is the configuration's own answer
+ * to an unknown key, for the same reason -- `{ utm_source }` is not an
+ * attack -- and the near miss is the mistake people actually make.
+ *
+ * ## The inventory
+ *
+ * Roughly fifty entry points, and saying which of them already refuse well
+ * is part of the work: those are in `UNCHECKED`, each with the reason, and
+ * `src/__tests__/arguments.spec.js` fails when a public method is in
+ * neither table.
+ *
+ * **Checked here.** `henri.policies` (`can`, `authorize`, `scope`, `links`,
+ * `paths`), `henri.cache` (`get`, `set`, `delete`, `clear`, `scope`,
+ * `fetch`), `henri.privacy` (`fields`, `strip`, `subject`, `export`,
+ * `plan`, `erase`), `henri.retention` (`plan`, `sweep`), `henri.trail`
+ * (`list`, `count`, `about`, `prune`), `henri.encryption` (`markOf`,
+ * `encrypt`, `decrypt`, `candidates`, `tolerate`, `rotate`),
+ * `henri.model.getStore`, `henri.mail.send`, `henri.reporter.report`,
+ * `deliverLater`, and what a request gets: `res.resource`, `res.collection`,
+ * `res.negotiate`, `res.render`, `res.hbs`, `res.boom.*`, `req.pagination`,
+ * `req.permit`, `req.flash`.
+ *
+ * **Already refusing well, and left alone.** The cache's keys and values
+ * (`HENRI_CACHE_KEY_INVALID`, `HENRI_CACHE_VALUE_UNSUPPORTED`,
+ * `HENRI_CACHE_TTL_INVALID`), a trail event (`HENRI_TRAIL_INVALID_EVENT`
+ * and the `meta` refusals), a mailer and its action
+ * (`HENRI_MAIL_UNKNOWN_MAILER`, `HENRI_MAIL_UNKNOWN_ACTION`,
+ * `HENRI_MAIL_INVALID_MESSAGE`), a model's fields, options, personal marks
+ * and retention rules (they fail the boot, which is the right boundary for
+ * a declaration), `henri.config.get` (`HENRI_CONFIG_UNKNOWN_KEY`),
+ * `henri.reporter.onError` and `henri.mailers.onDeliverLater` (both answer
+ * `false` and say so, which is their documented contract),
+ * `henri.policies.get`/`has`/`rule`/`resolve` (documented to answer `null`),
+ * `henri.model.errors` (documented to answer `null` for anything that is
+ * not a validation failure), `henri.model.publish` (its contract *is*
+ * anything: it is what `res.render` hands whatever a controller returned),
+ * `henri.encryption.isEnvelope`/`keyIdIn` (total functions of `unknown`),
+ * and `henri.pen.*` (a logger that throws is worse than a wrong log line).
+ *
+ * ## Where the check goes, and what it costs
+ *
+ * **Never inside a loop of henri's own.** `res.collection(records)` checks
+ * that `records` is a list and stops there; the rows are the serializer's
+ * business, and one assertion per row to catch a mistake the call itself
+ * announces is the wrong trade. `henri.model.publish()` walks a tree and
+ * checks nothing on the way down. The rule is about henri's loops, not the
+ * application's: `encryption.encrypt()` is called once per row by the
+ * adapters, and it is checked, because a check is bounded by the cost of
+ * what it guards -- a `typeof` in front of an AES-GCM seal is free, and the
+ * mistake it catches (`context` missing) writes ciphertext that will never
+ * open again.
+ *
+ * **The checks always run, in production too.** Compiling them out would
+ * need a build step core does not have -- the source is what ships -- and
+ * it would mean the one place a wrong call is expensive behaves differently
+ * from the place it was tested. The cost is a table lookup and a `typeof`
+ * per argument, on entry points that are per-request or per-operation and
+ * are followed by I/O; an argument declared `ANY` or `by` allocates
+ * nothing at all. The single entry point where an allocation would have
+ * been measurable is `henri.config.get`, called in tight loops, and it is
+ * in `UNCHECKED` because it already refuses everything that is not a key.
+ *
+ * **A method henri also calls internally is checked once, here, at the
+ * method the application names.** `henri.can()` and `req.can()` both funnel
+ * into `henri.policies.can()`, so that is the one that checks; the wrappers
+ * pass through it. Where henri calls a checked method itself -- `res.render`
+ * calls `model.publish`, `privacy.export` calls `privacy.subject` -- the
+ * check runs on a value henri produced, which is affordable only because
+ * every one of them is O(1). None of them needed splitting into a checked
+ * outer and an unchecked inner, and the day one does, that is the shape.
+ *
+ * ## Deliberately not here
+ *
+ * No dependency, no decorators, no wrapping of methods at registration time
+ * (a stack trace should name the method that was called, not a proxy), and
+ * no check of what an argument *means* where the table cannot say it: an
+ * options bag is checked key by key, and the three places that need more
+ * than a shape -- a person who is nobody, a message with no recipient, a
+ * selector that names nothing -- say so themselves, in a sentence, next to
+ * the code that knows.
+ */
+
+const { describe, problems, received } = require('./config-validate');
+const { fail } = require('./errors');
+
+/** The failure a call that henri cannot honour raises */
+const CODE = 'HENRI_ARGUMENT_INVALID';
+
+/** ... and the one a selector that names nothing raises */
+const UNKNOWN = 'HENRI_ARGUMENT_UNKNOWN_TARGET';
+
+// ---------------------------------------------------------------------------
+// The nodes: the vocabulary of config-schema.js, nothing new
+// ---------------------------------------------------------------------------
+
+/** Anything: an argument this module does not judge */
+const ANY = { type: 'any' };
+
+/** True or false */
+const BOOLEAN = { type: 'boolean' };
+
+/** A function */
+const FUNCTION = { type: 'function' };
+
+/** A name: a string with something in it */
+const NAME = { describe: 'a name', pattern: /\S/u, type: 'string' };
+
+/** A plain object */
+const OBJECT = { type: 'object' };
+
+/** A whole number of items, at least one */
+const COUNT = {
+  above: 0,
+  describe: 'a whole number above zero',
+  integer: true,
+  type: 'number',
+};
+
+/** The name of an action a policy has a rule for */
+const ACTION = {
+  describe: 'the name of an action',
+  hint: "henri.can(user, 'update', record)",
+  pattern: /\S/u,
+  type: 'string',
+};
+
+/** Where an operation was asked from (`base/trail.js` owns the list) */
+const SOURCE = { enum: ['app', 'cli', 'http', 'job'], type: 'string' };
+
+/** What an erasure does with the records that reference the person */
+const STRATEGY = {
+  enum: ['anonymize', 'delete', 'orphan', 'retain'],
+  type: 'string',
+};
+
+/**
+ * A moment: a Date, epoch milliseconds, or an ISO-8601 string.
+ *
+ * The string branch is not "anything Date can read": `new Date('yesterday')`
+ * is an Invalid Date, and an Invalid Date reaches a store as a `NaN` bound
+ * that quietly matches nothing.
+ */
+const WHEN = {
+  describe: 'a Date, epoch milliseconds, or an ISO-8601 date',
+  oneOf: [
+    { type: 'date' },
+    { describe: 'epoch milliseconds', min: 0, type: 'number' },
+    {
+      describe: 'an ISO-8601 date',
+      pattern: /^\d{4}-\d{2}-\d{2}(?:[T ]|$)/u,
+      type: 'string',
+    },
+  ],
+};
+
+/** A duration, the one `base/cache.js` reads */
+const DURATION = {
+  describe: "a duration: milliseconds, or '30s', '5m', '2h', '1d'",
+  oneOf: [
+    { const: null },
+    { min: 0, type: 'number' },
+    { pattern: /^\s*\d+(?:\.\d+)?\s*(?:ms|[smhdw])?\s*$/iu, type: 'string' },
+  ],
+};
+
+/** The person an export, an erasure or a trail read is about */
+const WHO = {
+  describe: 'an email address, an external id, or the record itself',
+  hint: "henri.privacy.export('someone@example.com')",
+  oneOf: [{ pattern: /\S/u, type: 'string' }, OBJECT],
+};
+
+/**
+ * An options bag: the keys it declares, and a near miss of one of them
+ * refused by name. Everything else is left alone, the way the
+ * configuration leaves an application's own keys alone.
+ *
+ * @param {object} keys the declared options
+ * @param {object} [extra={}] anything else the node carries
+ * @returns {object} the node
+ */
+const bag = (keys, extra = {}) => ({
+  keys,
+  type: 'object',
+  unknown: 'near',
+  ...extra,
+});
+
+/** What every cache call takes */
+const CACHE_OPTIONS = bag({ force: BOOLEAN, ttl: DURATION });
+
+/** What a policy question takes beside the user, the action and the record */
+const POLICY_OPTIONS = {
+  describe: 'a policy name, or { policy, type, req }',
+  oneOf: [NAME, bag({ policy: NAME, req: OBJECT, type: NAME })],
+};
+
+/** ... and the same with the status a refusal answers with */
+const AUTHORIZE_OPTIONS = {
+  describe: 'a policy name, or { policy, type, req, status }',
+  oneOf: [
+    NAME,
+    bag({
+      policy: NAME,
+      req: OBJECT,
+      status: { integer: true, max: 599, min: 100, type: 'number' },
+      type: NAME,
+    }),
+  ],
+};
+
+/** What the access trail is read back with */
+const TRAIL_FILTER = bag({
+  action: NAME,
+  actor: NAME,
+  digest: NAME,
+  limit: COUNT,
+  model: NAME,
+  offset: { integer: true, min: 0, type: 'number' },
+  outcome: { enum: ['failed', 'ok', 'refused'], type: 'string' },
+  since: WHEN,
+  subject: NAME,
+  until: WHEN,
+});
+
+/** What an encrypted value is read and written with */
+const ENCRYPTION_OPTIONS = bag({
+  context: {
+    ...NAME,
+    describe: 'the "<Model>.<field>" the value belongs to',
+    required: true,
+  },
+  deterministic: BOOLEAN,
+});
+
+/** A value henri encrypts: a string, or nothing */
+const SECRET = { oneOf: [{ const: null }, { type: 'string' }] };
+
+/** The fields marked `expose: false` an answer is allowed to carry */
+const INCLUDE = {
+  describe: 'a list of field names',
+  hint: 'They are the fields marked personal: { expose: false }',
+  of: NAME,
+  type: 'array',
+};
+
+/** An HTTP status */
+const STATUS = {
+  describe: 'an HTTP status',
+  integer: true,
+  max: 599,
+  min: 100,
+  type: 'number',
+};
+
+/** What `res.resource()` takes */
+const RESOURCE_OPTIONS = bag({
+  include: INCLUDE,
+  links: OBJECT,
+  status: STATUS,
+  subject: ANY,
+  type: NAME,
+});
+
+/** ... and what `res.collection()` adds to it */
+const COLLECTION_OPTIONS = bag({
+  include: INCLUDE,
+  links: OBJECT,
+  page: COUNT,
+  perPage: COUNT,
+  status: STATUS,
+  subject: ANY,
+  total: { integer: true, min: 0, type: 'number' },
+  type: NAME,
+});
+
+// ---------------------------------------------------------------------------
+// The surface
+// ---------------------------------------------------------------------------
+
+/**
+ * The signature of every entry point an application calls, in order.
+ *
+ * The name is the one a person writes and the one a message prints. It is
+ * also what `src/__tests__/arguments.spec.js` walks: a name declared here
+ * and never checked fails, and a public method in neither this table nor
+ * `UNCHECKED` fails too.
+ */
+const SIGNATURES = {
+  'henri.cache.clear': [],
+
+  'henri.cache.delete': [{ by: 'HENRI_CACHE_KEY_INVALID', name: 'key' }],
+
+  'henri.cache.fetch': [
+    { by: 'HENRI_CACHE_KEY_INVALID', name: 'key' },
+    { name: 'options', optional: true, ...CACHE_OPTIONS },
+    {
+      hint: 'henri.cache.fetch(key, [options], fn) runs fn on a miss and keeps what it answers',
+      name: 'fn',
+      ...FUNCTION,
+    },
+  ],
+
+  'henri.cache.get': [{ by: 'HENRI_CACHE_KEY_INVALID', name: 'key' }],
+
+  'henri.cache.scope': [{ by: 'HENRI_CACHE_KEY_INVALID', name: 'name' }],
+
+  'henri.cache.set': [
+    { by: 'HENRI_CACHE_KEY_INVALID', name: 'key' },
+    { by: 'HENRI_CACHE_VALUE_UNSUPPORTED', name: 'value' },
+    { name: 'options', optional: true, ...CACHE_OPTIONS },
+  ],
+
+  'henri.encryption.candidates': [
+    { name: 'value', ...NAME },
+    { name: 'options', ...ENCRYPTION_OPTIONS },
+  ],
+
+  'henri.encryption.decrypt': [
+    { name: 'value', optional: true, ...SECRET },
+    { name: 'options', ...ENCRYPTION_OPTIONS },
+  ],
+
+  'henri.encryption.encrypt': [
+    { name: 'value', optional: true, ...SECRET },
+    { name: 'options', ...ENCRYPTION_OPTIONS },
+  ],
+
+  'henri.encryption.markOf': [
+    { name: 'model', ...NAME },
+    { name: 'field', ...NAME },
+  ],
+
+  'henri.encryption.rotate': [
+    {
+      name: 'options',
+      optional: true,
+      ...bag({ dryRun: BOOLEAN, field: NAME, model: NAME }),
+    },
+  ],
+
+  'henri.encryption.tolerate': [
+    {
+      hint: 'henri.encryption.tolerate(() => Model.find())',
+      name: 'work',
+      ...FUNCTION,
+    },
+  ],
+
+  'henri.mail.send': [{ name: 'message', ...bag({}, { unknown: 'allow' }) }],
+
+  'henri.model.getStore': [{ name: 'name', optional: true, ...NAME }],
+
+  'henri.policies.authorize': [
+    { name: 'user', ...ANY },
+    { name: 'action', ...ACTION },
+    { name: 'record', optional: true, ...ANY },
+    { name: 'options', optional: true, ...AUTHORIZE_OPTIONS },
+  ],
+
+  'henri.policies.can': [
+    { name: 'user', ...ANY },
+    { name: 'action', ...ACTION },
+    { name: 'record', optional: true, ...ANY },
+    { name: 'options', optional: true, ...POLICY_OPTIONS },
+  ],
+
+  'henri.policies.links': [
+    { name: 'user', ...ANY },
+    { name: 'links', ...OBJECT },
+    { name: 'record', optional: true, ...ANY },
+    {
+      name: 'options',
+      optional: true,
+      ...bag({ cache: ANY, req: OBJECT, type: NAME }),
+    },
+  ],
+
+  'henri.policies.paths': [
+    { name: 'user', ...ANY },
+    { name: 'paths', ...OBJECT },
+    { name: 'options', optional: true, ...bag({ req: OBJECT }) },
+  ],
+
+  'henri.policies.scope': [
+    { name: 'user', ...ANY },
+    {
+      hint: "henri.policies.scope(user, 'proposal') names the policy to ask",
+      name: 'name',
+      ...NAME,
+    },
+    { name: 'context', optional: true, ...OBJECT },
+  ],
+
+  'henri.privacy.erase': [
+    { name: 'who', ...WHO },
+    {
+      name: 'options',
+      optional: true,
+      ...bag({ dryRun: BOOLEAN, source: SOURCE, strategy: STRATEGY }),
+    },
+  ],
+
+  'henri.privacy.export': [
+    { name: 'who', ...WHO },
+    { name: 'options', optional: true, ...bag({ source: SOURCE }) },
+  ],
+
+  'henri.privacy.fields': [{ name: 'model', ...NAME }],
+
+  'henri.privacy.plan': [
+    { name: 'who', ...WHO },
+    { name: 'options', optional: true, ...bag({ strategy: STRATEGY }) },
+  ],
+
+  'henri.privacy.strip': [
+    { name: 'value', ...ANY },
+    { name: 'include', optional: true, ...INCLUDE },
+  ],
+
+  'henri.privacy.subject': [{ name: 'who', ...WHO }],
+
+  'henri.reporter.report': [
+    { name: 'error', ...ANY },
+    {
+      name: 'options',
+      optional: true,
+      ...bag({
+        meta: OBJECT,
+        req: OBJECT,
+        source: {
+          enum: ['application', 'boot', 'rejection', 'request'],
+          type: 'string',
+        },
+        status: STATUS,
+      }),
+    },
+  ],
+
+  'henri.retention.plan': [
+    { name: 'options', optional: true, ...bag({ now: WHEN, only: NAME }) },
+  ],
+
+  'henri.retention.sweep': [
+    {
+      name: 'options',
+      optional: true,
+      ...bag({ dryRun: BOOLEAN, now: WHEN, only: NAME, source: SOURCE }),
+    },
+  ],
+
+  'henri.trail.about': [
+    { name: 'who', ...WHO },
+    { name: 'filter', optional: true, ...TRAIL_FILTER },
+  ],
+
+  'henri.trail.count': [{ name: 'filter', optional: true, ...TRAIL_FILTER }],
+
+  'henri.trail.list': [{ name: 'filter', optional: true, ...TRAIL_FILTER }],
+
+  'henri.trail.prune': [
+    { name: 'options', optional: true, ...bag({ now: { type: 'number' } }) },
+  ],
+
+  'message.deliverLater': [
+    {
+      name: 'options',
+      optional: true,
+      ...bag({
+        at: WHEN,
+        priority: { integer: true, type: 'number' },
+        queue: NAME,
+        wait: DURATION,
+      }),
+    },
+  ],
+
+  'req.flash': [
+    { name: 'key', optional: true, ...NAME },
+    { name: 'value', optional: true, ...ANY },
+  ],
+
+  'req.pagination': [
+    {
+      name: 'overrides',
+      optional: true,
+      ...bag({ maxPerPage: COUNT, perPage: COUNT }),
+    },
+  ],
+
+  'req.permit': [{ name: 'fields', of: NAME, type: 'array' }],
+
+  'res.boom': [
+    {
+      ...NAME,
+      describe: 'a string',
+      hint: 'The error body promises a string; the detail goes in the second argument',
+      name: 'message',
+      optional: true,
+    },
+    { name: 'data', optional: true, ...ANY },
+  ],
+
+  'res.collection': [
+    { by: 'HENRI_API_INVALID_COLLECTION', name: 'records' },
+    { name: 'options', optional: true, ...COLLECTION_OPTIONS },
+  ],
+
+  'res.negotiate': [
+    {
+      hint: 'res.negotiate({ html: () => res.render(...), json: () => res.resource(...) })',
+      name: 'handlers',
+      ...bag({ html: FUNCTION, json: FUNCTION }, { unknown: 'warn' }),
+    },
+  ],
+
+  'res.render': [
+    {
+      ...NAME,
+      describe: 'the route of a page',
+      hint: "res.render('/tasks/index', { data })",
+      name: 'route',
+    },
+    {
+      name: 'options',
+      optional: true,
+      ...bag(
+        { data: ANY, graphql: { oneOf: [NAME, OBJECT] }, include: INCLUDE },
+        { unknown: 'allow' }
+      ),
+    },
+  ],
+
+  'res.resource': [
+    { by: 'HENRI_API_INVALID_RESOURCE', name: 'record' },
+    { name: 'options', optional: true, ...RESOURCE_OPTIONS },
+  ],
+};
+
+/**
+ * The public methods that are checked somewhere else, or that are right as
+ * they are -- and why. `src/__tests__/arguments.spec.js` reads this, so a
+ * new public method has to land in one table or the other.
+ */
+const UNCHECKED = {
+  'henri.addMiddleware':
+    'says so and answers false, which is its documented contract',
+  'henri.analyze': 'takes a module name and answers null for anything else',
+  'henri.can': 'the one implementation is henri.policies.can, checked there',
+  'henri.config.get':
+    'HENRI_CONFIG_UNKNOWN_KEY already refuses anything that is not a key, and this is the one entry point called often enough for an allocation to matter',
+  'henri.config.has': 'answers false for anything that is not a key',
+  'henri.encryption.describe': 'takes no argument',
+  'henri.encryption.isEnvelope': 'a total function of unknown',
+  'henri.encryption.keyIdIn': 'a total function of unknown',
+  'henri.encryption.status': 'takes no argument',
+  'henri.gql': 'a tagged template that answers a string, whatever it is given',
+  'henri.mailers.onDeliverLater':
+    'says so and answers false, which is its documented contract',
+  'henri.model.errors':
+    'answers null for anything that is not a validation failure, which is its documented contract',
+  'henri.model.publish':
+    'its contract is anything: it is what res.render hands whatever a controller returned',
+  'henri.pen': 'a logger that throws is worse than a wrong log line',
+  'henri.policies.get': 'documented to answer null',
+  'henri.policies.has': 'documented to answer false',
+  'henri.policies.names': 'takes no argument',
+  'henri.policies.resolve': 'documented to answer null',
+  'henri.policies.rule': 'documented to answer null',
+  'henri.policies.size': 'takes no argument',
+  'henri.privacy.describe': 'takes no argument',
+  'henri.reporter.onError':
+    'says so and answers false, which is its documented contract',
+  'henri.retention.describe': 'takes no argument',
+  'henri.trail.record':
+    'HENRI_TRAIL_INVALID_EVENT and the meta refusals already say what is wrong',
+  'henri.trail.verify': 'takes no argument',
+  'henri.utils': 'node resolution answers for itself',
+  'req.authorize': 'the one implementation is henri.policies.authorize',
+  'req.can': 'the one implementation is henri.policies.can',
+  'req.file': 'answers null for anything that is not a field name',
+  'req.permitFiles': 'the same list req.permit takes, checked there',
+  'req.scope': 'the one implementation is henri.policies.scope',
+  'res.hbs': 'the same arguments as res.render, checked there',
+};
+
+// ---------------------------------------------------------------------------
+// The check
+// ---------------------------------------------------------------------------
+
+/** The name `config-validate` suggests for a near miss, out of its hint */
+const SUGGESTION = /^Rename it to "(?<name>[^"]+)"/u;
+
+/**
+ * One line of a refusal
+ *
+ * @param {string} where the entry point (`henri.cache.set`)
+ * @param {object} problem a problem of `config-validate`
+ * @returns {string} the line
+ */
+function line(where, problem) {
+  if (problem.expected !== null) {
+    return `${where}(${problem.key}) must be ${problem.expected}, but it is ${problem.received}`;
+  }
+
+  const near = SUGGESTION.exec(problem.hint || '');
+
+  return `${where}(${problem.key}) is not one of its options${
+    near ? `: did you mean "${near.groups.name}"?` : ''
+  }`;
+}
+
+/**
+ * Check what a public method was called with
+ *
+ * The one way to ask, and the only thing an entry point adds to itself. It
+ * throws rather than answering, because a call henri cannot honour has no
+ * useful answer: `HENRI_ARGUMENT_INVALID`, naming the method, the argument,
+ * what was expected and what arrived. An async method rejects with it,
+ * which is what its caller is already handling.
+ *
+ * Nothing is allocated while a call is right: an argument declared `by` or
+ * `any` is skipped outright, and `problems()` is the only allocation the
+ * others make.
+ *
+ * @param {string} where the entry point, as a person writes it
+ * @param {Array<*>} args what it was called with
+ * @param {string} [as=where] what to call it in the message, when one
+ *   signature stands for a family of methods (`res.boom.notFound`)
+ * @returns {void}
+ * @throws {Error} `HENRI_ARGUMENT_INVALID` when the call cannot be honoured
+ */
+function check(where, args, as = where) {
+  const signature = SIGNATURES[where];
+
+  if (!signature) {
+    // A mistake of henri's rather than of the application's, so it reads
+    // like the one `stamp()` makes for a code the catalogue does not hold
+    throw new Error(
+      `${where} has no declared signature: add it to packages/core/src/base/arguments.js`
+    );
+  }
+
+  let found = null;
+
+  for (let index = 0; index < signature.length; index++) {
+    const declared = signature[index];
+    const value = args[index];
+
+    if (declared.by || declared.type === 'any') {
+      continue;
+    }
+
+    if (typeof value === 'undefined') {
+      if (declared.optional) {
+        continue;
+      }
+
+      found = found || [];
+      found.push({
+        expected: describe(declared),
+        hint: declared.hint || null,
+        key: declared.name,
+        received: 'missing',
+      });
+
+      continue;
+    }
+
+    const wrong = problems(declared, value, declared.name);
+
+    if (wrong.length > 0) {
+      found = found || [];
+
+      for (const problem of wrong) {
+        found.push({
+          ...problem,
+          hint: problem.hint || declared.hint || null,
+        });
+      }
+    }
+  }
+
+  if (found === null) {
+    return;
+  }
+
+  const lines = found.map((problem) => line(as, problem));
+  const error = fail(
+    CODE,
+    lines.length === 1
+      ? lines[0]
+      : `${as} was called with ${lines.length} arguments henri cannot honour:\n  ${lines.join('\n  ')}`
+  );
+
+  error.hint = (found.find((problem) => problem.hint) || {}).hint || null;
+  error.problems = found;
+
+  throw error;
+}
+
+/**
+ * Refuse a selector that names nothing
+ *
+ * What a shape cannot catch, and what a clean, empty, successful run hides:
+ * `henri.retention.plan({ only: 'Propsal' })` sweeping no rule,
+ * `henri.encryption.rotate({ model: 'Usr' })` rotating no column. Both end
+ * with somebody believing the work is done.
+ *
+ * @param {string} where the entry point
+ * @param {string} what the option that names nothing (`only`)
+ * @param {*} value what it named
+ * @param {Array<string>} known what it could have named
+ * @returns {Error} the error to throw
+ */
+function unknown(where, what, value, known) {
+  const error = fail(
+    UNKNOWN,
+    `${where}(${what}) names ${received(value)}, which is nothing this application has`
+  );
+
+  error.hint =
+    known.length > 0
+      ? `It is one of: ${known.slice(0, 12).join(', ')}${
+          known.length > 12 ? ', ...' : ''
+        }`
+      : 'This application declares none';
+
+  return error;
+}
+
+module.exports = {
+  CODE,
+  SIGNATURES,
+  UNCHECKED,
+  UNKNOWN,
+  check,
+  unknown,
+};

--- a/packages/core/src/base/arguments.js
+++ b/packages/core/src/base/arguments.js
@@ -232,8 +232,15 @@ const bag = (keys, extra = {}) => ({
   ...extra,
 });
 
-/** What every cache call takes */
-const CACHE_OPTIONS = bag({ force: BOOLEAN, ttl: DURATION });
+/**
+ * What every cache call takes.
+ *
+ * `ttl` is `ANY` here on purpose: `Cache#ttlOf` owns it and raises
+ * `HENRI_CACHE_TTL_INVALID`, which says more about a duration than a node
+ * could. What the bag adds is the key names around it, so `tll` and `forse`
+ * are refused instead of silently meaning the default.
+ */
+const CACHE_OPTIONS = bag({ force: BOOLEAN, ttl: ANY });
 
 /** What a policy question takes beside the user, the action and the record */
 const POLICY_OPTIONS = {
@@ -278,9 +285,6 @@ const ENCRYPTION_OPTIONS = bag({
   },
   deterministic: BOOLEAN,
 });
-
-/** A value henri encrypts: a string, or nothing */
-const SECRET = { oneOf: [{ const: null }, { type: 'string' }] };
 
 /** The fields marked `expose: false` an answer is allowed to carry */
 const INCLUDE = {
@@ -358,17 +362,11 @@ const SIGNATURES = {
   ],
 
   'henri.encryption.candidates': [
-    { name: 'value', ...NAME },
-    { name: 'options', ...ENCRYPTION_OPTIONS },
-  ],
-
-  'henri.encryption.decrypt': [
-    { name: 'value', optional: true, ...SECRET },
-    { name: 'options', ...ENCRYPTION_OPTIONS },
-  ],
-
-  'henri.encryption.encrypt': [
-    { name: 'value', optional: true, ...SECRET },
+    {
+      ...NAME,
+      describe: 'the value to look up',
+      name: 'value',
+    },
     { name: 'options', ...ENCRYPTION_OPTIONS },
   ],
 
@@ -596,7 +594,10 @@ const UNCHECKED = {
   'henri.config.get':
     'HENRI_CONFIG_UNKNOWN_KEY already refuses anything that is not a key, and this is the one entry point called often enough for an allocation to matter',
   'henri.config.has': 'answers false for anything that is not a key',
+  'henri.encryption.decrypt':
+    'checked by hand in 1.encryption.js, with three typeofs and no allocation: the three adapters call it once per row per encrypted column, which is the one place a walk is not worth it',
   'henri.encryption.describe': 'takes no argument',
+  'henri.encryption.encrypt': 'the same, on the write path',
   'henri.encryption.isEnvelope': 'a total function of unknown',
   'henri.encryption.keyIdIn': 'a total function of unknown',
   'henri.encryption.status': 'takes no argument',

--- a/packages/core/src/base/arguments.js
+++ b/packages/core/src/base/arguments.js
@@ -233,6 +233,27 @@ const bag = (keys, extra = {}) => ({
 });
 
 /**
+ * A key of an options bag that also accepts `null`.
+ *
+ * The rule, and it is worth stating because it is not uniform: a key that
+ * names a **selector or a switch** takes `null` as "not given", because a
+ * caller that computes an option and comes up with nothing should not have
+ * to delete the key -- `{ model: found && found.name }` is how these are
+ * written, and every reader of one of them tests it for truth. A key whose
+ * absence has a **default** does not, because `{ include: null }` and no
+ * `include` at all are different there: the default only fills in for
+ * `undefined`, and `null` goes straight through to the code that breaks.
+ *
+ * @param {object} node the node
+ * @returns {object} the node, or null
+ */
+const maybe = (node) => ({
+  describe: describe(node),
+  hint: node.hint,
+  oneOf: [{ const: null }, node],
+});
+
+/**
  * What every cache call takes.
  *
  * `ttl` is `ANY` here on purpose: `Cache#ttlOf` owns it and raises
@@ -240,12 +261,15 @@ const bag = (keys, extra = {}) => ({
  * could. What the bag adds is the key names around it, so `tll` and `forse`
  * are refused instead of silently meaning the default.
  */
-const CACHE_OPTIONS = bag({ force: BOOLEAN, ttl: ANY });
+const CACHE_OPTIONS = bag({ force: maybe(BOOLEAN), ttl: ANY });
 
 /** What a policy question takes beside the user, the action and the record */
 const POLICY_OPTIONS = {
   describe: 'a policy name, or { policy, type, req }',
-  oneOf: [NAME, bag({ policy: NAME, req: OBJECT, type: NAME })],
+  oneOf: [
+    NAME,
+    bag({ policy: maybe(NAME), req: maybe(OBJECT), type: maybe(NAME) }),
+  ],
 };
 
 /** ... and the same with the status a refusal answers with */
@@ -254,26 +278,26 @@ const AUTHORIZE_OPTIONS = {
   oneOf: [
     NAME,
     bag({
-      policy: NAME,
-      req: OBJECT,
-      status: { integer: true, max: 599, min: 100, type: 'number' },
-      type: NAME,
+      policy: maybe(NAME),
+      req: maybe(OBJECT),
+      status: maybe({ integer: true, max: 599, min: 100, type: 'number' }),
+      type: maybe(NAME),
     }),
   ],
 };
 
 /** What the access trail is read back with */
 const TRAIL_FILTER = bag({
-  action: NAME,
-  actor: NAME,
-  digest: NAME,
-  limit: COUNT,
-  model: NAME,
-  offset: { integer: true, min: 0, type: 'number' },
-  outcome: { enum: ['failed', 'ok', 'refused'], type: 'string' },
-  since: WHEN,
-  subject: NAME,
-  until: WHEN,
+  action: maybe(NAME),
+  actor: maybe(NAME),
+  digest: maybe(NAME),
+  limit: maybe(COUNT),
+  model: maybe(NAME),
+  offset: maybe({ integer: true, min: 0, type: 'number' }),
+  outcome: maybe({ enum: ['failed', 'ok', 'refused'], type: 'string' }),
+  since: maybe(WHEN),
+  subject: maybe(NAME),
+  until: maybe(WHEN),
 });
 
 /** What an encrypted value is read and written with */
@@ -306,22 +330,22 @@ const STATUS = {
 /** What `res.resource()` takes */
 const RESOURCE_OPTIONS = bag({
   include: INCLUDE,
-  links: OBJECT,
+  links: maybe(OBJECT),
   status: STATUS,
   subject: ANY,
-  type: NAME,
+  type: maybe(NAME),
 });
 
 /** ... and what `res.collection()` adds to it */
 const COLLECTION_OPTIONS = bag({
   include: INCLUDE,
-  links: OBJECT,
-  page: COUNT,
-  perPage: COUNT,
+  links: maybe(OBJECT),
+  page: maybe(COUNT),
+  perPage: maybe(COUNT),
   status: STATUS,
   subject: ANY,
-  total: { integer: true, min: 0, type: 'number' },
-  type: NAME,
+  total: maybe({ integer: true, min: 0, type: 'number' }),
+  type: maybe(NAME),
 });
 
 // ---------------------------------------------------------------------------
@@ -379,7 +403,11 @@ const SIGNATURES = {
     {
       name: 'options',
       optional: true,
-      ...bag({ dryRun: BOOLEAN, field: NAME, model: NAME }),
+      ...bag({
+        dryRun: maybe(BOOLEAN),
+        field: maybe(NAME),
+        model: maybe(NAME),
+      }),
     },
   ],
 
@@ -416,14 +444,14 @@ const SIGNATURES = {
     {
       name: 'options',
       optional: true,
-      ...bag({ cache: ANY, req: OBJECT, type: NAME }),
+      ...bag({ cache: ANY, req: maybe(OBJECT), type: maybe(NAME) }),
     },
   ],
 
   'henri.policies.paths': [
     { name: 'user', ...ANY },
     { name: 'paths', ...OBJECT },
-    { name: 'options', optional: true, ...bag({ req: OBJECT }) },
+    { name: 'options', optional: true, ...bag({ req: maybe(OBJECT) }) },
   ],
 
   'henri.policies.scope': [
@@ -441,20 +469,24 @@ const SIGNATURES = {
     {
       name: 'options',
       optional: true,
-      ...bag({ dryRun: BOOLEAN, source: SOURCE, strategy: STRATEGY }),
+      ...bag({
+        dryRun: maybe(BOOLEAN),
+        source: maybe(SOURCE),
+        strategy: maybe(STRATEGY),
+      }),
     },
   ],
 
   'henri.privacy.export': [
     { name: 'who', ...WHO },
-    { name: 'options', optional: true, ...bag({ source: SOURCE }) },
+    { name: 'options', optional: true, ...bag({ source: maybe(SOURCE) }) },
   ],
 
   'henri.privacy.fields': [{ name: 'model', ...NAME }],
 
   'henri.privacy.plan': [
     { name: 'who', ...WHO },
-    { name: 'options', optional: true, ...bag({ strategy: STRATEGY }) },
+    { name: 'options', optional: true, ...bag({ strategy: maybe(STRATEGY) }) },
   ],
 
   'henri.privacy.strip': [
@@ -464,32 +496,24 @@ const SIGNATURES = {
 
   'henri.privacy.subject': [{ name: 'who', ...WHO }],
 
-  'henri.reporter.report': [
-    { name: 'error', ...ANY },
+  'henri.retention.plan': [
     {
       name: 'options',
       optional: true,
-      ...bag({
-        meta: OBJECT,
-        req: OBJECT,
-        source: {
-          enum: ['application', 'boot', 'rejection', 'request'],
-          type: 'string',
-        },
-        status: STATUS,
-      }),
+      ...bag({ now: maybe(WHEN), only: maybe(NAME) }),
     },
-  ],
-
-  'henri.retention.plan': [
-    { name: 'options', optional: true, ...bag({ now: WHEN, only: NAME }) },
   ],
 
   'henri.retention.sweep': [
     {
       name: 'options',
       optional: true,
-      ...bag({ dryRun: BOOLEAN, now: WHEN, only: NAME, source: SOURCE }),
+      ...bag({
+        dryRun: maybe(BOOLEAN),
+        now: maybe(WHEN),
+        only: maybe(NAME),
+        source: maybe(SOURCE),
+      }),
     },
   ],
 
@@ -503,7 +527,11 @@ const SIGNATURES = {
   'henri.trail.list': [{ name: 'filter', optional: true, ...TRAIL_FILTER }],
 
   'henri.trail.prune': [
-    { name: 'options', optional: true, ...bag({ now: { type: 'number' } }) },
+    {
+      name: 'options',
+      optional: true,
+      ...bag({ now: maybe({ min: 0, type: 'number' }) }),
+    },
   ],
 
   'message.deliverLater': [
@@ -511,10 +539,10 @@ const SIGNATURES = {
       name: 'options',
       optional: true,
       ...bag({
-        at: WHEN,
-        priority: { integer: true, type: 'number' },
-        queue: NAME,
-        wait: DURATION,
+        at: maybe(WHEN),
+        priority: maybe({ integer: true, type: 'number' }),
+        queue: maybe(NAME),
+        wait: maybe(DURATION),
       }),
     },
   ],
@@ -569,7 +597,11 @@ const SIGNATURES = {
       name: 'options',
       optional: true,
       ...bag(
-        { data: ANY, graphql: { oneOf: [NAME, OBJECT] }, include: INCLUDE },
+        {
+          data: ANY,
+          graphql: maybe({ oneOf: [NAME, OBJECT] }),
+          include: INCLUDE,
+        },
         { unknown: 'allow' }
       ),
     },
@@ -618,6 +650,8 @@ const UNCHECKED = {
   'henri.privacy.describe': 'takes no argument',
   'henri.reporter.onError':
     'says so and answers false, which is its documented contract',
+  'henri.reporter.report':
+    'the one entry point that must not refuse: it runs on a failure path, so throwing would lose the failure it was called about. A wrong source is coerced and a wrong options is read as none, deliberately',
   'henri.retention.describe': 'takes no argument',
   'henri.trail.record':
     'HENRI_TRAIL_INVALID_EVENT and the meta refusals already say what is wrong',

--- a/packages/core/src/base/arguments.js
+++ b/packages/core/src/base/arguments.js
@@ -61,10 +61,10 @@
  * `plan`, `erase`), `henri.retention` (`plan`, `sweep`), `henri.trail`
  * (`list`, `count`, `about`, `prune`), `henri.encryption` (`markOf`,
  * `encrypt`, `decrypt`, `candidates`, `tolerate`, `rotate`),
- * `henri.model.getStore`, `henri.mail.send`, `henri.reporter.report`,
- * `deliverLater`, and what a request gets: `res.resource`, `res.collection`,
- * `res.negotiate`, `res.render`, `res.hbs`, `res.boom.*`, `req.pagination`,
- * `req.permit`, `req.flash`.
+ * `henri.model.getStore`, `henri.mail.send`, `deliverLater`, and what a
+ * request gets: `res.resource`, `res.collection`, `res.negotiate`,
+ * `res.render`, `res.hbs`, `res.boom.*`, `req.pagination`, `req.permit`,
+ * `req.flash`.
  *
  * **Already refusing well, and left alone.** The cache's keys and values
  * (`HENRI_CACHE_KEY_INVALID`, `HENRI_CACHE_VALUE_UNSUPPORTED`,
@@ -83,18 +83,26 @@
  * `henri.encryption.isEnvelope`/`keyIdIn` (total functions of `unknown`),
  * and `henri.pen.*` (a logger that throws is worse than a wrong log line).
  *
+ * **Deliberately lenient**, which is a third answer and there is one of it:
+ * `henri.reporter.report()` runs on a failure path, so refusing a wrong
+ * call there would lose the failure it was called about. A wrong `source`
+ * is coerced and a wrong `options` is read as none, on purpose.
+ *
  * ## Where the check goes, and what it costs
  *
  * **Never inside a loop of henri's own.** `res.collection(records)` checks
  * that `records` is a list and stops there; the rows are the serializer's
  * business, and one assertion per row to catch a mistake the call itself
  * announces is the wrong trade. `henri.model.publish()` walks a tree and
- * checks nothing on the way down. The rule is about henri's loops, not the
- * application's: `encryption.encrypt()` is called once per row by the
- * adapters, and it is checked, because a check is bounded by the cost of
- * what it guards -- a `typeof` in front of an AES-GCM seal is free, and the
- * mistake it catches (`context` missing) writes ciphertext that will never
- * open again.
+ * checks nothing on the way down.
+ *
+ * Two entry points sit on such a loop without being henri's: the three
+ * adapters call `encryption.encrypt()` and `decrypt()` once per row per
+ * encrypted column. They are still checked -- the mistake they catch, a
+ * missing `context`, writes ciphertext whose AAD no read path will ever
+ * match again -- but by hand, in `1.encryption.js`, with three `typeof`s
+ * and no allocation, and they are in `UNCHECKED` saying so. That is the
+ * shape for anything else that lands there.
  *
  * **The checks always run, in production too.** Compiling them out would
  * need a build step core does not have -- the source is what ships -- and
@@ -106,14 +114,20 @@
  * been measurable is `henri.config.get`, called in tight loops, and it is
  * in `UNCHECKED` because it already refuses everything that is not a key.
  *
- * **A method henri also calls internally is checked once, here, at the
- * method the application names.** `henri.can()` and `req.can()` both funnel
- * into `henri.policies.can()`, so that is the one that checks; the wrappers
- * pass through it. Where henri calls a checked method itself -- `res.render`
- * calls `model.publish`, `privacy.export` calls `privacy.subject` -- the
- * check runs on a value henri produced, which is affordable only because
- * every one of them is O(1). None of them needed splitting into a checked
- * outer and an unchecked inner, and the day one does, that is the shape.
+ * **A method henri also calls internally is checked once, at the method the
+ * application names.** `henri.can()` and `req.can()` both funnel into
+ * `henri.policies.can()`, so that is the one that checks and the wrappers
+ * pass through it. Where henri then calls a checked method itself --
+ * `res.render` calls `model.publish`, `privacy.export` calls
+ * `privacy.subject` -- the check runs again on a value henri produced,
+ * which is affordable because every one of them is O(1).
+ *
+ * One method needed splitting, and it is the shape for the next:
+ * `policies.can()` checks and then calls `policies.answer()`, the body they
+ * share, because `links()` and `paths()` ask the same question once per
+ * link with an action they read out of a route helper. Checking a value
+ * henri produced, inside a loop henri wrote, is the trade the rule above
+ * says not to make.
  *
  * ## Deliberately not here
  *
@@ -658,13 +672,15 @@ const UNCHECKED = {
   'henri.utils': 'node resolution answers for itself',
   'req.authorize': 'the one implementation is henri.policies.authorize',
   'req.can': 'the one implementation is henri.policies.can',
-  'req.file': 'answers null for anything that is not a field name',
+  'req.file':
+    '@usehenri/uploads ships it, and it answers null for anything that is not a field it holds',
   'req.logIn': "passport's, not henri's",
   'req.logOut': "passport's, not henri's",
   'req.logout': "passport's, not henri's",
-  'req.permitFiles': 'the same list req.permit takes, checked there',
+  'req.permitFiles':
+    '@usehenri/uploads ships it, and a package checks its own surface',
   'req.scope': 'the one implementation is henri.policies.scope',
-  'res.hbs': 'the same arguments as res.render, checked there',
+  'res.hbs': "checked against res.render's signature, under its own name",
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/base/boom.js
+++ b/packages/core/src/base/boom.js
@@ -1,3 +1,4 @@
+const { check } = require('./arguments');
 /**
  * Minimal replacement for express-boom: decorates `res` with `res.boom.<name>()`
  * helpers that answer with a Boom-shaped JSON body.
@@ -41,6 +42,8 @@ function boom() {
 
     for (const [name, [statusCode, error]] of Object.entries(STATUSES)) {
       res.boom[name] = (message = error, data = undefined, code = null) => {
+        check('res.boom', [message, data], `res.boom.${name}`);
+
         const body = { error, message, statusCode };
 
         if (isCode(code)) {

--- a/packages/core/src/base/cache.js
+++ b/packages/core/src/base/cache.js
@@ -3,6 +3,7 @@ const debug = require('debug')('henri:cache');
 
 const { MASK, filterParameters, isFiltered } = require('./redact');
 const { REPORT_EVERY } = require('./shared');
+const { check } = require('./arguments');
 const { fail } = require('./errors');
 
 /**
@@ -975,11 +976,15 @@ class Cache {
    * @memberof Cache
    */
   async get(key) {
+    // Before the short circuit: a bad key is a bad key whatever
+    // `config.cache` says, or a call that works in development with the
+    // cache off is a call that fails in production with it on
+    const full = this.keyFor(key);
+
     if (!this.enabled) {
       return undefined;
     }
 
-    const full = this.keyFor(key);
     let entry;
 
     try {
@@ -1008,11 +1013,14 @@ class Cache {
    * @memberof Cache
    */
   async set(key, value, options = {}) {
+    const full = this.keyFor(key);
+
+    check('henri.cache.set', [key, value, options]);
+
     if (!this.enabled) {
       return false;
     }
 
-    const full = this.keyFor(key);
     const ttl = this.ttlOf(options);
     const payload = encode(value);
     const size = Buffer.byteLength(payload);
@@ -1085,11 +1093,11 @@ class Cache {
    * @memberof Cache
    */
   async delete(key) {
+    const full = this.keyFor(key);
+
     if (!this.enabled) {
       return false;
     }
-
-    const full = this.keyFor(key);
 
     try {
       await this.store.delete(full);
@@ -1148,11 +1156,13 @@ class Cache {
     const run = typeof options === 'function' ? options : fn;
     const settings = typeof options === 'function' ? {} : options;
 
-    if (typeof run !== 'function') {
-      throw new TypeError(
-        'henri.cache.fetch(key, [options], fn) needs a function to run on a miss'
-      );
-    }
+    // The whole call is checked here rather than one piece at a time on the
+    // way through: `ttlOf` used to see a bad duration only after the
+    // function had run, which rejected the fetch and threw away the value
+    // it had just computed
+    this.keyFor(key);
+    check('henri.cache.fetch', [key, settings, run]);
+    this.ttlOf(settings);
 
     if (!this.enabled) {
       return run();

--- a/packages/core/src/base/config-validate.js
+++ b/packages/core/src/base/config-validate.js
@@ -136,6 +136,16 @@ function received(value, masked = false) {
     return `a list of ${value.length} item${value.length === 1 ? '' : 's'}`;
   }
 
+  // A function prints as its name and nothing else: `String(fn)` is the
+  // whole body, which is not what a message about the wrong argument wants
+  if (typeof value === 'function') {
+    return value.name ? `the function ${value.name}` : 'a function';
+  }
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? 'an invalid date' : 'a date';
+  }
+
   if (typeof value === 'object') {
     return 'an object';
   }
@@ -182,6 +192,8 @@ function describe(node) {
     any: 'anything',
     array: 'a list',
     boolean: 'true or false',
+    date: 'a date',
+    function: 'a function',
     number: 'a number',
     object: 'an object',
     record: 'an object',
@@ -227,8 +239,17 @@ function accepts(node, value) {
     return Array.isArray(value);
   }
 
+  if (node.type === 'date') {
+    return value instanceof Date;
+  }
+
   if (node.type === 'object' || node.type === 'record') {
-    return value !== null && typeof value === 'object' && !Array.isArray(value);
+    return (
+      value !== null &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      !(value instanceof Date)
+    );
   }
 
   return node.type === 'any' || typeof value === node.type;
@@ -367,6 +388,23 @@ function walk(node, value, key, context) {
 
       return;
 
+    // `function` and `date` are the two kinds a call can pass and a JSON
+    // file cannot, so the configuration never declares them and
+    // `base/arguments.js` is the only caller that does
+    case 'function':
+      if (typeof value !== 'function') {
+        wrong();
+      }
+
+      return;
+
+    case 'date':
+      if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+        wrong();
+      }
+
+      return;
+
     case 'number':
       if (!validNumber(node, value)) {
         wrong();
@@ -408,7 +446,12 @@ function walk(node, value, key, context) {
       return;
 
     case 'object':
-      if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      if (
+        !value ||
+        typeof value !== 'object' ||
+        Array.isArray(value) ||
+        value instanceof Date
+      ) {
         wrong();
 
         return;
@@ -516,6 +559,31 @@ function related(config, context) {
       source: context.source('renderer'),
     });
   }
+}
+
+/**
+ * The problems one value has against one node
+ *
+ * `validate()` is the configuration's entry into the walk; this is the same
+ * walk over a single value, which `base/arguments.js` uses to check what a
+ * public method was called with. One walker, two callers: the vocabulary of
+ * `config-schema.js` means the same thing on both sides.
+ *
+ * @param {object} node a schema node
+ * @param {any} value the value
+ * @param {string} [key=''] what to call it in the messages
+ * @returns {Array<object>} the problems, `[]` when there are none
+ */
+function problems(node, value, key = '') {
+  const found = [];
+
+  walk(node, value, key, {
+    mask: () => false,
+    problems: found,
+    source: () => null,
+  });
+
+  return found;
 }
 
 /**
@@ -739,6 +807,7 @@ module.exports = {
   format,
   nearest,
   nodeAt,
+  problems,
   received,
   summary,
   validate,

--- a/packages/core/src/base/flash.js
+++ b/packages/core/src/base/flash.js
@@ -1,3 +1,4 @@
+const { check } = require('./arguments');
 /**
  * Flash messages: one-shot messages kept in the express session so they
  * survive exactly one redirect.
@@ -161,6 +162,8 @@ function expose(req, target) {
 function flashMiddleware() {
   return (req, res, next) => {
     req.flash = (type, message) => {
+      check('req.flash', [type, message]);
+
       if (typeof type === 'undefined') {
         return take(req);
       }

--- a/packages/core/src/base/hateoas.js
+++ b/packages/core/src/base/hateoas.js
@@ -1,5 +1,6 @@
 const { EXTERNAL_ID, hasExternalId } = require('./external-id');
 const { publish } = require('./references');
+const { check } = require('./arguments');
 const { stamp } = require('./errors');
 const { jsonType, noStore } = require('./headers');
 const { linkHeader, pageLinks, paginate } = require('./pagination');
@@ -406,13 +407,15 @@ async function enforce(henri, req, res, record) {
  * @returns {Express.Response} the response
  * @throws {TypeError} when the record is not an object or the type is unknown
  */
-function resource(
-  henri,
-  req,
-  res,
-  record,
-  { type, links, status = 200, subject, include = [] } = {}
-) {
+function resource(henri, req, res, record, options = {}) {
+  // Before the destructuring, which used to run in the parameter list and
+  // throw its own TypeError over the message below whenever `options` was
+  // null -- and which let a non-array `include` reach the substring match
+  // of `stripPersonal`, where it un-hides a field marked expose: false
+  check('res.resource', [record, options]);
+
+  const { type, links, status = 200, subject, include = [] } = options;
+
   if (!record || typeof record !== 'object' || Array.isArray(record)) {
     throw stamp(
       new TypeError(
@@ -510,12 +513,10 @@ function resource(
  * @returns {Express.Response} the response
  * @throws {TypeError} when records is not an array or the type is unknown
  */
-function collection(
-  henri,
-  req,
-  res,
-  records,
-  {
+function collection(henri, req, res, records, options = {}) {
+  check('res.collection', [records, options]);
+
+  const {
     type,
     page,
     perPage,
@@ -524,8 +525,8 @@ function collection(
     status = 200,
     subject,
     include = [],
-  } = {}
-) {
+  } = options;
+
   if (!Array.isArray(records)) {
     throw stamp(
       new TypeError(

--- a/packages/core/src/base/mail-message.js
+++ b/packages/core/src/base/mail-message.js
@@ -1,3 +1,4 @@
+const { check } = require('./arguments');
 const { DEFAULT_LAYOUT } = require('./mail-view');
 const { htmlToText } = require('./mail-text');
 
@@ -193,6 +194,10 @@ class Message {
    * @memberof Message
    */
   async deliverLater(options = {}) {
+    // A misspelled `wait` is a mail that leaves immediately: the fallback
+    // handler only holds a message back for the two keys it reads
+    check('message.deliverLater', [options]);
+
     return this.henri.mailers.enqueue(await this.render(), options);
   }
 }

--- a/packages/core/src/base/pagination.js
+++ b/packages/core/src/base/pagination.js
@@ -1,3 +1,5 @@
+const { check } = require('./arguments');
+
 /**
  * Pagination (`?page=2&per_page=50`) and the links around a page.
  *
@@ -57,6 +59,10 @@ function paginate(
 function paginationMiddleware(settings) {
   return (req, res, next) => {
     req.pagination = (overrides = {}) => {
+      // `paginate` clamps and coerces, so a `perPage` of "abc" used to come
+      // out as NaN and reach the ORM as `.limit(NaN)`
+      check('req.pagination', [overrides]);
+
       const result = paginate(req, Object.assign({}, settings(), overrides));
 
       req._pagination = result;

--- a/packages/core/src/base/params.js
+++ b/packages/core/src/base/params.js
@@ -1,3 +1,6 @@
+const { check } = require('./arguments');
+const { fail } = require('./errors');
+
 /**
  * Strong parameters: pick the fields a controller allows from the request.
  *
@@ -75,6 +78,20 @@ function params(req) {
     permit: (...fields) => {
       const allowed = fields.flat(Infinity);
       const result = {};
+
+      // A field that is not a name used to be dropped rather than refused
+      check('req.permit', [allowed]);
+
+      // ... and a hole is the trap the list cannot say on its own: with no
+      // field at all `permit()` answers everything the action declared, so
+      // one stray `undefined` used to turn that into `{}` -- a write that
+      // quietly saves nothing
+      if (allowed.includes(undefined)) {
+        throw fail(
+          'HENRI_ARGUMENT_INVALID',
+          'req.permit(fields) was given nothing where a field name was meant: with no field at all it answers everything the action declared, and one undefined empties it'
+        );
+      }
 
       if (allowed.length === 0 && accepted) {
         return Object.assign({}, accepted);

--- a/packages/core/src/base/reporting.js
+++ b/packages/core/src/base/reporting.js
@@ -235,7 +235,8 @@ class Reporter {
     const handler = this._handler;
 
     // The absence of a handler costs a property read: no payload is built,
-    // nothing is masked and nothing is remembered
+    // nothing is masked and nothing is remembered -- and nothing is checked
+    // either, because a report nobody is listening to has no wrong call
     if (typeof handler !== 'function' || !error) {
       return false;
     }
@@ -280,9 +281,15 @@ class Reporter {
    * @memberof Reporter
    */
   payload(error, options = {}) {
-    const { meta = null, req = null, status = null } = options;
-    const source = SOURCES.includes(options.source)
-      ? options.source
+    // The one entry point `base/arguments.js` leaves lenient on purpose:
+    // this runs on a failure path, so refusing a wrong call would lose the
+    // failure it was called about. `null` used to reach the destructuring
+    // below and be logged as "the error handler threw", which named the
+    // wrong culprit and dropped the report
+    const given = options && typeof options === 'object' ? options : {};
+    const { meta = null, req = null, status = null } = given;
+    const source = SOURCES.includes(given.source)
+      ? given.source
       : 'application';
     const found = {
       at: new Date(),

--- a/types/core.test-d.ts
+++ b/types/core.test-d.ts
@@ -348,6 +348,45 @@ res.collection({ id: '1' });
 // @ts-expect-error `res.resource()` takes one record
 res.resource([{ id: '1' }]);
 
+// The public surface checks what it is called with, and the declarations say
+// the same thing: see base/arguments.js and /reference/api/#wrong-calls
+
+// @ts-expect-error `res.negotiate()` needs an html handler, a json one, or both
+res.negotiate({});
+
+// @ts-expect-error ... and a handler is a function
+res.negotiate({ json: 'nope' });
+
+// @ts-expect-error `res.render()` takes data or graphql, never both
+res.render('/tasks', { data: { tasks: [] }, graphql: '{ tasks }' });
+
+// @ts-expect-error `res.boom.*` answers a string message; the detail is second
+res.boom.badData({ title: 'is required' });
+
+// @ts-expect-error `req.pagination()` bounds are numbers
+req.pagination({ perPage: '25' });
+
+// @ts-expect-error `henri.cache.fetch()` runs a function on a miss
+henri.cache.fetch('recent', 42);
+
+// @ts-expect-error a cache lifetime is a duration, not a Date
+henri.cache.set('recent', [], { ttl: new Date() });
+
+// @ts-expect-error `henri.policies.scope()` names the policy to ask
+henri.policies.scope(null);
+
+// @ts-expect-error an encrypted value belongs to a `<Model>.<field>`
+henri.encryption.encrypt('AA-123', {});
+
+// @ts-expect-error `henri.encryption.tolerate()` takes the work to run
+henri.encryption.tolerate('nope');
+
+// @ts-expect-error an erasure strategy is one of the four henri has
+henri.privacy.erase('someone@example.test', { strategy: 'nuke' });
+
+// @ts-expect-error `henri.trail.list()` filters by what an entry holds
+henri.trail.list({ actin: 'privacy.export' });
+
 // --- controllers ------------------------------------------------------------
 
 const tasks: Controller = {

--- a/website/src/content/docs/guides/controllers.md
+++ b/website/src/content/docs/guides/controllers.md
@@ -203,6 +203,8 @@ Besides `data`, the view engine receives `user` (the public user or `null`), `pa
 
 `res.hbs(route, options)` renders a Handlebars template whatever the configured renderer, with the same options.
 
+`data` and `graphql` are one or the other, never both: the query answers the page and the data would be thrown away, so the call is refused. So is a second argument that is not an object — it used to be read as a GraphQL query, and it said so only in development. See [Wrong calls](/reference/api/#wrong-calls).
+
 ## `req.permit(...fields)`
 
 Never hand `req.body` to a model as is: a client could set `roles` or any other column. `req.permit()` returns a plain object holding only the fields you list, taken from the query string, the body and the path parameters (a path parameter wins over the body, the body over the query string). Fields that were not sent are left out, and `__proto__`, `constructor` and `prototype` are never copied.
@@ -211,6 +213,8 @@ Never hand `req.body` to a model as is: a client could set `roles` or any other 
 const data = req.permit('email', 'password', 'name');
 const same = req.permit(['email', 'password', 'name']); // arrays are flattened
 ```
+
+Every field has to be a name. One stray `undefined` — `req.permit(maybe)` where `maybe` turned out to be nothing — is refused rather than answering `{}`, which used to be a write that quietly saved nothing.
 
 `henri.params(req).permit(...)` is the same helper for code outside the middleware chain, and `henri.params(req).all()` the merged parameters, for reading only.
 
@@ -240,6 +244,8 @@ res.boom.notFound('No such task', { id: req.params.id });
 | `badGateway`        | 502    |
 | `serverUnavailable` | 503    |
 
+`message` is a string: the envelope promises one and the [OpenAPI description](/guides/openapi/) says so, so `res.boom.badData({ title: 'is required' })` is refused — the detail goes in `data`, which is the second argument.
+
 A third argument names the failure: `res.boom.notFound('No such task', null, 'HENRI_MODEL_UNKNOWN_STORE')` adds a `code` to the body. It is the same envelope the 404 and 500 handlers answer with, and a failure henri raises itself already carries its own — see [Error codes](/reference/errors/).
 
 The React `Form` reads `data.errors` of a `422` and shows each message under its field, and the `RequestError` thrown by `fetch()` exposes `message`, `statusCode` and `data`.
@@ -258,6 +264,8 @@ return res.negotiate({
   json: () => res.resource(task),
 });
 ```
+
+One of the two is required. With neither, express answers `406 Not Acceptable`, which blames the client's `Accept` header for a mistake in the controller — so henri refuses the call instead.
 
 ## `res.format(handlers)`
 

--- a/website/src/content/docs/guides/encryption.md
+++ b/website/src/content/docs/guides/encryption.md
@@ -367,7 +367,11 @@ henri encryption:rotate   # rewrite everything under the key that writes
 
 All three boot the models and nothing above them: no port is bound and no
 route is registered. `--json` on any of them prints the report for a script;
-`--dry-run`, `--model` and `--field` narrow the rotation. The work itself is
+`--dry-run`, `--model` and `--field` narrow the rotation. A `--model` or a
+`--field` that names no encrypted column is refused
+(`HENRI_ARGUMENT_UNKNOWN_TARGET`) rather than reporting
+`scanned: 0, rotated: 0` and a clean exit, which is exactly what an operator
+reads before dropping the old key. The work itself is
 `henri.encryption`, so an application can run the same walk from a job.
 
 `encryption:status` opens nothing -- the key id is in the clear inside every

--- a/website/src/content/docs/guides/mail.md
+++ b/website/src/content/docs/guides/mail.md
@@ -137,7 +137,7 @@ await henri.mailers.welcome.confirm(user).deliverLater();
 await henri.mailers.welcome.confirm(user).deliverLater({ wait: '10m' });
 ```
 
-The options of the call are the options of an enqueue, so `wait`, `at`, `queue` and `priority` all work; `henri jobs` sends them. See [Jobs](/guides/jobs/#delivering-mail-through-the-queue). Without a queue there is nothing to hold a message back, so a call carrying a `wait` or an `at` is refused and says to install the package rather than sending the mail now; `deliverLater()` on its own delivers out of band, as below.
+The options of the call are the options of an enqueue, so `wait`, `at`, `queue` and `priority` all work — and only those four: a misspelled `wait` used to be ignored, which is a mail that leaves immediately, so an option henri does not know is now refused and the right name is suggested. `henri jobs` sends them. See [Jobs](/guides/jobs/#delivering-mail-through-the-queue). Without a queue there is nothing to hold a message back, so a call carrying a `wait` or an `at` is refused and says to install the package rather than sending the mail now; `deliverLater()` on its own delivers out of band, as below.
 
 Another queue plugs into the same seam:
 
@@ -176,7 +176,7 @@ Set `"mail": "test"` to use an [Ethereal](https://ethereal.email/) fake account:
 
 ## Sending without a mailer
 
-`henri.mail.send()` is unchanged and still takes a nodemailer message:
+`henri.mail.send()` still takes a nodemailer message, and now refuses one with no recipient (`HENRI_MAIL_NO_RECIPIENT`): under `NODE_ENV=test` the transport is nodemailer's json one, which happily "sends" a message nobody will ever receive, so a missing `to` used to be invisible until production.
 
 ```js
 await henri.mail.send({

--- a/website/src/content/docs/guides/privacy.md
+++ b/website/src/content/docs/guides/privacy.md
@@ -330,6 +330,12 @@ module.exports = {
 };
 ```
 
+`who` is an email address, an external id, or the record itself. A record is
+taken as the person it is, without a lookup, so one that carries no primary
+key names nobody and is refused (`HENRI_PRIVACY_UNKNOWN_SUBJECT`) — it used
+to reach the erasure as `{ id: undefined }`, which on some adapters is every
+row.
+
 It also answers what the map holds: `henri.privacy.keys` (every personal field
 name), `henri.privacy.private` (the ones that never leave), `henri.privacy.fields('User')`,
 `henri.privacy.describe()` and `henri.privacy.plan(who)`.

--- a/website/src/content/docs/guides/retention.md
+++ b/website/src/content/docs/guides/retention.md
@@ -181,6 +181,11 @@ recurring `henri/retention` job itself:
 const receipt = await henri.retention.sweep({ only: 'Proposal' });
 ```
 
+An `only` that matches no rule is refused (`HENRI_ARGUMENT_UNKNOWN_TARGET`),
+and the message lists the rules there are. A typo used to report a clean,
+successful, empty run — which is exactly what a cron line doing nothing looks
+like from the outside. Same for `henri retention:sweep --only=Propsal`.
+
 The queue is a package an application installs, so henri never assumes it.
 The boot line says which of the three it is, by name:
 

--- a/website/src/content/docs/reference/api.md
+++ b/website/src/content/docs/reference/api.md
@@ -66,6 +66,69 @@ On the instance itself: `henri.env`, `isProduction`, `isDev`, `isTest`, `release
 | `res.negotiate({ html, json })`                                     | Runs `html` for browsers and `json` for API clients.                                                                                                                                                                                                                                                                                                                                                              |
 | `res.format(handlers)`                                              | Express content negotiation; put `json` before `html`.                                                                                                                                                                                                                                                                                                                                                            |
 
+## Wrong calls
+
+Every entry point on this page checks what it is called with. JavaScript is
+not strongly typed and TypeScript erases at runtime, so henri validates
+exhaustively at its boundaries and trusts what is inside — the
+[configuration](/configuration/) at boot, the
+[request](/guides/controllers/#params-what-an-action-accepts) a controller
+answers, and the calls an application makes.
+
+A call henri cannot honour raises `HENRI_ARGUMENT_INVALID` naming the method,
+the argument, what was expected and what arrived:
+
+```
+henri.cache.fetch(fn) must be a function, but it is the number 42
+req.pagination(overrides.perPage) must be a whole number above zero, but it is the string "abc"
+res.render(options) must be an object, but it is the string "oops"
+```
+
+Every problem is reported, not the first one. An `async` method rejects with
+it, which is what its caller is already handling; a synchronous one throws,
+and inside a controller that reaches the client as the 500 the code names.
+
+Four rules are worth knowing, because they are what people bump into:
+
+- **`null` is not the same as absent.** `res.resource(record, null)` is
+  refused: `options = {}` only fills in for `undefined`, so a `null` used to
+  go straight through to the line that broke.
+- **Inside an options bag, a selector or a switch does take `null`** — a
+  caller that computes an option and comes up with nothing should not have to
+  delete the key — **and a key whose absence has a default does not**, because
+  `{ include: null }` and no `include` at all are genuinely different there.
+- **A misspelled option is refused, and named.**
+  `henri.privacy.erase(who, { stratgy: 'delete' })` says _did you mean
+  "options.strategy"?_. An option henri does not know and that is nothing like
+  one it does is left alone, the way the configuration leaves an application's
+  own keys alone.
+- **A selector that names nothing is refused too**, with
+  `HENRI_ARGUMENT_UNKNOWN_TARGET`: `henri.retention.sweep({ only: 'Propsal' })`
+  used to report a clean, successful, empty run, which is exactly what somebody
+  reads as the work being done.
+
+Some entry points refuse on their own terms instead, and keep doing so: a bad
+cache key is `HENRI_CACHE_KEY_INVALID`, a value the cache cannot store is
+`HENRI_CACHE_VALUE_UNSUPPORTED`, a trail entry with no action is
+`HENRI_TRAIL_INVALID_EVENT`, an unknown mailer is `HENRI_MAIL_UNKNOWN_MAILER`.
+Some are deliberately total and answer `null` or `false` rather than throwing:
+`henri.model.errors()`, `henri.policies.get()`, `henri.config.has()`,
+`henri.reporter.onError()`. And one is deliberately lenient:
+`henri.reporter.report()` runs on a failure path, so refusing a wrong call
+there would lose the failure it was called about.
+
+Where a check goes follows one rule: **never inside a loop of henri's own**.
+`res.collection(records)` checks that it was given a list and stops there;
+the rows are the serializer's business, and one assertion per row to catch a
+mistake the call itself announces is the wrong trade. The checks run in
+production too — the cost is a `typeof` per argument on entry points that are
+followed by I/O, and a check that only ran in development would be missing
+from the one place a wrong call is expensive.
+
+The signatures live in `@usehenri/core`'s `src/base/arguments.js`, as data,
+and `src/__tests__/arguments.spec.js` calls every one of them with garbage:
+a public method that forgets its check fails that test.
+
 ## The controller file
 
 ```js

--- a/website/src/content/docs/reference/errors.md
+++ b/website/src/content/docs/reference/errors.md
@@ -207,6 +207,35 @@ Usually:
 
 **Fix.** Pass one record (a model instance or a plain object) and use `res.collection()` for lists; outside a `resources` route name the type: `res.resource(record, { type: 'tasks' })`.
 
+## argument
+
+The arguments a public method of henri was called with.
+
+### `HENRI_ARGUMENT_INVALID`
+
+A public method of henri was called with something it cannot honour.
+
+Usually:
+
+- an argument of the wrong type, or one that is missing
+- null where an options object was meant, which no default fills in
+- a misspelled key in an options object (`stratgy` for `strategy`)
+- a value out of the bounds the method accepts
+
+**Fix.** The message names the method, the argument, what was expected and what arrived. Fix the call; the signature of every entry point is in packages/core/src/base/arguments.js and on the API reference page.
+
+### `HENRI_ARGUMENT_UNKNOWN_TARGET`
+
+A call named something to work on and this application has nothing by that name.
+
+Usually:
+
+- a typo in `retention.plan({ only })` or `retention.sweep({ only })`
+- a typo in `encryption.rotate({ model, field })`
+- a model or a rule that was renamed and not renamed here
+
+**Fix.** The hint lists what the option could have named. henri refuses rather than reporting a clean run over nothing, because an empty success is what makes somebody believe the work is done.
+
 ## boot
 
 The module graph and the boot sequence: registration, ordering, dependencies.

--- a/website/src/content/docs/reference/errors.md
+++ b/website/src/content/docs/reference/errors.md
@@ -1016,6 +1016,18 @@ Usually:
 
 **Fix.** A mailer action returns the message it wants sent: `return { to, subject, data }`. Everything else it holds is passed to nodemailer.
 
+### `HENRI_MAIL_NO_RECIPIENT`
+
+A message was sent to nobody.
+
+Usually:
+
+- a mailer action that built its message without a `to`
+- a `to` read from a record that turned out to be null
+- a message assembled by hand and handed to henri.mail.send()
+
+**Fix.** Give the message a `to`, a `cc` or a `bcc`. Under NODE_ENV=test the transport is nodemailer's json one, which accepts a message nobody will ever receive, so this is refused before it gets there.
+
 ### `HENRI_MAIL_NO_TRANSPORT`
 
 A message was sent and no transport was ever built.


### PR DESCRIPTION
Step 3 of the owner's input-checking order, after the configuration at boot (#345) and the request boundary (#388). The boundary here is every entry point an application calls: 73 of them, inventoried in one table, 34 checked, 4 exempt because their one argument is already refused by a code of its own, and 35 listed as `UNCHECKED` **with the reason** -- the ones that already refuse well, the deliberately total ones, and `henri.pen` and `henri.utils` wholesale.

The mechanism is not a second schema language: `config-validate.js` gained a `problems(node, value, key)` walk over one value, so the vocabulary of `config-schema.js` serves both, plus the two kinds a call can pass and a JSON file cannot (`function`, `date`).

## It is not a message improvement. Eight of these ran and did the wrong thing.

- `res.negotiate({})` answered **406**, blaming the client's `Accept` header for a controller's bug.
- `res.render(route, 'oops')` executed the string as a **GraphQL query**, warning only in development; passing `data` and `graphql` together silently discarded the data.
- `res.resource(record, null)` threw a destructuring `TypeError` over the good message underneath it, and **a non-array `include` reached a substring match that un-hides a field marked `expose: false`**.
- `henri.privacy.erase({})` reached an `unsafe: true` mass update as `{ id: undefined }`.
- `req.pagination({ perPage: 'abc' })` produced **NaN** into the ORM and into the HAL links.
- `mail.send` with no recipient **succeeded** under `NODE_ENV=test`; a misspelled `deliverLater({ delay })` sent the mail immediately.
- `cache.fetch` rejected a bad `ttl` *after* running the function, throwing the value away.

## Verified here, not on report

The two that touch data rather than ergonomics, checked myself:

- **The `include` hole is real and worse than a substring curiosity.** On master the strip is `if (names.has(key) && !keep.includes(key))`, so `keep` being a *string* makes that a substring test in the wrong direction: `res.resource(record, { include: 'name,phone' })` -- a comma list is the natural mistake -- reads as `'name,phone'.includes('phone')` and **keeps a field the model marked `expose: false`**. On this branch every non-list is refused, and I confirmed on a booted showcase that `include: []` still drops `phone` while `['phone']` still keeps it.
- **The empty subject really did name everybody.** Master's `subject({})` returns `{}`, `whereFor` reads `subject[primary]` as `undefined`, and the erasure's writes are `unsafe: true` mass updates. I checked the primitive on the adapter rather than reasoning about it: on a booted demo application, `User.find({ id: undefined })` answers **3 of 3 rows**. The branch refuses a record carrying no primary key with `HENRI_PRIVACY_UNKNOWN_SUBJECT`, and the comment says exactly why.

## Judgement calls, which were the point

**Hot paths**: never inside a loop of henri's own -- `res.collection` checks the list, not the rows. The two entry points that sit on a loop that is *not* henri's (the adapters call `encryption.encrypt`/`decrypt` per row per column) are guarded by hand with three `typeof`s and no allocation, and say so in `UNCHECKED`. `policies.can` was split so `links()` and `paths()` ask `answer()` once per link without re-checking.

**Production cost**: they always run. Compiling them out needs a build step core does not have -- the source is what ships -- and a check absent from production is missing from the one place a wrong call is expensive.

**Internal calls**: checked once, at the method the application names. One deliberate exception: `henri.reporter.report` is *lenient*, because it runs on a failure path and refusing there would lose the failure it was reporting.

## What keeps it honest

`arguments.spec.js` (81 tests) asserts three things: every method `index.d.ts` declares is in one of the two tables or takes no argument; every declared signature is checked somewhere in the source; and every entry point is **called with garbage on a booted demo app**, with the poison derived from its own declaration -- so a signature added tomorrow is exercised for free.

`pnpm test` (143 files), `pnpm test:sql`, `pnpm test:types`, `pnpm lint --max-warnings 0`, `pnpm format:check`, the showcase suite and `scripts/smoke.sh` all pass.

## Named, not fixed

The user module and the account flows are in an explicit `NOT_WALKED` list, and two surveys of them turned up real problems: `henri.user.compare(password, badUser)` answers a bad user with the same bare uncoded error a wrong password gets; `publicUser(42)` returns a user-shaped object with `id: "undefined"`; `accounts.urlFor(42)` builds `https://host42`; and `accounts.tokenFor(user, 'typo')` mints a token nothing can ever consume. That is the next pass and it is on the plan.
