### PR TITLE
Call logs, inbound and outbound

### DIFF
--- a/.changeset/call-logs.md
+++ b/.changeset/call-logs.md
@@ -1,0 +1,41 @@
+---
+'@usehenri/core': minor
+'@usehenri/cli': minor
+'@usehenri/webhooks': minor
+'@usehenri/drizzle': patch
+---
+
+Call logs, inbound and outbound: `henri.calls`.
+
+Two records joined by the request id henri already threads through everything — the call an application answered, and every call it made because of it — so that "what happened during request `X`" is one question with one answer:
+
+```bash
+henri calls 018f5c2e-1f2a-7c31-9f0a-2b7c1d3e4f56
+```
+
+```
+  2026-09-06T14:22:31.004Z  <- 201        84ms  POST   /orders
+  2026-09-06T14:22:31.019Z  -> 200        41ms  POST   https://api.billing.test/v1/charges
+                              service billing
+  2026-09-06T14:22:31.062Z  -> 200        12ms  POST   https://hooks.example.test/orders
+                              service webhooks
+```
+
+Both directions live in one table henri owns (`henri_calls`, a `direction` column), reached through the store adapter's `query()` or a MongoDB collection the way the access trail reaches its own. One table rather than two because the join is the whole point: one `SELECT` on one index instead of two reads and a merge.
+
+**It is the deliberate opposite of the access trail, and the guide says so in its first paragraph.** The trail records field _names_, counts and digests and refuses a value; it is hash-chained evidence kept for a year. A call log holds **values** — the body that came in, the body that went out — because one that does not is a slower copy of the web server's access log. It is a debugging instrument: sampled, capped, kept for thirty days, and never evidence of anything. Neither substitutes for the other.
+
+Four bounds keep it from being a denial of service, and each of them is a decision rather than a default:
+
+- **Off unless configured.** No `config.calls`, no table, no middleware, no allocation. When it is on, the middleware is mounted right after the request id and before everything else, so a request refused by the rate limit, the body parser or the CSRF check — exactly the one worth having — is in the log.
+- **The write never blocks the answer.** A finished call goes onto a bounded buffer and the response goes out; a timer writes with one multi-row `INSERT`. A flush that fails is reported once and dropped rather than retried, because a call log that can fail a request turns a database hiccup into an outage. What the buffer drops is counted, and `henri calls:stats` says so.
+- **The payload is capped before it is stored** (`calls.maxBody`, 8kb, with a truncation marker), and only a body henri can _walk_ is stored at all — a plain object or an array is redacted key by key, a string, a buffer or an HTML page is a size and a shape. That is why the response body is taken from `res.json(value)` rather than off the socket.
+- **What one client can cause is bounded twice.** `calls.sample` bounds the steady state proportionally; `calls.maxPerSecond` is an absolute per-process ceiling, because one percent of a million requests a second is still ten thousand rows a second. The sampling decision is a hash of the request id **seeded with `config.secret`**: a hash so the inbound call and every outbound call it caused agree in every process without carrying state, and seeded because the request id comes from a header a client chooses. `calls.always` keeps the failures sampling dropped, without their bodies.
+
+It holds values, so the redaction is the feature. Everything stored goes through the redactor of `config.filterParameters` and the `personal` marks, at every depth, and on top of that `authorization`, `proxy-authorization`, `cookie`, `set-cookie`, `x-csrf-token`, `x-api-key` and `webhook-signature` are masked whatever the configuration says, a url loses its userinfo, and the person is their `externalId` and never an address.
+
+`calls.keep` (30 days) is pruned by the retention sweep, and **where the dialect has range partitions it drops periods instead of rows**: `calls.partition: "day"` on PostgreSQL and MySQL makes the sweep a metadata operation whatever the table held, which is the difference between a sweep that works at ten million rows and one that times out. There is always a catch-all partition, so no row is ever refused for want of one. sqlite, SQL Server and MongoDB have no ranges and get a bounded delete loop; asking them to partition fails the boot rather than being ignored.
+
+henri wraps nobody's HTTP client: `henri.calls.track()` and `henri.calls.outbound()` are the seam, two lines around whatever an application already uses. The calls henri makes itself are populated without anything to write — every mail send, and every webhook delivery attempt, whose request id is stamped into the delivery job at `emit()` time so a delivery three retries later still joins the request that caused it.
+
+`henri calls [<request-id>]`, `henri calls:stats` and `henri calls:sweep --yes` are the commands, `config.calls` is the configuration, and the guide is [Call logs](https://usehenri.io/guides/calls/).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,30 +74,30 @@ has to be named per record or per process. An application's own suite keeps
 
 ## Layout
 
-| Path                           | Package               | Role                                                                                                                                                                                                                                                  |
-| ------------------------------ | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `packages/henri`               | `henri`               | The CLI binary users install; delegates to `@usehenri/cli`.                                                                                                                                                                                           |
-| `packages/cli`                 | `@usehenri/cli`       | `new`, `init`, `server`, `console`, `routes`, `openapi`, `generate` (incl. `authentication`), `destroy`, `build`, `test`, `db`, `jobs`, `webhooks`, `privacy`, `encryption`, `doctor`, `audit`, `mcp`, `clean`, `about`, `analyze`; the app templates |
-| `packages/core`                | `@usehenri/core`      | The framework: modules, server, router, models, views, users, policies, mail                                                                                                                                                                          |
-| `packages/mongoose`            | `@usehenri/mongoose`  | MongoDB adapter (Mongoose 9)                                                                                                                                                                                                                          |
-| `packages/disk`                | `@usehenri/disk`      | Zero-config local MongoDB (mongodb-memory-server) on top of mongoose                                                                                                                                                                                  |
-| `packages/drizzle`             | `@usehenri/drizzle`   | henri's SQL data layer: Drizzle ORM (sqlite, postgres, mysql) with drizzle-kit migrations (`henri db:*`). The default of `henri new`, on sqlite                                                                                                       |
-| `packages/postgresql`, `mysql` | `@usehenri/*`         | `@usehenri/drizzle` with the dialect and the driver chosen; `mariadb` is served by `@usehenri/mysql`                                                                                                                                                  |
-| `packages/sequelize`           | `@usehenri/sequelize` | Sequelize 6, only under `@usehenri/mssql`: Drizzle has no SQL Server dialect                                                                                                                                                                          |
-| `packages/mssql`               | `@usehenri/mssql`     | SQL Server, on `@usehenri/sequelize`. No migrations; `henri db:status` reports the drift                                                                                                                                                              |
-| `packages/react`               | `@usehenri/react`     | Next.js 16 view engine (pages router), `withHenri`, `useHenri`, form components; supported and frozen                                                                                                                                                 |
-| `packages/inertia`             | `@usehenri/inertia`   | Inertia.js view engine on Vite + React 19; the default renderer of `henri new`                                                                                                                                                                        |
-| `packages/jobs`                | `@usehenri/jobs`      | Background jobs: a database backed queue with retries, a dead letter queue and recurring jobs (`henri jobs`), new in 1.1; ships its own module, left core in 1.2                                                                                      |
-| `packages/graphql`             | `@usehenri/graphql`   | GraphQL: the models' types and resolvers merged and served by Apollo Server; left core in 1.2                                                                                                                                                         |
-| `packages/webhooks`            | `@usehenri/webhooks`  | Outbound webhooks: endpoints henri stores, Standard Webhooks signatures, an SSRF check at request time; delivers through the queue, new in 1.2                                                                                                        |
-| `packages/uploads`             | `@usehenri/uploads`   | File uploads: bounded multipart parsing (busboy), files typed by their bytes and a storage seam; ships its own module, new in 1.2                                                                                                                     |
-| `packages/redis`               | `@usehenri/redis`     | The shared store of `config.shared`: the rate limit, the sign-in lockout and the idempotency keys counted in Redis instead of one process                                                                                                             |
-| `packages/testing`             | `@usehenri/testing`   | Boots an app for Vitest and binds supertest to it                                                                                                                                                                                                     |
-| `packages/mcp`                 | `@usehenri/mcp`       | `henri mcp`: stdio MCP server exposing routes, models, generators, tests and doctor to coding agents                                                                                                                                                  |
-| `packages/websocket`           | private               | Not published, never wired into core                                                                                                                                                                                                                  |
-| `packages/demo`                | private               | Demo app used by core's tests (`NODE_ENV=test` chdirs into it)                                                                                                                                                                                        |
-| `showcase`                     | private               | Lineup, the showcase application (Inertia + Drizzle on PostgreSQL); its own suite, `pnpm test:showcase`                                                                                                                                               |
-| `website`                      | private               | usehenri.io, deployed by Vercel from `website/`, master only (`vercel.json`)                                                                                                                                                                          |
+| Path                           | Package               | Role                                                                                                                                                                                                                                                           |
+| ------------------------------ | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/henri`               | `henri`               | The CLI binary users install; delegates to `@usehenri/cli`.                                                                                                                                                                                                    |
+| `packages/cli`                 | `@usehenri/cli`       | `new`, `init`, `server`, `console`, `routes`, `openapi`, `generate` (incl. `authentication`), `destroy`, `build`, `test`, `db`, `jobs`, `webhooks`, `privacy`, `encryption`, `calls`, `doctor`, `audit`, `mcp`, `clean`, `about`, `analyze`; the app templates |
+| `packages/core`                | `@usehenri/core`      | The framework: modules, server, router, models, views, users, policies, mail                                                                                                                                                                                   |
+| `packages/mongoose`            | `@usehenri/mongoose`  | MongoDB adapter (Mongoose 9)                                                                                                                                                                                                                                   |
+| `packages/disk`                | `@usehenri/disk`      | Zero-config local MongoDB (mongodb-memory-server) on top of mongoose                                                                                                                                                                                           |
+| `packages/drizzle`             | `@usehenri/drizzle`   | henri's SQL data layer: Drizzle ORM (sqlite, postgres, mysql) with drizzle-kit migrations (`henri db:*`). The default of `henri new`, on sqlite                                                                                                                |
+| `packages/postgresql`, `mysql` | `@usehenri/*`         | `@usehenri/drizzle` with the dialect and the driver chosen; `mariadb` is served by `@usehenri/mysql`                                                                                                                                                           |
+| `packages/sequelize`           | `@usehenri/sequelize` | Sequelize 6, only under `@usehenri/mssql`: Drizzle has no SQL Server dialect                                                                                                                                                                                   |
+| `packages/mssql`               | `@usehenri/mssql`     | SQL Server, on `@usehenri/sequelize`. No migrations; `henri db:status` reports the drift                                                                                                                                                                       |
+| `packages/react`               | `@usehenri/react`     | Next.js 16 view engine (pages router), `withHenri`, `useHenri`, form components; supported and frozen                                                                                                                                                          |
+| `packages/inertia`             | `@usehenri/inertia`   | Inertia.js view engine on Vite + React 19; the default renderer of `henri new`                                                                                                                                                                                 |
+| `packages/jobs`                | `@usehenri/jobs`      | Background jobs: a database backed queue with retries, a dead letter queue and recurring jobs (`henri jobs`), new in 1.1; ships its own module, left core in 1.2                                                                                               |
+| `packages/graphql`             | `@usehenri/graphql`   | GraphQL: the models' types and resolvers merged and served by Apollo Server; left core in 1.2                                                                                                                                                                  |
+| `packages/webhooks`            | `@usehenri/webhooks`  | Outbound webhooks: endpoints henri stores, Standard Webhooks signatures, an SSRF check at request time; delivers through the queue, new in 1.2                                                                                                                 |
+| `packages/uploads`             | `@usehenri/uploads`   | File uploads: bounded multipart parsing (busboy), files typed by their bytes and a storage seam; ships its own module, new in 1.2                                                                                                                              |
+| `packages/redis`               | `@usehenri/redis`     | The shared store of `config.shared`: the rate limit, the sign-in lockout and the idempotency keys counted in Redis instead of one process                                                                                                                      |
+| `packages/testing`             | `@usehenri/testing`   | Boots an app for Vitest and binds supertest to it                                                                                                                                                                                                              |
+| `packages/mcp`                 | `@usehenri/mcp`       | `henri mcp`: stdio MCP server exposing routes, models, generators, tests and doctor to coding agents                                                                                                                                                           |
+| `packages/websocket`           | private               | Not published, never wired into core                                                                                                                                                                                                                           |
+| `packages/demo`                | private               | Demo app used by core's tests (`NODE_ENV=test` chdirs into it)                                                                                                                                                                                                 |
+| `showcase`                     | private               | Lineup, the showcase application (Inertia + Drizzle on PostgreSQL); its own suite, `pnpm test:showcase`                                                                                                                                                        |
+| `website`                      | private               | usehenri.io, deployed by Vercel from `website/`, master only (`vercel.json`)                                                                                                                                                                                   |
 
 ## How core works
 
@@ -142,7 +142,7 @@ afterLogin, sessionMaxAge, signup, passwordReset, confirmation }`),
   `baseRole`, `externalIds`, `policies`, `trustProxy`, `csrf`, `graphql`,
   `mail`, `mailers`, `api`, `jobs`, `webhooks`, `rateLimit`, `shared`,
   `cache`, `helmet`, `csp`, `filterParameters`, `encryption`, `privacy`,
-  `retention`, `trail`, `bodyLimit`, `uploads`, `requestTimeout`,
+  `retention`, `trail`, `calls`, `bodyLimit`, `uploads`, `requestTimeout`,
   `shutdown`, `errors`.
 - The configuration is validated at boot, before any other module starts:
   `base/config-schema.js` declares every key henri owns (as data, in the order
@@ -480,6 +480,41 @@ model }` or Mongoose's `ref` -- which `res.render()`, `res.resource()`,
   prefix plus a `trail.pruned` checkpoint. `henri trail`,
   `henri trail:about <who>` and `henri trail:verify` read it back, and the
   guide is `guides/trail.md`.
+- The call log is `4.calls.js` (`henri.calls`), `base/calls.js` and
+  `base/call-store.js`, off unless `config.calls` says otherwise. It is the
+  **deliberate opposite of the trail**: two records -- the call an
+  application answered and every call it made -- joined by the request id,
+  in one table (`henri_calls`, a `direction` column) that henri owns the way
+  the trail owns its own, and it holds **values** where the trail refuses
+  them. Four bounds keep it from being a denial of service and each is
+  argued in the module header: off unless configured (`2.server.js` mounts
+  the middleware right after `requestId()`, and only then, so a request the
+  rate limit refused is in the log); the write never blocks the answer (a
+  bounded buffer, a multi-row `INSERT` on a timer, a failed flush dropped
+  rather than retried and never able to fail a request); the payload capped
+  (`calls.maxBody`, and only a body the redactor can _walk_ is stored at
+  all, which is why the response body comes from `res.json(value)` rather
+  than off the socket); and what one client can cause bounded twice --
+  `calls.sample`, a hash of the request id **seeded with `config.secret`**
+  so the inbound call and its outbound calls agree and a chosen
+  `X-Request-Id` cannot buy its way into the sample, plus
+  `calls.maxPerSecond`, an absolute per-process ceiling, with
+  `calls.always` keeping the failures sampling dropped (without their
+  bodies). Everything stored goes through `redactor(henri)` and, on top of
+  it, `authorization`/`cookie`/`set-cookie`/`x-csrf-token`/`x-api-key`/
+  `webhook-signature` are masked whatever `filterParameters` says, a url
+  loses its userinfo and the person is their `externalId`. `calls.keep`
+  (30d) is pruned by the retention sweep, and where the dialect has ranges
+  (`calls.partition`, PostgreSQL and MySQL) the sweep drops whole periods
+  instead of rows -- with a catch-all partition so no row is ever refused,
+  and a period the sweep dropped never coming back, because MySQL keeps its
+  ranges in increasing order. `henri.calls.track()`/`outbound()` is the seam
+  an application's own HTTP client goes through (henri wraps nobody's
+  client); the mail transport and the webhook deliveries use it themselves,
+  and `emit()` stamps the request id into the delivery job so an
+  asynchronous delivery still joins. `henri calls <request-id>`,
+  `henri calls:stats` and `henri calls:sweep` read it back, and the guide is
+  `guides/calls.md`.
 - Encrypted attributes live in `1.encryption.js` (`henri.encryption`,
   runlevel 1, so a model that declares one finds a keyring already built),
   `base/encryption.js` (the envelope) and `base/rewrap.js` (the rotation
@@ -812,12 +847,14 @@ the LICENSE and a README into every public package at publish time
   reports a column change without a statement because it has no
   `ALTER COLUMN`.
 - The tables henri owns in a drizzle store (`henri_jobs`,
-  `henri_jobs_schedules`, `henri_trail`) are created through raw SQL, so
-  drizzle-kit sees them as tables the schema no longer wants.
-  `Drizzle#reservedTables()` is what keeps a push from dropping them; a
-  table an application renames through `jobs.table` or `trail.table` is
-  read from the configuration, and anything else henri comes to own has to
-  be added there.
+  `henri_jobs_schedules`, `henri_trail`, `henri_calls`) are created through
+  raw SQL, so drizzle-kit sees them as tables the schema no longer wants.
+  `Drizzle#reservedTables()` is what keeps a push from dropping them, and
+  `reservedPrefixes()` covers the one set of names henri cannot write down
+  in advance (the partitions of a partitioned call log, one PostgreSQL
+  table per period); a table an application renames through `jobs.table`,
+  `trail.table` or `calls.table` is read from the configuration, and
+  anything else henri comes to own has to be added there.
 - drizzle-kit does not alter a mysql table on a push: `henri db:push` and the
   development boot create the tables that are missing and report the ones
   whose columns drifted (`Migrations#completeMySQLPlan`); a mysql schema
@@ -868,5 +905,15 @@ the LICENSE and a README into every public package at publish time
   `mongo.spec.js`; `pnpm test:sql:live` runs the SQL ones on real servers with
   concurrent connection pools). MSSQL only has its generated DDL and claim
   statement covered offline, like the rest of that adapter.
+- The call log (`config.calls`) is new. Its table, its join, its bodies and
+  its bounded delete are covered on sqlite offline and on the live
+  PostgreSQL and MySQL of `pnpm test:sql:live`
+  (`packages/drizzle/__tests__/calls.spec.js`), and on MongoDB through the
+  demo application core's suite boots. The **partitions only exist on
+  PostgreSQL and MySQL**, so that half of the suite is skipped offline;
+  MSSQL has neither partitions nor coverage beyond its generated DDL, like
+  the rest of that adapter. There is no tracing (no span, no propagation
+  header: the join is the request id and nothing more), no capture of a
+  streamed or non-JSON body, and no cross-process ceiling.
 - The scaffolded app pins ESLint 9 because `eslint-plugin-react` does not
   support ESLint 10 yet.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -248,6 +248,26 @@ module.exports = [
     },
   },
   {
+    // And so does the call log: a row is the snake_case columns of
+    // base/call-store.js, and the header names of an exchange are whatever
+    // the wire calls them
+    files: [
+      'packages/core/src/base/call-store.js',
+      'packages/core/src/base/calls.js',
+      'packages/core/src/__tests__/calls.spec.js',
+    ],
+    rules: {
+      camelcase: 'off',
+    },
+  },
+  {
+    // ... and the key order of a compound index is the index, not a list
+    files: ['packages/core/src/base/call-store.js'],
+    rules: {
+      'sort-keys': 'off',
+    },
+  },
+  {
     // The endpoints live in a table this package owns: a row is the
     // snake_case columns of packages/webhooks/src/store/schema.js
     files: ['packages/webhooks/**/*.js'],

--- a/packages/cli/__tests__/audit.spec.js
+++ b/packages/cli/__tests__/audit.spec.js
@@ -640,6 +640,41 @@ describe('henri audit', () => {
     );
   });
 
