### PR TITLE
Mask a connection string wherever it is, not only on its own

### DIFF
--- a/.changeset/mask-a-connection-string-anywhere.md
+++ b/.changeset/mask-a-connection-string-anywhere.md
@@ -1,0 +1,13 @@
+---
+'@usehenri/core': patch
+---
+
+The boot report masks the password of a connection string wherever the string
+is, not only when the value is the url itself.
+
+`DATABASE_URL` has always printed `postgres://henri:[FILTERED]@host/db`. The
+same url arriving inside an object — `HENRI_CONFIG_JSON__stores`, or a store
+block from the encrypted credentials — went through the redaction that matches
+_key names_, and `url` is a name no `filterParameters` list would ever hold, so
+the password was printed in the clear. Both paths now walk the value and mask
+every connection string in it.

--- a/packages/core/src/0.config.js
+++ b/packages/core/src/0.config.js
@@ -517,6 +517,53 @@ function provenance(file, secrets, applied) {
  * @param {Array<string>} filters the filtered parameter names
  * @returns {string} what to print
  */
+/** The password of a connection string: `postgres://user:secret@host/db` */
+const CREDENTIALS = /^([a-z][a-z0-9+.-]*:\/\/[^:@/\s]+):[^@\s/]*@/iu;
+
+/** How deep the walk goes, the same bound `base/redact.js` uses */
+const CREDENTIALS_DEPTH = 8;
+
+/**
+ * The same value with the password of every connection string in it masked.
+ *
+ * A url is the one secret no filter list ever names: nobody writes `url` in
+ * `filterParameters`, and the password lives inside the string rather than
+ * under a key of its own. The scalar case was always masked -- `DATABASE_URL`
+ * prints `postgres://henri:[FILTERED]@...` -- but the same value arriving as
+ * part of an object (`HENRI_CONFIG_JSON__stores`, a credentials file) went
+ * through the key-name redaction, which has no key to match here, and printed
+ * the password in the clear.
+ *
+ * @param {*} value a configuration value, of any shape
+ * @param {number} [depth=0] how deep the walk is
+ * @returns {*} the value, with every connection string masked
+ */
+function withoutCredentials(value, depth = 0) {
+  if (typeof value === 'string') {
+    return value.replace(CREDENTIALS, `$1:${MASK}@`);
+  }
+
+  if (
+    value === null ||
+    typeof value !== 'object' ||
+    depth >= CREDENTIALS_DEPTH
+  ) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => withoutCredentials(entry, depth + 1));
+  }
+
+  const copy = {};
+
+  for (const [key, held] of Object.entries(value)) {
+    copy[key] = withoutCredentials(held, depth + 1);
+  }
+
+  return copy;
+}
+
 function display(entry, filters) {
   const { key, value, variable } = entry;
   const last = segments(key).pop();
@@ -530,13 +577,10 @@ function display(entry, filters) {
   }
 
   if (value !== null && typeof value === 'object') {
-    return JSON.stringify(redact(value, filters));
+    return JSON.stringify(withoutCredentials(redact(value, filters)));
   }
 
-  return String(value).replace(
-    /^([a-z][a-z0-9+.-]*:\/\/[^:@/\s]+):[^@\s/]*@/i,
-    `$1:${MASK}@`
-  );
+  return withoutCredentials(String(value));
 }
 
 /**

--- a/packages/core/src/__tests__/config.spec.js
+++ b/packages/core/src/__tests__/config.spec.js
@@ -345,6 +345,23 @@ describe('config from the environment', () => {
       expect(lines.join('\n')).not.toContain('hunter2');
     });
 
+    test('masks a connection string wherever it is, not only on its own', () => {
+      // The scalar case was always masked. The same url inside the object a
+      // JSON variable carries reached the report through the key-name
+      // redaction, which has no key to match: `url` is a name no
+      // filterParameters list would ever hold
+      const { applied, config } = applyEnv(file(), {
+        [`${ENV_JSON_PREFIX}stores`]:
+          '{"default":{"adapter":"drizzle","url":"postgres://henri:hunter2@db.internal:5432/app"}}',
+      });
+      const lines = report(config, applied).join('\n');
+
+      expect(lines).toContain(
+        'postgres://henri:[FILTERED]@db.internal:5432/app'
+      );
+      expect(lines).not.toContain('hunter2');
+    });
+
     test('masks what config.filterParameters names, and nothing else', () => {
       const { applied, config } = applyEnv(
         { filterParameters: ['apiKey'] },


### PR DESCRIPTION
Found while verifying the call log tranche, in the boot output of an application I started with `HENRI_CONFIG_JSON__stores`. Two lines of the same log:

```
config  from the environment  stores.default.url = postgres://henri:[FILTERED]@127.0.0.1:55433/henri_calls_probe  DATABASE_URL
config  from the environment  stores = {"default":{...,"url":"postgres://henri:henri@127.0.0.1:55433/henri_calls_probe"}}  HENRI_CONFIG_JSON__stores
```

The scalar path masks a connection string's password. The object path redacts by **key name**, and `url` is a name no `filterParameters` list would ever hold — so the same secret printed in the clear depending on which environment variable carried it. It reaches a store block from the encrypted credentials the same way.

This is the shape #390 fixed for `encryption`: a rule written against a *path* (`encryption.keys`, and here the scalar url) that the parent object walks straight past. The documentation already promised the stronger behaviour — `configuration.md` says the password of a connection string is masked, "which no filter list would ever name".

`withoutCredentials()` now walks a value at every depth and masks every connection string in it, bounded at the same depth `base/redact.js` uses, and both paths in `display()` go through it. A test pins it: with the fix the object prints `postgres://henri:[FILTERED]@db.internal:5432/app`, without it the test goes red on `hunter2`.

`pnpm test` (148 files), `pnpm test:types`, `pnpm lint --max-warnings 0` and `pnpm format:check` pass.