### PR TITLE
A name is matched literally, backslash included

### DIFF
--- a/packages/cli/__tests__/doctor.spec.js
+++ b/packages/cli/__tests__/doctor.spec.js
@@ -8,6 +8,7 @@ const {
   definesGraphql,
   exportsOf,
   ignores,
+  imports,
   looksPlural,
   mailerActions,
   moduleDeclaration,
@@ -161,6 +162,23 @@ module.exports = {
   // What the stripper protects, with nothing to fall back on: a mailer whose
   // `defaults` carries a url would otherwise have no actions at all, and
   // `mailers.view` would quietly stop looking
+  test('matches a package name literally, backslash included', () => {
+    // The escape covered `/`, `@` and `-` and not `\\`, so a name holding one
+    // made the character after it an escape sequence of the name's choosing
+    expect(imports("import x from '@usehenri/react';", '@usehenri/react')).toBe(
+      true
+    );
+    expect(
+      imports("import x from '@usehenri/inertia';", '@usehenri/react')
+    ).toBe(false);
+    // `.` is not a wildcard, `+` is not a repetition, and a backslash is a
+    // backslash: each of these matches itself and nothing else
+    expect(imports("require('a.b')", 'a.b')).toBe(true);
+    expect(imports("require('axb')", 'a.b')).toBe(false);
+    expect(imports("require('a\\\\d')", 'a\\\\d')).toBe(true);
+    expect(imports("require('a1')", 'a\\\\d')).toBe(false);
+  });
+
   test('finds the actions of a mailer whose defaults carry a url', () => {
     expect(
       mailerActions(`module.exports = {

--- a/packages/cli/scripts/doctor.js
+++ b/packages/cli/scripts/doctor.js
@@ -528,6 +528,22 @@ const listSources = (dir, extensions) => {
 };
 
 /**
+ * A string as a regular expression matches itself and nothing else.
+ *
+ * Every metacharacter, `\\` included: escaping the few that happen to appear
+ * in a package name is the same bug as not escaping at all, one input away,
+ * and an unescaped backslash turns the next character into an escape
+ * sequence of somebody else's choosing. `@`, `/` and `-` are *not* escaped:
+ * they mean themselves outside a character class, and a unicode pattern
+ * refuses an escape that is not one.
+ *
+ * @param {string} value The string to match literally
+ * @returns {string} The pattern
+ */
+const literally = (value) =>
+  String(value).replace(/[\\^$.*+?()[\]{}|]/gu, '\\$&');
+
+/**
  * Does a source import a package, by either spelling and at any sub-path?
  * (`from '@usehenri/react'`, `require('@usehenri/react/forms')`)
  *
@@ -537,7 +553,8 @@ const listSources = (dir, extensions) => {
  */
 const imports = (source, name) =>
   new RegExp(
-    `(?:from|require\\()\\s*\\(?\\s*['"]${name.replace(/[/@-]/g, '\\$&')}(?:/[^'"]*)?['"]`
+    `(?:from|require\\()\\s*\\(?\\s*['"]${literally(name)}(?:/[^'"]*)?['"]`,
+    'u'
   ).test(uncommented(source));
 
 /**
@@ -549,7 +566,9 @@ const imports = (source, name) =>
  * @returns {boolean} Defined or not
  */
 const definesAction = (source, action) =>
-  new RegExp(`(^|[\\s,{])(async\\s+)?${action}\\s*[:(]`, 'm').test(source);
+  new RegExp(`(^|[\\s,{])(async\\s+)?${literally(action)}\\s*[:(]`, 'mu').test(
+    source
+  );
 
 /**
  * Does a model source declare a `graphql` key?
@@ -2351,3 +2370,4 @@ module.exports.moduleDeclaration = moduleDeclaration;
 module.exports.policyFor = policyFor;
 module.exports.storeOf = storeOf;
 module.exports.uncommented = uncommented;
+module.exports.imports = imports;


### PR DESCRIPTION
CodeQL raised `js/insufficient-escaping` (high) on `packages/cli/scripts/doctor.js:540` from #394, which I merged before reading the result — my mistake, and the reason this is a follow-up rather than a fixup.

The two readers that build a regular expression from a name escaped `/`, `@` and `-` and **not** `\\`: a name carrying a backslash turned the character after it into an escape sequence of the name's choosing, and an unescaped `.` matched any character. The names are henri's own constants today (`@usehenri/react`, `@usehenri/inertia`, and the action names of a routes file), so this is a defect and not an incident — and that is exactly the argument for fixing it rather than dismissing it, because the reader takes a string and the caller decides which.

`literally()` now escapes every metacharacter and only metacharacters. `@`, `/` and `-` are deliberately not escaped: they mean themselves outside a character class, and a `u` pattern **refuses** an escape that is not one — which is the mistake the first version of this fix made, caught by the suite before it left the machine.

A test pins it: a package name matches itself and not its sibling, `a.b` does not match `axb`, and `a\\d` does not match `a1`. Reverting the escape turns it red along with five other doctor tests.

`pnpm test` (143 files), `pnpm lint --max-warnings 0` and `pnpm format:check` pass.