+  test('reports a call log nothing ever sweeps, and only in production', () => {
+    // A call log holds what users sent. Its retention is part of the
+    // feature, and `keep: false` is the one spelling that takes it away
+    const { findings: found, names } = withConfig(
+      app,
+      'config/production.json',
+      { calls: { keep: false } }
+    );
+
+    expect(names).toContain('calls.kept-forever');
+    expect(found).toContainEqual(
+      expect.objectContaining({
+        asvs: 'V7.1.1',
+        check: 'calls.kept-forever',
+        file: 'config/production.json',
+        message: expect.stringContaining('without a sweep'),
+        owasp: 'A09:2021 Security Logging and Monitoring Failures',
+        severity: 'medium',
+      })
+    );
+
+    // A period, no call log at all, and a laptop keeping its own requests
+    // are all somebody's decision rather than a finding
+    expect(
+      withConfig(app, 'config/production.json', { calls: { keep: '30d' } })
+        .names
+    ).not.toContain('calls.kept-forever');
+    expect(
+      withConfig(app, 'config/production.json', { calls: false }).names
+    ).not.toContain('calls.kept-forever');
+    expect(
+      withConfig(app, 'config/dev.json', { calls: { keep: false } }).names
+    ).not.toContain('calls.kept-forever');
+  });
+
   test('reports password hashes that are not bound to their row', () => {
     // An application that turned the binding off is telling anyone who can
     // write its database that a hash copied onto another row still works

--- a/packages/cli/__tests__/calls.spec.js
+++ b/packages/cli/__tests__/calls.spec.js
@@ -1,0 +1,130 @@
+const path = require('path');
+
+const { CliError } = require('../scripts/errors');
+const { cleanup, henri, linkAdapter, tmpdir } = require('./helpers');
+const calls = require('../scripts/calls');
+
+// The same minimal application `henri db`, `henri privacy` and
+// `henri retention` run against: a drizzle store on sqlite. What it proves
+// here is the SQL half of the call log -- the table is created through
+// `adapter.query()` on a real adapter, the command reads it back, and the
+// sweep runs -- and that a log an application does not keep says so.
+const fixture = path.join(__dirname, 'fixtures', 'seed-app');
+
+describe('henri calls', () => {
+  describe('usage', () => {
+    test('a sweep removes rows, so it needs to be told twice', async () => {
+      const error = await calls
+        .sweep({ _: ['sweep'] })
+        .catch((thrown) => thrown);
+
+      expect(error).toBeInstanceOf(CliError);
+      expect(error.code).toBe('HENRI_CLI_USAGE');
+      expect(error.hint).toContain('--yes');
+    });
+  });
+
+  describe('against a real application (drizzle, sqlite)', () => {
+    let dir;
+    let env;
+
+    /**
+     * Runs a command against the fixture
+     *
+     * @param {Array<string>} args The arguments
+     * @param {object} [extra={}] Extra environment
+     * @returns {object} The result of the command
+     */
+    const run = (args, extra = {}) =>
+      henri(args, {
+        cwd: fixture,
+        env: { ...env, ...extra },
+        timeout: 120000,
+      });
+
+    beforeAll(() => {
+      linkAdapter(fixture, 'drizzle');
+      dir = tmpdir('henri-calls-');
+      env = {
+        ...process.env,
+        DATABASE_URL: `file:${path.join(dir, 'app.db')}`,
+        // The call log is off unless an application asks for it
+        HENRI_CONFIG_JSON__calls: JSON.stringify({ keep: '1d' }),
+      };
+    });
+
+    afterAll(() => {
+      cleanup(dir);
+    });
+
+    test('the table is created on the store, and it is empty', () => {
+      const { status, stdout } = run(['calls:stats', '--json']);
+      const result = JSON.parse(stdout);
+
+      expect(status).toBe(0);
+      expect(result).toMatchObject({
+        buffered: 0,
+        enabled: true,
+        partitions: [],
+        total: 0,
+        written: 0,
+      });
+    });
+
+    test('a request nobody recorded answers nothing rather than everything', () => {
+      const result = JSON.parse(
+        run(['calls', '018f5c2e-1f2a-7c31-9f0a-2b7c1d3e4f56', '--json']).stdout
+      );
+
+      expect(result.command).toBe('list');
+      expect(result.requestId).toBe('018f5c2e-1f2a-7c31-9f0a-2b7c1d3e4f56');
+      expect(result.calls).toEqual([]);
+    });
+
+    test('a listing is a listing, and takes the filters', () => {
+      const result = JSON.parse(
+        run(['calls', '--direction=out', '--limit=5', '--json']).stdout
+      );
+
+      expect(result.requestId).toBeNull();
+      expect(result.filter).toMatchObject({ direction: 'out', limit: 5 });
+      expect(result.calls).toEqual([]);
+    });
+
+    test('a sweep runs, and says what it took and what it dropped', () => {
+      const { status, stdout } = run(['calls:sweep', '--yes', '--json']);
+      const result = JSON.parse(stdout);
+
+      expect(status).toBe(0);
+      expect(result.removed).toBe(0);
+      // Sqlite has no range partitions: the delete path, and the guide says so
+      expect(result.partitions).toEqual([]);
+      expect(result.before).toEqual(expect.any(Number));
+    });
+
+    test('a partition scheme sqlite cannot carry out fails the boot', () => {
+      const { status, stderr } = run(['calls:stats', '--json'], {
+        HENRI_CONFIG_JSON__calls: JSON.stringify({ partition: 'day' }),
+      });
+
+      expect(status).not.toBe(0);
+      expect(stderr).toContain('HENRI_CALLS_PARTITION_UNSUPPORTED');
+    });
+
+    test('reading a call log an application does not keep says so', () => {
+      const { status, stderr } = run(['calls', '--json'], {
+        HENRI_CONFIG_JSON__calls: 'false',
+      });
+
+      expect(status).toBe(1);
+      expect(stderr).toContain('HENRI_CALLS_DISABLED');
+    });
+
+    test('an unknown subcommand prints the usage and exits 2', () => {
+      const { status, stderr } = run(['calls:nope', '--json']);
+
+      expect(status).toBe(2);
+      expect(stderr).toContain('HENRI_CLI_USAGE');
+    });
+  });
+});

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -74,6 +74,7 @@ module.exports = (pkg, args) => {
 
   // Rails style: `henri db:migrate` is `henri db migrate`
   for (const group of [
+    'calls',
     'credentials',
     'db',
     'encryption',

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,6 +51,7 @@
     "analyze",
     "audit",
     "build",
+    "calls",
     "clean",
     "console",
     "credentials",

--- a/packages/cli/scripts/audit.js
+++ b/packages/cli/scripts/audit.js
@@ -74,6 +74,13 @@ const STANDARDS = { asvs: '4.0.3', owasp: 'Top 10:2021' };
  */
 const CHECKS = [
   {
+    asvs: 'V7.1.1',
+    check: 'calls.kept-forever',
+    level: 1,
+    owasp: 'A09',
+    what: '"calls": { "keep": false }: a table of request and response values that nothing ever sweeps',
+  },
+  {
     asvs: 'V14.5.3',
     check: 'cors.permissive',
     level: 1,
@@ -1013,6 +1020,27 @@ const configFindings = (config, { file, hasUser }) => {
         'V12.4.1'
       );
     }
+  }
+
+  // A call log holds values -- the body that came in, the body that went
+  // out -- which is what it is for and what makes its retention part of the
+  // feature rather than a setting. `keep: false` is the one spelling that
+  // takes it away, and only a file a production boot reads is worth the
+  // word: a developer's laptop keeping its own requests forever is nobody's
+  // problem.
+  if (
+    isObject(config.calls) &&
+    config.calls.keep === false &&
+    PRODUCTION_CONFIGS.includes(file)
+  ) {
+    add(
+      'medium',
+      'calls.kept-forever',
+      OWASP.A09,
+      'calls.keep is false, so the call log keeps every request and response body it captured for as long as the database lasts: it is a copy of what users sent, growing without a sweep',
+      `Give it a period in ${file} ("calls": { "keep": "30d" }), which the retention sweep enforces`,
+      'V7.1.1'
+    );
   }
 
   // The two escape hatches of the outbound webhooks are what a development

--- a/packages/cli/scripts/calls.js
+++ b/packages/cli/scripts/calls.js
@@ -1,0 +1,335 @@
+const { CliError } = require('./errors');
+const { usage } = require('./help');
+const { boot, validInstall } = require('./utils');
+
+/**
+ * `henri calls`: the calls the application answered and the calls it made.
+ *
+ * - `henri calls <request-id>` is the one worth having the table for: the
+ *   call that came in, every call that went out because of it, in the order
+ *   they happened, with the timings. `henri calls` on its own prints the
+ *   latest calls instead, filtered by `--direction`, `--service`,
+ *   `--status`, `--since` and `--until`.
+ * - `henri calls:stats` says what has been written and what was dropped
+ *   rather than written -- by the sampling, by the per-second ceiling or by
+ *   a full buffer -- and lists the partitions when there are any.
+ * - `henri calls:sweep` takes the calls past `config.calls.keep` away. The
+ *   retention sweep already does it; this is for running it on its own.
+ *
+ * All three boot to runlevel 4: no port is bound and no route is
+ * registered. The work is `henri.calls` (`core/src/4.calls.js`).
+ */
+
+const COMMANDS = ['list', 'stats', 'sweep'];
+
+/** How many calls a listing prints unless `--limit` says */
+const LIMIT = 25;
+
+/** Anything shaped like a request id, so `henri calls <id>` needs no flag */
+const REQUEST_ID = /^[A-Za-z0-9._-]{6,200}$/;
+
+/**
+ * Runs one operation against a booted application and stops it again
+ *
+ * @param {function} work `(henri) => result`
+ * @returns {Promise<*>} What the work resolved with
+ */
+const withHenri = async (work) => {
+  const henri = await boot({ runlevel: 4 });
+
+  try {
+    return await work(henri);
+  } finally {
+    await henri.stop();
+  }
+};
+
+/**
+ * The filter the command line asked for
+ *
+ * @param {object} args CLI arguments
+ * @returns {object} The filter
+ */
+const filterOf = (args) => {
+  const text = (name) =>
+    typeof args[name] === 'string' && args[name] !== ''
+      ? args[name]
+      : undefined;
+
+  return {
+    direction: text('direction'),
+    limit: Number(args.limit) || LIMIT,
+    outcome: text('outcome'),
+    service: text('service'),
+    since: text('since'),
+    status: Number(args.status) || undefined,
+    until: text('until'),
+  };
+};
+
+/**
+ * The latest calls, or one request's story
+ *
+ * @param {object} args CLI arguments
+ * @returns {Promise<object>} The result
+ */
+const list = async (args) => {
+  const [first, second] = args._;
+  const named =
+    typeof args.request === 'string'
+      ? args.request
+      : [first, second].find(
+          (value) =>
+            typeof value === 'string' &&
+            value !== 'list' &&
+            REQUEST_ID.test(value)
+        ) || null;
+  const filter = filterOf(args);
+  const calls = await withHenri((henri) =>
+    named ? henri.calls.about(named, filter) : henri.calls.list(filter)
+  );
+
+  return { calls, command: 'list', filter, ok: true, requestId: named };
+};
+
+/**
+ * What was written, and what was not
+ *
+ * @returns {Promise<object>} The result
+ */
+const stats = async () => {
+  const found = await withHenri((henri) => henri.calls.stats());
+
+  return { command: 'stats', ok: true, ...found };
+};
+
+/**
+ * Takes the calls past `config.calls.keep` away
+ *
+ * @param {object} args CLI arguments
+ * @returns {Promise<object>} The result
+ * @throws {CliError} USAGE when nobody said yes
+ */
+const sweep = async (args) => {
+  if (args.yes !== true) {
+    throw new CliError('USAGE', 'henri calls:sweep removes rows', {
+      hint: 'Run it again with --yes. `henri calls:stats` says how many there are',
+    });
+  }
+
+  const result = await withHenri((henri) => henri.calls.prune());
+
+  return { command: 'sweep', ok: true, ...result };
+};
+
+/**
+ * How long a call took, padded
+ *
+ * @param {?number} duration Milliseconds, or nothing
+ * @returns {string} The column
+ */
+const took = (duration) =>
+  duration === null ? '     -' : `${String(duration).padStart(4)}ms`;
+
+/**
+ * Prints a listing
+ *
+ * @param {object} result What list() answered
+ * @returns {void}
+ */
+const printList = ({ calls, requestId }) => {
+  console.log('');
+
+  if (calls.length === 0) {
+    console.log(
+      requestId
+        ? `  Nothing was recorded for request ${requestId}.`
+        : '  The call log holds nothing matching that.'
+    );
+    console.log('');
+
+    return;
+  }
+
+  if (requestId) {
+    console.log(`  Request ${requestId}`);
+    console.log('');
+  }
+
+  for (const call of calls) {
+    const arrow = call.direction === 'in' ? '<-' : '->';
+    const what = call.direction === 'in' ? call.route || call.url : call.url;
+
+    console.log(
+      `  ${call.at}  ${arrow} ${String(call.status || call.outcome).padEnd(
+        8
+      )} ${took(call.duration)}  ${call.method.padEnd(6)} ${what || ''}`
+    );
+
+    const notes = [
+      call.service ? `service ${call.service}` : null,
+      call.actor ? `actor ${call.actor}` : null,
+      call.error ? `error ${call.error}` : null,
+      call.truncated.length > 0
+        ? `truncated ${call.truncated.join(', ')}`
+        : null,
+    ].filter(Boolean);
+
+    if (notes.length > 0) {
+      console.log(`  ${''.padStart(24)}  ${notes.join('  ')}`);
+    }
+  }
+
+  console.log('');
+
+  if (!requestId) {
+    console.log(
+      '  henri calls <request-id> prints one request and everything it caused.'
+    );
+    console.log('');
+  }
+};
+
+/**
+ * Prints the counters
+ *
+ * @param {object} result What stats() answered
+ * @returns {void}
+ */
+const printStats = (result) => {
+  console.log('');
+
+  if (!result.enabled) {
+    console.log('  This application keeps no call log.');
+    console.log('  Turn it on with "calls": {} in config/<env>.json.');
+    console.log('');
+
+    return;
+  }
+
+  console.log(`  ${result.total} row(s), ${result.buffered} waiting`);
+  console.log(`  written    ${result.written}`);
+  console.log(
+    `  dropped    ${result.dropped.rate} over the per-second ceiling`
+  );
+  console.log(`             ${result.dropped.buffer} with a full buffer`);
+  console.log(`             ${result.dropped.failed} the store refused`);
+
+  if (result.partitions.length > 0) {
+    console.log('');
+    console.log(`  ${result.partitions.length} partition(s):`);
+
+    for (const partition of result.partitions.slice(0, 10)) {
+      console.log(
+        `    ${partition.name}  ${new Date(partition.from)
+          .toISOString()
+          .slice(
+            0,
+            10
+          )} to ${new Date(partition.to).toISOString().slice(0, 10)}`
+      );
+    }
+  }
+
+  console.log('');
+};
+
+/**
+ * Prints a sweep
+ *
+ * @param {object} result What sweep() answered
+ * @returns {void}
+ */
+const printSweep = ({ before, partitions, removed }) => {
+  console.log('');
+
+  if (before === null) {
+    console.log('  Nothing to sweep: the call log is off, or keeps forever.');
+    console.log('');
+
+    return;
+  }
+
+  console.log(
+    `  ${removed} row(s) removed, everything before ${new Date(
+      before
+    ).toISOString()}`
+  );
+
+  if (partitions.length > 0) {
+    console.log(`  ${partitions.length} partition(s) dropped whole:`);
+    console.log(`    ${partitions.join(', ')}`);
+  }
+
+  console.log('');
+};
+
+/**
+ * Runs `henri calls [list|stats|sweep]` (`henri calls:<command>` too)
+ *
+ * @param {object} args CLI arguments
+ * @returns {Promise<void>} Resolves when done
+ * @throws {CliError} USAGE on an unknown command, NOT_A_PROJECT elsewhere
+ */
+const main = async (args) => {
+  const [first] = args._;
+  const command = COMMANDS.includes(first) ? first : 'list';
+
+  // `henri calls stats` is a command, `henri calls 018f-...` is a request
+  if (
+    typeof first === 'string' &&
+    first !== '' &&
+    command === 'list' &&
+    !REQUEST_ID.test(first)
+  ) {
+    if (!args.json) {
+      console.log(usage('calls'));
+    }
+
+    throw new CliError('USAGE', `Unknown calls command "${first}"`, {
+      hint: `Available commands: ${COMMANDS.join(', ')}, or a request id`,
+    });
+  }
+
+  validInstall({ fatal: true });
+
+  const log = console.log;
+
+  // With --json stdout is the result only: the boot log goes to stderr
+  if (args.json) {
+    console.log = (...parts) => console.error(...parts);
+  }
+
+  let result;
+
+  try {
+    if (command === 'stats') {
+      result = await stats();
+    } else if (command === 'sweep') {
+      result = await sweep(args);
+    } else {
+      result = await list(args);
+    }
+  } finally {
+    console.log = log;
+  }
+
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else if (result.command === 'stats') {
+    printStats(result);
+  } else if (result.command === 'sweep') {
+    printSweep(result);
+  } else {
+    printList(result);
+  }
+
+  // The drivers are closed by henri.stop(); leave nothing behind
+  process.exit(result.ok ? 0 : 1);
+};
+
+module.exports = main;
+module.exports.COMMANDS = COMMANDS;
+module.exports.list = list;
+module.exports.stats = stats;
+module.exports.sweep = sweep;

--- a/packages/cli/scripts/help.js
+++ b/packages/cli/scripts/help.js
@@ -1099,6 +1099,72 @@ const COMMANDS = [
   },
   {
     description: [
+      'The calls this application answered and the calls it made, joined by',
+      'the request id henri threads through everything. It holds values --',
+      'the body that came in, the body that went out -- which is what makes',
+      'it the opposite of the access trail rather than a second one.',
+      '',
+      'henri calls <request-id> is what the two records are for: the call',
+      'that came in, every call that went out because of it, in order, with',
+      'the timings.',
+      '',
+      'It is off until config.calls says otherwise, and it is sampled, capped',
+      'and swept: henri calls:stats says what was written and what was',
+      'dropped rather than written.',
+    ],
+    examples: [
+      {
+        command: 'henri calls 018f5c2e-1f2a-7c31-9f0a-2b7c1d3e4f56',
+        description: 'One request and everything it caused',
+      },
+      {
+        command: 'henri calls --direction=out --service=billing',
+        description: 'The latest calls to one service',
+      },
+      {
+        command: 'henri calls:stats',
+        description: 'What was written, and what was dropped',
+      },
+      {
+        command: 'henri calls:sweep --yes',
+        description: 'Take the calls past calls.keep away',
+      },
+    ],
+    flags: [
+      { description: 'only in or only out', flag: '--direction=<in|out>' },
+      { description: 'only this service, outbound', flag: '--service=<name>' },
+      { description: 'only this status', flag: '--status=<n>' },
+      { description: 'only ok, failed or aborted', flag: '--outcome=<name>' },
+      { description: 'calls at or after this moment', flag: '--since=<date>' },
+      { description: 'calls at or before this moment', flag: '--until=<date>' },
+      { description: 'how many calls to print (25)', flag: '--limit=<n>' },
+      { description: 'required by calls:sweep', flag: '--yes' },
+      JSON_FLAG,
+    ],
+    name: 'calls',
+    summary: 'the calls answered and the calls made, joined by request id',
+    targets: [
+      {
+        description: 'the latest calls, or one request id (the default)',
+        name: 'list',
+      },
+      {
+        description: 'what was written, and what was dropped',
+        name: 'stats',
+      },
+      {
+        description: 'take the calls past calls.keep away',
+        name: 'sweep',
+      },
+    ],
+    usage: [
+      'henri calls [<request-id>] [--direction=<in|out>] [--limit=<n>] [--json]',
+      'henri calls:stats [--json]',
+      'henri calls:sweep --yes [--json]',
+    ],
+  },
+  {
+    description: [
       'Starts the MCP server of @usehenri/mcp on stdio for the application',
       'in the current directory. Claude Code reads it from .mcp.json, Cursor',
       'from .cursor/mcp.json (both: { "command": "henri", "args": ["mcp"] }).',

--- a/packages/core/error-codes.json
+++ b/packages/core/error-codes.json
@@ -22,6 +22,10 @@
       "what": "the cache of `henri.cache`: the keys it is given, the values it is asked to keep and the backend they go to"
     },
     {
+      "area": "calls",
+      "what": "the call log of `henri.calls`: the table it owns, the store it lives in and the partitions it sweeps"
+    },
+    {
       "area": "cli",
       "what": "the henri command line: arguments, the project it runs in, the commands themselves"
     },
@@ -443,6 +447,36 @@
       "code": "HENRI_CACHE_VALUE_UNSUPPORTED",
       "fix": "The cache keeps what JSON keeps, plus `Date`. Store the plain shape you want back: `record.toJSON()`, or `henri.model.stores.default.toPlain(record)`. Cache `null` where you meant \"there is nothing\".",
       "what": "A value was refused because it would not come back the way it went in."
+    },
+    {
+      "area": "calls",
+      "causes": [
+        "`config.calls` is absent or false",
+        "the call log could not be started"
+      ],
+      "code": "HENRI_CALLS_DISABLED",
+      "fix": "Turn the call log on with `\"calls\": {}` in `config/<env>.json`; henri creates its table on the next boot. Recording is a no-op while it is off, but reading it back says so rather than answering with nothing.",
+      "what": "The call log was read back and this application keeps none."
+    },
+    {
+      "area": "calls",
+      "causes": [
+        "`config.calls.partition` is set on a sqlite, SQL Server or MongoDB store"
+      ],
+      "code": "HENRI_CALLS_PARTITION_UNSUPPORTED",
+      "fix": "Only PostgreSQL and MySQL range-partition a table, which is what lets a sweep drop a period instead of deleting its rows. Everywhere else the sweep deletes in bounded batches: leave `calls.partition` out.",
+      "what": "The call log was asked to partition its table in a store that cannot."
+    },
+    {
+      "area": "calls",
+      "causes": [
+        "`config.calls.store` names a store this application does not have",
+        "the store adapter has neither `query()` nor a MongoDB connection",
+        "the MongoDB store is not connected"
+      ],
+      "code": "HENRI_CALLS_UNSUPPORTED_STORE",
+      "fix": "The call log owns a table in one of the application's stores. Point `config.calls.store` at a store backed by mongoose, drizzle or sequelize, or leave `config.calls` out to keep no call log at all.",
+      "what": "The call log cannot be kept in the store it was pointed at."
     },
     {
       "area": "cli",

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -741,6 +741,11 @@ declare namespace start {
     retention?: RetentionConfig;
     /** The access trail; absent or `false` keeps none. */
     trail?: false | TrailConfig;
+    /**
+     * The call log: the calls the application answered and the calls it
+     * made. Absent (or `false`) keeps none, and no table is created.
+     */
+    calls?: false | CallsConfig;
     /** Maximum size of a JSON or form body (`"1mb"`). */
     bodyLimit?: string | number;
     /**
@@ -859,6 +864,78 @@ declare namespace start {
     /** Which of `config.stores` the table lives in (`"default"`). */
     store?: string;
     /** The table henri creates and appends to (`"henri_trail"`). */
+    table?: string;
+  }
+
+  /**
+   * `config.calls`: the calls an application answered and the calls it
+   * made, joined by the request id. Absent (or `false`) keeps none: no
+   * table is created and no middleware is mounted.
+   *
+   * It holds **values**, which the access trail deliberately does not. See
+   * the guide before turning it on.
+   */
+  interface CallsConfig {
+    /**
+     * The outcomes sampling never drops (`["error"]`). They are recorded
+     * without their bodies: the decision not to capture one was made before
+     * the status was known.
+     */
+    always?: Array<'aborted' | 'client-error' | 'error'>;
+    /** How many buffered rows trigger a flush before the timer does (`500`). */
+    batch?: number;
+    /** `false` keeps the timings and the headers and captures no body. */
+    bodies?: boolean;
+    /**
+     * How many rows may wait to be written (`1000`). Past it a row is
+     * dropped and counted rather than queued forever.
+     */
+    buffer?: number;
+    /** How often the buffer is written, in milliseconds (`1000`). */
+    flush?: number;
+    /**
+     * Path prefixes that are never recorded. The health probes never are,
+     * whatever this says.
+     */
+    ignore?: string[];
+    /** `false` stops henri mounting the middleware at all. */
+    inbound?: boolean;
+    /**
+     * How long a row is kept (`"30d"`); `false` keeps them forever. The
+     * retention sweep is what prunes them.
+     */
+    keep?: string | number | false;
+    /**
+     * How much of a body is stored before it is cut and marked truncated
+     * (`"8kb"`).
+     */
+    maxBody?: string | number | false;
+    /**
+     * The absolute per-process ceiling on rows a second (`100`), or `false`
+     * for none. Sampling is proportional and a burst is not.
+     */
+    maxPerSecond?: number | false;
+    /** `false` makes `track()` and `outbound()` no-ops. */
+    outbound?: boolean;
+    /**
+     * Range partitions by `at`, on PostgreSQL and MySQL only: the sweep
+     * then drops a partition instead of deleting rows. Anything else fails
+     * the boot with `HENRI_CALLS_PARTITION_UNSUPPORTED`.
+     */
+    partition?: 'day' | 'month' | false;
+    /** How many periods are kept ready in front of the clock (`7`). */
+    partitionsAhead?: number;
+    /**
+     * The share of requests recorded (`1`), decided by a hash of the
+     * request id seeded with `config.secret` so the inbound call and every
+     * outbound call it caused agree.
+     */
+    sample?: number;
+    /** Which of `config.stores` the table lives in (`"default"`). */
+    store?: string;
+    /** How many rows one pass of the delete path takes at a time (`5000`). */
+    sweep?: number;
+    /** The table henri creates and writes to (`"henri_calls"`). */
     table?: string;
   }
 
@@ -2574,6 +2651,145 @@ declare namespace start {
     }>;
   }
 
+  /** One call of the call log, inbound or outbound. */
+  interface CallRecord {
+    id: string;
+    /** When the call started, as an ISO-8601 string. */
+    at: string;
+    /** `"in"` for a call answered, `"out"` for a call made. */
+    direction: 'in' | 'out';
+    /** The join: the inbound call and its outbound calls share it. */
+    requestId: string | null;
+    /** Which service an outbound call went to; `null` inbound. */
+    service: string | null;
+    method: string;
+    /** The url, without its userinfo and with the filtered query masked. */
+    url: string | null;
+    /** The route pattern of an inbound call. */
+    route: string | null;
+    status: number | null;
+    /** How long it took, in milliseconds. */
+    duration: number | null;
+    /** The `externalId` of the person, never an address. */
+    actor: string | null;
+    outcome: 'aborted' | 'failed' | 'ok';
+    error: string | null;
+    request: { headers: Record<string, string> | null; body: unknown };
+    response: { headers: Record<string, string> | null; body: unknown };
+    /** Which bodies were cut: `["request"]`, `["response"]`, both, none. */
+    truncated: string[];
+    meta: Record<string, unknown> | string | null;
+  }
+
+  /**
+   * `henri.calls`: the calls the application answered and the calls it
+   * made, joined by the request id. Off unless `config.calls` says
+   * otherwise.
+   *
+   * It holds values, so everything it stores goes through the redactor,
+   * and the credentials of an exchange are masked whatever
+   * `filterParameters` says. It is not the access trail and does not
+   * replace it.
+   */
+  interface CallsModule {
+    name: 'calls';
+    /** `config.calls`, normalized. */
+    settings: {
+      enabled: boolean;
+      keep: number | null;
+      inbound: boolean;
+      outbound: boolean;
+      sample: number;
+      maxPerSecond: number;
+      maxBody: number;
+      partition: 'day' | 'month' | false;
+      store: string;
+      table: string;
+    };
+    /** Whether anything is being recorded. */
+    enabled: boolean;
+    /**
+     * Records one finished outbound call. Answers `false` on a disabled
+     * log, on a request the sampling dropped, and when a bound refused it.
+     */
+    outbound(call: {
+      service?: string;
+      method?: string;
+      url?: string;
+      status?: number | null;
+      duration?: number;
+      at?: number;
+      requestId?: string | null;
+      route?: string | null;
+      actor?: string | null;
+      outcome?: 'aborted' | 'failed' | 'ok';
+      error?: string | null;
+      request?: { headers?: object | null; body?: unknown } | null;
+      response?: { headers?: object | null; body?: unknown } | null;
+      meta?: Record<string, unknown>;
+    }): boolean;
+    /**
+     * Times one outbound call. The seam an application's own HTTP client
+     * goes through: henri wraps nobody's client.
+     */
+    track(details: {
+      service?: string;
+      method?: string;
+      url?: string;
+      requestId?: string | null;
+      request?: { headers?: object | null; body?: unknown } | null;
+      meta?: Record<string, unknown>;
+    }): (answer?: {
+      status?: number | null;
+      headers?: object | null;
+      body?: unknown;
+      error?: string | null;
+      url?: string;
+      meta?: Record<string, unknown>;
+    }) => boolean | null;
+    /** The calls matching a filter. */
+    list(filter?: {
+      requestId?: string;
+      direction?: 'in' | 'out';
+      service?: string;
+      actor?: string;
+      outcome?: 'aborted' | 'failed' | 'ok';
+      status?: number;
+      since?: Date | string | number;
+      until?: Date | string | number;
+      limit?: number;
+      offset?: number;
+    }): Promise<CallRecord[]>;
+    count(filter?: Record<string, unknown>): Promise<number>;
+    /**
+     * Everything that happened during one request: the call that came in
+     * and every call that went out because of it, oldest first.
+     */
+    about(
+      requestId: string,
+      filter?: Record<string, unknown>
+    ): Promise<CallRecord[]>;
+    /**
+     * Takes the calls past `config.calls.keep` away. Drops whole partitions
+     * where the dialect has them, and deletes rows in bounded batches for
+     * whatever is left.
+     */
+    prune(options?: { now?: number }): Promise<{
+      removed: number;
+      partitions: string[];
+      before: number | null;
+    }>;
+    /** What was written, and what was dropped rather than written. */
+    stats(): Promise<{
+      enabled: boolean;
+      buffered: number;
+      written: number;
+      total: number;
+      dropped: { buffer: number; failed: number; rate: number };
+      partitions: Array<{ name: string; from: number; to: number }>;
+    }>;
+  }
+
   /** `henri.model`. */
   interface ModelModule {
     name: 'model';
@@ -3158,6 +3374,11 @@ declare namespace start {
     retention: RetentionModule;
     /** The append-only record of who read or changed personal data. */
     trail: TrailModule;
+    /**
+     * The calls the application answered and the calls it made, joined by
+     * the request id. Off unless `config.calls` says otherwise.
+     */
+    calls: CallsModule;
     /**
      * The queue, when the application depends on `@usehenri/jobs`. It is
      * `undefined` when it does not -- core carries no queue of its own --

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -2709,6 +2709,12 @@ declare namespace start {
     /** Whether anything is being recorded. */
     enabled: boolean;
     /**
+     * The id of the request being handled, or `null` outside one. The seam
+     * a package outside core reaches for when it has to carry the id into
+     * a job.
+     */
+    requestId(): string | null;
+    /**
      * Records one finished outbound call. Answers `false` on a disabled
      * log, on a request the sampling dropped, and when a bound refused it.
      */

--- a/packages/core/src/1.mailer.js
+++ b/packages/core/src/1.mailer.js
@@ -152,7 +152,25 @@ class Mailer extends BaseModule {
       );
     }
 
-    const info = await this.transporter.sendMail(opts);
+    const finish = this.tracked();
+    let info;
+
+    try {
+      info = await this.transporter.sendMail(opts);
+    } catch (error) {
+      finish({ error: error.code || error.name, status: null });
+
+      throw error;
+    }
+
+    finish({
+      meta: {
+        accepted: (info.accepted || []).length,
+        messageId: info.messageId,
+        rejected: (info.rejected || []).length,
+      },
+      status: (info.rejected || []).length > 0 ? 550 : 250,
+    });
 
     this.henri.pen.info('mail', `Message sent: ${info.messageId}`);
     this.testAccount &&
@@ -162,6 +180,56 @@ class Mailer extends BaseModule {
       );
 
     return info;
+  }
+
+  /**
+   * The endpoint the transport talks to, as a url.
+   *
+   * There is no address in it and there is none in the row either: a
+   * recipient is personal data, and what a call log is asked is "did the
+   * mail go out during this request, and how long did it take". The counts
+   * and the message id answer that; the addresses are the mailer's own
+   * concern (`guides/calls.md` says so).
+   *
+   * @returns {string} a url
+   * @memberof Mailer
+   */
+  endpoint() {
+    const config = this.config;
+
+    if (!config || typeof config !== 'object') {
+      return 'mail://transport';
+    }
+
+    if (config.host) {
+      return `smtp://${config.host}:${config.port || 587}`;
+    }
+
+    if (config.service) {
+      return `smtp://${config.service}`;
+    }
+
+    return config.jsonTransport ? 'mail://json' : 'mail://transport';
+  }
+
+  /**
+   * Starts timing one send, when there is a call log to time it into
+   *
+   * @returns {function} the finisher (a no-op without a call log)
+   * @memberof Mailer
+   */
+  tracked() {
+    const { calls } = this.henri;
+
+    if (!calls || !calls.enabled) {
+      return () => null;
+    }
+
+    return calls.track({
+      method: 'SEND',
+      service: 'mail',
+      url: this.endpoint(),
+    });
   }
 
   /**

--- a/packages/core/src/2.server.js
+++ b/packages/core/src/2.server.js
@@ -18,6 +18,7 @@ const { apiVersion, secureHeaders } = require('./base/headers');
 const { paginationMiddleware } = require('./base/pagination');
 const { authLimiter, limiter } = require('./base/rate-limit');
 const { requestId } = require('./base/request-id');
+const { callsConfig, inbound } = require('./base/calls');
 const { createShared, manyProcesses } = require('./base/shared');
 const requestTimeout = require('./base/timeout');
 const { drain, settings: stopSettings } = require('./base/shutdown');
@@ -386,12 +387,23 @@ class Server extends BaseModule {
     ));
     const { settings } = api;
 
-    // Middleware order: request id, timeout, secure headers, compression,
-    // cors, body parsers, cookies, boom, api version, pagination, the health
-    // endpoints, static files. The user module adds permit, session, passport
-    // and csrf (runlevel 4), start() adds the rate limits, the router, the
-    // 404 and the error handler.
+    // Middleware order: request id, the call log, timeout, secure headers,
+    // compression, cors, body parsers, cookies, boom, api version,
+    // pagination, the health endpoints, static files. The user module adds
+    // permit, session, passport and csrf (runlevel 4), start() adds the rate
+    // limits, the router, the 404 and the error handler.
     app.use(requestId());
+
+    // The call log goes second when `config.calls` asked for it, and is not
+    // mounted at all when it did not: an application that keeps no call log
+    // pays nothing for the feature, not even a middleware that returns.
+    // Second is the point -- a request refused by the rate limit, the body
+    // parser or the CSRF check is exactly the one worth having in the log,
+    // and anything mounted further down never sees it. `henri.calls` itself
+    // comes up at runlevel 4 and is read per request
+    if (callsConfig(config).inbound) {
+      app.use(inbound(this.henri));
+    }
 
     if (settings.requestTimeout) {
       app.use(requestTimeout(this.henri, settings.requestTimeout));

--- a/packages/core/src/4.calls.js
+++ b/packages/core/src/4.calls.js
@@ -233,6 +233,22 @@ class Calls extends BaseModule {
   }
 
   /**
+   * The id of the request being handled, when there is one.
+   *
+   * The seam a package outside core reaches for: `@usehenri/webhooks`
+   * stamps it into the delivery job it enqueues, so the delivery that goes
+   * out ten seconds later still joins the request that caused it. It
+   * answers whether or not the log is on, because it is a fact about the
+   * request rather than about the log.
+   *
+   * @returns {?string} the id, or null outside a request
+   * @memberof Calls
+   */
+  requestId() {
+    return currentRequestId();
+  }
+
+  /**
    * Records one finished inbound call.
    *
    * Called from `res.on('close')`, so the answer is already on its way out

--- a/packages/core/src/4.calls.js
+++ b/packages/core/src/4.calls.js
@@ -452,6 +452,13 @@ class Calls extends BaseModule {
 
     this.flushing = (async () => {
       try {
+        // A process that ran past the periods created at boot would write
+        // into the catch-all; topping the plan up here costs a number
+        // comparison per flush and nothing at all when there are none
+        if (this.store.covered && Date.now() >= this.store.covered) {
+          await this.store.ensure();
+        }
+
         await this.store.insert(rows);
         this.counters.written += rows.length;
         this.complained = false;

--- a/packages/core/src/4.calls.js
+++ b/packages/core/src/4.calls.js
@@ -1,0 +1,621 @@
+const BaseModule = require('./base/module');
+
+const debug = require('debug')('henri:calls');
+const { randomUUID } = require('node:crypto');
+
+const { check } = require('./base/arguments');
+const { fail } = require('./base/errors');
+const { currentRequestId } = require('./base/request-id');
+const { storeFor } = require('./base/call-store');
+const {
+  BUCKETS,
+  Ceiling,
+  actorOf,
+  always,
+  callsConfig,
+  checkPartition,
+  contextOf,
+  hash32,
+  outcomeOf,
+  seedOf,
+  toCall,
+  toRow,
+  track,
+} = require('./base/calls');
+
+/**
+ * The call log: `henri.calls`, the calls an application answered and the
+ * calls it made.
+ *
+ * The design -- why it is not the access trail, the four bounds that keep
+ * it from being a denial of service, and exactly what the redaction refuses
+ * -- is in the header of `base/calls.js`, and the storage, the partitions
+ * and the sweep are in `base/call-store.js`. This is the module: it owns
+ * the table, buffers, flushes, reads back and prunes.
+ *
+ * It is off unless `config.calls` says otherwise, and off means off: no
+ * table is created, `2.server.js` mounts no middleware, and every entry
+ * point here answers without allocating. Everything inside core that
+ * records a call goes through `outbound()` or `track()`, which are no-ops
+ * on a disabled log, so nothing in the framework has to ask first.
+ *
+ * @class Calls
+ * @extends {BaseModule}
+ */
+class Calls extends BaseModule {
+  /**
+   * Creates an instance of Calls.
+   * @memberof Calls
+   */
+  constructor() {
+    super();
+
+    this.reloadable = true;
+    // The models are where the table lives, and the privacy map is what
+    // says which field names are masked in a captured body
+    this.needs = ['config', 'model'];
+    this.after = ['privacy'];
+    // The middleware is mounted by 2.server.js, but the router is what
+    // turns a request into a route, and a row carries the route
+    this.before = ['router'];
+    this.runlevel = 4;
+    this.name = 'calls';
+    this.henri = null;
+
+    /** `config.calls`, normalized */
+    this.settings = callsConfig(null);
+    /** Whether anything is being recorded */
+    this.enabled = false;
+    /** The backend (`base/call-store.js`), or null */
+    this.store = null;
+    /** The rows waiting to be written */
+    this.buffer = [];
+    /** The absolute per-process ceiling */
+    this.ceiling = new Ceiling(0);
+    /** The redaction context, built once rather than once per row */
+    this.context = null;
+    /** What the sampling hashes with */
+    this.seed = 0;
+    /** The flush timer */
+    this.timer = null;
+    /** The flush in flight, so two never interleave */
+    this.flushing = null;
+    /** What was written, and what was not */
+    this.counters = { buffer: 0, failed: 0, rate: 0, written: 0 };
+    /** Whether a failed flush has already been reported */
+    this.complained = false;
+
+    this.init = this.init.bind(this);
+    this.reload = this.reload.bind(this);
+    this.stop = this.stop.bind(this);
+    this.finished = this.finished.bind(this);
+    this.outbound = this.outbound.bind(this);
+    this.track = this.track.bind(this);
+    this.list = this.list.bind(this);
+    this.about = this.about.bind(this);
+    this.prune = this.prune.bind(this);
+
+    debug('constructor initialized');
+  }
+
+  /**
+   * Module initialization: prepares the table when the log is on
+   *
+   * @async
+   * @returns {Promise<string>} the name of the module
+   * @throws HENRI_CALLS_UNSUPPORTED_STORE when the store cannot hold it
+   * @throws HENRI_CALLS_PARTITION_UNSUPPORTED on a dialect without ranges
+   * @memberof Calls
+   */
+  async init() {
+    const { config, pen } = this.henri;
+
+    this.settings = callsConfig(config);
+
+    if (!this.settings.enabled) {
+      debug('no config.calls: nothing is recorded');
+
+      return this.name;
+    }
+
+    const stores = (this.henri.model && this.henri.model.stores) || {};
+    const adapter = stores[this.settings.store];
+
+    if (!adapter) {
+      throw fail(
+        'HENRI_CALLS_UNSUPPORTED_STORE',
+        `config.calls.store names "${this.settings.store}", which is not one of this application's stores`
+      );
+    }
+
+    this.store = storeFor(adapter, this.settings);
+
+    checkPartition(this.store.dialect, this.settings.partition);
+
+    await this.store.install();
+
+    this.context = contextOf(this.henri, this.settings);
+    this.seed = seedOf(config);
+    this.ceiling = new Ceiling(this.settings.maxPerSecond);
+    this.enabled = true;
+
+    this.timer = setInterval(() => {
+      this.flush().catch(() => null);
+    }, this.settings.flush);
+
+    /* istanbul ignore else */
+    if (typeof this.timer.unref === 'function') {
+      this.timer.unref();
+    }
+
+    pen.info(
+      'calls',
+      `writing to ${this.settings.table}`,
+      this.settings.partition
+        ? `${this.settings.partition} partitions`
+        : 'swept by deleting rows',
+      `sample ${this.settings.sample}, at most ${this.settings.maxPerSecond}/s`
+    );
+
+    return this.name;
+  }
+
+  /**
+   * Rebuilds the module after a reload
+   *
+   * @async
+   * @returns {Promise<string>} the name of the module
+   * @memberof Calls
+   */
+  async reload() {
+    await this.stop();
+
+    return this.init();
+  }
+
+  /**
+   * Writes what is buffered and stops the timer
+   *
+   * @async
+   * @returns {Promise<string|boolean>} the module name, or false
+   * @memberof Calls
+   */
+  async stop() {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+
+    if (!this.enabled) {
+      return false;
+    }
+
+    await this.flush();
+
+    this.enabled = false;
+    this.store = null;
+    this.buffer = [];
+
+    return this.name;
+  }
+
+  /**
+   * Is this request one of the sampled ones?
+   *
+   * A seeded hash of the request id rather than a coin flip, so the inbound
+   * call and every outbound call it caused answer the same in every process
+   * without carrying state. The seed is `config.secret`, because the
+   * request id comes from a header a client can choose (`base/calls.js`
+   * says more).
+   *
+   * @param {?string} requestId the id of the request
+   * @returns {boolean} whether it is recorded
+   * @memberof Calls
+   */
+  samples(requestId) {
+    const { sample } = this.settings;
+
+    if (sample >= 1) {
+      return true;
+    }
+
+    if (sample <= 0) {
+      return false;
+    }
+
+    if (typeof requestId !== 'string' || requestId === '') {
+      return Math.random() < sample;
+    }
+
+    return (
+      hash32(requestId, this.seed) % BUCKETS < Math.round(sample * BUCKETS)
+    );
+  }
+
+  /**
+   * Records one finished inbound call.
+   *
+   * Called from `res.on('close')`, so the answer is already on its way out
+   * and nothing here is on the hot path. A request the sampling dropped is
+   * still recorded when it matches `calls.always` -- without its bodies,
+   * because the decision not to capture them was made before the status was
+   * known and there is nothing to go back for.
+   *
+   * @param {object} req the request
+   * @param {object} res the response
+   * @param {object} state `at`, `started`, `body`, `keep`
+   * @returns {boolean} whether a row was buffered
+   * @memberof Calls
+   */
+  finished(req, res, state) {
+    if (!this.enabled) {
+      return false;
+    }
+
+    const aborted = res.writableFinished === false;
+    const status = aborted ? null : res.statusCode;
+    const outcome = outcomeOf({ aborted, status });
+
+    if (!state.keep && !always({ outcome, status }, this.settings.always)) {
+      return false;
+    }
+
+    const duration = Number(
+      (process.hrtime.bigint() - state.started) / 1000000n
+    );
+
+    return this.record({
+      actor: actorOf(req.user),
+      at: state.at,
+      direction: 'in',
+      duration,
+      id: randomUUID(),
+      method: req.method,
+      outcome,
+      request: {
+        body: state.keep ? req.body : null,
+        headers: req.headers,
+      },
+      requestBytes: Number(req.headers['content-length']) || undefined,
+      requestId: req.id || null,
+      response: {
+        body: state.keep ? state.body : null,
+        headers: typeof res.getHeaders === 'function' ? res.getHeaders() : null,
+      },
+      responseBytes: Number(res.getHeader('content-length')) || undefined,
+      route: req.route && req.route.path ? req.route.path : null,
+      status,
+      url: req.originalUrl || req.url,
+    });
+  }
+
+  /**
+   * Records one finished outbound call.
+   *
+   * The seam an application's own HTTP client goes through, and the one
+   * henri's webhook deliveries and mail sends go through themselves. henri
+   * wraps nobody's client: there is nothing to install.
+   *
+   * @param {object} call `service`, `method`, `url`, `status`, `duration`,
+   *   `request`, `response`, `error`, `requestId`, `meta`
+   * @returns {boolean} whether a row was buffered
+   * @memberof Calls
+   */
+  outbound(call) {
+    check('henri.calls.outbound', [call]);
+
+    return this.write(call);
+  }
+
+  /**
+   * The same, unchecked: what `track()`'s finisher calls, so one call is
+   * not checked twice
+   *
+   * @param {object} call the call
+   * @returns {boolean} whether a row was buffered
+   * @memberof Calls
+   */
+  write(call) {
+    if (!this.enabled || !this.settings.outbound) {
+      return false;
+    }
+
+    const requestId =
+      call.requestId === null ? null : call.requestId || currentRequestId();
+    const row = {
+      ...call,
+      at: call.at || Date.now(),
+      direction: 'out',
+      id: randomUUID(),
+      requestId,
+    };
+
+    if (this.samples(requestId)) {
+      return this.record(row);
+    }
+
+    const outcome = call.outcome || outcomeOf(call);
+
+    if (!always({ outcome, status: call.status }, this.settings.always)) {
+      return false;
+    }
+
+    // Sampling said no and `calls.always` said yes: the row is written
+    // without its bodies, which is the same answer the inbound half gives
+    return this.record({
+      ...row,
+      request: { headers: call.request && call.request.headers },
+      response: { headers: call.response && call.response.headers },
+    });
+  }
+
+  /**
+   * Times one outbound call: `const finish = calls.track({...})`, then
+   * `finish({ status, headers, body })` when the answer arrives
+   *
+   * @param {object} details `service`, `method`, `url`, `request`
+   * @returns {function} the finisher
+   * @memberof Calls
+   */
+  track(details) {
+    check('henri.calls.track', [details]);
+
+    return track(this, details);
+  }
+
+  /**
+   * Buffers one row.
+   *
+   * The two bounds of decision 4 live here: the per-second ceiling, then
+   * the buffer itself. Neither of them throws and neither of them is
+   * silent -- what they dropped is counted and `stats()` says so.
+   *
+   * @param {object} call the call
+   * @returns {boolean} whether it was buffered
+   * @memberof Calls
+   */
+  record(call) {
+    if (!this.enabled) {
+      return false;
+    }
+
+    if (!this.ceiling.take(call.at)) {
+      this.counters.rate += 1;
+
+      return false;
+    }
+
+    if (this.buffer.length >= this.settings.buffer) {
+      this.counters.buffer += 1;
+
+      return false;
+    }
+
+    try {
+      this.buffer.push(toRow(call, this.context));
+    } catch (error) {
+      // A row henri cannot build is a row nobody gets: a call log must not
+      // be able to fail the thing it was watching
+      debug('unable to build a row: %s', error.message);
+      this.counters.failed += 1;
+
+      return false;
+    }
+
+    if (this.buffer.length >= this.settings.batch) {
+      this.flush().catch(() => null);
+    }
+
+    return true;
+  }
+
+  /**
+   * Writes what is buffered.
+   *
+   * Never rejects: a call log that can fail a request, a job or a shutdown
+   * is a liability. A failure is counted, reported once, and the rows are
+   * dropped rather than retried -- a retry queue for debugging rows is a
+   * second thing to run out of memory.
+   *
+   * @async
+   * @returns {Promise<number>} how many rows were written
+   * @memberof Calls
+   */
+  async flush() {
+    if (this.flushing) {
+      return this.flushing;
+    }
+
+    if (!this.enabled || !this.store || this.buffer.length === 0) {
+      return 0;
+    }
+
+    const rows = this.buffer;
+
+    this.buffer = [];
+
+    this.flushing = (async () => {
+      try {
+        await this.store.insert(rows);
+        this.counters.written += rows.length;
+        this.complained = false;
+
+        return rows.length;
+      } catch (error) {
+        this.counters.failed += rows.length;
+
+        if (!this.complained) {
+          this.complained = true;
+          this.henri.pen.warn(
+            'calls',
+            `unable to write ${rows.length} rows; they are dropped`,
+            error.message
+          );
+        }
+
+        return 0;
+      } finally {
+        this.flushing = null;
+      }
+    })();
+
+    return this.flushing;
+  }
+
+  /**
+   * The calls matching a filter
+   *
+   * @async
+   * @param {object} [filter={}] `requestId`, `direction`, `service`,
+   *   `actor`, `outcome`, `status`, `since`, `until`, `limit`, `offset`
+   * @returns {Promise<Array<object>>} the calls
+   * @memberof Calls
+   */
+  async list(filter = {}) {
+    check('henri.calls.list', [filter]);
+
+    const rows = await this.ready().list(this.filter(filter));
+
+    return rows.map(toCall);
+  }
+
+  /**
+   * How many calls match a filter
+   *
+   * @async
+   * @param {object} [filter={}] the filter
+   * @returns {Promise<number>} the count
+   * @memberof Calls
+   */
+  async count(filter = {}) {
+    check('henri.calls.count', [filter]);
+
+    return this.ready().count(this.filter(filter));
+  }
+
+  /**
+   * Everything that happened during one request: the call that came in and
+   * every call that went out because of it, oldest first
+   *
+   * @async
+   * @param {string} requestId the request id
+   * @param {object} [filter={}] the rest of the filter
+   * @returns {Promise<Array<object>>} the calls
+   * @memberof Calls
+   */
+  async about(requestId, filter = {}) {
+    check('henri.calls.about', [requestId, filter]);
+
+    return this.list({ ...filter, requestId });
+  }
+
+  /**
+   * A filter with its moments turned into milliseconds
+   *
+   * @param {object} filter the filter
+   * @returns {object} the filter the store reads
+   * @memberof Calls
+   */
+  filter(filter) {
+    const moment = (value) =>
+      typeof value === 'undefined' || value === null
+        ? undefined
+        : new Date(value).getTime();
+
+    return {
+      ...filter,
+      since: moment(filter.since),
+      until: moment(filter.until),
+    };
+  }
+
+  /**
+   * Takes the calls past `config.calls.keep` away.
+   *
+   * Called by the retention sweep, the way the trail's prune is. Where the
+   * dialect partitions, this drops whole periods and the rest is a bounded
+   * delete over what is left; everywhere else it is only the delete.
+   *
+   * @async
+   * @param {object} [options={}] `now`
+   * @returns {Promise<object>} `{ removed, partitions, before }`
+   * @memberof Calls
+   */
+  async prune(options = {}) {
+    check('henri.calls.prune', [options]);
+
+    const { now = Date.now() } = options;
+
+    if (!this.enabled || !this.store || !this.settings.keep) {
+      return { before: null, partitions: [], removed: 0 };
+    }
+
+    await this.flush();
+
+    const before = now - this.settings.keep;
+    const result = await this.store.sweep(before, {
+      batch: this.settings.sweep,
+      now,
+    });
+
+    return { before, ...result };
+  }
+
+  /**
+   * What has been written, and what was dropped rather than written
+   *
+   * @async
+   * @returns {Promise<object>} the counters, the buffer and the partitions
+   * @memberof Calls
+   */
+  async stats() {
+    if (!this.enabled || !this.store) {
+      return {
+        buffered: 0,
+        dropped: { buffer: 0, failed: 0, rate: 0 },
+        enabled: false,
+        partitions: [],
+        total: 0,
+        written: 0,
+      };
+    }
+
+    return {
+      buffered: this.buffer.length,
+      dropped: {
+        buffer: this.counters.buffer,
+        failed: this.counters.failed,
+        rate: this.counters.rate,
+      },
+      enabled: true,
+      partitions: await this.store.partitions(),
+      total: await this.store.count(),
+      written: this.counters.written,
+    };
+  }
+
+  /**
+   * The backend, or a readable error
+   *
+   * @returns {object} the backend
+   * @throws HENRI_CALLS_DISABLED when nothing is being recorded
+   * @memberof Calls
+   */
+  ready() {
+    if (!this.enabled || !this.store) {
+      const error = fail(
+        'HENRI_CALLS_DISABLED',
+        'this application keeps no call log, so there is nothing to read back'
+      );
+
+      error.hint =
+        'Turn it on with "calls": {} in config/<env>.json; henri creates its table on the next boot';
+
+      throw error;
+    }
+
+    return this.store;
+  }
+}
+
+module.exports = Calls;

--- a/packages/core/src/4.retention.js
+++ b/packages/core/src/4.retention.js
@@ -50,7 +50,7 @@ class Retention extends BaseModule {
     // the privacy map says is personal
     this.needs = ['config', 'model', 'privacy'];
     // A sweep is recorded in the trail when there is one
-    this.after = ['trail', 'jobs'];
+    this.after = ['calls', 'trail', 'jobs'];
     this.runlevel = 4;
     this.name = 'retention';
     this.henri = null;
@@ -276,6 +276,7 @@ class Retention extends BaseModule {
     receipt.file = options.dryRun ? null : this.write(receipt);
 
     await this.tell(receipt, options);
+    await this.sweepCalls(options);
 
     const swept = receipt.rules.reduce(
       (total, rule) => total + rule.written,
@@ -290,6 +291,49 @@ class Retention extends BaseModule {
     );
 
     return receipt;
+  }
+
+  /**
+   * Prunes the call log, the way `tell()` prunes the trail.
+   *
+   * A call log is the one table henri owns whose retention has to work at a
+   * volume no model reaches, so it is where the partition drop lives
+   * (`base/call-store.js`). It is also the one whose failure must not fail
+   * the sweep: the models have already been swept by the time this runs and
+   * a debugging table that cannot be pruned is a warning, not an outage.
+   *
+   * @async
+   * @param {object} options the options of the sweep
+   * @returns {Promise<?object>} what was taken away, or null
+   * @memberof Retention
+   */
+  async sweepCalls(options) {
+    const { calls, pen } = this.henri;
+
+    if (!calls || !calls.enabled || options.dryRun) {
+      return null;
+    }
+
+    try {
+      const result = await calls.prune({
+        now: options.now ? new Date(options.now).getTime() : Date.now(),
+      });
+
+      pen.info(
+        'retention',
+        'call log',
+        `${result.removed} row(s)`,
+        result.partitions.length > 0
+          ? `and ${result.partitions.length} partition(s) dropped`
+          : ''
+      );
+
+      return result;
+    } catch (error) {
+      pen.warn('retention', 'unable to prune the call log', error.message);
+
+      return null;
+    }
   }
 
   /**

--- a/packages/core/src/__tests__/arguments.spec.js
+++ b/packages/core/src/__tests__/arguments.spec.js
@@ -41,6 +41,7 @@ const ROOT = path.resolve(__dirname, '..');
  */
 const INTERFACES = {
   Cache: 'henri.cache',
+  CallsModule: 'henri.calls',
   ConfigModule: 'henri.config',
   EncryptionModule: 'henri.encryption',
   Henri: 'henri',

--- a/packages/core/src/__tests__/calls.spec.js
+++ b/packages/core/src/__tests__/calls.spec.js
@@ -474,6 +474,34 @@ describe('the module, in the demo application', () => {
     expect(JSON.stringify(call)).not.toMatch(/sk_live/u);
   });
 
+  test('the route is the pattern, and the person is a public identifier', async () => {
+    const agent = supertest.agent(henri.server.app);
+    const email = 'called@demo.test';
+    const password = 'difference-engine';
+
+    await agent.post('/register').send({ email, name: 'Called', password });
+    await agent.post('/login').send({ email, password });
+
+    const id = `spec-actor-${Date.now()}`;
+
+    await agent.get('/profile').set('X-Request-Id', id);
+    await henri.calls.flush();
+
+    const [call] = await henri.calls.about(id);
+
+    // The pattern rather than the path, which is what makes a listing of
+    // the slow calls of one endpoint add up
+    expect(call.route).toBe('/profile');
+    // The public identifier, and nothing else: not the primary key, and
+    // not the address the session was opened with
+    expect(call.actor).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/u
+    );
+    expect(JSON.stringify(call)).not.toMatch(/called@demo\.test/u);
+    // ... and the session cookie the request carried is not in it either
+    expect(call.request.headers.cookie).toBe('[FILTERED]');
+  });
+
   test('the health probes are not in it', async () => {
     await request.get('/livez');
     await henri.calls.flush();

--- a/packages/core/src/__tests__/calls.spec.js
+++ b/packages/core/src/__tests__/calls.spec.js
@@ -1,0 +1,683 @@
+const supertest = require('supertest');
+const Henri = require('../henri');
+
+const {
+  Ceiling,
+  always,
+  bytes,
+  callsConfig,
+  capture,
+  checkPartition,
+  hash32,
+  headers,
+  ignored,
+  outcomeOf,
+  safeUrl,
+  toCall,
+  toRow,
+  walkable,
+} = require('../base/calls');
+const {
+  boundsOf,
+  install,
+  partitionName,
+  planOf,
+  startOf,
+} = require('../base/call-store');
+const { redactor, urlRedactor } = require('../base/redact');
+
+/** A configuration module standing in for the real one */
+const config = (calls) => ({
+  get: (key) => ({ calls, filterParameters: ['password', 'token'] })[key],
+  has: (key) => ['calls', 'filterParameters'].includes(key),
+});
+
+/** The context `toRow` reads, with a couple of personal names marked */
+const context = (settings = {}) => {
+  const instance = {
+    config: config(true),
+    privacy: { keys: new Set(['name', 'phone']) },
+  };
+
+  return {
+    filters: ['password', 'token'],
+    keys: instance.privacy.keys,
+    mask: urlRedactor(instance),
+    redact: redactor(instance),
+    settings: { ...callsConfig(config({})), ...settings },
+  };
+};
+
+describe('the settings', () => {
+  test('nothing said is nothing kept', () => {
+    for (const raw of [undefined, false, null]) {
+      const settings = callsConfig(config(raw));
+
+      expect(settings.enabled).toBe(false);
+      expect(settings.inbound).toBe(false);
+      expect(settings.outbound).toBe(false);
+      expect(settings.maxBody).toBe(0);
+    }
+
+    expect(callsConfig(null).enabled).toBe(false);
+  });
+
+  test('an empty object is the defaults', () => {
+    const settings = callsConfig(config({}));
+
+    expect(settings).toMatchObject({
+      always: ['error'],
+      buffer: 1000,
+      enabled: true,
+      inbound: true,
+      maxBody: 8192,
+      maxPerSecond: 100,
+      outbound: true,
+      partition: false,
+      sample: 1,
+      store: 'default',
+      table: 'henri_calls',
+    });
+    expect(settings.keep).toBe(30 * 86400000);
+  });
+
+  test('the bounds can be lifted one at a time, and each of them says so', () => {
+    expect(callsConfig(config({ keep: false })).keep).toBeNull();
+    expect(callsConfig(config({ maxPerSecond: false })).maxPerSecond).toBe(
+      Infinity
+    );
+    expect(callsConfig(config({ bodies: false })).maxBody).toBe(0);
+    expect(callsConfig(config({ maxBody: '1kb' })).maxBody).toBe(1024);
+    expect(callsConfig(config({ sample: 2 })).sample).toBe(1);
+    expect(callsConfig(config({ sample: -1 })).sample).toBe(0);
+    expect(callsConfig(config({ always: ['nope', 'aborted'] })).always).toEqual(
+      ['aborted']
+    );
+    expect(callsConfig(config({ partition: 'week' })).partition).toBe(false);
+    expect(callsConfig(config({ partition: 'day' })).partition).toBe('day');
+  });
+
+  test('a size is a number of bytes or a string', () => {
+    expect(bytes('8kb', 1)).toBe(8192);
+    expect(bytes(64, 1)).toBe(64);
+    expect(bytes('2mb', 1)).toBe(2097152);
+    expect(bytes(false, 1)).toBe(0);
+    expect(bytes('a lot', 7)).toBe(7);
+  });
+
+  test('a partition scheme a dialect cannot carry out fails loudly', () => {
+    expect(checkPartition('postgres', 'day')).toBe(true);
+    expect(checkPartition('mysql', 'month')).toBe(true);
+    expect(checkPartition('sqlite', false)).toBe(true);
+    expect(checkPartition('mongodb', false)).toBe(true);
+
+    for (const dialect of ['sqlite', 'mssql', 'mongodb']) {
+      let error = null;
+
+      try {
+        checkPartition(dialect, 'day');
+      } catch (thrown) {
+        error = thrown;
+      }
+
+      expect(error.code).toBe('HENRI_CALLS_PARTITION_UNSUPPORTED');
+      expect(error.hint).toMatch(/PostgreSQL and MySQL/u);
+    }
+  });
+});
+
+/**
+ * The redaction rule of `base/calls.js`, which is the reason this table is
+ * the most dangerous one henri writes. It has a test of its own the way the
+ * trail's refusal does, and each of these is a sentence of the header.
+ */
+describe('what never reaches a row', () => {
+  const head = {
+    filters: ['password', 'token'],
+    keys: new Set(['name']),
+    max: 50,
+  };
+
+  test('the credentials of an exchange are masked whatever the filters say', () => {
+    // Not one of them is in `filterParameters`: the point is that no
+    // application has to remember to write them down
+    expect(
+      headers(
+        {
+          accept: 'application/json',
+          authorization: 'Bearer sk_live_1234',
+          cookie: 'henri.sid=s%3Aabc',
+          'proxy-authorization': 'Basic zzz',
+          'set-cookie': 'henri.sid=s%3Aabc; HttpOnly',
+          'webhook-signature': 'v1,abc',
+          'x-api-key': 'key_1234',
+          'x-csrf-token': 'tok',
+        },
+        { ...head, filters: [] }
+      )
+    ).toEqual({
+      accept: 'application/json',
+      authorization: '[FILTERED]',
+      cookie: '[FILTERED]',
+      'proxy-authorization': '[FILTERED]',
+      'set-cookie': '[FILTERED]',
+      'webhook-signature': '[FILTERED]',
+      'x-api-key': '[FILTERED]',
+      'x-csrf-token': '[FILTERED]',
+    });
+  });
+
+  test("and so is anything the application's own filters name", () => {
+    expect(
+      headers({ 'x-name': 'Ada', 'x-session-token': 'abc' }, head)
+    ).toEqual({ 'x-name': 'Ada', 'x-session-token': '[FILTERED]' });
+  });
+
+  test('a body is walked: filters as substrings, personal names exactly', () => {
+    const stored = capture(
+      {
+        deep: { passwordConfirmation: 'hunter2', phone: '555' },
+        encryption: { keys: ['deadbeef'] },
+        name: 'Ada Lovelace',
+        note: 'kept',
+        password: 'hunter2',
+      },
+      { max: 8192, redact: context().redact }
+    );
+    const body = JSON.parse(stored.body);
+
+    expect(body.password).toBe('[FILTERED]');
+    // A substring, the way `filterParameters` matches
+    expect(body.deep.passwordConfirmation).toBe('[FILTERED]');
+    // Exactly, the way a `personal` mark matches
+    expect(body.name).toBe('[FILTERED]');
+    expect(body.deep.phone).toBe('[FILTERED]');
+    // The one no configuration lifts
+    expect(body.encryption).toBe('[FILTERED]');
+    expect(body.note).toBe('kept');
+    expect(stored.truncated).toBe(false);
+  });
+
+  test('a body henri cannot walk is not stored, only its shape', () => {
+    expect(walkable({ a: 1 })).toBe(true);
+    expect(walkable([1])).toBe(true);
+    expect(walkable('<html>secret</html>')).toBe(false);
+    expect(walkable(Buffer.from('secret'))).toBe(false);
+    expect(walkable(new Date())).toBe(false);
+
+    expect(
+      capture('<html>secret</html>', { max: 8192, redact: (x) => x })
+    ).toEqual({ body: null, kind: 'string', truncated: false });
+    expect(
+      capture(Buffer.from('secret'), { max: 8192, redact: (x) => x })
+    ).toEqual({ body: null, kind: 'buffer', truncated: false });
+  });
+
+  test('a body past the cap is cut and says so', () => {
+    const stored = capture(
+      { long: 'x'.repeat(500) },
+      { max: 64, redact: (value) => value }
+    );
+
+    expect(stored.truncated).toBe(true);
+    expect(stored.body).toHaveLength(64 + '…[truncated]'.length);
+    expect(stored.body.endsWith('…[truncated]')).toBe(true);
+    expect(
+      toCall({ request_body: stored.body, truncated: 'request' }).truncated
+    ).toEqual(['request']);
+  });
+
+  test('a url loses its userinfo and its filtered query values', () => {
+    const mask = context().mask;
+
+    expect(safeUrl('https://key:s3cret@api.example.test/v1/x', mask)).toBe(
+      'https://api.example.test/v1/x'
+    );
+    expect(safeUrl('/login?token=abc&page=2', mask)).toBe(
+      '/login?token=%5BFILTERED%5D&page=2'
+    );
+    expect(safeUrl(null, mask)).toBeNull();
+  });
+
+  test('a whole row keeps no credential and no address', () => {
+    const row = toRow(
+      {
+        at: 1,
+        direction: 'out',
+        id: 'x',
+        method: 'post',
+        request: {
+          body: { email: 'ada@example.test', name: 'Ada', token: 'abc' },
+          headers: { authorization: 'Bearer sk_live' },
+        },
+        response: { body: { ok: true }, headers: { 'set-cookie': 'a=b' } },
+        service: 'billing',
+        status: 200,
+        url: 'https://user:pass@api.example.test/charge?token=abc',
+      },
+      context()
+    );
+    const text = JSON.stringify(row);
+
+    expect(text).not.toMatch(/sk_live/u);
+    expect(text).not.toMatch(/a=b/u);
+    expect(text).not.toMatch(/Ada/u);
+    expect(text).not.toMatch(/user:pass/u);
+    expect(text).not.toMatch(/abc/u);
+    // The address is not a personal *name*, so this is what is left to say:
+    // an application marks `email` personal and the guide says to
+    expect(row.url).toBe(
+      'https://api.example.test/charge?token=%5BFILTERED%5D'
+    );
+    expect(row.method).toBe('POST');
+    expect(row.outcome).toBe('ok');
+  });
+});
+
+describe('the four bounds', () => {
+  test('an outcome is what decides whether sampling gets to drop it', () => {
+    expect(outcomeOf({ status: 200 })).toBe('ok');
+    expect(outcomeOf({ status: 404 })).toBe('ok');
+    expect(outcomeOf({ status: 500 })).toBe('failed');
+    expect(outcomeOf({ aborted: true })).toBe('aborted');
+    expect(outcomeOf({ error: 'ECONNRESET', status: null })).toBe('failed');
+
+    expect(always({ outcome: 'ok', status: 200 }, ['error'])).toBe(false);
+    expect(always({ outcome: 'failed', status: 500 }, ['error'])).toBe(true);
+    expect(always({ outcome: 'ok', status: 422 }, ['error'])).toBe(false);
+    expect(always({ outcome: 'ok', status: 422 }, ['client-error'])).toBe(true);
+    expect(always({ outcome: 'aborted', status: null }, ['aborted'])).toBe(
+      true
+    );
+    expect(always({ outcome: 'failed', status: 500 }, [])).toBe(false);
+  });
+
+  test('the ceiling is absolute and refills every second', () => {
+    const ceiling = new Ceiling(2);
+
+    expect(ceiling.take(1000)).toBe(true);
+    expect(ceiling.take(1100)).toBe(true);
+    expect(ceiling.take(1200)).toBe(false);
+    expect(ceiling.take(2000)).toBe(true);
+    expect(new Ceiling(Infinity).take(1)).toBe(true);
+  });
+
+  test('the sampling is a hash, so it is stable and it is seeded', () => {
+    const bucket = (id, seed) => hash32(id, seed) % 10000;
+    const ids = Array.from({ length: 2000 }, (unused, i) => `req-${i}`);
+
+    // Stable: the same id answers the same, which is what lets the inbound
+    // call and its outbound calls agree without carrying state
+    expect(bucket('req-1', 7)).toBe(bucket('req-1', 7));
+
+    // Seeded: the request id comes from a header a client can choose, so
+    // which ids are sampled must not be something a client can work out
+    const one = ids.filter((id) => bucket(id, 7) < 500);
+    const two = ids.filter((id) => bucket(id, 99) < 500);
+
+    expect(one.length).toBeGreaterThan(50);
+    expect(one.filter((id) => two.includes(id)).length).toBeLessThan(
+      one.length
+    );
+
+    // Spread evenly enough to mean 5%
+    expect(one.length / ids.length).toBeGreaterThan(0.02);
+    expect(one.length / ids.length).toBeLessThan(0.09);
+  });
+
+  test('the health probes are never recorded, whatever ignore says', () => {
+    expect(ignored('/livez', [])).toBe(true);
+    expect(ignored('/readyz', [])).toBe(true);
+    expect(ignored('/_henri/health', [])).toBe(true);
+    expect(ignored('/version', [])).toBe(false);
+    expect(ignored('/assets/app.css', ['/assets'])).toBe(true);
+  });
+});
+
+describe('the table, per dialect', () => {
+  test('every dialect gets the same columns and the same three indexes', () => {
+    for (const dialect of ['sqlite', 'postgres', 'mysql', 'mssql']) {
+      const statements = install(dialect, 'henri_calls').join('\n');
+
+      expect(statements).toContain('request_id');
+      expect(statements).toContain('PRIMARY KEY (at, id)');
+      expect(statements).toContain('henri_calls_request');
+      expect(statements).toContain('henri_calls_at');
+      expect(statements).toContain('henri_calls_service');
+    }
+  });
+
+  test('a table name that is not an identifier is refused', () => {
+    expect(() => install('sqlite', 'drop me')).toThrow(/invalid table name/u);
+    expect(() => install('oracle', 'henri_calls')).toThrow(
+      /cannot be kept in a oracle store/u
+    );
+  });
+
+  test('postgres declares the scheme, then the periods and a default', () => {
+    const statements = install('postgres', 'henri_calls', {
+      ahead: 2,
+      now: Date.UTC(2026, 8, 6, 12),
+      partition: 'day',
+    });
+    const text = statements.join('\n');
+
+    expect(text).toContain('PARTITION BY RANGE (at)');
+    expect(text).toContain(
+      `"henri_calls_p20260906" PARTITION OF "henri_calls" FOR VALUES FROM (${Date.UTC(
+        2026,
+        8,
+        6
+      )}) TO (${Date.UTC(2026, 8, 7)})`
+    );
+    expect(text).toContain('"henri_calls_p20260908"');
+    // Nothing henri writes is ever refused for want of a partition
+    expect(text).toContain('"henri_calls_pdefault" PARTITION OF');
+  });
+
+  test('mysql puts the periods in the CREATE TABLE and keeps a MAXVALUE', () => {
+    const text = install('mysql', 'henri_calls', {
+      ahead: 1,
+      now: Date.UTC(2026, 8, 6, 12),
+      partition: 'month',
+    }).join('\n');
+
+    expect(text).toContain('PARTITION BY RANGE (at) (');
+    expect(text).toContain(
+      `PARTITION p20260901 VALUES LESS THAN (${Date.UTC(2026, 9, 1)})`
+    );
+    expect(text).toContain('PARTITION pmax VALUES LESS THAN MAXVALUE');
+  });
+
+  test('a partition says what it covers through its name', () => {
+    expect(startOf(Date.UTC(2026, 8, 6, 23, 59), 'day')).toBe(
+      Date.UTC(2026, 8, 6)
+    );
+    expect(startOf(Date.UTC(2026, 8, 6, 23, 59), 'month')).toBe(
+      Date.UTC(2026, 8, 1)
+    );
+    expect(partitionName('postgres', 'henri_calls', Date.UTC(2026, 8, 6))).toBe(
+      'henri_calls_p20260906'
+    );
+    expect(partitionName('mysql', 'henri_calls', Date.UTC(2026, 8, 6))).toBe(
+      'p20260906'
+    );
+    expect(boundsOf('henri_calls_p20260906', 'day')).toEqual({
+      from: Date.UTC(2026, 8, 6),
+      to: Date.UTC(2026, 8, 7),
+    });
+    expect(boundsOf('henri_calls_pdefault', 'day')).toBeNull();
+    expect(boundsOf('pmax', 'month')).toBeNull();
+    expect(planOf(Date.UTC(2026, 8, 6, 3), { ahead: 2, every: 'day' })).toEqual(
+      [Date.UTC(2026, 8, 6), Date.UTC(2026, 8, 7), Date.UTC(2026, 8, 8)]
+    );
+  });
+});
+
+describe('the module, in the demo application', () => {
+  let henri = null;
+  let request = null;
+  const skipWorkers = process.env.SKIP_WORKERS;
+
+  beforeAll(async () => {
+    process.env.SKIP_WORKERS = '1';
+    henri = new Henri();
+    await henri.init();
+    global.henri = henri;
+    request = supertest(henri.server.app);
+  }, 60000);
+
+  afterAll(async () => {
+    await henri.stop();
+    delete global.henri;
+    if (typeof skipWorkers === 'undefined') {
+      delete process.env.SKIP_WORKERS;
+    } else {
+      process.env.SKIP_WORKERS = skipWorkers;
+    }
+  }, 60000);
+
+  test('it is on, it owns a table, and MongoDB gets the delete path', () => {
+    expect(henri.calls.enabled).toBe(true);
+    expect(henri.calls.settings.table).toBe('henri_calls');
+    expect(henri.calls.store.kind).toBe('mongo');
+    expect(henri.calls.store.partition).toBe(false);
+  });
+
+  test('an answered call is recorded, off the hot path', async () => {
+    const id = `spec-in-${Date.now()}`;
+    const answer = await request
+      .post('/echo')
+      .set('X-Request-Id', id)
+      .set('Authorization', 'Bearer sk_live_should_not_be_stored')
+      .send({ password: 'hunter2', title: 'Kept' });
+
+    expect(answer.status).toBe(200);
+
+    // Nothing was written yet: the answer went out first
+    expect(henri.calls.buffer.length).toBeGreaterThan(0);
+
+    await henri.calls.flush();
+
+    const [call] = await henri.calls.about(id);
+
+    expect(call.direction).toBe('in');
+    expect(call.method).toBe('POST');
+    expect(call.url).toBe('/echo');
+    expect(call.status).toBe(200);
+    expect(call.outcome).toBe('ok');
+    expect(call.duration).toBeGreaterThanOrEqual(0);
+    expect(call.request.body.title).toBe('Kept');
+    expect(call.request.body.password).toBe('[FILTERED]');
+    expect(call.request.headers.authorization).toBe('[FILTERED]');
+    expect(call.response.body.sequence).toEqual(expect.any(Number));
+    expect(JSON.stringify(call)).not.toMatch(/sk_live/u);
+  });
+
+  test('the health probes are not in it', async () => {
+    await request.get('/livez');
+    await henri.calls.flush();
+
+    expect(await henri.calls.count({ service: null, status: 200 })).toEqual(
+      expect.any(Number)
+    );
+    expect(
+      (await henri.calls.list({ limit: 200 })).filter(
+        (call) => call.url === '/livez'
+      )
+    ).toEqual([]);
+  });
+
+  test('the join is the feature: one request, its call in and its calls out', async () => {
+    const id = `spec-join-${Date.now()}`;
+
+    // An outbound call recorded by hand is the seam an application's own
+    // client goes through: henri wraps nobody's client
+    const finish = henri.calls.track({
+      method: 'POST',
+      request: {
+        body: { amount: 100 },
+        headers: { authorization: 'Bearer x' },
+      },
+      requestId: id,
+      service: 'billing',
+      url: 'https://key:secret@api.example.test/v1/charges',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    finish({ body: { id: 'ch_1' }, status: 201 });
+
+    henri.calls.outbound({
+      method: 'GET',
+      requestId: id,
+      service: 'search',
+      status: 200,
+      url: 'https://search.example.test/q',
+    });
+
+    await henri.calls.flush();
+
+    const story = await henri.calls.about(id);
+
+    expect(story.map((call) => call.service)).toEqual(['billing', 'search']);
+    expect(story[0].direction).toBe('out');
+    expect(story[0].url).toBe('https://api.example.test/v1/charges');
+    expect(story[0].status).toBe(201);
+    expect(story[0].duration).toBeGreaterThanOrEqual(1);
+    expect(story[0].request.headers.authorization).toBe('[FILTERED]');
+    expect(story[0].response.body).toEqual({ id: 'ch_1' });
+  });
+
+  test('a mail is one of the outbound calls henri makes itself', async () => {
+    const before = await henri.calls.count({ service: 'mail' });
+
+    await henri.mail.send({
+      html: '<p>hello</p>',
+      subject: 'Hello',
+      to: 'someone@example.test',
+    });
+
+    await henri.calls.flush();
+
+    const [sent] = await henri.calls.list({ service: 'mail' });
+
+    expect(await henri.calls.count({ service: 'mail' })).toBe(before + 1);
+    expect(sent.direction).toBe('out');
+    expect(sent.method).toBe('SEND');
+    expect(sent.status).toBe(250);
+    expect(sent.meta.messageId).toEqual(expect.any(String));
+    // The recipient is not in the table, and the guide says why
+    expect(JSON.stringify(sent)).not.toMatch(/someone@example\.test/u);
+  });
+
+  test('the ceiling drops rather than queues, and says how many', () => {
+    const ceiling = henri.calls.ceiling;
+    const dropped = henri.calls.counters.rate;
+
+    henri.calls.ceiling = new Ceiling(0);
+
+    expect(
+      henri.calls.outbound({ service: 'over', status: 200, url: '/x' })
+    ).toBe(false);
+    expect(henri.calls.counters.rate).toBe(dropped + 1);
+
+    henri.calls.ceiling = ceiling;
+  });
+
+  test('a full buffer drops rather than growing, and says how many', () => {
+    const buffer = henri.calls.buffer;
+    const dropped = henri.calls.counters.buffer;
+
+    henri.calls.buffer = new Array(henri.calls.settings.buffer).fill({});
+
+    expect(
+      henri.calls.outbound({ service: 'over', status: 200, url: '/x' })
+    ).toBe(false);
+    expect(henri.calls.counters.buffer).toBe(dropped + 1);
+
+    henri.calls.buffer = buffer;
+  });
+
+  test('sampling drops a call, and calls.always keeps the failures', () => {
+    const sample = henri.calls.settings.sample;
+
+    henri.calls.settings.sample = 0;
+
+    expect(
+      henri.calls.outbound({ service: 'quiet', status: 200, url: '/x' })
+    ).toBe(false);
+
+    // ... unless it failed, and then without its bodies: the decision not
+    // to capture them was made before the status was known
+    expect(
+      henri.calls.outbound({
+        request: { body: { secretish: 1 }, headers: { accept: '*/*' } },
+        service: 'loud',
+        status: 503,
+        url: '/x',
+      })
+    ).toBe(true);
+
+    const row = henri.calls.buffer[henri.calls.buffer.length - 1];
+
+    expect(row.service).toBe('loud');
+    expect(row.request_body).toBeNull();
+    expect(row.request_headers).toContain('accept');
+
+    henri.calls.settings.sample = sample;
+  });
+
+  test('a flush that fails never fails the caller', async () => {
+    const insert = henri.calls.store.insert;
+
+    henri.calls.store.insert = async () => {
+      throw new Error('the database went away');
+    };
+
+    henri.calls.outbound({ service: 'doomed', status: 200, url: '/x' });
+
+    await expect(henri.calls.flush()).resolves.toBe(0);
+    expect(henri.calls.counters.failed).toBeGreaterThan(0);
+
+    henri.calls.store.insert = insert;
+  });
+
+  test('the sweep takes the old rows away', async () => {
+    henri.calls.outbound({
+      at: Date.now() - 40 * 86400000,
+      service: 'ancient',
+      status: 200,
+      url: '/x',
+    });
+
+    await henri.calls.flush();
+
+    expect(await henri.calls.count({ service: 'ancient' })).toBe(1);
+
+    const result = await henri.calls.prune();
+
+    expect(result.removed).toBeGreaterThan(0);
+    expect(result.partitions).toEqual([]);
+    expect(await henri.calls.count({ service: 'ancient' })).toBe(0);
+  });
+
+  test('the retention sweep is what runs it', async () => {
+    henri.calls.outbound({
+      at: Date.now() - 40 * 86400000,
+      service: 'swept',
+      status: 200,
+      url: '/x',
+    });
+
+    await henri.calls.flush();
+    await henri.retention.sweep({ dryRun: false });
+
+    expect(await henri.calls.count({ service: 'swept' })).toBe(0);
+  });
+
+  test('stats say what was written and what was not', async () => {
+    const stats = await henri.calls.stats();
+
+    expect(stats.enabled).toBe(true);
+    expect(stats.written).toBeGreaterThan(0);
+    expect(stats.total).toBeGreaterThan(0);
+    expect(stats.dropped.rate).toBeGreaterThan(0);
+    expect(stats.partitions).toEqual([]);
+  });
+
+  test('reading a log that is off says so rather than answering nothing', async () => {
+    const enabled = henri.calls.enabled;
+
+    henri.calls.enabled = false;
+
+    await expect(henri.calls.list()).rejects.toMatchObject({
+      code: 'HENRI_CALLS_DISABLED',
+    });
+    expect(await henri.calls.stats()).toMatchObject({ enabled: false });
+    // Recording is a no-op, so nothing in core has to ask first
+    expect(henri.calls.outbound({ service: 'x' })).toBe(false);
+    expect(henri.calls.track({ service: 'x' })()).toBeNull();
+
+    henri.calls.enabled = enabled;
+  });
+});

--- a/packages/core/src/__tests__/config-schema.spec.js
+++ b/packages/core/src/__tests__/config-schema.spec.js
@@ -463,6 +463,7 @@ describe('the schema, the declarations and the documentation', () => {
     ['PrivacyConfig', () => Object.keys(SCHEMA.privacy.keys)],
     ['RetentionConfig', () => Object.keys(SCHEMA.retention.keys)],
     ['TrailConfig', () => Object.keys(SCHEMA.trail.oneOf[1].keys)],
+    ['CallsConfig', () => Object.keys(SCHEMA.calls.oneOf[1].keys)],
     ['RateLimitConfig', rateLimitKeys],
     ['SharedConfig', () => Object.keys(SCHEMA.shared.keys)],
     ['CacheConfig', () => Object.keys(SCHEMA.cache.oneOf[1].keys)],

--- a/packages/core/src/base/arguments.js
+++ b/packages/core/src/base/arguments.js
@@ -59,7 +59,8 @@
  * `paths`), `henri.cache` (`get`, `set`, `delete`, `clear`, `scope`,
  * `fetch`), `henri.privacy` (`fields`, `strip`, `subject`, `export`,
  * `plan`, `erase`), `henri.retention` (`plan`, `sweep`), `henri.trail`
- * (`list`, `count`, `about`, `prune`), `henri.encryption` (`markOf`,
+ * (`list`, `count`, `about`, `prune`), `henri.calls` (`list`, `count`,
+ * `about`, `prune`, `outbound`, `track`), `henri.encryption` (`markOf`,
  * `encrypt`, `decrypt`, `candidates`, `tolerate`, `rotate`),
  * `henri.model.getStore`, `henri.mail.send`, `deliverLater`, and what a
  * request gets: `res.resource`, `res.collection`, `res.negotiate`,
@@ -341,6 +342,58 @@ const STATUS = {
   type: 'number',
 };
 
+/** What the call log is read back with */
+const CALL_FILTER = bag({
+  actor: maybe(NAME),
+  direction: maybe({ enum: ['in', 'out'], type: 'string' }),
+  limit: maybe(COUNT),
+  offset: maybe({ integer: true, min: 0, type: 'number' }),
+  outcome: maybe({ enum: ['aborted', 'failed', 'ok'], type: 'string' }),
+  requestId: maybe(NAME),
+  service: maybe(NAME),
+  since: maybe(WHEN),
+  status: maybe(STATUS),
+  until: maybe(WHEN),
+});
+
+/**
+ * One half of a call: the headers and the body of a request or an answer.
+ *
+ * The body is `ANY` on purpose -- an outbound call carries whatever the
+ * service takes -- and what it is *allowed to become* is not this module's
+ * question: `base/calls.js` stores a body it can walk and redact, and
+ * records the shape of anything else instead of the thing itself.
+ */
+const CALL_SIDE = maybe(bag({ body: ANY, headers: maybe(OBJECT) }));
+
+/** What an outbound call records */
+const CALL = bag({
+  actor: maybe(NAME),
+  at: maybe({ min: 0, type: 'number' }),
+  duration: maybe({ min: 0, type: 'number' }),
+  error: maybe(NAME),
+  meta: maybe(OBJECT),
+  method: maybe(NAME),
+  outcome: maybe({ enum: ['aborted', 'failed', 'ok'], type: 'string' }),
+  request: CALL_SIDE,
+  requestId: maybe(NAME),
+  response: CALL_SIDE,
+  route: maybe(NAME),
+  service: maybe(NAME),
+  status: maybe(STATUS),
+  url: maybe(NAME),
+});
+
+/** ... and what starts timing one */
+const CALL_TRACK = bag({
+  meta: maybe(OBJECT),
+  method: maybe(NAME),
+  request: CALL_SIDE,
+  requestId: maybe(NAME),
+  service: maybe(NAME),
+  url: maybe(NAME),
+});
+
 /** What `res.resource()` takes */
 const RESOURCE_OPTIONS = bag({
   include: INCLUDE,
@@ -398,6 +451,27 @@ const SIGNATURES = {
     { by: 'HENRI_CACHE_VALUE_UNSUPPORTED', name: 'value' },
     { name: 'options', optional: true, ...CACHE_OPTIONS },
   ],
+
+  'henri.calls.about': [
+    { name: 'requestId', ...NAME },
+    { name: 'filter', optional: true, ...CALL_FILTER },
+  ],
+
+  'henri.calls.count': [{ name: 'filter', optional: true, ...CALL_FILTER }],
+
+  'henri.calls.list': [{ name: 'filter', optional: true, ...CALL_FILTER }],
+
+  'henri.calls.outbound': [{ name: 'call', ...CALL }],
+
+  'henri.calls.prune': [
+    {
+      name: 'options',
+      optional: true,
+      ...bag({ now: maybe({ min: 0, type: 'number' }) }),
+    },
+  ],
+
+  'henri.calls.track': [{ name: 'details', ...CALL_TRACK }],
 
   'henri.encryption.candidates': [
     {

--- a/packages/core/src/base/call-store.js
+++ b/packages/core/src/base/call-store.js
@@ -1,0 +1,1076 @@
+/**
+ * The table the call log is written to, and the two backends that reach it.
+ *
+ * A table henri owns, the way the trail and the queue own theirs: raw SQL
+ * through the store adapter's `query()`, or a MongoDB collection, never a
+ * henri model. `base/trail-store.js` gives the reasons and they all hold
+ * here, plus one of this table's own -- a model would be swept by the
+ * retention rules an application wrote for its *own* records, and this one
+ * has a retention of its own that has to work at a volume no model reaches.
+ *
+ * Both directions of a call live in one table, discriminated by
+ * `direction`. `base/calls.js` argues that; the consequence here is that
+ * the join a call log exists for is one `SELECT` on one index.
+ *
+ * ## Partitions, where the dialect has them
+ *
+ * A sweep that deletes rows is fine at a thousand rows a day and hopeless
+ * at ten million: the deletes are logged, the indexes are rewritten, the
+ * table bloats and the sweep runs longer than the interval between sweeps.
+ * PostgreSQL and MySQL both range-partition, and dropping a partition is a
+ * metadata operation whatever it held. So `calls.partition` (`'day'` or
+ * `'month'`) creates the table partitioned by `at`, keeps
+ * `calls.partitionsAhead` periods ready in front of the clock, and the
+ * sweep drops whole periods.
+ *
+ * Two details that are decisions rather than mechanics:
+ *
+ * - **there is always a catch-all** -- a `DEFAULT` partition on PostgreSQL,
+ *   a `VALUES LESS THAN MAXVALUE` partition on MySQL. Without one, a row
+ *   whose `at` fell outside every declared range is *refused*, which turns
+ *   a partition henri forgot to create into failed inserts. The cost is
+ *   that a `CREATE TABLE ... PARTITION OF` has to check the default for
+ *   conflicting rows, which is fast while the default is empty and is the
+ *   normal case;
+ * - **the bounds are UTC and they are in the name.** A partition is called
+ *   `<table>_p20260906` (PostgreSQL) or `p20260906` (MySQL), so the sweep
+ *   works out what a partition covers from its name instead of parsing a
+ *   bound expression in two dialects' spellings.
+ *
+ * sqlite, SQL Server and MongoDB have no range partitioning, so they get
+ * the delete path: a bounded loop, `calls.sweep` rows at a time, selecting
+ * the doomed rows and then deleting them by id. `calls.partition` on one of
+ * those fails the boot (`HENRI_CALLS_PARTITION_UNSUPPORTED`) rather than
+ * being quietly ignored.
+ *
+ * Moments are BIGINT milliseconds since the epoch, for the reason the queue
+ * and the trail both give.
+ *
+ * @module base/call-store
+ */
+
+const debug = require('debug')('henri:calls');
+
+const { fail } = require('./errors');
+const { DIALECTS, reasons, toNumber } = require('./trail-store');
+
+/** A table name henri is willing to interpolate into a statement */
+const SAFE_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/** The columns of the call table, in insert order */
+const COLUMNS = [
+  'id',
+  'at',
+  'direction',
+  'request_id',
+  'service',
+  'method',
+  'url',
+  'route',
+  'status',
+  'duration',
+  'actor',
+  'outcome',
+  'error',
+  'request_headers',
+  'request_body',
+  'response_headers',
+  'response_body',
+  'truncated',
+  'meta',
+];
+
+/** A day, in milliseconds */
+const DAY = 86400000;
+
+/**
+ * The column definitions of the table.
+ *
+ * The primary key is `(at, id)` in every dialect, partitioned or not: both
+ * PostgreSQL and MySQL require the partitioning column in every unique key,
+ * and clustering a log by time is what you would have chosen anyway.
+ *
+ * @param {object} dialect a dialect description from `trail-store.js`
+ * @returns {Array<string>} the column definitions
+ */
+const columnsFor = (dialect) => [
+  'id VARCHAR(36) NOT NULL',
+  'at BIGINT NOT NULL',
+  'direction VARCHAR(3) NOT NULL',
+  'request_id VARCHAR(64) NULL',
+  'service VARCHAR(120) NULL',
+  'method VARCHAR(12) NOT NULL',
+  `url ${dialect.text} NULL`,
+  'route VARCHAR(190) NULL',
+  `status ${dialect.int} NULL`,
+  `duration ${dialect.int} NULL`,
+  'actor VARCHAR(64) NULL',
+  'outcome VARCHAR(16) NOT NULL',
+  'error VARCHAR(190) NULL',
+  `request_headers ${dialect.text} NULL`,
+  `request_body ${dialect.text} NULL`,
+  `response_headers ${dialect.text} NULL`,
+  `response_body ${dialect.text} NULL`,
+  'truncated VARCHAR(32) NULL',
+  `meta ${dialect.text} NULL`,
+  'PRIMARY KEY (at, id)',
+];
+
+/**
+ * The indexes of the call table.
+ *
+ * `request_id` is the one that matters: it is the join the whole feature
+ * exists for. The other two are the listings a person actually asks for --
+ * the recent calls, and the recent calls of one service.
+ *
+ * @param {string} table the table name
+ * @returns {Array<object>} `{ name, columns }` entries
+ */
+const indexesFor = (table) => [
+  { columns: ['request_id'], name: `${table}_request` },
+  { columns: ['at'], name: `${table}_at` },
+  { columns: ['direction', 'service', 'at'], name: `${table}_service` },
+];
+
+/**
+ * The start of the period a moment falls in, in UTC
+ *
+ * @param {number} moment epoch milliseconds
+ * @param {string} every `day` or `month`
+ * @returns {number} the start of the period
+ */
+const startOf = (moment, every) => {
+  const when = new Date(moment);
+
+  if (every === 'month') {
+    return Date.UTC(when.getUTCFullYear(), when.getUTCMonth(), 1);
+  }
+
+  return Date.UTC(when.getUTCFullYear(), when.getUTCMonth(), when.getUTCDate());
+};
+
+/**
+ * The start of the period after this one
+ *
+ * @param {number} start the start of a period
+ * @param {string} every `day` or `month`
+ * @returns {number} the next start
+ */
+const nextOf = (start, every) => {
+  if (every === 'month') {
+    const when = new Date(start);
+
+    return Date.UTC(when.getUTCFullYear(), when.getUTCMonth() + 1, 1);
+  }
+
+  return start + DAY;
+};
+
+/**
+ * The `yyyymmdd` a partition is named after
+ *
+ * @param {number} start the start of the period
+ * @returns {string} the stamp
+ */
+const stampOf = (start) =>
+  new Date(start).toISOString().slice(0, 10).replace(/-/gu, '');
+
+/**
+ * The name of one partition
+ *
+ * @param {string} dialect the dialect
+ * @param {string} table the table
+ * @param {number} start the start of the period
+ * @returns {string} the partition name
+ */
+const partitionName = (dialect, table, start) =>
+  dialect === 'mysql' ? `p${stampOf(start)}` : `${table}_p${stampOf(start)}`;
+
+/** The catch-all partition: nothing henri writes is ever refused */
+const catchAll = (dialect, table) =>
+  dialect === 'mysql' ? 'pmax' : `${table}_pdefault`;
+
+/**
+ * The period a partition covers, read back from its name
+ *
+ * @param {string} name the partition name
+ * @param {string} every `day` or `month`
+ * @returns {?{from: number, to: number}} the bounds, or null for the
+ *   catch-all and anything else that is not one of ours
+ */
+const boundsOf = (name, every) => {
+  const found = /p(\d{4})(\d{2})(\d{2})$/u.exec(String(name));
+
+  if (!found) {
+    return null;
+  }
+
+  const from = Date.UTC(
+    Number(found[1]),
+    Number(found[2]) - 1,
+    Number(found[3])
+  );
+
+  return { from, to: nextOf(from, every) };
+};
+
+/**
+ * The periods a table should have partitions for
+ *
+ * @param {number} now the moment
+ * @param {object} options `every` and `ahead`
+ * @returns {Array<number>} the starts, oldest first
+ */
+const planOf = (now, { ahead, every }) => {
+  const starts = [];
+  let start = startOf(now, every);
+
+  for (let step = 0; step <= ahead; step += 1) {
+    starts.push(start);
+    start = nextOf(start, every);
+  }
+
+  return starts;
+};
+
+/**
+ * Every statement that creates the table and its indexes, in order
+ *
+ * @param {string} name the dialect (sqlite, postgres, mysql, mssql)
+ * @param {string} table the table name
+ * @param {object} [options={}] `partition`, `ahead`, `now`
+ * @returns {Array<string>} the statements, all of them idempotent
+ * @throws HENRI_CALLS_UNSUPPORTED_STORE on a dialect henri cannot talk to
+ * @throws HENRI_CONFIG_INVALID on a table name that is not an identifier
+ */
+const install = (name, table, options = {}) => {
+  const dialect = DIALECTS[name];
+
+  if (!dialect) {
+    throw fail(
+      'HENRI_CALLS_UNSUPPORTED_STORE',
+      `the call log cannot be kept in a ${name} store`
+    );
+  }
+
+  if (!SAFE_NAME.test(table)) {
+    throw fail(
+      'HENRI_CONFIG_INVALID',
+      `calls.table: invalid table name "${table}": letters, digits and underscores only`
+    );
+  }
+
+  const { ahead = 7, now = Date.now(), partition = false } = options;
+  const quoted = dialect.quote(table);
+  const definitions = [...columnsFor(dialect)];
+  const indexes = indexesFor(table);
+  const statements = [];
+
+  if (dialect.inlineIndexes) {
+    for (const index of indexes) {
+      definitions.push(
+        `KEY ${dialect.quote(index.name)} (${index.columns.join(', ')})`
+      );
+    }
+  }
+
+  const create = [
+    'CREATE TABLE',
+    dialect.ifNotExists,
+    `${quoted} (\n  ${definitions.join(',\n  ')}\n)`,
+    partition
+      ? partitionClause(name, table, { ahead, every: partition, now })
+      : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  statements.push(
+    dialect.guardTable ? dialect.guardTable(table, create) : create
+  );
+
+  if (!dialect.inlineIndexes) {
+    for (const index of indexes) {
+      const statement = [
+        'CREATE INDEX',
+        dialect.guardIndex ? '' : dialect.ifNotExists,
+        `${dialect.quote(index.name)} ON ${quoted} (${index.columns.join(', ')})`,
+      ]
+        .filter(Boolean)
+        .join(' ');
+
+      statements.push(
+        dialect.guardIndex
+          ? dialect.guardIndex(table, index.name, statement)
+          : statement
+      );
+    }
+  }
+
+  if (partition && name === 'postgres') {
+    statements.push(
+      ...planOf(now, { ahead, every: partition }).map((start) =>
+        createPartition(name, table, start, partition)
+      ),
+      `CREATE TABLE IF NOT EXISTS "${catchAll(name, table)}" PARTITION OF ${quoted} DEFAULT`
+    );
+  }
+
+  return statements;
+};
+
+/**
+ * The `PARTITION BY` tail of a `CREATE TABLE`
+ *
+ * PostgreSQL declares the scheme and the partitions separately; MySQL puts
+ * the whole list inside the `CREATE TABLE`, which is why the two do not
+ * share a code path here.
+ *
+ * @param {string} name the dialect
+ * @param {string} table the table
+ * @param {object} options `every`, `ahead`, `now`
+ * @returns {string} the clause
+ */
+const partitionClause = (name, table, { ahead, every, now }) => {
+  if (name === 'postgres') {
+    return 'PARTITION BY RANGE (at)';
+  }
+
+  if (name !== 'mysql') {
+    return '';
+  }
+
+  const parts = planOf(now, { ahead, every }).map(
+    (start) =>
+      `PARTITION ${partitionName(name, table, start)} VALUES LESS THAN (${nextOf(start, every)})`
+  );
+
+  return `PARTITION BY RANGE (at) (\n  ${parts.join(',\n  ')},\n  PARTITION ${catchAll(name, table)} VALUES LESS THAN MAXVALUE\n)`;
+};
+
+/**
+ * The statement that adds one partition
+ *
+ * @param {string} name the dialect
+ * @param {string} table the table
+ * @param {number} start the start of the period
+ * @param {string} every `day` or `month`
+ * @returns {string} the statement
+ */
+const createPartition = (name, table, start, every) => {
+  const partition = partitionName(name, table, start);
+  const to = nextOf(start, every);
+
+  if (name === 'postgres') {
+    return `CREATE TABLE IF NOT EXISTS "${partition}" PARTITION OF "${table}" FOR VALUES FROM (${start}) TO (${to})`;
+  }
+
+  // MySQL grows the table by splitting the catch-all, which is empty while
+  // henri keeps ahead of the clock and is therefore a cheap rebuild
+  return `ALTER TABLE \`${table}\` REORGANIZE PARTITION ${catchAll(name, table)} INTO (PARTITION ${partition} VALUES LESS THAN (${to}), PARTITION ${catchAll(name, table)} VALUES LESS THAN MAXVALUE)`;
+};
+
+/**
+ * The statement that takes one partition away
+ *
+ * @param {string} name the dialect
+ * @param {string} table the table
+ * @param {string} partition the partition name
+ * @returns {string} the statement
+ */
+const dropPartition = (name, table, partition) =>
+  name === 'postgres'
+    ? `DROP TABLE IF EXISTS "${partition}"`
+    : `ALTER TABLE \`${table}\` DROP PARTITION ${partition}`;
+
+/**
+ * The query that lists the partitions of a table
+ *
+ * @param {string} name the dialect
+ * @returns {?{sql: string, params: Array}} the query, or null
+ */
+const listPartitions = (name) => {
+  if (name === 'postgres') {
+    return {
+      params: [],
+      sql: 'SELECT c.relname AS name FROM pg_inherits i JOIN pg_class c ON c.oid = i.inhrelid JOIN pg_class p ON p.oid = i.inhparent WHERE p.relname = ?',
+    };
+  }
+
+  if (name === 'mysql') {
+    return {
+      params: [],
+      sql: 'SELECT PARTITION_NAME AS name FROM information_schema.PARTITIONS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND PARTITION_NAME IS NOT NULL',
+    };
+  }
+
+  return null;
+};
+
+/** Errors that mean the object was created by another process first */
+const ALREADY_THERE =
+  /already exists|duplicate key|duplicate table|there is already an object named|Duplicate partition name/iu;
+
+/**
+ * The SQL backend
+ *
+ * @class SqlCalls
+ */
+class SqlCalls {
+  /**
+   * Creates an instance of SqlCalls.
+   *
+   * @param {object} adapter a henri store adapter with `query()`
+   * @param {object} options `dialect`, `dollars`, `table`, `partition`,
+   *   `ahead`
+   * @memberof SqlCalls
+   */
+  constructor(
+    adapter,
+    { ahead = 7, dialect, dollars = false, partition = false, table }
+  ) {
+    this.adapter = adapter;
+    this.ahead = ahead;
+    this.dialect = dialect;
+    this.dollars = dollars;
+    this.kind = 'sql';
+    this.partition = partition;
+    this.table = table;
+    /** The moment the partitions in front of the clock run out */
+    this.covered = 0;
+  }
+
+  /**
+   * The statement with the placeholders this driver expects
+   *
+   * @param {string} sql a statement written with `?`
+   * @returns {string} the statement
+   * @memberof SqlCalls
+   */
+  prepare(sql) {
+    if (!this.dollars) {
+      return sql;
+    }
+
+    let index = 0;
+
+    return sql.replace(/\?/gu, () => {
+      index += 1;
+
+      return `$${index}`;
+    });
+  }
+
+  /**
+   * Runs a statement that returns no rows
+   *
+   * @param {string} sql the statement
+   * @param {Array} [params=[]] the parameters
+   * @returns {Promise<void>} resolves when done
+   * @memberof SqlCalls
+   */
+  async run(sql, params = []) {
+    debug('run %s', sql);
+
+    await this.adapter.query(this.prepare(sql), params);
+  }
+
+  /**
+   * Runs a query and answers with its rows
+   *
+   * @param {string} sql the query
+   * @param {Array} [params=[]] the parameters
+   * @returns {Promise<Array<object>>} the rows
+   * @memberof SqlCalls
+   */
+  async select(sql, params = []) {
+    const rows = await this.adapter.query(this.prepare(sql), params, {
+      type: 'SELECT',
+    });
+
+    return Array.isArray(rows) ? rows : [];
+  }
+
+  /**
+   * Creates the table, its indexes and its partitions; idempotent
+   *
+   * @param {number} [now=Date.now()] the moment
+   * @returns {Promise<Array<string>>} the statements that ran
+   * @memberof SqlCalls
+   */
+  async install(now = Date.now()) {
+    const statements = install(this.dialect, this.table, {
+      ahead: this.ahead,
+      now,
+      partition: this.partition,
+    });
+
+    for (const statement of statements) {
+      try {
+        await this.run(statement);
+      } catch (error) {
+        if (!ALREADY_THERE.test(reasons(error))) {
+          throw error;
+        }
+
+        debug('another process created it first: %s', error.message);
+      }
+    }
+
+    if (this.partition) {
+      await this.ensure(now);
+    }
+
+    return statements;
+  }
+
+  /**
+   * Makes sure there are partitions in front of the clock.
+   *
+   * Cheap to call: it remembers how far it covered and does nothing until
+   * the clock catches up with it. A failure here is not fatal -- the
+   * catch-all partition takes the rows and the next sweep tries again --
+   * so it reports rather than throws.
+   *
+   * @param {number} [now=Date.now()] the moment
+   * @returns {Promise<Array<string>>} the partitions that were created
+   * @memberof SqlCalls
+   */
+  async ensure(now = Date.now()) {
+    if (!this.partition) {
+      return [];
+    }
+
+    const starts = planOf(now, { ahead: this.ahead, every: this.partition });
+    const made = [];
+
+    for (const start of starts) {
+      const statement = createPartition(
+        this.dialect,
+        this.table,
+        start,
+        this.partition
+      );
+
+      try {
+        await this.run(statement);
+        made.push(partitionName(this.dialect, this.table, start));
+      } catch (error) {
+        if (!ALREADY_THERE.test(reasons(error))) {
+          debug('unable to create a partition: %s', error.message);
+        }
+      }
+    }
+
+    this.covered = starts[starts.length - 1];
+
+    return made;
+  }
+
+  /**
+   * The partitions of the table, newest bound first
+   *
+   * @returns {Promise<Array<object>>} `{ name, from, to }` entries
+   * @memberof SqlCalls
+   */
+  async partitions() {
+    const query = listPartitions(this.dialect);
+
+    if (!query || !this.partition) {
+      return [];
+    }
+
+    const rows = await this.select(query.sql, [this.table]);
+
+    return rows
+      .map((row) => {
+        const name = row.name || row.NAME;
+        const bounds = boundsOf(name, this.partition);
+
+        return bounds ? { name, ...bounds } : null;
+      })
+      .filter(Boolean)
+      .sort((one, two) => two.from - one.from);
+  }
+
+  /**
+   * Writes rows, in one statement
+   *
+   * @param {Array<object>} rows the rows, in database shape
+   * @returns {Promise<number>} how many were written
+   * @memberof SqlCalls
+   */
+  async insert(rows) {
+    if (rows.length === 0) {
+      return 0;
+    }
+
+    const placeholders = `(${COLUMNS.map(() => '?').join(', ')})`;
+    const params = [];
+
+    for (const row of rows) {
+      for (const column of COLUMNS) {
+        params.push(typeof row[column] === 'undefined' ? null : row[column]);
+      }
+    }
+
+    await this.run(
+      `INSERT INTO ${this.table} (${COLUMNS.join(', ')}) VALUES ${rows
+        .map(() => placeholders)
+        .join(', ')}`,
+      params
+    );
+
+    return rows.length;
+  }
+
+  /**
+   * The tail of a query: an order, then a window
+   *
+   * @param {string} order the ordering
+   * @param {number} limit how many rows
+   * @param {number} [offset=0] how many to skip
+   * @returns {string} the clause
+   * @memberof SqlCalls
+   */
+  paging(order, limit, offset = 0) {
+    if (this.dialect === 'mssql') {
+      return ` ORDER BY ${order} OFFSET ${offset} ROWS FETCH NEXT ${limit} ROWS ONLY`;
+    }
+
+    return ` ORDER BY ${order} LIMIT ${limit} OFFSET ${offset}`;
+  }
+
+  /**
+   * The WHERE of a filter
+   *
+   * @param {object} filter the filter
+   * @returns {{sql: string, params: Array}} the clause and its parameters
+   * @memberof SqlCalls
+   */
+  conditions(filter) {
+    const parts = [];
+    const params = [];
+    const equals = {
+      actor: filter.actor,
+      direction: filter.direction,
+      outcome: filter.outcome,
+      request_id: filter.requestId,
+      service: filter.service,
+    };
+
+    for (const column of Object.keys(equals).sort()) {
+      if (typeof equals[column] === 'string' && equals[column] !== '') {
+        parts.push(`${column} = ?`);
+        params.push(equals[column]);
+      }
+    }
+
+    if (Number.isFinite(filter.status)) {
+      parts.push('status = ?');
+      params.push(filter.status);
+    }
+
+    if (Number.isFinite(filter.since)) {
+      parts.push('at >= ?');
+      params.push(filter.since);
+    }
+
+    if (Number.isFinite(filter.until)) {
+      parts.push('at <= ?');
+      params.push(filter.until);
+    }
+
+    return {
+      params,
+      sql: parts.length > 0 ? ` WHERE ${parts.join(' AND ')}` : '',
+    };
+  }
+
+  /**
+   * The rows matching a filter.
+   *
+   * A request id answers oldest first -- that listing is one exchange read
+   * as a story -- and everything else answers newest first.
+   *
+   * @param {object} [filter={}] the filter
+   * @returns {Promise<Array<object>>} the rows
+   * @memberof SqlCalls
+   */
+  async list(filter = {}) {
+    const { sql, params } = this.conditions(filter);
+    const limit = Math.min(Math.max(Number(filter.limit) || 100, 1), 1000);
+    const offset = Math.max(Number(filter.offset) || 0, 0);
+    const order = filter.requestId ? 'at ASC, direction DESC' : 'at DESC';
+
+    return this.select(
+      `SELECT * FROM ${this.table}${sql}${this.paging(order, limit, offset)}`,
+      params
+    );
+  }
+
+  /**
+   * How many rows match a filter
+   *
+   * @param {object} [filter={}] the filter
+   * @returns {Promise<number>} the count
+   * @memberof SqlCalls
+   */
+  async count(filter = {}) {
+    const { sql, params } = this.conditions(filter);
+    const [row] = await this.select(
+      `SELECT COUNT(*) AS total FROM ${this.table}${sql}`,
+      params
+    );
+
+    return toNumber(row && (row.total || row.TOTAL)) || 0;
+  }
+
+  /**
+   * Takes the rows past `before` away.
+   *
+   * The partitioned path drops whole periods and then runs the bounded
+   * delete over whatever is left -- the current period's older half, and
+   * anything the catch-all took. The unpartitioned path is only the second
+   * half.
+   *
+   * @param {number} before a timestamp in milliseconds
+   * @param {object} [options={}] `batch` and `now`
+   * @returns {Promise<object>} `{ removed, partitions, remaining }`
+   * @memberof SqlCalls
+   */
+  async sweep(before, options = {}) {
+    const { batch = 5000, now = Date.now() } = options;
+    const dropped = [];
+
+    if (this.partition) {
+      for (const partition of await this.partitions()) {
+        if (partition.to <= before) {
+          await this.run(
+            dropPartition(this.dialect, this.table, partition.name)
+          );
+          dropped.push(partition.name);
+        }
+      }
+
+      await this.ensure(now);
+    }
+
+    let removed = 0;
+
+    for (;;) {
+      const rows = await this.select(
+        `SELECT id FROM ${this.table} WHERE at < ?${this.paging('at ASC', batch)}`,
+        [before]
+      );
+
+      if (rows.length === 0) {
+        break;
+      }
+
+      await this.run(
+        `DELETE FROM ${this.table} WHERE at < ? AND id IN (${rows
+          .map(() => '?')
+          .join(', ')})`,
+        [before, ...rows.map((row) => row.id || row.ID)]
+      );
+
+      removed += rows.length;
+
+      if (rows.length < batch) {
+        break;
+      }
+    }
+
+    return { partitions: dropped, removed };
+  }
+}
+
+/**
+ * The MongoDB backend. The documents carry the SQL column names, so both
+ * backends hand the module the same rows.
+ *
+ * @class MongoCalls
+ */
+class MongoCalls {
+  /**
+   * Creates an instance of MongoCalls.
+   *
+   * @param {object} adapter a henri mongoose (or disk) adapter
+   * @param {string} table the collection name
+   * @memberof MongoCalls
+   */
+  constructor(adapter, table) {
+    this.adapter = adapter;
+    this.dialect = 'mongodb';
+    this.kind = 'mongo';
+    this.partition = false;
+    this.table = table;
+  }
+
+  /**
+   * The collection
+   *
+   * @returns {object} a MongoDB collection
+   * @throws HENRI_CALLS_UNSUPPORTED_STORE when the store is not connected
+   * @memberof MongoCalls
+   */
+  collection() {
+    const connection =
+      this.adapter.mongoose && this.adapter.mongoose.connection;
+
+    if (!connection || connection.readyState !== 1 || !connection.db) {
+      throw fail(
+        'HENRI_CALLS_UNSUPPORTED_STORE',
+        `the call log cannot be written: the ${this.adapter.name} store is not connected`
+      );
+    }
+
+    return connection.db.collection(this.table);
+  }
+
+  /**
+   * Creates the indexes; idempotent
+   *
+   * @returns {Promise<Array<string>>} what was created
+   * @memberof MongoCalls
+   */
+  async install() {
+    const collection = this.collection();
+
+    await collection.createIndex({ request_id: 1 });
+    await collection.createIndex({ at: -1 });
+    await collection.createIndex({ direction: 1, service: 1, at: -1 });
+
+    return [`${this.table}.request_id`, `${this.table}.at`];
+  }
+
+  /**
+   * Nothing to keep ahead of: MongoDB has no range partitions
+   *
+   * @returns {Promise<Array>} an empty list
+   * @memberof MongoCalls
+   */
+  async ensure() {
+    return [];
+  }
+
+  /**
+   * Nothing to list either
+   *
+   * @returns {Promise<Array>} an empty list
+   * @memberof MongoCalls
+   */
+  async partitions() {
+    return [];
+  }
+
+  /**
+   * Writes rows
+   *
+   * @param {Array<object>} rows the rows
+   * @returns {Promise<number>} how many were written
+   * @memberof MongoCalls
+   */
+  async insert(rows) {
+    if (rows.length === 0) {
+      return 0;
+    }
+
+    await this.collection().insertMany(
+      rows.map((row) => ({ ...row, _id: row.id })),
+      { ordered: false }
+    );
+
+    return rows.length;
+  }
+
+  /**
+   * The filter of a listing
+   *
+   * @param {object} filter the filter
+   * @returns {object} a MongoDB filter
+   * @memberof MongoCalls
+   */
+  conditions(filter) {
+    const query = {};
+    const equals = {
+      actor: filter.actor,
+      direction: filter.direction,
+      outcome: filter.outcome,
+      request_id: filter.requestId,
+      service: filter.service,
+    };
+
+    for (const key of Object.keys(equals).sort()) {
+      if (typeof equals[key] === 'string' && equals[key] !== '') {
+        query[key] = equals[key];
+      }
+    }
+
+    if (Number.isFinite(filter.status)) {
+      query.status = filter.status;
+    }
+
+    if (Number.isFinite(filter.since) || Number.isFinite(filter.until)) {
+      query.at = {};
+
+      if (Number.isFinite(filter.since)) {
+        query.at.$gte = filter.since;
+      }
+
+      if (Number.isFinite(filter.until)) {
+        query.at.$lte = filter.until;
+      }
+    }
+
+    return query;
+  }
+
+  /**
+   * The rows matching a filter
+   *
+   * @param {object} [filter={}] the filter
+   * @returns {Promise<Array<object>>} the rows
+   * @memberof MongoCalls
+   */
+  async list(filter = {}) {
+    const limit = Math.min(Math.max(Number(filter.limit) || 100, 1), 1000);
+    const sort = filter.requestId ? { at: 1, direction: -1 } : { at: -1 };
+
+    return this.collection()
+      .find(this.conditions(filter), { sort })
+      .skip(Math.max(Number(filter.offset) || 0, 0))
+      .limit(limit)
+      .toArray();
+  }
+
+  /**
+   * How many rows match a filter
+   *
+   * @param {object} [filter={}] the filter
+   * @returns {Promise<number>} the count
+   * @memberof MongoCalls
+   */
+  count(filter = {}) {
+    return this.collection().countDocuments(this.conditions(filter));
+  }
+
+  /**
+   * Takes the rows past `before` away, a batch at a time
+   *
+   * @param {number} before a timestamp in milliseconds
+   * @param {object} [options={}] `batch`
+   * @returns {Promise<object>} `{ removed, partitions }`
+   * @memberof MongoCalls
+   */
+  async sweep(before, options = {}) {
+    const { batch = 5000 } = options;
+    const collection = this.collection();
+    let removed = 0;
+
+    for (;;) {
+      const rows = await collection
+        .find(
+          { at: { $lt: before } },
+          { projection: { _id: 1 }, sort: { at: 1 } }
+        )
+        .limit(batch)
+        .toArray();
+
+      if (rows.length === 0) {
+        break;
+      }
+
+      const result = await collection.deleteMany({
+        _id: { $in: rows.map((row) => row._id) },
+      });
+
+      removed += (result && result.deletedCount) || 0;
+
+      if (rows.length < batch) {
+        break;
+      }
+    }
+
+    return { partitions: [], removed };
+  }
+}
+
+/**
+ * The dialect of a store adapter, or nothing when it is not SQL
+ *
+ * @param {object} adapter a henri store adapter
+ * @returns {?{dialect: string, dollars: boolean}} how to talk to it
+ */
+const describe = (adapter) => {
+  if (adapter.dialect && typeof adapter.dialect === 'object') {
+    return {
+      dialect: adapter.dialect.name,
+      dollars: adapter.dialect.placeholder(1) === '$1',
+    };
+  }
+
+  if (typeof adapter.ensureConnector === 'function') {
+    return { dialect: adapter.ensureConnector().getDialect(), dollars: false };
+  }
+
+  return null;
+};
+
+/**
+ * The backend of a store adapter
+ *
+ * @param {object} adapter a henri store adapter
+ * @param {object} settings the normalized `config.calls`
+ * @returns {object} the backend
+ * @throws HENRI_CALLS_UNSUPPORTED_STORE when the adapter cannot hold it
+ */
+const storeFor = (adapter, settings) => {
+  if (!adapter) {
+    throw fail(
+      'HENRI_CALLS_UNSUPPORTED_STORE',
+      'the call log has no store to be written to'
+    );
+  }
+
+  if (adapter.mongoose) {
+    return new MongoCalls(adapter, settings.table);
+  }
+
+  const described = typeof adapter.query === 'function' && describe(adapter);
+
+  if (!described || !DIALECTS[described.dialect]) {
+    throw fail(
+      'HENRI_CALLS_UNSUPPORTED_STORE',
+      `the call log cannot be kept in the ${adapter.adapterName || 'unknown'} store: it has neither query() nor a MongoDB connection henri can use`
+    );
+  }
+
+  return new SqlCalls(adapter, {
+    ...described,
+    ahead: settings.partitionsAhead,
+    partition: settings.partition,
+    table: settings.table,
+  });
+};
+
+module.exports = {
+  COLUMNS,
+  DAY,
+  MongoCalls,
+  SqlCalls,
+  boundsOf,
+  catchAll,
+  createPartition,
+  describe,
+  dropPartition,
+  install,
+  listPartitions,
+  nextOf,
+  partitionName,
+  planOf,
+  stampOf,
+  startOf,
+  storeFor,
+};

--- a/packages/core/src/base/call-store.js
+++ b/packages/core/src/base/call-store.js
@@ -527,10 +527,14 @@ class SqlCalls {
   /**
    * Makes sure there are partitions in front of the clock.
    *
-   * Cheap to call: it remembers how far it covered and does nothing until
-   * the clock catches up with it. A failure here is not fatal -- the
-   * catch-all partition takes the rows and the next sweep tries again --
-   * so it reports rather than throws.
+   * **A period is only ever added above every existing one**, which is not
+   * an optimization: MySQL keeps its ranges in increasing order, so
+   * reorganizing the catch-all into a period that sits below one that is
+   * already there is refused. A period the sweep dropped therefore does not
+   * come back -- and does not need to, since what it held is gone.
+   *
+   * A failure here is not fatal: the catch-all takes the rows and the next
+   * sweep tries again, so this reports rather than throws.
    *
    * @param {number} [now=Date.now()] the moment
    * @returns {Promise<Array<string>>} the partitions that were created
@@ -541,10 +545,18 @@ class SqlCalls {
       return [];
     }
 
-    const starts = planOf(now, { ahead: this.ahead, every: this.partition });
+    const existing = await this.partitions();
+    const highest = existing.reduce((most, one) => Math.max(most, one.to), 0);
     const made = [];
 
-    for (const start of starts) {
+    for (const start of planOf(now, {
+      ahead: this.ahead,
+      every: this.partition,
+    })) {
+      if (start < highest) {
+        continue;
+      }
+
       const statement = createPartition(
         this.dialect,
         this.table,
@@ -555,6 +567,7 @@ class SqlCalls {
       try {
         await this.run(statement);
         made.push(partitionName(this.dialect, this.table, start));
+        this.covered = Math.max(this.covered, nextOf(start, this.partition));
       } catch (error) {
         if (!ALREADY_THERE.test(reasons(error))) {
           debug('unable to create a partition: %s', error.message);
@@ -562,7 +575,7 @@ class SqlCalls {
       }
     }
 
-    this.covered = starts[starts.length - 1];
+    this.covered = Math.max(this.covered, highest);
 
     return made;
   }

--- a/packages/core/src/base/calls.js
+++ b/packages/core/src/base/calls.js
@@ -1,0 +1,967 @@
+/**
+ * Call logs: the request an application answered, and the requests it made
+ * because of it.
+ *
+ * Two records joined by the request id `base/request-id.js` already threads
+ * through everything:
+ *
+ * - **inbound**, one row per call the application answered -- the method,
+ *   the path, the route, the status, how long it took, the person when one
+ *   is known, and the bodies henri can read;
+ * - **outbound**, one row per call the application made -- the same, plus
+ *   the service it went to.
+ *
+ * They are one table with a `direction` column rather than two tables, and
+ * that is the feature rather than an economy: the question worth keeping
+ * either of them for is "what happened during request `X`", and the answer
+ * is one `SELECT ... WHERE request_id = ? ORDER BY at` instead of two reads
+ * and a merge. One table also means one sweep, one partition scheme and one
+ * set of indexes to keep honest.
+ *
+ * ## This is not the access trail, and the difference is the point
+ *
+ * `base/trail.js` records field *names*, counts, public identifiers and
+ * digests, and it **refuses** a value (`HENRI_TRAIL_VALUE_REFUSED`). It is
+ * evidence: hash-chained, append-only, kept for a year, and the thing you
+ * hand a regulator.
+ *
+ * A call log is the opposite by design. It holds **values** -- the body
+ * that came in, the body that went out -- because a call log that does not
+ * is a slower version of the web server's access log. It is a debugging
+ * instrument: kept for days rather than years, sampled rather than
+ * complete, and never evidence of anything, because nothing stops a writer
+ * from editing a row.
+ *
+ * So: **the trail answers "who saw this record", the call log answers "what
+ * did this request do".** An application that reaches for the wrong one
+ * either gets a second copy of its personal data (the trail's failure mode,
+ * which the trail refuses) or a record that proves nothing (this one's).
+ * Neither substitutes for the other and neither should be turned on to do
+ * the other's job.
+ *
+ * ## Four decisions, because the naive version is a denial of service
+ *
+ * A table that grows without bound, written on the hot path, holding the
+ * one copy of every payload an attacker can make large, is an outage
+ * waiting for traffic. Each of these is a decision rather than a default:
+ *
+ * 1. **Off unless configured.** No `config.calls`, no table, no middleware,
+ *    no allocation: `2.server.js` reads the configuration before it builds
+ *    the middleware chain and mounts nothing. An application that says
+ *    nothing pays nothing, and the cost of being wrong here is paid by
+ *    every application rather than by the ones that asked.
+ * 2. **The write never blocks the answer.** A finished call is pushed onto
+ *    a bounded in-memory buffer and the response goes out; a timer (and a
+ *    full buffer) flushes with one multi-row `INSERT`. A flush that fails
+ *    is logged once and dropped -- a call log that can fail a request is a
+ *    liability that turns a database hiccup into an outage. The buffer is
+ *    bounded too (`calls.buffer`), and what it drops is counted and
+ *    reported by `henri.calls.stats()` rather than lost quietly.
+ * 3. **The payload is bounded before it is stored.** A body is captured up
+ *    to `calls.maxBody` (8kb) and marked truncated; only a body henri can
+ *    *walk* is captured at all, because only a walked body can be redacted
+ *    (see below). Everything else is a size and a content type.
+ * 4. **The number of rows a client can cause is bounded twice, and the two
+ *    bounds answer different failures.** `calls.sample` is a fraction and
+ *    bounds the steady state proportionally to traffic. It is not enough on
+ *    its own: one percent of a million requests a second is still ten
+ *    thousand rows a second, so `calls.maxPerSecond` is an absolute
+ *    per-process ceiling that a burst cannot argue with. Sampling keeps the
+ *    table the size the application chose; the ceiling keeps a spike from
+ *    turning the log into the outage.
+ *
+ * ### Why the sampling decision is keyed with the secret
+ *
+ * The decision has to be the *same* for the inbound call and every outbound
+ * call it caused, in every process, without carrying state -- otherwise a
+ * sampled request shows up with half its outbound calls missing, which is
+ * worse than not sampling it. So it is a hash of the request id rather than
+ * a coin flip.
+ *
+ * And the request id is **attacker-controlled**: `base/request-id.js` takes
+ * it from the `X-Request-Id` header when it looks sane, because a proxy
+ * sets one. A plain hash would let a client pick ids that land in the
+ * sampled bucket and defeat `calls.sample` entirely. The hash is therefore
+ * seeded with `config.secret`, so which ids are sampled is not something a
+ * client can work out. `calls.maxPerSecond` is the backstop that holds even
+ * if it could.
+ *
+ * ## What the redaction refuses
+ *
+ * This is the most dangerous table henri writes, so the rule is written
+ * here and has a test of its own (`__tests__/calls.spec.js`):
+ *
+ * - everything stored goes through `redactor(henri)` -- `filterParameters`
+ *   as substrings, the fields the models marked `personal` matched exactly,
+ *   and the always-masked set (`encryption`) that no configuration lifts --
+ *   at every depth, headers and bodies alike;
+ * - `DENIED` headers are masked whatever the configuration says:
+ *   `authorization`, `proxy-authorization`, `cookie`, `set-cookie`,
+ *   `x-csrf-token`, `x-api-key` and the webhook signature. They are the
+ *   credentials of the exchange and no `filterParameters` list has to
+ *   remember them;
+ * - the url keeps its path and loses the filtered query values
+ *   (`urlRedactor`), and an outbound url loses its userinfo entirely --
+ *   `https://user:pass@host/` is stored as `https://host/`;
+ * - **only a body henri can walk is stored.** A plain object or an array is
+ *   redacted key by key and kept; a string, a buffer, a stream or an HTML
+ *   page is *not*, because there is no key to match and no way to redact
+ *   inside it. Its size and its content type are kept instead. This is why
+ *   the inbound response body is taken from `res.json(value)` -- the value,
+ *   before it is serialized -- rather than by tapping the socket;
+ * - the person is the `externalId` and nothing else. Not the primary key,
+ *   not the email address: `publicUser()` already decided what a person
+ *   looks like when they leave the server and this follows it.
+ *
+ * ## How it is swept
+ *
+ * `calls.keep` (30 days) with the retention sweep pruning it, the way
+ * `config.trail.keep` is pruned -- and, where the dialect has it,
+ * **partitions instead of rows**. `base/call-store.js` has the mechanics;
+ * the short version is that dropping a partition is a metadata operation
+ * and deleting ten million rows is not, which is the difference between a
+ * sweep that works at scale and one that times out.
+ *
+ * @module base/calls
+ */
+
+const { EXTERNAL_ID } = require('./external-id');
+const { currentRequestId } = require('./request-id');
+const { isFiltered, redactor, urlRedactor } = require('./redact');
+const { fail } = require('./errors');
+const { period } = require('./retention');
+
+/** The table the calls are written to, unless the configuration says */
+const DEFAULT_TABLE = 'henri_calls';
+
+/** How long a row is kept, unless the configuration says */
+const DEFAULT_KEEP = '30d';
+
+/** How much of a body is stored, unless the configuration says */
+const DEFAULT_BODY = 8192;
+
+/** What `calls.always` accepts: the outcomes sampling never drops */
+const ALWAYS = ['aborted', 'client-error', 'error'];
+
+/** What `calls.partition` accepts */
+const PARTITIONS = ['day', 'month'];
+
+/** The dialects that can partition a table by range */
+const PARTITIONABLE = ['mysql', 'postgres'];
+
+/**
+ * The headers whose value is never stored, whatever `filterParameters`
+ * says. They are the credentials of the exchange, and a list an
+ * application has to remember to write down is a list it forgets.
+ */
+const DENIED = Object.freeze([
+  'authorization',
+  'cookie',
+  'proxy-authorization',
+  'set-cookie',
+  'webhook-signature',
+  'x-api-key',
+  'x-csrf-token',
+]);
+
+/** What a row says when a body was longer than `calls.maxBody` */
+const TRUNCATED = '…[truncated]';
+
+/** The paths henri never records: its own probes, which run every second */
+const PROBES = Object.freeze([
+  '/_henri/health',
+  '/healthz',
+  '/livez',
+  '/readyz',
+]);
+
+/** The two directions of a call */
+const DIRECTIONS = ['in', 'out'];
+
+/** The outcomes a row carries */
+const OUTCOMES = ['aborted', 'failed', 'ok'];
+
+/** How many buckets the sampling fraction is measured in */
+const BUCKETS = 10000;
+
+/** The offset basis of the 32 bit FNV-1a used by the sampling */
+const FNV_BASIS = 2166136261;
+
+/** Its prime */
+const FNV_PRIME = 16777619;
+
+/**
+ * A 32 bit FNV-1a, seeded.
+ *
+ * Not a cryptographic hash and not pretending to be one: what it has to do
+ * is spread ids evenly and be unpredictable without the seed, and it is
+ * called once per request, which rules out an HMAC.
+ *
+ * @param {string} value what to hash
+ * @param {number} [seed=FNV_BASIS] the starting state
+ * @returns {number} a 32 bit unsigned integer
+ */
+function hash32(value, seed = FNV_BASIS) {
+  let state = seed >>> 0;
+
+  for (let index = 0; index < value.length; index += 1) {
+    state ^= value.charCodeAt(index);
+    state = Math.imul(state, FNV_PRIME) >>> 0;
+  }
+
+  return state >>> 0;
+}
+
+/**
+ * A size, as a number of bytes or as `'8kb'`
+ *
+ * @param {*} value what the configuration said
+ * @param {number} fallbackTo what to use when it said nothing
+ * @returns {number} a number of bytes, or 0 for "store no body"
+ */
+function bytes(value, fallbackTo) {
+  if (value === false) {
+    return 0;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+    return Math.floor(value);
+  }
+
+  if (typeof value !== 'string') {
+    return fallbackTo;
+  }
+
+  const found = /^\s*(\d+(?:\.\d+)?)\s*(b|kb|mb|gb)?\s*$/iu.exec(value);
+
+  if (!found) {
+    return fallbackTo;
+  }
+
+  const scale = { gb: 1073741824, kb: 1024, mb: 1048576 };
+  const unit = (found[2] || '').toLowerCase();
+
+  return Math.floor(Number(found[1]) * (scale[unit] || 1));
+}
+
+/**
+ * A whole number from the configuration, or the default
+ *
+ * @param {*} value what the configuration said
+ * @param {number} fallbackTo what to use when it said nothing
+ * @param {number} [least=1] the smallest accepted value
+ * @returns {number} the number
+ */
+function whole(value, fallbackTo, least = 1) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return fallbackTo;
+  }
+
+  return Math.max(Math.floor(value), least);
+}
+
+/**
+ * `config.calls`, normalized.
+ *
+ * Off is the absence of the key, `false`, or an object saying so: a
+ * disabled call log creates no table, mounts no middleware and allocates
+ * nothing.
+ *
+ * @param {object} config henri's config module (or anything with get/has)
+ * @returns {object} the settings
+ */
+function callsConfig(config) {
+  const has = config && typeof config.has === 'function' && config.has('calls');
+  const raw = has ? config.get('calls') : false;
+
+  if (raw === false || raw === null || typeof raw === 'undefined') {
+    return {
+      always: [],
+      batch: 500,
+      buffer: 1000,
+      enabled: false,
+      flush: 1000,
+      ignore: [],
+      inbound: false,
+      keep: null,
+      maxBody: 0,
+      maxPerSecond: 0,
+      outbound: false,
+      partition: false,
+      partitionsAhead: 0,
+      sample: 0,
+      store: 'default',
+      sweep: 5000,
+      table: DEFAULT_TABLE,
+    };
+  }
+
+  const settings = raw && typeof raw === 'object' ? raw : {};
+  const sample =
+    typeof settings.sample === 'number' && Number.isFinite(settings.sample)
+      ? Math.min(Math.max(settings.sample, 0), 1)
+      : 1;
+
+  return {
+    always: Array.isArray(settings.always)
+      ? settings.always.filter((name) => ALWAYS.includes(name))
+      : ['error'],
+    batch: whole(settings.batch, 500),
+    buffer: whole(settings.buffer, 1000),
+    enabled: true,
+    flush: whole(settings.flush, 1000),
+    ignore: Array.isArray(settings.ignore)
+      ? settings.ignore.filter((one) => typeof one === 'string' && one !== '')
+      : [],
+    inbound: settings.inbound !== false,
+    keep:
+      settings.keep === false ? null : period(settings.keep || DEFAULT_KEEP),
+    maxBody:
+      settings.bodies === false ? 0 : bytes(settings.maxBody, DEFAULT_BODY),
+    maxPerSecond:
+      settings.maxPerSecond === false
+        ? Infinity
+        : whole(settings.maxPerSecond, 100),
+    outbound: settings.outbound !== false,
+    partition: PARTITIONS.includes(settings.partition)
+      ? settings.partition
+      : false,
+    partitionsAhead: whole(settings.partitionsAhead, 7),
+    sample,
+    store: settings.store || 'default',
+    sweep: whole(settings.sweep, 5000),
+    table:
+      typeof settings.table === 'string' && settings.table !== ''
+        ? settings.table
+        : DEFAULT_TABLE,
+  };
+}
+
+/**
+ * Is this a value the redactor can walk, key by key?
+ *
+ * The whole capture rule in one predicate: a plain object or an array can
+ * be redacted and is kept, anything else cannot and is not.
+ *
+ * @param {*} value a body
+ * @returns {boolean} whether it can be stored
+ */
+function walkable(value) {
+  if (Array.isArray(value)) {
+    return true;
+  }
+
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  if (Buffer.isBuffer(value) || value instanceof Date) {
+    return false;
+  }
+
+  const proto = Object.getPrototypeOf(value);
+
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * A body, redacted, serialized and capped.
+ *
+ * Anything that is not walkable answers `{ body: null, kind }`, which is
+ * how the row says "there was a payload and it is not in here".
+ *
+ * @param {*} value the body
+ * @param {object} options `redact` (the instance's redactor) and `max`
+ * @returns {{body: ?string, truncated: boolean, kind: ?string}} the capture
+ */
+function capture(value, { max, redact }) {
+  if (typeof value === 'undefined' || value === null || max === 0) {
+    return { body: null, kind: null, truncated: false };
+  }
+
+  if (!walkable(value)) {
+    return {
+      body: null,
+      kind: Buffer.isBuffer(value) ? 'buffer' : typeof value,
+      truncated: false,
+    };
+  }
+
+  let text;
+
+  try {
+    text = JSON.stringify(redact(value));
+  } catch (error) {
+    return { body: null, kind: 'unserializable', truncated: false };
+  }
+
+  if (typeof text !== 'string') {
+    return { body: null, kind: 'unserializable', truncated: false };
+  }
+
+  if (text.length <= max) {
+    return { body: text, kind: 'json', truncated: false };
+  }
+
+  return {
+    body: text.slice(0, max) + TRUNCATED,
+    kind: 'json',
+    truncated: true,
+  };
+}
+
+/**
+ * The headers of a call, masked.
+ *
+ * `DENIED` first and unconditionally, then the application's own filters
+ * and the personal field names, so a header called `x-customer-email` in an
+ * application that marked `email` personal is masked like everything else.
+ *
+ * @param {object} source the headers
+ * @param {object} options `filters`, `keys` and `max`
+ * @returns {?object} the headers, or null when there are none
+ */
+function headers(source, { filters, keys, max }) {
+  if (!source || typeof source !== 'object') {
+    return null;
+  }
+
+  const result = {};
+  let count = 0;
+
+  for (const name of Object.keys(source)) {
+    if (count >= max) {
+      break;
+    }
+
+    const lower = name.toLowerCase();
+
+    count += 1;
+    result[name] =
+      DENIED.includes(lower) || isFiltered(name, filters, keys)
+        ? '[FILTERED]'
+        : String(source[name]).slice(0, 200);
+  }
+
+  return count > 0 ? result : null;
+}
+
+/**
+ * A url with its userinfo removed and its filtered query values masked.
+ *
+ * The userinfo goes first and unconditionally: `https://key:secret@host/`
+ * is a credential in a field no `filterParameters` list covers.
+ *
+ * @param {string} url a url or a path
+ * @param {function} mask the instance's url redactor
+ * @returns {?string} the url, or null
+ */
+function safeUrl(url, mask) {
+  if (typeof url !== 'string' || url === '') {
+    return null;
+  }
+
+  let text = url;
+
+  if (/^[a-z][a-z0-9+.-]*:\/\//iu.test(text)) {
+    try {
+      const parsed = new URL(text);
+
+      parsed.username = '';
+      parsed.password = '';
+      text = parsed.toString();
+    } catch (error) {
+      return null;
+    }
+  }
+
+  return mask(text).slice(0, 2000);
+}
+
+/**
+ * The outcome of a finished call
+ *
+ * @param {object} call what was recorded
+ * @returns {string} one of OUTCOMES
+ */
+function outcomeOf(call) {
+  if (call.aborted) {
+    return 'aborted';
+  }
+
+  return call.error || !call.status || call.status >= 500 ? 'failed' : 'ok';
+}
+
+/**
+ * Does this call match one of the `calls.always` conditions?
+ *
+ * These are the calls sampling does not get to drop. They are recorded
+ * without their bodies -- the decision not to capture was made before the
+ * status was known and there is nothing to go back for, which is honest and
+ * costs nothing.
+ *
+ * @param {object} row a row about to be written
+ * @param {Array<string>} list `calls.always`
+ * @returns {boolean} whether it is kept anyway
+ */
+function always(row, list) {
+  if (list.length === 0) {
+    return false;
+  }
+
+  if (row.outcome === 'aborted') {
+    return list.includes('aborted');
+  }
+
+  if (row.status >= 500 || row.outcome === 'failed') {
+    return list.includes('error');
+  }
+
+  return row.status >= 400 && list.includes('client-error');
+}
+
+/**
+ * The `externalId` of whoever the request belonged to, and nothing else
+ *
+ * @param {*} user `req.user`, or nothing
+ * @returns {?string} the public identifier, or null
+ */
+function actorOf(user) {
+  if (!user || typeof user !== 'object') {
+    return null;
+  }
+
+  const external = user[EXTERNAL_ID];
+
+  return typeof external === 'string' && external !== '' ? external : null;
+}
+
+/**
+ * Should this path be recorded at all?
+ *
+ * The health probes never are: they run every second, they answer nothing
+ * interesting and they would be most of the table.
+ *
+ * @param {string} path the request path
+ * @param {Array<string>} ignore `calls.ignore`
+ * @returns {boolean} whether to skip it
+ */
+function ignored(path, ignore) {
+  if (PROBES.includes(path)) {
+    return true;
+  }
+
+  return ignore.some((prefix) => path === prefix || path.startsWith(prefix));
+}
+
+/**
+ * A bounded, per-second token bucket.
+ *
+ * The absolute ceiling of decision 4. It is per process, deliberately:
+ * henri cannot know how many processes run (`base/shared.js` says so about
+ * the rate limit), and a ceiling that needs a round trip to a shared store
+ * to decide whether to write a debugging row would cost more than the row.
+ *
+ * @class Ceiling
+ */
+class Ceiling {
+  /**
+   * Creates an instance of Ceiling.
+   *
+   * @param {number} perSecond how many rows a second are allowed
+   * @memberof Ceiling
+   */
+  constructor(perSecond) {
+    this.perSecond = perSecond;
+    this.second = 0;
+    this.used = 0;
+  }
+
+  /**
+   * Takes one, if there is one
+   *
+   * @param {number} [now=Date.now()] the moment
+   * @returns {boolean} whether the row may be written
+   * @memberof Ceiling
+   */
+  take(now = Date.now()) {
+    if (this.perSecond === Infinity) {
+      return true;
+    }
+
+    const second = Math.floor(now / 1000);
+
+    if (second !== this.second) {
+      this.second = second;
+      this.used = 0;
+    }
+
+    if (this.used >= this.perSecond) {
+      return false;
+    }
+
+    this.used += 1;
+
+    return true;
+  }
+}
+
+/**
+ * The middleware that records the inbound half.
+ *
+ * Mounted by `2.server.js` right after `requestId()` and only when
+ * `config.calls` asked for it, so it is the outermost thing in the chain
+ * that has an id to join on. That position is the point: a request refused
+ * by the rate limit, by the body parser or by the CSRF check is exactly the
+ * one worth having in the log, and a middleware mounted further down would
+ * never see it.
+ *
+ * @param {object} henri the instance
+ * @returns {function} express middleware
+ */
+function inbound(henri) {
+  return (req, res, next) => {
+    const calls = henri.calls;
+
+    if (!calls || !calls.enabled || !calls.settings.inbound) {
+      next();
+
+      return;
+    }
+
+    if (ignored(req.path, calls.settings.ignore)) {
+      next();
+
+      return;
+    }
+
+    const at = Date.now();
+    const started = process.hrtime.bigint();
+    const keep = calls.samples(req.id);
+    const state = { body: undefined, keep };
+
+    // The response body is taken as a *value* from `res.json`, never off
+    // the socket: a value can be walked and redacted, bytes cannot. Only a
+    // sampled request pays for the wrapper
+    if (keep && calls.settings.maxBody > 0) {
+      const json = res.json;
+
+      res.json = function wrapped(value) {
+        state.body = value;
+
+        return json.call(this, value);
+      };
+    }
+
+    let done = false;
+
+    res.on('close', () => {
+      if (done) {
+        return;
+      }
+
+      done = true;
+      calls.finished(req, res, { at, started, ...state });
+    });
+
+    next();
+  };
+}
+
+/**
+ * The seam an application's own HTTP client goes through.
+ *
+ * henri wraps nobody's client: there is no interceptor to install and no
+ * patched `fetch`. An application that wants its outbound calls in the log
+ * calls this around whatever it already uses, which is two lines and works
+ * with every client there is.
+ *
+ * @param {object} calls the module
+ * @param {object} details `service`, `method`, `url`, `headers`, `body`
+ * @returns {function} `finish({ status, headers, body, error })`
+ */
+function track(calls, details) {
+  if (!calls || !calls.enabled || !calls.settings.outbound) {
+    return () => null;
+  }
+
+  const at = Date.now();
+  const started = process.hrtime.bigint();
+  const requestId =
+    details.requestId === null ? null : details.requestId || currentRequestId();
+  let done = false;
+
+  return (answer = {}) => {
+    if (done) {
+      return null;
+    }
+
+    done = true;
+
+    return calls.write({
+      at,
+      duration: Number((process.hrtime.bigint() - started) / 1000000n),
+      error: answer.error || null,
+      meta: { ...details.meta, ...answer.meta },
+      method: details.method,
+      request: details.request || null,
+      requestId,
+      response: { body: answer.body, headers: answer.headers },
+      service: details.service,
+      status: answer.status,
+      url: answer.url || details.url,
+    });
+  };
+}
+
+/**
+ * The row a call becomes, redacted and bounded.
+ *
+ * One function for both directions, which is what keeps the redaction from
+ * having two implementations that agree today.
+ *
+ * @param {object} call the call
+ * @param {object} context `filters`, `keys`, `redact`, `mask`, `settings`
+ * @returns {object} the row, in database shape
+ */
+function toRow(call, context) {
+  const { mask, redact, settings } = context;
+  const max = settings.maxBody;
+  const head = { filters: context.filters, keys: context.keys, max: 50 };
+  const request = capture(call.request && call.request.body, { max, redact });
+  const response = capture(call.response && call.response.body, {
+    max,
+    redact,
+  });
+  const truncated = [
+    request.truncated ? 'request' : null,
+    response.truncated ? 'response' : null,
+  ].filter(Boolean);
+
+  return {
+    actor: call.actor || null,
+    at: call.at,
+    direction: DIRECTIONS.includes(call.direction) ? call.direction : 'out',
+    duration: Number.isFinite(call.duration) ? Math.round(call.duration) : null,
+    error: call.error ? String(call.error).slice(0, 190) : null,
+    id: call.id,
+    meta: metaOf(call, { request, response }, redact),
+    method: String(call.method || 'GET')
+      .toUpperCase()
+      .slice(0, 12),
+    outcome: OUTCOMES.includes(call.outcome) ? call.outcome : outcomeOf(call),
+    request_body: request.body,
+    request_headers: jsonOf(
+      headers(call.request && call.request.headers, head)
+    ),
+    request_id: call.requestId ? String(call.requestId).slice(0, 64) : null,
+    response_body: response.body,
+    response_headers: jsonOf(
+      headers(call.response && call.response.headers, head)
+    ),
+    route: call.route ? String(call.route).slice(0, 190) : null,
+    service: call.service ? String(call.service).slice(0, 120) : null,
+    status: Number.isFinite(call.status) ? Math.round(call.status) : null,
+    truncated: truncated.length > 0 ? truncated.join(',') : null,
+    url: safeUrl(call.url, mask),
+  };
+}
+
+/**
+ * A value as JSON, or null
+ *
+ * @param {*} value anything already redacted
+ * @returns {?string} the JSON, or null
+ */
+function jsonOf(value) {
+  if (value === null || typeof value === 'undefined') {
+    return null;
+  }
+
+  try {
+    return JSON.stringify(value);
+  } catch (error) {
+    return null;
+  }
+}
+
+/**
+ * The `meta` of a row: what the capture could not keep, and whatever the
+ * caller added
+ *
+ * @param {object} call the call
+ * @param {object} captured the two captures
+ * @param {function} redact the instance's redactor
+ * @returns {?string} the JSON, or null
+ */
+function metaOf(call, captured, redact) {
+  const meta = {};
+
+  if (captured.request.kind && captured.request.kind !== 'json') {
+    meta.requestBody = captured.request.kind;
+  }
+
+  if (captured.response.kind && captured.response.kind !== 'json') {
+    meta.responseBody = captured.response.kind;
+  }
+
+  if (Number.isFinite(call.requestBytes)) {
+    meta.requestBytes = call.requestBytes;
+  }
+
+  if (Number.isFinite(call.responseBytes)) {
+    meta.responseBytes = call.responseBytes;
+  }
+
+  if (call.meta && typeof call.meta === 'object') {
+    Object.assign(meta, redact(call.meta));
+  }
+
+  return Object.keys(meta).length > 0 ? jsonOf(meta) : null;
+}
+
+/**
+ * A stored row, read back as a call
+ *
+ * @param {object} row a row from the store
+ * @returns {object} the call
+ */
+function toCall(row) {
+  const parse = (value) => {
+    if (typeof value !== 'string' || value === '') {
+      return null;
+    }
+
+    try {
+      return JSON.parse(value);
+    } catch (error) {
+      // A truncated body is not valid JSON any more, and saying so is
+      // better than answering null: it is what was captured
+      return value;
+    }
+  };
+
+  const at = Number(row.at);
+
+  return {
+    actor: row.actor || null,
+    at: Number.isFinite(at) ? new Date(at).toISOString() : null,
+    direction: row.direction,
+    duration: row.duration === null ? null : Number(row.duration),
+    error: row.error || null,
+    id: row.id,
+    meta: parse(row.meta),
+    method: row.method,
+    outcome: row.outcome,
+    request: {
+      body: parse(row.request_body),
+      headers: parse(row.request_headers),
+    },
+    requestId: row.request_id || null,
+    response: {
+      body: parse(row.response_body),
+      headers: parse(row.response_headers),
+    },
+    route: row.route || null,
+    service: row.service || null,
+    status: row.status === null ? null : Number(row.status),
+    truncated: row.truncated ? row.truncated.split(',') : [],
+    url: row.url || null,
+  };
+}
+
+/**
+ * The redaction context of an instance, built once per flush rather than
+ * once per row
+ *
+ * @param {object} henri the instance
+ * @param {object} settings the normalized settings
+ * @returns {object} `{ filters, keys, mask, redact, settings }`
+ */
+function contextOf(henri, settings) {
+  const { config, privacy } = henri;
+  const filters =
+    config && config.has('filterParameters')
+      ? config.get('filterParameters')
+      : [];
+
+  return {
+    filters: Array.isArray(filters) ? filters : [],
+    keys: (privacy && privacy.keys) || new Set(),
+    mask: urlRedactor(henri),
+    redact: redactor(henri),
+    settings,
+  };
+}
+
+/**
+ * The seed the sampling hashes with: `config.secret`, folded once.
+ *
+ * @param {object} config the config module
+ * @returns {number} the seed
+ */
+function seedOf(config) {
+  const secret =
+    config && config.has('secret') ? String(config.get('secret') || '') : '';
+
+  return hash32(secret);
+}
+
+/**
+ * Refuses a partition scheme the dialect cannot carry out
+ *
+ * @param {string} dialect the store's dialect
+ * @param {string|boolean} partition `calls.partition`
+ * @returns {boolean} true when there is nothing to refuse
+ * @throws HENRI_CALLS_PARTITION_UNSUPPORTED when the dialect has no ranges
+ */
+function checkPartition(dialect, partition) {
+  if (!partition || PARTITIONABLE.includes(dialect)) {
+    return true;
+  }
+
+  const error = fail(
+    'HENRI_CALLS_PARTITION_UNSUPPORTED',
+    `calls.partition asked for "${partition}" partitions and a ${dialect} store has none`
+  );
+
+  error.hint =
+    'PostgreSQL and MySQL partition by range; sqlite, SQL Server and MongoDB sweep by deleting rows. Leave calls.partition out on those.';
+
+  throw error;
+}
+
+module.exports = {
+  ALWAYS,
+  BUCKETS,
+  Ceiling,
+  DEFAULT_BODY,
+  DEFAULT_KEEP,
+  DEFAULT_TABLE,
+  DENIED,
+  DIRECTIONS,
+  OUTCOMES,
+  PARTITIONABLE,
+  PARTITIONS,
+  PROBES,
+  TRUNCATED,
+  actorOf,
+  always,
+  bytes,
+  callsConfig,
+  capture,
+  checkPartition,
+  contextOf,
+  hash32,
+  headers,
+  ignored,
+  inbound,
+  jsonOf,
+  outcomeOf,
+  safeUrl,
+  seedOf,
+  toCall,
+  toRow,
+  track,
+  walkable,
+};

--- a/packages/core/src/base/config-schema.js
+++ b/packages/core/src/base/config-schema.js
@@ -61,6 +61,12 @@ const ON_ERASE = ['anonymize', 'delete', 'orphan', 'retain'];
 
 /** What `trail.reads` accepts (`base/trail.js`) */
 const READS = ['all', 'personal'];
+
+/** What `calls.always` accepts (`base/calls.js`) */
+const ALWAYS = ['aborted', 'client-error', 'error'];
+
+/** What `calls.partition` accepts (`base/call-store.js`) */
+const PARTITIONS = ['day', 'month'];
 /**
  * One `encryption.keys` entry: 32 bytes as 64 hexadecimal characters.
  *
@@ -1247,6 +1253,136 @@ const SCHEMA = {
     ],
   },
 
+  calls: {
+    default: false,
+    describe: 'an object of call log settings, or false to keep none',
+    hint: 'The call log holds request and response values; it is off until this says otherwise, and it is not the access trail (see the guide)',
+    oneOf: [
+      { const: false },
+      {
+        keys: {
+          always: {
+            default: ['error'],
+            describe: `a list of ${ALWAYS.join(', ')}, or an empty list`,
+            hint: 'The outcomes sampling never drops. They are recorded without their bodies: the decision not to capture one was made before the status was known',
+            of: { enum: ALWAYS, type: 'string' },
+            type: 'array',
+          },
+          batch: {
+            default: 500,
+            describe: 'a whole number above zero',
+            hint: 'How many buffered rows trigger a flush before the timer does',
+            above: 0,
+            integer: true,
+            type: 'number',
+          },
+          bodies: {
+            default: true,
+            describe: 'true or false',
+            hint: 'false keeps the timings, the statuses and the headers and captures no body at all',
+            type: 'boolean',
+          },
+          buffer: {
+            default: 1000,
+            describe: 'a whole number above zero',
+            hint: 'How many rows may wait to be written; past it a row is dropped and counted rather than queued forever',
+            above: 0,
+            integer: true,
+            type: 'number',
+          },
+          flush: {
+            default: 1000,
+            describe: 'a number of milliseconds above zero',
+            hint: 'How often the buffer is written',
+            above: 0,
+            integer: true,
+            type: 'number',
+          },
+          ignore: {
+            default: [],
+            describe: 'a list of path prefixes',
+            hint: 'Paths that are never recorded. The health probes never are, whatever this says',
+            of: text(),
+            type: 'array',
+          },
+          inbound: {
+            default: true,
+            describe: 'true or false',
+            hint: 'false stops henri mounting the middleware at all',
+            type: 'boolean',
+          },
+          keep: keeps({
+            default: '30d',
+            hint: 'A call log holds values, so keeping it forever is a decision to make on purpose; the retention sweep prunes it',
+            oneOf: [{ const: false }, ...keeps().oneOf],
+          }),
+          maxBody: sizeLimit({
+            default: '8kb',
+            hint: 'How much of a body is stored before it is cut and marked truncated',
+          }),
+          maxPerSecond: {
+            default: 100,
+            describe: 'a whole number above zero, or false for no ceiling',
+            hint: 'The absolute per-process ceiling: sampling is proportional and a burst is not, so this is what a spike runs into',
+            oneOf: [
+              { const: false },
+              { above: 0, integer: true, type: 'number' },
+            ],
+          },
+          outbound: {
+            default: true,
+            describe: 'true or false',
+            hint: 'false makes henri.calls.track() and outbound() no-ops',
+            type: 'boolean',
+          },
+          partition: {
+            default: false,
+            describe: `one of ${PARTITIONS.join(', ')}, or false`,
+            hint: 'PostgreSQL and MySQL only: the sweep then drops a partition instead of deleting rows. Anything else fails the boot',
+            oneOf: [{ const: false }, { enum: PARTITIONS, type: 'string' }],
+          },
+          partitionsAhead: {
+            default: 7,
+            describe: 'a whole number above zero',
+            hint: 'How many periods are kept ready in front of the clock',
+            above: 0,
+            integer: true,
+            type: 'number',
+          },
+          sample: {
+            default: 1,
+            describe: 'a fraction between 0 and 1',
+            hint: 'The share of requests recorded, decided by a hash of the request id seeded with config.secret so the inbound call and its outbound calls agree',
+            max: 1,
+            min: 0,
+            type: 'number',
+          },
+          store: text({
+            default: 'default',
+            describe: 'the name of a store',
+            hint: 'Which of config.stores the table lives in',
+          }),
+          sweep: {
+            default: 5000,
+            describe: 'a whole number above zero',
+            hint: 'How many rows one pass of the delete path takes at a time',
+            above: 0,
+            integer: true,
+            type: 'number',
+          },
+          table: {
+            default: 'henri_calls',
+            describe: 'a table name: letters, digits and underscores',
+            hint: 'henri creates it on boot; changing calls.partition afterwards needs a migration of your own',
+            pattern: /^[A-Za-z_][A-Za-z0-9_]*$/u,
+            type: 'string',
+          },
+        },
+        type: 'object',
+      },
+    ],
+  },
+
   bodyLimit: {
     default: '1mb',
     describe: 'a size, as a string ("1mb") or a number of bytes',
@@ -1365,8 +1501,10 @@ const SCHEMA = {
 
 module.exports = {
   ADAPTERS,
+  ALWAYS,
   DIALECTS,
   LOG_FORMATS,
+  PARTITIONS,
   READS,
   RENDERERS,
   SCHEMA,

--- a/packages/core/src/henri.js
+++ b/packages/core/src/henri.js
@@ -17,6 +17,7 @@ const Model = require('./3.model');
 const Policies = require('./3.policies');
 const Privacy = require('./3.privacy');
 const View = require('./3.view');
+const Calls = require('./4.calls');
 const Retention = require('./4.retention');
 const Trail = require('./4.trail');
 const User = require('./4.user');
@@ -74,6 +75,7 @@ class Henri extends HenriBase {
    */
   async init() {
     this.modules.add(new Cache());
+    this.modules.add(new Calls());
     this.modules.add(new Config());
     this.modules.add(new Encryption());
     this.modules.add(new Mailer());

--- a/packages/demo/config/test.json
+++ b/packages/demo/config/test.json
@@ -44,5 +44,10 @@
   },
   "trail": {
     "keep": "1y"
+  },
+  "calls": {
+    "keep": "7d",
+    "maxBody": "2kb",
+    "ignore": ["/_henri/gql"]
   }
 }

--- a/packages/drizzle/__tests__/calls.spec.js
+++ b/packages/drizzle/__tests__/calls.spec.js
@@ -1,0 +1,306 @@
+// The call log against a real Drizzle store.
+//
+// It lives in @usehenri/core and reaches a database the adapter opened
+// through `query()`, like the access trail, so this file runs it on
+// whatever the environment points at -- sqlite offline, a PostgreSQL or a
+// MySQL server with HENRI_TEST_POSTGRES_URL or HENRI_TEST_MYSQL_URL
+// (`pnpm test:sql:live`).
+//
+// The partitions are the half that only shows up on a real server: sqlite
+// has no range partitioning, so the second describe here is skipped
+// offline and is the reason this suite exists at all.
+const { build, target } = require('./helpers');
+
+const { storeFor } = require('../../core/src/base/call-store');
+const { callsConfig, toCall, toRow } = require('../../core/src/base/calls');
+const { redact } = require('../../core/src/base/redact');
+
+/** A day, in milliseconds */
+const DAY = 86400000;
+
+/** The settings a store is built from, with the defaults filled in */
+const settings = (calls = {}) =>
+  callsConfig({
+    get: () => ({ ...calls }),
+    has: (key) => key === 'calls',
+  });
+
+/** The redaction context of a suite that has no privacy map */
+const context = (over = {}) => ({
+  filters: ['password'],
+  keys: new Set(),
+  mask: (url) => url,
+  redact: (value) => redact(value, ['password']),
+  settings: settings(over),
+});
+
+/** One row, ready to insert */
+const row = (call) =>
+  toRow(
+    {
+      at: Date.now(),
+      direction: 'out',
+      id: `${Math.random().toString(36).slice(2)}${Date.now()}`.slice(0, 36),
+      method: 'GET',
+      outcome: 'ok',
+      status: 200,
+      url: 'https://example.test/x',
+      ...call,
+    },
+    context()
+  );
+
+describe(`the call log on ${target.name}`, () => {
+  let adapter = null;
+  let store = null;
+
+  beforeAll(async () => {
+    ({ adapter } = build());
+    await adapter.start();
+    store = storeFor(adapter, settings());
+    await store.install();
+  }, 60000);
+
+  afterAll(async () => {
+    await adapter.stop();
+  });
+
+  test('the install is idempotent', async () => {
+    await expect(store.install()).resolves.toBeDefined();
+    expect(store.kind).toBe('sql');
+  });
+
+  test('a page of rows goes in with one statement', async () => {
+    const rows = Array.from({ length: 25 }, (unused, index) =>
+      row({ requestId: 'bulk', service: `svc-${index % 3}`, status: 200 })
+    );
+
+    expect(await store.insert(rows)).toBe(25);
+    expect(await store.insert([])).toBe(0);
+    expect(await store.count({ requestId: 'bulk' })).toBe(25);
+    expect(await store.count({ requestId: 'bulk', service: 'svc-0' })).toBe(9);
+  });
+
+  test('the join is one read, oldest first, the answer before what it caused', async () => {
+    const at = Date.now();
+
+    await store.insert([
+      row({
+        at: at + 2,
+        direction: 'out',
+        requestId: 'story',
+        service: 'search',
+      }),
+      row({
+        at,
+        direction: 'in',
+        method: 'POST',
+        requestId: 'story',
+        route: '/orders',
+        url: '/orders?page=1',
+      }),
+      row({
+        at: at + 1,
+        direction: 'out',
+        requestId: 'story',
+        service: 'billing',
+      }),
+    ]);
+
+    const story = (await store.list({ requestId: 'story' })).map(toCall);
+
+    expect(story.map((call) => call.direction)).toEqual(['in', 'out', 'out']);
+    expect(story.map((call) => call.service)).toEqual([
+      null,
+      'billing',
+      'search',
+    ]);
+    expect(story[0].route).toBe('/orders');
+    expect(story[0].url).toBe('/orders?page=1');
+  });
+
+  test('a body and its headers come back as they went in', async () => {
+    await store.insert([
+      toRow(
+        {
+          at: Date.now(),
+          direction: 'in',
+          id: 'body-and-headers',
+          method: 'POST',
+          request: {
+            body: { deep: { list: [1, 2] }, password: 'hunter2' },
+            headers: { accept: 'application/json', authorization: 'Bearer x' },
+          },
+          response: { body: { ok: true } },
+          status: 201,
+          url: '/things',
+        },
+        context()
+      ),
+    ]);
+
+    const [call] = (await store.list({ limit: 1000 }))
+      .filter((found) => found.id === 'body-and-headers')
+      .map(toCall);
+
+    expect(call.request.body).toEqual({
+      deep: { list: [1, 2] },
+      password: '[FILTERED]',
+    });
+    expect(call.request.headers.authorization).toBe('[FILTERED]');
+    expect(call.request.headers.accept).toBe('application/json');
+    expect(call.response.body).toEqual({ ok: true });
+    expect(call.at).toMatch(/^\d{4}-/u);
+  });
+
+  test('a filter the store cannot use narrows rather than widening', async () => {
+    const since = Date.now() + DAY;
+
+    expect(await store.count({ since })).toBe(0);
+    expect(await store.count({ direction: 'in', since })).toBe(0);
+    expect(await store.count({ status: 999 })).toBe(0);
+    expect((await store.list({ limit: 5 })).length).toBe(5);
+  });
+
+  test('the sweep deletes in bounded batches and stops when it is done', async () => {
+    const old = Date.now() - 90 * DAY;
+
+    await store.insert(
+      Array.from({ length: 12 }, (unused, index) =>
+        row({ at: old + index, requestId: 'ancient', service: 'gone' })
+      )
+    );
+
+    const before = Date.now() - 30 * DAY;
+    const result = await store.sweep(before, { batch: 5 });
+
+    expect(result.removed).toBe(12);
+    expect(result.partitions).toEqual([]);
+    expect(await store.count({ requestId: 'ancient' })).toBe(0);
+    // What is not old enough is still there
+    expect(await store.count({ requestId: 'bulk' })).toBe(25);
+    // And a second pass finds nothing rather than looping
+    expect((await store.sweep(before, { batch: 5 })).removed).toBe(0);
+  });
+});
+
+/**
+ * The partitions, which only exist on a server that has them.
+ *
+ * This is the half of the sweep that makes it work at ten million rows:
+ * dropping a partition is a metadata operation whatever it held, and
+ * deleting ten million rows is not. sqlite has no range partitioning at
+ * all, so there is nothing here to run offline and the guide says so
+ * plainly.
+ */
+const partitioned = ['mysql', 'postgres'].includes(target.name)
+  ? describe
+  : describe.skip;
+
+partitioned(`partitions on ${target.name}`, () => {
+  const every = 'day';
+  const table = 'henri_calls_p';
+  // Fixed rather than "now", so what a partition covers is not a race with
+  // the clock the suite runs on
+  const now = Date.UTC(2026, 8, 20, 12);
+  let adapter = null;
+  let store = null;
+
+  beforeAll(async () => {
+    ({ adapter } = build());
+    await adapter.start();
+    store = storeFor(
+      adapter,
+      settings({ partition: every, partitionsAhead: 3, table })
+    );
+    await store.install(now);
+  }, 60000);
+
+  afterAll(async () => {
+    await adapter.stop();
+  });
+
+  /**
+   * What a period is called on this server: PostgreSQL partitions are
+   * tables of their own and carry the table name, MySQL's do not
+   *
+   * @param {number} day The day of September 2026
+   * @returns {string} The partition name
+   */
+  const named = (day) =>
+    `${target.name === 'mysql' ? '' : `${table}_`}p202609${day}`;
+
+  test('the table is created partitioned, with the periods in front', async () => {
+    const found = await store.partitions();
+
+    expect(found.map((one) => one.name)).toEqual([23, 22, 21, 20].map(named));
+    expect(found[3]).toMatchObject({
+      from: Date.UTC(2026, 8, 20),
+      to: Date.UTC(2026, 8, 21),
+    });
+  });
+
+  test('the install is idempotent, partitions included', async () => {
+    await expect(store.install(now)).resolves.toBeDefined();
+    expect(await store.partitions()).toHaveLength(4);
+  });
+
+  test('a row lands in the partition of its own day', async () => {
+    await store.insert([
+      row({ at: Date.UTC(2026, 8, 20, 1), requestId: 'day-20' }),
+      row({ at: Date.UTC(2026, 8, 21, 1), requestId: 'day-21' }),
+      row({ at: Date.UTC(2026, 8, 22, 1), requestId: 'day-22' }),
+    ]);
+
+    expect(await store.count({ requestId: 'day-20' })).toBe(1);
+    expect(await store.count({ requestId: 'day-22' })).toBe(1);
+  });
+
+  test('a row outside every period is kept by the catch-all, not refused', async () => {
+    // The reason there is a DEFAULT partition (MAXVALUE on mysql): a
+    // partition henri did not create in time would otherwise be failed
+    // inserts rather than a slower sweep
+    await expect(
+      store.insert([row({ at: Date.UTC(2030, 0, 1), requestId: 'far-future' })])
+    ).resolves.toBe(1);
+
+    expect(await store.count({ requestId: 'far-future' })).toBe(1);
+  });
+
+  test('the sweep drops whole periods and keeps the rest', async () => {
+    const before = Date.UTC(2026, 8, 22);
+    const result = await store.sweep(before, { batch: 100, now: before });
+
+    // The 20th and the 21st are entirely past the cutoff
+    expect(result.partitions.sort()).toEqual([named(20), named(21)].sort());
+    expect(await store.count({ requestId: 'day-20' })).toBe(0);
+    expect(await store.count({ requestId: 'day-21' })).toBe(0);
+    expect(await store.count({ requestId: 'day-22' })).toBe(1);
+    // And the catch-all keeps what is not old enough
+    expect(await store.count({ requestId: 'far-future' })).toBe(1);
+  });
+
+  test('and tops the plan back up in front of the clock', async () => {
+    const found = await store.partitions();
+
+    // A period that was dropped does not come back -- MySQL keeps its
+    // ranges in increasing order, so a range below an existing one cannot
+    // be added, and what that period held is gone anyway
+    expect(found.map((one) => one.name).sort()).toEqual([
+      named(22),
+      named(23),
+      named(24),
+      named(25),
+    ]);
+  });
+
+  test('what the catch-all took is still swept, by deleting it', async () => {
+    const result = await store.sweep(Date.UTC(2031, 0, 1), {
+      batch: 100,
+      now: Date.UTC(2031, 0, 1),
+    });
+
+    expect(result.removed).toBeGreaterThan(0);
+    expect(await store.count({ requestId: 'far-future' })).toBe(0);
+  });
+});

--- a/packages/drizzle/__tests__/retention.spec.js
+++ b/packages/drizzle/__tests__/retention.spec.js
@@ -158,6 +158,7 @@ describe(`the access trail on ${target.name}`, () => {
     // Drizzle-kit compares the schema to the database and would offer to
     // drop a table it does not know; the trail's is not drizzle's to drop
     expect([...adapter.reservedTables()].sort()).toEqual([
+      'henri_calls',
       'henri_jobs',
       'henri_jobs_schedules',
       'henri_trail',

--- a/packages/drizzle/index.js
+++ b/packages/drizzle/index.js
@@ -1108,26 +1108,41 @@ class Drizzle {
   }
 
   /**
-   * The tables that live in this database and are not drizzle's.
+   * The `config` blocks that name a table henri owns
    *
-   * `@usehenri/jobs` and the access trail of core own tables of their own
-   * and create them through raw SQL, because both have to work on a store
-   * that has no models at all. drizzle-kit compares the schema to the
-   * database and would offer to drop them; a push that did would take an
-   * application's job history, or its audit trail, with it.
-   *
-   * @returns {Set<string>} The table names a push must leave alone
+   * @returns {object} `{ calls, jobs, trail, webhooks }`
    * @memberof Drizzle
    */
-  reservedTables() {
+  reservedBlocks() {
     const config = (this.henri && this.henri.config) || null;
     const read = (key) =>
       config && config.has && config.has(key) ? config.get(key) : null;
     const block = (value) =>
       value && typeof value === 'object' && !Array.isArray(value) ? value : {};
-    const jobs = block(read('jobs'));
-    const trail = block(read('trail'));
-    const webhooks = block(read('webhooks'));
+
+    return {
+      calls: block(read('calls')),
+      jobs: block(read('jobs')),
+      trail: block(read('trail')),
+      webhooks: block(read('webhooks')),
+    };
+  }
+
+  /**
+   * The tables that live in this database and are not drizzle's.
+   *
+   * `@usehenri/jobs`, the access trail and the call log of core own tables
+   * of their own and create them through raw SQL, because all of them have
+   * to work on a store that has no models at all. drizzle-kit compares the
+   * schema to the database and would offer to drop them; a push that did
+   * would take an application's job history, its audit trail, or its call
+   * log with it.
+   *
+   * @returns {Set<string>} The table names a push must leave alone
+   * @memberof Drizzle
+   */
+  reservedTables() {
+    const { calls, jobs, trail, webhooks } = this.reservedBlocks();
     const name = (value, fallback) =>
       typeof value === 'string' && value !== '' ? value : fallback;
     const queue = name(jobs.table, 'henri_jobs');
@@ -1135,9 +1150,37 @@ class Drizzle {
     return new Set([
       queue,
       `${queue}_schedules`,
+      name(calls.table, 'henri_calls'),
       name(trail.table, 'henri_trail'),
       name(webhooks.table, 'henri_webhooks'),
     ]);
+  }
+
+  /**
+   * The prefixes of the tables henri owns whose names it cannot know in
+   * advance.
+   *
+   * There is one: a partitioned call log (`config.calls.partition`). Every
+   * partition is a table of its own in PostgreSQL, named after the period
+   * it covers (`henri_calls_p20260906`), so the set of names changes every
+   * day and a push has to be told about the shape rather than the names.
+   *
+   * @returns {Array<string>} The prefixes a push must leave alone
+   * @memberof Drizzle
+   */
+  reservedPrefixes() {
+    const { calls } = this.reservedBlocks();
+
+    if (!calls.partition) {
+      return [];
+    }
+
+    const table =
+      typeof calls.table === 'string' && calls.table !== ''
+        ? calls.table
+        : 'henri_calls';
+
+    return [`${table}_p`];
   }
 
   /**

--- a/packages/drizzle/migrations.js
+++ b/packages/drizzle/migrations.js
@@ -65,23 +65,38 @@ const ORIGIN = '00000000-0000-0000-0000-000000000000';
 const DESTRUCTIVE = /\bDROP\s+(?:TABLE|COLUMN)\b/iu;
 
 /**
- * Does this statement drop one of the tables henri owns?
+ * Is this table one of henri's?
  *
  * The names are checked whole and quoted the way every dialect quotes them,
  * so a table called `henri_trail_archive` is nobody's business but the
- * application's.
+ * application's. The prefixes are the one exception and there is one of
+ * them: the partitions of a partitioned call log, whose names carry the day
+ * they cover and are therefore not a list anybody can write down
+ * (`Drizzle#reservedPrefixes`).
+ *
+ * @param {string} table A table name
+ * @param {Set<string>} reserved The table names henri owns
+ * @param {Array<string>} prefixes The prefixes henri owns
+ * @returns {boolean} true when a push must leave it alone
+ */
+const isReserved = (table, reserved, prefixes) =>
+  reserved.has(table) || prefixes.some((prefix) => table.startsWith(prefix));
+
+/**
+ * Does this statement drop one of the tables henri owns?
  *
  * @param {string} statement A DDL statement
  * @param {Set<string>} reserved The table names henri owns
+ * @param {Array<string>} prefixes The prefixes henri owns
  * @returns {boolean} true when the statement would drop one of them
  */
-const drops = (statement, reserved) => {
+const drops = (statement, reserved, prefixes) => {
   const match =
     /^\s*DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?[["`]?([A-Za-z0-9_]+)/iu.exec(
       statement
     );
 
-  return Boolean(match) && reserved.has(match[1]);
+  return Boolean(match) && isReserved(match[1], reserved, prefixes);
 };
 
 /**
@@ -766,8 +781,12 @@ class Migrations {
   async plan({ interactive = false } = {}) {
     const { adapter } = this;
     const reserved = adapter.reservedTables();
+    const prefixes =
+      typeof adapter.reservedPrefixes === 'function'
+        ? adapter.reservedPrefixes()
+        : [];
     const existing = (await adapter.listTables()).filter(
-      (table) => !reserved.has(table)
+      (table) => !isReserved(table, reserved, prefixes)
     );
     const wanted = adapter.tableNames();
     const added = wanted.filter((table) => !existing.includes(table));
@@ -800,7 +819,7 @@ class Migrations {
     // application's job history or its audit trail with it
     const proposed = plan.statementsToExecute || [];
     const statements = proposed.filter(
-      (statement) => !drops(statement, reserved)
+      (statement) => !drops(statement, reserved, prefixes)
     );
     const result = {
       // The data loss drizzle-kit reported is the data loss of the

--- a/packages/webhooks/__tests__/delivery.spec.js
+++ b/packages/webhooks/__tests__/delivery.spec.js
@@ -341,4 +341,51 @@ describe('a delivery, end to end', () => {
     await work();
     await webhooks.remove(endpoint.id);
   });
+  test('a delivery is one of the outbound calls the call log holds', async () => {
+    // The stand-in is `henri.calls` of core: what this package asks it for
+    // is the request id at emit time and one `track()` per attempt
+    const recorded = [];
+
+    henri.calls = {
+      enabled: true,
+      requestId: () => 'req-from-the-request',
+      track: (details) => (answer) => {
+        recorded.push({ ...details, ...answer });
+
+        return true;
+      },
+    };
+
+    const server = await serve();
+    const endpoint = await webhooks.register({
+      events: ['tracked.event'],
+      url: server.url,
+    });
+
+    await webhooks.emit('tracked.event', { total: 7 });
+    await work();
+
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0]).toMatchObject({
+      method: 'POST',
+      service: 'webhooks',
+      status: 200,
+      url: server.url,
+    });
+    // The request that caused the emit is over: the id travelled with the
+    // job, which is what makes the join work at all
+    expect(recorded[0].requestId).toBe('req-from-the-request');
+    // The envelope goes in as an object, because a body the log cannot walk
+    // is a body it cannot redact
+    expect(recorded[0].request.body).toMatchObject({
+      data: { total: 7 },
+      type: 'tracked.event',
+    });
+    expect(recorded[0].request.headers['webhook-signature']).toEqual(
+      expect.any(String)
+    );
+
+    henri.calls = null;
+    await webhooks.remove(endpoint.id);
+  });
 });

--- a/packages/webhooks/__tests__/helpers.js
+++ b/packages/webhooks/__tests__/helpers.js
@@ -17,19 +17,23 @@ if (typeof afterAll === 'function') {
 /**
  * A minimal henri stand-in
  *
+ * `logged` holds the pen lines: `calls` is `henri.calls`, the call log of
+ * core, and a stand-in that shadowed it would hide the one thing this
+ * package asks it for (the request id a delivery joins on).
+ *
  * @param {object} [options={}] `secret`, `cache`, `jobs`
- * @returns {object} A fake henri, with the pen calls in `calls`
+ * @returns {object} A fake henri, with the pen lines in `logged`
  */
 const fakeHenri = (options = {}) => {
-  const calls = [];
+  const logged = [];
   const pen = {};
 
   ['error', 'info', 'warn'].forEach((level) => {
-    pen[level] = (...args) => calls.push([level, ...args]);
+    pen[level] = (...args) => logged.push([level, ...args]);
   });
 
   pen.fatal = (...args) => {
-    calls.push(['fatal', ...args]);
+    logged.push(['fatal', ...args]);
 
     return new Error(args.join(' '));
   };
@@ -41,13 +45,14 @@ const fakeHenri = (options = {}) => {
 
   return {
     cache: options.cache || null,
-    calls,
+    calls: options.calls || null,
     config: {
       get: (key) => values[key],
       has: (key) => typeof values[key] !== 'undefined',
     },
     cwd: () => process.cwd(),
     jobs: options.jobs || null,
+    logged,
     pen,
   };
 };

--- a/packages/webhooks/__tests__/module.spec.js
+++ b/packages/webhooks/__tests__/module.spec.js
@@ -73,7 +73,7 @@ describe('the henri module', () => {
     expect(await module.init()).toBe('webhooks');
     expect(module.enabled).toBe(true);
     expect(
-      henri.calls.some(
+      henri.logged.some(
         ([level, , said]) =>
           level === 'warn' && String(said).includes('no running job queue')
       )
@@ -114,7 +114,7 @@ describe('the henri module', () => {
     await module.init();
 
     const [, ...said] =
-      henri.calls.find(
+      henri.logged.find(
         ([level, , first]) =>
           level === 'info' && String(first).includes('deliveries on')
       ) || [];

--- a/packages/webhooks/__tests__/secrets.spec.js
+++ b/packages/webhooks/__tests__/secrets.spec.js
@@ -138,7 +138,7 @@ describe('an application with no secret of its own', () => {
 
     expect(row.secrets).toContain(endpoint.secret);
     expect(
-      built.henri.calls.filter(
+      built.henri.logged.filter(
         ([level, , said]) =>
           level === 'warn' && String(said).includes('not encrypted')
       )

--- a/packages/webhooks/src/webhooks.js
+++ b/packages/webhooks/src/webhooks.js
@@ -946,9 +946,19 @@ class Webhooks {
       timestamp: new Date().toISOString(),
       type: event,
     });
+    // The request that caused the emit is over by the time the delivery
+    // goes out, so the id has to travel with the job: without it the call
+    // log would hold the outbound call and nothing to join it to
+    const { calls } = this.henri || {};
     const job = await this.queue().perform(
       DELIVERY_JOB,
-      { body, endpoint: id, event, id: delivery },
+      {
+        body,
+        endpoint: id,
+        event,
+        id: delivery,
+        requestId: (calls && calls.requestId()) || null,
+      },
       {
         at: options.at,
         queue: this.config.queue,
@@ -993,6 +1003,8 @@ class Webhooks {
       }),
     };
 
+    const finish = this.tracked(row.url, args, headers);
+
     try {
       const answer = await deliver({
         allowHttp: this.config.allowHttp,
@@ -1001,6 +1013,15 @@ class Webhooks {
         headers,
         timeout: this.config.timeout,
         url: row.url,
+      });
+
+      finish({
+        meta: {
+          attempt: (context.job && context.job.attempt) || 1,
+          endpoint: row.id,
+          event: args.event,
+        },
+        status: answer.status,
       });
 
       this.log(
@@ -1020,6 +1041,16 @@ class Webhooks {
         status: answer.status,
       };
     } catch (error) {
+      finish({
+        error: error.code || error.name,
+        meta: {
+          attempt: (context.job && context.job.attempt) || 1,
+          endpoint: row.id,
+          event: args.event,
+        },
+        status: error.status || null,
+      });
+
       if (error.gone) {
         await this.disable(row.id, {
           reason: 'the receiver answered 410 Gone',
@@ -1028,6 +1059,45 @@ class Webhooks {
 
       throw error;
     }
+  }
+
+  /**
+   * Starts timing one delivery, when the application keeps a call log.
+   *
+   * The body is the envelope this package built, parsed back into the
+   * object it was: the call log stores a body it can walk and redact, and
+   * a JSON string is not one. What the receiver answered is deliberately
+   * *not* recorded -- it is untrusted text nothing can redact, and the
+   * queue's own job row already holds the excerpt an operator reads.
+   *
+   * @param {string} url Where the delivery goes
+   * @param {object} args The job arguments
+   * @param {object} sent The headers of the request
+   * @returns {Function} The finisher (a no-op without a call log)
+   * @memberof Webhooks
+   */
+  tracked(url, args, sent) {
+    const { calls } = this.henri || {};
+
+    if (!calls || !calls.enabled) {
+      return () => null;
+    }
+
+    let body;
+
+    try {
+      body = JSON.parse(args.body);
+    } catch (error) {
+      body = null;
+    }
+
+    return calls.track({
+      method: 'POST',
+      request: { body, headers: sent },
+      requestId: args.requestId || null,
+      service: 'webhooks',
+      url,
+    });
   }
 
   /**

--- a/types/core.test-d.ts
+++ b/types/core.test-d.ts
@@ -11,6 +11,7 @@ import type {
   Boom,
   Cache,
   CacheStats,
+  CallRecord,
   Configuration,
   Controller,
   Henri,
@@ -386,6 +387,23 @@ henri.privacy.erase('someone@example.test', { strategy: 'nuke' });
 
 // @ts-expect-error `henri.trail.list()` filters by what an entry holds
 henri.trail.list({ actin: 'privacy.export' });
+
+// The call log: the join, and the seam an application's own client goes
+// through. `track()` answers the finisher rather than the row
+expectType<Promise<CallRecord[]>>(henri.calls.about(req.id));
+const finishCall = henri.calls.track({
+  method: 'POST',
+  service: 'billing',
+  url: 'https://api.billing.test/v1/charges',
+});
+
+finishCall({ body: { id: 'ch_1' }, status: 201 });
+
+// @ts-expect-error a call goes in one of the two directions henri records
+henri.calls.list({ direction: 'sideways' });
+
+// @ts-expect-error a call log is read back by request id, never by address
+henri.calls.about({ email: 'someone@example.test' });
 
 // --- controllers ------------------------------------------------------------
 

--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -65,6 +65,7 @@ Every key below is declared in `@usehenri/core`, so an editor completes them as 
 | `privacy`          |               | What henri does with the fields the models marked `personal`, see below. See [Personal data](/guides/privacy/).                                            |
 | `retention`        |               | What runs the retention sweep and what it may do, see below. How long a model keeps its records is said in the model. See [Retention](/guides/retention/). |
 | `trail`            | off           | The append-only record of who read or changed personal data, see below. See [The access trail](/guides/trail/).                                            |
+| `calls`            | off           | The calls the application answered and the calls it made, joined by the request id, see below. See [Call logs](/guides/calls/).                            |
 | `bodyLimit`        | `1mb`         | Maximum size of a JSON or form body.                                                                                                                       |
 | `uploads`          |               | File uploads: where they go, the limits and the accepted types, see below; needs `@usehenri/uploads`. `false` accepts no file.                             |
 | `requestTimeout`   | `30000`       | Milliseconds before a running request is answered `503`; `false` disables it.                                                                              |
@@ -366,6 +367,50 @@ is issued. See [The access trail](/guides/trail/).
 | `reads` | off             | `"personal"` records the answers carrying a model with a personal field, `"all"` every answer henri serializes, `false` none. Every recorded read costs a round trip and an insert.       |
 | `store` | `"default"`     | Which of `stores` the table lives in.                                                                                                                                                     |
 | `table` | `"henri_trail"` | The table henri creates at boot and only ever `INSERT`s into and `SELECT`s from.                                                                                                          |
+
+## The `calls` object
+
+The calls the application answered and the calls it made, joined by the
+request id. It is off until this key says otherwise, and off means no table
+is created and no middleware is mounted. It holds **values**, which the
+access trail deliberately does not: read [Call logs](/guides/calls/) before
+turning it on.
+
+```json
+{
+  "calls": {
+    "keep": "30d",
+    "sample": 0.05,
+    "maxPerSecond": 100,
+    "maxBody": "8kb",
+    "partition": "day",
+    "always": ["error"],
+    "ignore": ["/assets"],
+    "store": "default",
+    "table": "henri_calls"
+  }
+}
+```
+
+| Key               | Default         | Description                                                                                                                                                                                    |
+| ----------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `keep`            | `"30d"`         | How long a row is kept. The retention sweep prunes them; `false` keeps them forever, which on this table is a decision to make on purpose.                                                     |
+| `sample`          | `1`             | The share of requests recorded, from `0` to `1`. The decision is a hash of the request id seeded with `secret`, so the inbound call and every outbound call it caused agree, in every process. |
+| `maxPerSecond`    | `100`           | The absolute per-process ceiling on rows a second, or `false` for none. Sampling is proportional and a burst is not, so this is what a spike runs into.                                        |
+| `always`          | `["error"]`     | The outcomes sampling never drops: `"error"`, `"client-error"`, `"aborted"`. They are recorded without their bodies.                                                                           |
+| `maxBody`         | `"8kb"`         | How much of a body is stored before it is cut and marked truncated. `false` stores no body.                                                                                                    |
+| `bodies`          | `true`          | `false` keeps the timings, the statuses and the headers and captures no body at all.                                                                                                           |
+| `partition`       | off             | `"day"` or `"month"` on PostgreSQL and MySQL: the sweep then drops a partition instead of deleting rows. Anything else fails the boot with `HENRI_CALLS_PARTITION_UNSUPPORTED`.                |
+| `partitionsAhead` | `7`             | How many periods are kept ready in front of the clock.                                                                                                                                         |
+| `inbound`         | `true`          | `false` stops henri mounting the middleware at all.                                                                                                                                            |
+| `outbound`        | `true`          | `false` makes `henri.calls.track()` and `henri.calls.outbound()` no-ops.                                                                                                                       |
+| `ignore`          | `[]`            | Path prefixes that are never recorded. The health probes never are, whatever this says.                                                                                                        |
+| `buffer`          | `1000`          | How many rows may wait to be written. Past it a row is dropped and counted rather than queued forever.                                                                                         |
+| `batch`           | `500`           | How many buffered rows trigger a flush before the timer does.                                                                                                                                  |
+| `flush`           | `1000`          | How often the buffer is written, in milliseconds.                                                                                                                                              |
+| `sweep`           | `5000`          | How many rows one pass of the delete path takes at a time.                                                                                                                                     |
+| `store`           | `"default"`     | Which of `stores` the table lives in.                                                                                                                                                          |
+| `table`           | `"henri_calls"` | The table henri creates at boot. Changing `partition` afterwards needs a migration of your own.                                                                                                |
 
 ## Uploads
 

--- a/website/src/content/docs/guides/calls.md
+++ b/website/src/content/docs/guides/calls.md
@@ -1,0 +1,281 @@
+---
+title: Call logs
+description: The calls an application answered and the calls it made, joined by the request id -- what it holds, the four bounds that keep it from being an outage, and how it is swept.
+---
+
+**Read this paragraph before turning it on.** A call log holds **values**:
+the body that came in, the body that went out. That is the point -- a call
+log that does not is a slower copy of your web server's access log -- and it
+is also why it is the most dangerous table henri writes. It is a debugging
+instrument, kept for days, sampled, capped and swept. It is not evidence and
+it is not [the access trail](/guides/trail/), which is the opposite thing on
+purpose.
+
+```json
+{ "calls": {} }
+```
+
+That is the whole setup. henri creates one table at boot, mounts one
+middleware, and starts recording. It is off until this key is there, and off
+means off: no table, no middleware, no allocation.
+
+## The two records, and why they are one table
+
+- **inbound**, one row per call your application answered: the method, the
+  path, the route, the status, how long it took, the person when one is
+  known, and the bodies henri can read;
+- **outbound**, one row per call your application made: the same, plus the
+  service it went to.
+
+They share a `direction` column in one table rather than living in two,
+because the question worth keeping either of them for is _what happened
+during request `X`_, and that is one read on one index instead of two reads
+and a merge:
+
+```bash
+henri calls 018f5c2e-1f2a-7c31-9f0a-2b7c1d3e4f56
+```
+
+```
+  Request 018f5c2e-1f2a-7c31-9f0a-2b7c1d3e4f56
+
+  2026-09-06T14:22:31.004Z  <- 201        84ms  POST   /orders
+  2026-09-06T14:22:31.019Z  -> 200        41ms  POST   https://api.billing.test/v1/charges
+                              service billing
+  2026-09-06T14:22:31.062Z  -> 200        12ms  POST   https://hooks.example.test/orders
+                              service webhooks
+```
+
+The join is the request id `X-Request-Id` already carries through everything
+(`req.id`, every `pen` line, every error body). A client's own id is used
+when it looks sane, and henri makes one otherwise.
+
+## This is not the access trail
+
+The two tables answer different questions and neither substitutes for the
+other:
+
+|                 | [The access trail](/guides/trail/)                 | This                                        |
+| --------------- | -------------------------------------------------- | ------------------------------------------- |
+| Answers         | who saw this record                                | what did this request do                    |
+| Holds           | field _names_, counts, public identifiers, digests | values: the bodies and the headers          |
+| Refuses a value | yes, loudly (`HENRI_TRAIL_VALUE_REFUSED`)          | no -- that is what it is for                |
+| Complete        | yes, by construction                               | no: sampled, capped, and dropped under load |
+| Kept            | a year                                             | thirty days                                 |
+| Is it evidence  | yes: hash-chained, append-only                     | no: nothing stops a writer editing a row    |
+
+Turning this on does not give you an audit trail, and turning the trail on
+does not give you a call log. Reaching for the wrong one either makes a
+second copy of your personal data or produces a record that proves nothing.
+
+## The four bounds
+
+A table that grows without bound, written on the hot path, holding the one
+copy of every payload an attacker can make large, is an outage waiting for
+traffic. Each of these is a decision rather than a default, and each of them
+can be tuned.
+
+### 1. Off unless configured
+
+No `config.calls`, no table, no middleware, no allocation. `inbound: false`
+and `outbound: false` turn off one half each.
+
+### 2. The write never blocks the answer
+
+A finished call is pushed onto an in-memory buffer and the response goes
+out; a timer (`calls.flush`, a second) and a full batch (`calls.batch`)
+write it with one multi-row `INSERT`. A flush that fails is reported once
+and **dropped** -- a call log that can fail a request turns a database
+hiccup into an outage.
+
+The buffer is bounded too (`calls.buffer`, 1000 rows). Past it a row is
+dropped and counted, never queued forever. `henri calls:stats` is where you
+see that it happened.
+
+### 3. The payload is bounded before it is stored
+
+A body is captured up to `calls.maxBody` (8kb), cut, and marked
+`truncated`. `calls.bodies: false` captures none at all.
+
+**Only a body henri can walk is stored.** A plain object or an array is
+redacted key by key and kept; a string, a buffer, a stream or an HTML page is
+not, because there is no key to match and no way to redact inside it -- its
+shape is recorded in `meta` instead. This is also why the inbound response
+body is taken from `res.json(value)`, the value before it is serialized,
+rather than off the socket: a controller answering with `res.send(html)` puts
+no body in the log, deliberately.
+
+### 4. What one client can cause is bounded twice
+
+`calls.sample` is a fraction and bounds the steady state proportionally to
+traffic. It is not enough on its own: one percent of a million requests a
+second is still ten thousand rows a second. `calls.maxPerSecond` (100) is an
+absolute per-process ceiling that a burst cannot argue with.
+
+The sampling decision is a **hash of the request id, seeded with
+`config.secret`**, not a coin flip, and both halves of that matter:
+
+- a hash, so the inbound call and every outbound call it caused decide the
+  same way, in every process, without carrying any state. A sampled request
+  with half its outbound calls missing would be worse than not sampling it;
+- seeded, because the request id comes from a header the client can choose.
+  A plain hash would let anyone pick ids that land in the sampled bucket and
+  defeat `calls.sample` entirely.
+
+`calls.always` (`["error"]`) is the exception: a call the sampling dropped is
+still recorded when it failed. Without its bodies -- the decision not to
+capture them was made before the status was known, and there is nothing to go
+back for.
+
+## What never reaches a row
+
+Everything stored goes through the same redactor as your logs:
+`config.filterParameters` as substrings, the fields your models marked
+[`personal`](/guides/privacy/) matched exactly, and the always-masked set
+(`encryption`) that no configuration lifts -- at every depth, in headers and
+bodies alike. On top of that:
+
+- **the credentials of an exchange are always masked**, whatever
+  `filterParameters` says: `authorization`, `proxy-authorization`, `cookie`,
+  `set-cookie`, `x-csrf-token`, `x-api-key` and `webhook-signature`. No
+  application should have to remember to write those down;
+- **a url loses its userinfo**: `https://key:secret@host/` is stored as
+  `https://host/`, and the filtered query values are masked;
+- **the person is their `externalId`** and nothing else. Not the primary key,
+  not the email address;
+- **a body henri cannot walk is not stored at all**, only its shape.
+
+What follows from that: mark the fields that are about a person `personal` in
+your models. That mark is what turns `{"email": "..."}` in a captured body
+into `[FILTERED]` here, in your logs, and in the answers henri builds, all at
+once.
+
+## The outbound half
+
+henri wraps nobody's HTTP client. There is no interceptor to install and no
+patched `fetch`: there is a seam, and it is two lines around whatever you
+already use.
+
+```js
+const finish = henri.calls.track({
+  service: 'billing',
+  method: 'POST',
+  url: 'https://api.billing.test/v1/charges',
+  request: { headers, body },
+});
+
+try {
+  const answer = await fetch(url, { method: 'POST', headers, body });
+  const json = await answer.json();
+
+  finish({ status: answer.status, headers: answer.headers, body: json });
+} catch (error) {
+  finish({ error: error.code });
+}
+```
+
+`henri.calls.outbound(call)` records a finished call in one go when you
+already have the timings. Both are no-ops when the log is off, so nothing has
+to ask first.
+
+### The calls henri makes itself
+
+Two are populated without you doing anything:
+
+- **mail.** Every `henri.mail.send()` is one `service: "mail"` row: the
+  transport it went to, how long it took, the message id and the counts. The
+  **recipients are not in it** -- an address is personal data and a call log
+  is not where it belongs.
+- **webhooks.** Every delivery attempt of
+  [`@usehenri/webhooks`](/guides/webhooks/) is one `service: "webhooks"` row.
+  The request id is stamped into the delivery job at `emit()` time, so a
+  delivery that goes out ten seconds (or three retries) after the request
+  that caused it still joins it. What the receiver answered is deliberately
+  left out: it is untrusted text nothing can redact, and
+  `henri jobs:show <id>` already holds the excerpt.
+
+A job that makes its own outbound calls is outside all of this, the same way
+a model call in a controller is outside the trail: `track()` is how it gets
+in.
+
+## How it is swept
+
+`calls.keep` (30 days), pruned by [the retention sweep](/guides/retention/) --
+the same sweep that enforces every other retention enforces this one, and
+`henri calls:sweep --yes` runs it on its own. A prune that fails is a warning
+rather than a failed sweep: your models have already been swept by then.
+
+**Where the dialect has partitions, whole periods are dropped instead of
+rows.** That is the difference between a sweep that works at ten million rows
+and one that times out, because dropping a partition is a metadata operation
+whatever it held:
+
+| Store              | How it is swept                                                              |
+| ------------------ | ---------------------------------------------------------------------------- |
+| PostgreSQL         | `PARTITION BY RANGE (at)`; the sweep drops the periods entirely past `keep`  |
+| MySQL              | `PARTITION BY RANGE (at)`; the same, with `ALTER TABLE ... DROP PARTITION`   |
+| sqlite, SQL Server | no range partitioning: a bounded `DELETE` loop, `calls.sweep` rows at a time |
+| MongoDB            | the same delete path                                                         |
+
+```json
+{ "calls": { "partition": "day", "partitionsAhead": 7, "keep": "30d" } }
+```
+
+`calls.partition` on a store that cannot do it fails the boot
+(`HENRI_CALLS_PARTITION_UNSUPPORTED`) rather than being quietly ignored. The
+bounds are UTC and they are in the partition's name (`henri_calls_p20260906`).
+
+Three things worth knowing about it:
+
+- **there is always a catch-all** -- a `DEFAULT` partition on PostgreSQL, a
+  `VALUES LESS THAN MAXVALUE` one on MySQL. Without one, a row whose `at`
+  fell outside every declared period would be _refused_, which turns a
+  partition henri did not create in time into failed inserts. Whatever the
+  catch-all takes is swept by the delete path;
+- **a period the sweep dropped does not come back.** MySQL keeps its ranges
+  in increasing order, so a period below one that is still there cannot be
+  added; henri only ever adds periods above every existing one, on both
+  servers, and what that period held is gone anyway;
+- **changing `calls.partition` on a table that exists needs a migration of
+  your own.** henri creates the table the way the configuration asked the
+  first time and does not rewrite it afterwards.
+
+## The commands
+
+```bash
+henri calls <request-id>              # one request, and everything it caused
+henri calls --direction=out --service=billing
+henri calls:stats                     # written, and dropped rather than written
+henri calls:sweep --yes               # the prune, on its own
+```
+
+`henri calls:stats` is the one to read when the log looks thin: it separates
+the rows dropped by the per-second ceiling, by a full buffer, and by a store
+that refused them.
+
+## Reading it back in code
+
+```js
+const story = await henri.calls.about(req.id);
+const failures = await henri.calls.list({ outcome: 'failed', limit: 50 });
+const count = await henri.calls.count({ direction: 'out', service: 'billing' });
+```
+
+`about()` answers oldest first -- one exchange read as a story -- and
+everything else answers newest first.
+
+## What is not here
+
+- **No tracing.** There is no span, no parent id and no propagation header
+  going out. This joins on the request id henri already has, and stops there;
+  a distributed trace is OpenTelemetry's job and this is not a worse version
+  of it.
+- **No streaming or file bodies.** A multipart upload is a size and a type
+  ([uploads](/guides/uploads/) is where a file lives), and a streamed answer
+  is a status and a duration.
+- **No UI.** `henri calls` and `henri.calls.list()` are the readers.
+- **No cross-process ceiling.** `calls.maxPerSecond` is per process,
+  deliberately: a round trip to a shared store to decide whether to write a
+  debugging row would cost more than the row.
+- **No retry of a failed write.** A flush that fails drops its rows. A retry
+  queue for debugging rows is a second thing to run out of memory.

--- a/website/src/content/docs/guides/security.md
+++ b/website/src/content/docs/guides/security.md
@@ -344,7 +344,10 @@ a configuration a production boot reads, `webhooks.allowPrivate: true`
 (`webhooks.private-addresses-allowed`, which lets a url someone registered
 reach the loopback, the private network or the metadata service) and
 `webhooks.allowHttp: true` (`webhooks.http-allowed`, which sends the payload
-and the signature that authenticates it in the clear).
+and the signature that authenticates it in the clear), and `calls.keep:
+false` (`calls.kept-forever`: a [call log](/guides/calls/) holds the bodies
+users sent, so a copy of them that nothing ever sweeps is not a setting but
+an accumulation).
 
 **Schema changes nobody reviewed** — an `mssql` store with `"sync": true`
 in `config/default.json` or `config/production.json`, which makes a

--- a/website/src/content/docs/guides/trail.md
+++ b/website/src/content/docs/guides/trail.md
@@ -205,3 +205,8 @@ registered.
   every row is not what this is for.
 - **Shipping the entries somewhere.** There is no exporter. `henri trail
 --json` and `henri.trail.list()` are what a log shipper or a report reads.
+- **The values themselves.** An entry holds names, counts and identifiers,
+  and a `meta` carrying a value is refused. What a request sent and what it
+  got back is a [call log](/guides/calls/), which is the deliberate opposite
+  of this one: it holds values, it is sampled rather than complete, and it is
+  not evidence of anything.

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -404,6 +404,25 @@ The append-only record of who read or changed personal data, read back. See [The
 | `about <who>` | Everything recorded about one person. The address is not in the table -- henri digests what you asked about -- so this still answers after the erasure took it away. |
 | `verify`      | Walks the hash chain and says whether a row was edited or removed, and where. Exits `1` on a break.                                                                  |
 
+## `calls`
+
+```bash
+henri calls [<request-id>] [--direction=<in|out>] [--service=<name>] [--status=<n>] [--outcome=<name>] [--since=<date>] [--until=<date>] [--limit=<n>] [--json]
+henri calls:stats [--json]
+henri calls:sweep --yes [--json]
+```
+
+The calls the application answered and the calls it made, joined by the request id. See [Call logs](/guides/calls/). It is off until `config.calls` says otherwise, and it holds values -- unlike [the access trail](/guides/trail/), which refuses them.
+
+| Command        | What it does                                                                                                                                                                        |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<request-id>` | One request and everything it caused: the call that came in, every call that went out because of it, in order, with the timings. This is what the two records are for.              |
+| (none)         | The latest calls, newest first, filtered by the flags.                                                                                                                              |
+| `stats`        | What was written, and what was dropped rather than written -- by the per-second ceiling, by a full buffer, or by a store that refused it -- plus the partitions when there are any. |
+| `sweep`        | Takes the calls past `config.calls.keep` away. The retention sweep already does this; the command is for running it on its own. Needs `--yes`, because it removes rows.             |
+
+A sweep drops whole partitions on PostgreSQL and MySQL when `config.calls.partition` asked for them, and deletes rows in bounded batches everywhere else.
+
 ## `doctor`
 
 ```bash

--- a/website/src/content/docs/reference/errors.md
+++ b/website/src/content/docs/reference/errors.md
@@ -469,6 +469,43 @@ Usually:
 
 **Fix.** The cache keeps what JSON keeps, plus `Date`. Store the plain shape you want back: `record.toJSON()`, or `henri.model.stores.default.toPlain(record)`. Cache `null` where you meant "there is nothing".
 
+## calls
+
+The call log of `henri.calls`: the table it owns, the store it lives in and the partitions it sweeps.
+
+### `HENRI_CALLS_DISABLED`
+
+The call log was read back and this application keeps none.
+
+Usually:
+
+- `config.calls` is absent or false
+- the call log could not be started
+
+**Fix.** Turn the call log on with `"calls": {}` in `config/<env>.json`; henri creates its table on the next boot. Recording is a no-op while it is off, but reading it back says so rather than answering with nothing.
+
+### `HENRI_CALLS_PARTITION_UNSUPPORTED`
+
+The call log was asked to partition its table in a store that cannot.
+
+Usually:
+
+- `config.calls.partition` is set on a sqlite, SQL Server or MongoDB store
+
+**Fix.** Only PostgreSQL and MySQL range-partition a table, which is what lets a sweep drop a period instead of deleting its rows. Everywhere else the sweep deletes in bounded batches: leave `calls.partition` out.
+
+### `HENRI_CALLS_UNSUPPORTED_STORE`
+
+The call log cannot be kept in the store it was pointed at.
+
+Usually:
+
+- `config.calls.store` names a store this application does not have
+- the store adapter has neither `query()` nor a MongoDB connection
+- the MongoDB store is not connected
+
+**Fix.** The call log owns a table in one of the application's stores. Point `config.calls.store` at a store backed by mongoose, drizzle or sequelize, or leave `config.calls` out to keep no call log at all.
+
 ## cli
 
 The henri command line: arguments, the project it runs in, the commands themselves.


### PR DESCRIPTION
A table of the calls an application answered and a table of the calls it made, joined by the request id henri already threads through everything: the payload in, the response, the status, the timing, and the person when one is known. Asked for by the owner, who has built it by hand more than once and named both its value and its two failure modes -- it is cumbersome, and it is a denial of service waiting to happen.

## Where it lives, and why it is not a package

In core, and the argument is the inbound half. The middleware has to be **the outermost one that has a request id**, because the requests worth having in a call log are precisely the ones something refused: a 429 from the rate limit, a 413 from the body parser, a 403 from CSRF, a 422 from the parameter check. A package's module comes up at runlevel 3 at the earliest, by which time `2.server.js` has installed all of those, so a packaged inbound log would silently miss exactly its most valuable rows. Splitting inbound into core and outbound into a package is worse than either: the two records exist to be joined, and they would have two homes, two redaction paths and two sweeps. **No new package, so nothing to bootstrap on npm.**

## The four bounds, each answering a different failure

1. **Off unless configured.** `2.server.js` reads `config.calls` before it builds the chain and mounts nothing when it is absent -- no table, no middleware, not even one that returns early.
2. **Off the hot path.** The row is built from `res.on('close')`, buffered, and written in batches by a timer. A failed flush is reported once and **dropped, not retried**: a retry queue for debugging rows is a second thing to run out of memory, and a call log that can fail a request turns a database hiccup into an outage. The buffer is bounded and what it drops is counted, never silent.
3. **A capped payload, and only one the redactor can walk.** `calls.maxBody` (8kb) with a truncation marker -- and a body is stored only if it can be walked key by key. A string, a buffer, a stream or an HTML page is recorded as a size and a shape, because there is no key to match inside it. That is why the response body is taken from `res.json(value)` rather than off the socket.
4. **Sampling and a rate, because they answer different failures.** `calls.sample` bounds the steady state proportionally; one percent of a million requests a second is still ten thousand rows a second, so `calls.maxPerSecond` is an absolute per-process ceiling. The sampling decision is a hash of the request id -- not a coin flip, so an inbound call and every outbound call it caused agree in every process with no shared state -- and it is **seeded with `config.secret`**, because `X-Request-Id` is attacker-controlled and a plain hash would let a client pick ids that land in the sampled bucket.

## The sweep, per dialect

`calls.keep` (30d), pruned by the retention sweep. PostgreSQL uses `PARTITION BY RANGE` and drops a table per period; MySQL uses `PARTITION BY RANGE` and `DROP PARTITION`; sqlite, SQL Server and MongoDB have no ranges and get a bounded delete loop -- and `calls.partition` on those **fails the boot** rather than being quietly ignored. Both partitioned dialects keep a catch-all, because without one a period henri did not create in time is *failed inserts* rather than a slower sweep. Running it against the real servers found the rule the code now states: MySQL keeps ranges in increasing order, so a dropped period cannot be reorganized back in below one that is still there.

## Verified here, not on report

This is the most dangerous table henri writes, so I did not take the redaction on trust. I booted the showcase in production against a scratch database with the log on, sent a login carrying an `Authorization: Bearer`, a session cookie, `?token=…`, and a body with an email, a password and a phone number, then read the rows back **with `psql`, outside henri entirely**:

```
url:              /login?token=%5BFILTERED%5D
request_headers:  "authorization":"[FILTERED]", "cookie":"[FILTERED]"
request_body:     {"email":"[FILTERED]","password":"[FILTERED]","phone":"[FILTERED]"}
response_headers: "set-cookie":"[FILTERED]"
response_body:    null            (the HTML page: not walkable, so a size and nothing else)
```

Every planted secret was counted in the table and every count was **zero** -- the query token, the bearer token, the cookie, the password, a second `?secret=`, the phone number and the email address. `email` and `phone` are masked because the showcase marks them `personal`, which is the mark doing the work rather than a list of header names.

`pnpm test` (148 files), `pnpm test:sql` against live PostgreSQL (37 files, partitions included), `pnpm test:types`, `pnpm lint --max-warnings 0`, `pnpm format:check`, the showcase suite and `scripts/smoke.sh` all pass.

## One thing to know about the sampling seed

The seed is `config.secret` folded to 32 bits, not a keyed MAC, so an attacker with a great many observations could in principle infer which ids are sampled. The consequence is bounded -- it defeats a *sampling rate*, not the redaction -- and `calls.maxPerSecond` is the backstop that holds regardless. Named here rather than left implicit.

## Deliberately out

No tracing, no propagation header: the join is the request id, and a distributed trace is OpenTelemetry's job. No streamed or non-JSON body capture, no UI, no cross-process ceiling (a round trip to a shared store to decide whether to write a debugging row costs more than the row), no retry of a failed write, and no mail recipients, because an address is personal data. The guide states each one and why.
