### PR TITLE
openapi describes the 422 a params declaration answers

### DIFF
--- a/.changeset/tidy-donuts-brake.md
+++ b/.changeset/tidy-donuts-brake.md
@@ -1,0 +1,16 @@
+---
+'@usehenri/core': patch
+'@usehenri/cli': patch
+---
+
+`henri openapi` describes the parameters an action declared, and the 422 they answer.
+
+The parameter check of a `params` declaration is registered next to the guards whatever the verb, so a `GET` declaring `page: { type: 'integer', min: 1 }` answers 422 on `?page=banana`. The document tied 422 to `mutating && idempotency`, so it denied that answer — and where it did emit one, the component said the `Idempotency-Key` had been reused, which is a different failure fixed a different way.
+
+The document now reads the declarations, from `henri.controllers.accepts()` on a booted application and from the same `declarations()` compiler over the controller files in the command, so both write the same document:
+
+- the declared fields are the query, path and body parameters of the operation, with the types, the bounds and the enums the rule wrote. A mutating action that declares `params` gets that as its request body — what henri actually checks — instead of the model's writable columns, which stay in `components.schemas` as `<Model>Input`.
+- every 422 names its cause: `InvalidParameters` (the parameter check), `IdempotencyMismatch` (the key was reused for a different request), `UnprocessableEntity` (both can happen on that operation), and `ValidationFailed` for the account endpoints henri mounts, which used to share the idempotency wording.
+- a controller the command could not load, or whose declaration would fail the boot, is marked rather than described as accepting nothing: `x-henri.params.read: false` on the operation, `info.x-henri.params.unread` in the document and a section in `henri openapi --summary`.
+
+`x-henri.enforced` is a list now (`['_links', 'params']`), because a route can enforce both.

--- a/packages/cli/__tests__/openapi.spec.js
+++ b/packages/cli/__tests__/openapi.spec.js
@@ -52,6 +52,103 @@ describe('henri openapi', () => {
     expect(document.paths['/livez']).toBeDefined();
   });
 
+  describe('what a controller declared it accepts', () => {
+    const controller = () => path.join(app, 'app', 'controllers', 'tasks.js');
+    let original;
+
+    beforeEach(() => {
+      original = fs.readFileSync(controller(), 'utf8');
+    });
+
+    afterEach(() => {
+      fs.writeFileSync(controller(), original);
+    });
+
+    /**
+     * Adds a `params` export to the scaffolded controller
+     *
+     * @param {string} block The block, as source
+     * @returns {object} The document `henri openapi` writes for it
+     */
+    const withParams = (block) => {
+      fs.writeFileSync(
+        controller(),
+        original.replace('module.exports = {', `module.exports = {\n${block}\n`)
+      );
+
+      return JSON.parse(henri(['openapi'], { cwd: app }).stdout);
+    };
+
+    test('is read from the controller file, with no server and no database', () => {
+      const document = withParams(
+        `  params: {
+    index: { q: { type: 'string', maxLength: 20 } },
+    create: { title: { type: 'string', required: true } },
+  },`
+      );
+      const index = document.paths['/tasks'].get;
+      const create = document.paths['/tasks'].post;
+
+      // A GET answers 422 as soon as it declares anything: the check is
+      // registered whatever the verb
+      expect(index.responses['422']).toEqual({
+        $ref: '#/components/responses/InvalidParameters',
+      });
+      expect(index.parameters).toContainEqual(
+        expect.objectContaining({
+          in: 'query',
+          name: 'q',
+          required: false,
+          schema: { maxLength: 20, type: 'string' },
+        })
+      );
+      expect(index['x-henri'].params).toEqual({ fields: ['q'] });
+
+      // A mutating route can answer 422 for two reasons, and says so
+      expect(create.responses['422']).toEqual({
+        $ref: '#/components/responses/UnprocessableEntity',
+      });
+      // The body is the declaration, not the model's writable columns
+      expect(
+        create.requestBody.content['application/json'].schema.properties
+      ).toEqual({ title: { type: 'string' } });
+      expect(
+        create.requestBody.content['application/json'].schema.required
+      ).toEqual(['title']);
+    });
+
+    test('says which declaration it could not read, and describes no parameters', async () => {
+      const document = withParams(
+        "  params: { index: { q: { type: 'nope' } } },"
+      );
+      const index = document.paths['/tasks'].get;
+
+      // A declaration that would fail the boot is one this command could
+      // not read: the operation says so rather than accepting everything
+      expect(index['x-henri'].params).toEqual({ read: false });
+      expect(index.responses['422']).toBeUndefined();
+      expect(index.description).toContain('could not read the `params`');
+      expect(document.info['x-henri'].params.unread).toContain('tasks#index');
+      expect(await validate(document)).toEqual({ valid: true });
+
+      const { stdout } = henri(['openapi', '--summary'], { cwd: app });
+
+      expect(stdout).toContain('could not be read');
+      expect(stdout).toContain('tasks#index');
+    });
+
+    test('a scaffolded application declares none, and nothing is invented', () => {
+      const document = JSON.parse(henri(['openapi'], { cwd: app }).stdout);
+
+      expect(document.info['x-henri'].params).toBeUndefined();
+      expect(document.paths['/tasks'].get['x-henri'].params).toBeUndefined();
+      expect(document.paths['/tasks'].get.responses['422']).toBeUndefined();
+      expect(document.paths['/tasks'].post.responses['422']).toEqual({
+        $ref: '#/components/responses/IdempotencyMismatch',
+      });
+    });
+  });
+
   test('writes the document with --out and reports what it covers', () => {
     const { status, stdout } = henri(['openapi', '--out', 'openapi.json'], {
       cwd: app,

--- a/packages/cli/scripts/openapi.js
+++ b/packages/cli/scripts/openapi.js
@@ -86,28 +86,44 @@ const scanActions = (source) => {
 };
 
 /**
- * Which `controller#action` the application actually exports.
+ * Which `controller#action` the application exports, and what each of them
+ * declared it accepts.
  *
  * A route pointing at an action that is not there answers 501 in
  * development and is never registered in production, and the document says
  * so rather than describing an endpoint nobody can call. `null` when
  * `app/controllers` does not exist, which is the honest "unknown".
  *
+ * The declarations are read the only way they can be: the `params` export is
+ * a JavaScript object holding regular expressions and functions, so there is
+ * nothing to scan for. This loads the controller with `require()`, which is
+ * what reading the actions already did, and compiles the block with the same
+ * `declarations()` the boot compiles it with -- so the document is the same
+ * one a booted application answers at `/_openapi.json`. A file that will not
+ * load outside a booted application, or whose declaration would fail the
+ * boot, is marked `null` here: the builder says so in the document rather
+ * than describing an action as accepting nothing.
+ *
  * @param {string} cwd The application directory
- * @returns {?object} `{ 'tasks#index': true }`, or null
+ * @returns {{accepts: ?object, actions: ?object}} `{ 'tasks#index': ... }`
  */
-const actionsOf = (cwd) => {
+const controllersOf = (cwd) => {
   const dir = path.join(cwd, 'app', 'controllers');
 
   if (!fs.existsSync(dir)) {
-    return null;
+    return { accepts: null, actions: null };
   }
 
+  const params = fromCore('src/base/params-schema', cwd);
+  const hooks = fromCore('src/base/hooks', cwd);
+  const reserved = new Set([...hooks.RESERVED, ...params.RESERVED]);
+  const accepts = {};
   const actions = {};
 
   for (const name of listing(dir)) {
     const file = path.join(dir, `${name}.js`);
     let names;
+    let rules = null;
 
     try {
       delete require.cache[require.resolve(file)];
@@ -115,8 +131,16 @@ const actionsOf = (cwd) => {
       const loaded = require(file) || {};
 
       names = Object.keys(loaded).filter(
-        (key) => key !== 'before' && typeof loaded[key] === 'function'
+        (key) => !reserved.has(key) && typeof loaded[key] === 'function'
       );
+
+      try {
+        rules = params.declarations(loaded, name, names);
+      } catch {
+        // A declaration henri could not carry out fails the boot; here it
+        // is one more thing this command could not read
+        rules = null;
+      }
     } catch {
       // A controller that cannot be loaded outside a booted application:
       // read the actions off the source instead of pretending there are none
@@ -125,11 +149,20 @@ const actionsOf = (cwd) => {
 
     for (const action of names) {
       actions[`${name}#${action}`] = true;
+      accepts[`${name}#${action}`] = rules ? rules[action] || {} : null;
     }
   }
 
-  return actions;
+  return { accepts, actions };
 };
+
+/**
+ * Which `controller#action` the application actually exports
+ *
+ * @param {string} cwd The application directory
+ * @returns {?object} `{ 'tasks#index': true }`, or null
+ */
+const actionsOf = (cwd) => controllersOf(cwd).actions;
 
 /**
  * The identity of the application, for `info`
@@ -162,9 +195,11 @@ const identity = (cwd) => {
 const describe = (cwd = process.cwd()) => {
   const { build } = fromCore('src/base/openapi', cwd);
   const { loadModules } = fromCore('src/utils', cwd);
+  const { accepts, actions } = controllersOf(cwd);
 
   return build({
-    actions: actionsOf(cwd),
+    accepts,
+    actions,
     config: readConfig(cwd, undefined),
     info: identity(cwd),
     models: Object.values(loadModules(path.join(cwd, 'app', 'models'))),
@@ -180,7 +215,7 @@ const describe = (cwd = process.cwd()) => {
  * @returns {string} The summary
  */
 const summary = (document) => {
-  const { coverage, excluded = [] } = document.info['x-henri'];
+  const { coverage, excluded = [], params = {} } = document.info['x-henri'];
   const unknown = [];
 
   for (const [route, item] of Object.entries(document.paths)) {
@@ -208,6 +243,13 @@ const summary = (document) => {
       '  What henri cannot know (the controller writes the body; only the failures henri answers itself are described):'
     );
     lines.push(...unknown.map((line) => `    ${line}`), '');
+  }
+
+  if (Array.isArray(params.unread) && params.unread.length > 0) {
+    lines.push(
+      '  Whose `params` declaration could not be read (the controller did not load here; a booted application describes them):'
+    );
+    lines.push(...params.unread.map((entry) => `    ${entry}`), '');
   }
 
   for (const entry of excluded) {
@@ -276,5 +318,6 @@ const main = async (args = {}) => {
 
 module.exports = main;
 module.exports.actionsOf = actionsOf;
+module.exports.controllersOf = controllersOf;
 module.exports.describe = describe;
 module.exports.summary = summary;

--- a/packages/core/src/5.router.js
+++ b/packages/core/src/5.router.js
@@ -241,12 +241,17 @@ class Router extends BaseModule {
    */
   describe() {
     const { config, controllers, model, policies } = this.henri;
+    const accepts = {};
     const actions = {};
     let info = {};
 
     for (const route of Object.values(this.routes)) {
       actions[route.controller] =
         typeof controllers.get(route.controller) === 'function';
+      // The compiled rules the boot already holds. `{}` and not null: this
+      // process read the controller, so an action declaring nothing is a
+      // fact here rather than something henri could not find out
+      accepts[route.controller] = controllers.accepts(route.controller) || {};
     }
 
     try {
@@ -264,6 +269,7 @@ class Router extends BaseModule {
     }
 
     return openapi.build({
+      accepts,
       actions,
       config,
       info,

--- a/packages/core/src/__tests__/openapi.spec.js
+++ b/packages/core/src/__tests__/openapi.spec.js
@@ -6,38 +6,49 @@ const Henri = require('../henri');
 const { build } = require('../base/openapi');
 const { expand } = require('../base/routes');
 const { loadModules } = require('../utils');
+const { RESERVED: HOOK_KEYS } = require('../base/hooks');
+const { RESERVED: PARAM_KEYS, declarations } = require('../base/params-schema');
 
 const demo = path.resolve(__dirname, '..', '..', '..', 'demo');
+const reserved = new Set([...HOOK_KEYS, ...PARAM_KEYS, 'globalId', 'identity']);
 
 /**
  * The document of the demo application, built from its files the way
- * `henri openapi` builds it
+ * `henri openapi` builds it: the actions the controllers export and the
+ * `params` each of them declared, compiled by the same `declarations()` the
+ * boot compiles them with
  *
  * @returns {object} the document
  */
-const describeDemo = () =>
-  build({
-    actions: Object.fromEntries(
-      Object.entries(
-        loadModules(path.join(demo, 'app', 'controllers'), {
-          keepDirectoryPath: true,
-        })
-      ).flatMap(([, controller]) =>
-        Object.keys(controller)
-          .filter(
-            (key) =>
-              !['before', 'globalId', 'identity'].includes(key) &&
-              typeof controller[key] === 'function'
-          )
-          .map((action) => [`${controller.identity}#${action}`, true])
-      )
-    ),
+const describeDemo = () => {
+  const controllers = loadModules(path.join(demo, 'app', 'controllers'), {
+    keepDirectoryPath: true,
+  });
+  const accepts = {};
+  const actions = {};
+
+  for (const controller of Object.values(controllers)) {
+    const names = Object.keys(controller).filter(
+      (key) => !reserved.has(key) && typeof controller[key] === 'function'
+    );
+    const rules = declarations(controller, controller.identity, names);
+
+    for (const action of names) {
+      actions[`${controller.identity}#${action}`] = true;
+      accepts[`${controller.identity}#${action}`] = rules[action] || {};
+    }
+  }
+
+  return build({
+    accepts,
+    actions,
     config: require(path.join(demo, 'config', 'default.json')),
     info: { title: 'demo', version: '1.0.0' },
     models: Object.values(loadModules(path.join(demo, 'app', 'models'))),
     policies: Object.keys(loadModules(path.join(demo, 'app', 'policies'))),
     routes: expand(require(path.join(demo, 'app', 'routes.js'))),
   });
+};
 
 /**
  * Every `$ref` of a document, with the path it sits at
@@ -155,6 +166,21 @@ describe('the OpenAPI description', () => {
     }
   });
 
+  test('no operation declares the same parameter twice', () => {
+    for (const { operation, route, verb } of operationsOf(document)) {
+      const seen = (operation.parameters || [])
+        .map((parameter) =>
+          parameter.$ref ? resolve(document, parameter.$ref) : parameter
+        )
+        .map((parameter) => `${parameter.in} ${parameter.name}`);
+
+      expect([`${verb} ${route}`, seen.length]).toEqual([
+        `${verb} ${route}`,
+        new Set(seen).size,
+      ]);
+    }
+  });
+
   test('every operation says whether henri knows what it answers', () => {
     for (const { operation, route, verb } of operationsOf(document)) {
       const marks = operation['x-henri'];
@@ -262,6 +288,88 @@ describe('the OpenAPI description', () => {
       expect(document.paths['/echo'].post.responses['409']).toBeUndefined();
     });
 
+    test('a GET declaring its parameters answers 422, and says so', () => {
+      // The check is registered whatever the verb (5.router.js), so a GET
+      // with a declaration refuses `?limit=banana` -- which is what the
+      // document used to deny by tying 422 to the idempotency of a
+      // mutating route
+      const search = document.paths['/notes/search'].get;
+      const named = Object.fromEntries(
+        search.parameters.map((parameter) => [parameter.name, parameter])
+      );
+
+      expect(search.responses['422']).toEqual({
+        $ref: '#/components/responses/InvalidParameters',
+      });
+      expect(search['x-henri'].params).toEqual({
+        fields: ['exact', 'limit', 'q'],
+      });
+      expect(search['x-henri'].enforced).toEqual(['params']);
+      expect(named.limit.schema).toEqual({
+        default: 10,
+        maximum: 50,
+        minimum: 1,
+        type: 'integer',
+      });
+      expect(named.q.schema).toEqual({ maxLength: 60, type: 'string' });
+      expect(named.exact.schema).toEqual({ default: false, type: 'boolean' });
+      expect(named.limit.required).toBe(false);
+    });
+
+    test('a mutating route names both 422s it can answer', () => {
+      // `notes#create` declares `title` and the route honours
+      // Idempotency-Key: two different failures, one status
+      const create = document.paths['/notes'].post;
+      const schema = create.requestBody.content['application/json'].schema;
+
+      expect(create.responses['422']).toEqual({
+        $ref: '#/components/responses/UnprocessableEntity',
+      });
+      expect(
+        document.components.responses.UnprocessableEntity.description
+      ).toContain('HENRI_PARAMS_INVALID');
+      expect(schema.properties.title).toEqual({
+        maxLength: 40,
+        type: 'string',
+      });
+      expect(schema.required).toEqual(['title']);
+      // Open on purpose: an undeclared key is dropped, not refused
+      expect(schema.additionalProperties).toBe(true);
+      expect(create.requestBody.required).toBe(true);
+      expect(create['x-henri'].enforced).toEqual(['_links', 'params']);
+    });
+
+    test('a route with no declaration keeps the idempotency 422 alone', () => {
+      expect(document.paths['/once'].post.responses['422']).toEqual({
+        $ref: '#/components/responses/IdempotencyMismatch',
+      });
+      expect(
+        document.components.responses.IdempotencyMismatch.description
+      ).not.toContain('params');
+      // ... and one that opted out of idempotency answers no 422 at all
+      expect(document.paths['/echo'].post.responses['422']).toBeUndefined();
+      expect(document.paths['/echo'].post['x-henri'].params).toBeUndefined();
+    });
+
+    test('a declared page replaces the paging parameter, never doubles it', () => {
+      const declared = build({
+        accepts: { 'tasks#index': { page: { min: 1, type: 'integer' } } },
+        actions: { 'tasks#index': true },
+        models: [],
+        routes: expand({ 'resources tasks': { only: ['index'] } }),
+      });
+      const index = declared.paths['/tasks'].get;
+      const names = index.parameters.map(
+        (parameter) => parameter.name || parameter.$ref
+      );
+
+      expect(names).toEqual(['page', '#/components/parameters/PerPage']);
+      expect(index.parameters[0].schema).toEqual({
+        minimum: 1,
+        type: 'integer',
+      });
+    });
+
     test('the endpoints henri mounts itself are described exactly', () => {
       const login = document.paths['/login'].post;
 
@@ -306,7 +414,7 @@ describe('the OpenAPI description', () => {
 
       expect(form['x-henri']).toMatchObject({
         answer: 'page',
-        enforced: '_links',
+        enforced: ['_links'],
         known: false,
       });
       expect(
@@ -340,6 +448,39 @@ describe('the OpenAPI description', () => {
       expect(operation.responses.default.description).toContain(
         '501 in development'
       );
+    });
+
+    test('a declaration it could not read is named, not invented', () => {
+      // The one case where the two ways of building the document differ: a
+      // controller `henri openapi` could not load. It says so rather than
+      // describing the action as accepting nothing
+      const blind = build({
+        accepts: { 'tasks#index': null },
+        actions: { 'tasks#index': true },
+        models: [],
+        routes: expand({ 'resources tasks': { only: ['index'] } }),
+      });
+      const index = blind.paths['/tasks'].get;
+
+      expect(index['x-henri'].params).toEqual({ read: false });
+      expect(index.responses['422']).toBeUndefined();
+      expect(index.description).toContain('could not read the `params`');
+      expect(blind.info['x-henri'].params).toEqual({
+        unread: ['tasks#index'],
+      });
+      // ... and a caller that passed no declarations at all is in the same
+      // position for every operation
+      expect(
+        build({
+          actions: { 'tasks#index': true },
+          models: [],
+          routes: expand({ 'resources tasks': { only: ['index'] } }),
+        }).paths['/tasks'].get['x-henri'].params
+      ).toEqual({ read: false });
+    });
+
+    test('the demo document read every declaration it needed', () => {
+      expect(document.info['x-henri'].params).toBeUndefined();
     });
 
     test('the coverage says how much of the document was derived', () => {
@@ -382,6 +523,83 @@ describe('the OpenAPI description', () => {
       expect(Object.keys(live.paths).sort()).toEqual(
         Object.keys(document.paths).sort()
       );
+    });
+
+    test('both ways of building it read the same declarations', () => {
+      // The compiled rules of a booted application and the ones
+      // `henri openapi` compiles from the files are the same rules: the
+      // parameters, the request bodies and the 422s they produce have to
+      // match operation for operation, or one of the two documents is lying
+      for (const { operation, route, verb } of operationsOf(document)) {
+        const other = (live.paths[route] || {})[verb] || {};
+        const where = `${verb} ${route}`;
+
+        expect([where, other['x-henri'] && other['x-henri'].params]).toEqual([
+          where,
+          operation['x-henri'].params,
+        ]);
+        expect([where, other.responses && other.responses['422']]).toEqual([
+          where,
+          operation.responses['422'],
+        ]);
+        expect([where, other.parameters]).toEqual([
+          where,
+          operation.parameters,
+        ]);
+        expect([where, other.requestBody]).toEqual([
+          where,
+          operation.requestBody,
+        ]);
+      }
+    });
+
+    test('a GET refuses what the document says it refuses', async () => {
+      const described = live.paths['/notes/search'].get;
+      const answer = await request
+        .get('/notes/search?limit=banana')
+        .set('Accept', 'application/json');
+
+      expect(answer.status).toBe(422);
+      expect(described.responses['422']).toEqual({
+        $ref: '#/components/responses/InvalidParameters',
+      });
+      expect(live.components.responses.InvalidParameters.description).toContain(
+        'HENRI_PARAMS_INVALID'
+      );
+      expect(answer.body.code).toBe('HENRI_PARAMS_INVALID');
+      expect(Object.keys(answer.body.data.errors)).toEqual(['limit']);
+
+      // ... and accepts what it says it accepts, in the shape it declared
+      const ok = await request
+        .get('/notes/search?limit=2&exact=true')
+        .set('Accept', 'application/json');
+
+      expect(ok.status).toBe(200);
+    });
+
+    test('a mutating route refuses a body the document declared', async () => {
+      const described = live.paths['/notes'].post;
+      const body = described.requestBody.content['application/json'].schema;
+      const answer = await request
+        .post('/notes')
+        .set('Accept', 'application/json')
+        .send({ title: 'x'.repeat(body.properties.title.maxLength + 1) });
+
+      expect(answer.status).toBe(422);
+      expect(described.responses['422']).toEqual({
+        $ref: '#/components/responses/UnprocessableEntity',
+      });
+      expect(answer.body.code).toBe('HENRI_PARAMS_INVALID');
+
+      // The schema says `title` is required, and so does the application
+      const missing = await request
+        .post('/notes')
+        .set('Accept', 'application/json')
+        .send({});
+
+      expect(body.required).toEqual(['title']);
+      expect(missing.status).toBe(422);
+      expect(Object.keys(missing.body.data.errors)).toEqual(['title']);
     });
 
     test('a described collection answers what the document says', async () => {

--- a/packages/core/src/base/openapi.js
+++ b/packages/core/src/base/openapi.js
@@ -14,6 +14,14 @@
  * A framework can only describe the answers it produces itself. henri
  * produces a lot of them:
  *
+ * - what an action declared it accepts (`params`, base/params-schema.js) is
+ *   checked by henri itself, on every verb: the fields become the query, the
+ *   path and the body parameters of the operation, with the types and the
+ *   bounds the declaration wrote, and the operation answers 422 when a
+ *   request does not match. That check is registered next to the guards
+ *   regardless of the verb, so a `GET` with a declaration answers 422 too --
+ *   which is the whole reason this document reads the declarations rather
+ *   than tying 422 to the idempotency of a mutating route.
  * - the routes expanded from `resources` and `crud` are HAL-guarded
  *   (`base/hateoas.js`): a successful JSON answer carries `_links`, and
  *   with `config.api.strict` one that does not is refused with a 500. That
@@ -44,21 +52,41 @@
  *   columns with their types and marks *nothing* required: what is there is
  *   right, what is missing is the application's business. Every schema is
  *   open (`additionalProperties`).
- * - **what a request body accepts.** `req.permit()` is the controller's
- *   decision, and a required column may well be set by the server (the
- *   speaker of a proposal is the session, never the body). The input
- *   schema is the model's writable columns, all optional, and a foreign
- *   key gets no type at all: what a form posts for it is the
- *   application's to say.
+ * - **what a request body accepts, when the action declared nothing.**
+ *   `req.permit('title')` names the fields and henri never sees that list,
+ *   and a required column may well be set by the server (the speaker of a
+ *   proposal is the session, never the body). Without a declaration the
+ *   input schema is the model's writable columns, all optional, and a
+ *   foreign key gets no type at all: what a form posts for it is the
+ *   application's to say. With one, the body is the declaration -- what
+ *   henri itself checks -- and it stays open, because an undeclared key is
+ *   dropped rather than refused and the action may still permit one by name.
  * - **the status of a success.** `res.resource()` defaults to 200 and takes
  *   any other; the document enumerates the statuses henri can produce and
  *   leaves the rest to the `default` response.
  *
  * Every operation carries an `x-henri` object saying which of the two it
  * is (`answer: 'collection' | 'resource' | 'page' | 'unknown'`, `known`)
- * and what henri actually checks on it (`enforced`), so a reader -- a
- * person or an agent -- never has to guess how much of the document was
+ * and what henri actually checks on it (`enforced`, a list), so a reader --
+ * a person or an agent -- never has to guess how much of the document was
  * derived and how much was assumed.
+ *
+ * ## The declarations, and the two paths that read them
+ *
+ * The `params` block lives in a controller file, which is code, and this
+ * builder is handed the compiled rules rather than reading any: a booted
+ * application passes what `henri.controllers.accepts()` already holds, and
+ * `henri openapi` passes what it compiled from the controllers it could
+ * load, through the same `declarations()` of base/params-schema.js. Same
+ * compiler, same answer.
+ *
+ * A controller the command could not load -- one that reaches for a model
+ * global at import time, or whose declaration would fail the boot -- is the
+ * one case where the two paths differ, so it is **said in the document**
+ * rather than quietly dropped: the operation carries
+ * `x-henri.params.read: false`, it declares no parameters of its own and no
+ * 422 for them, and `info.x-henri.params.unread` lists every such action.
+ * Nothing is invented in its place.
  *
  * ## Why 3.1 and not 3.0
  *
@@ -556,6 +584,176 @@ function fieldSchema(name, field, { resolves, settings, write = false }) {
 }
 
 /**
+ * One rule of a `params` declaration as a JSON Schema.
+ *
+ * The vocabulary is the models' (`type`, `enum`, `default`) plus the bounds
+ * a request needs, so most of it maps across unchanged. Two things do not:
+ * `minLength`/`maxLength` are the items of a list when the rule is a list
+ * (henri has one word for one meaning; JSON Schema has two keywords), and
+ * nothing is nullable -- `null` is an absent field to the checker, never a
+ * value it keeps.
+ *
+ * @param {object} compiled a compiled rule (base/params-schema.js)
+ * @returns {object} the schema
+ */
+function ruleSchema(compiled) {
+  const written = objectOf(compiled);
+  const list = written.type === 'array';
+  const known = TYPES[written.type];
+  const schema = {};
+
+  if (list) {
+    schema.type = 'array';
+    schema.items = ruleSchema(written.of);
+  } else if (known && known.type) {
+    schema.type = known.type;
+
+    if (known.format) {
+      schema.format = known.format;
+    }
+  }
+
+  if (Array.isArray(written.enum) && written.enum.length > 0) {
+    schema.enum = written.enum.slice();
+  }
+
+  if (publishableDefault(written.default)) {
+    schema.default = written.default;
+  }
+
+  if (Number.isFinite(written.min)) {
+    schema.minimum = written.min;
+  }
+
+  if (Number.isFinite(written.max)) {
+    schema.maximum = written.max;
+  }
+
+  if (Number.isFinite(written.minLength)) {
+    schema[list ? 'minItems' : 'minLength'] = written.minLength;
+  }
+
+  if (Number.isFinite(written.maxLength)) {
+    schema[list ? 'maxItems' : 'maxLength'] = written.maxLength;
+  }
+
+  if (written.pattern instanceof RegExp) {
+    schema.pattern = written.pattern.source;
+  }
+
+  return schema;
+}
+
+/**
+ * Where every declared field of an action is described.
+ *
+ * henri reads a field from the query string, the body and the path
+ * parameters, a later source winning; the document has to put each one
+ * somewhere, so it follows what the request can actually carry. A name the
+ * route templates is a path parameter. On a verb with no body, everything
+ * else is a query parameter. On a mutating verb, everything else is the
+ * request body -- which is where a form posts it and where henri writes a
+ * default -- and the description says the query string is read as well.
+ *
+ * @param {object} rules the compiled rules, by field
+ * @param {object} context `{ names, verb }`
+ * @returns {{body: object, path: object, query: object}} the three groups
+ */
+function splitDeclaration(rules, { names, verb }) {
+  const body = {};
+  const path = {};
+  const query = {};
+
+  for (const field of Object.keys(rules).sort()) {
+    if (names.includes(field)) {
+      path[field] = rules[field];
+    } else if (MUTATING.has(verb)) {
+      body[field] = rules[field];
+    } else {
+      query[field] = rules[field];
+    }
+  }
+
+  return { body, path, query };
+}
+
+/**
+ * What a parameter built from a declaration says about itself
+ *
+ * @param {string} where `query` or `path`
+ * @param {object} context `{ action, controller }`
+ * @returns {string} the description
+ */
+function declaredDescription(where, { action, controller }) {
+  return [
+    `Declared by \`${controller}#${action}\` (the \`params\` export): henri checks it before the action runs and answers 422 with a message for this field when it does not fit (\`HENRI_PARAMS_INVALID\`).`,
+    `The ${where === 'path' ? 'path' : 'query string'} is textual, so the value is parsed into the type above rather than checked against it.`,
+  ].join(' ');
+}
+
+/**
+ * The query parameters an action declared
+ *
+ * @param {object} rules the declared fields that arrive in the query
+ * @param {object} context `{ action, controller }`
+ * @returns {Array<object>} the parameter objects
+ */
+function declaredParameters(rules, context) {
+  return Object.keys(rules).map((name) => ({
+    name,
+    in: 'query',
+    required: rules[name].required === true,
+    description: declaredDescription('query', context),
+    schema: ruleSchema(rules[name]),
+  }));
+}
+
+/**
+ * The request body an action declared.
+ *
+ * Open, and deliberately: an undeclared key is dropped rather than refused
+ * (base/params-schema.js), and `req.permit('title')` can still name a field
+ * the declaration says nothing about.
+ *
+ * @param {object} rules the declared fields that arrive in the body
+ * @param {object} context `{ action, controller, model }`
+ * @returns {object} the request body object
+ */
+function declaredBody(rules, { action, controller, model }) {
+  const properties = {};
+  const required = [];
+
+  for (const name of Object.keys(rules)) {
+    properties[name] = ruleSchema(rules[name]);
+
+    if (rules[name].required === true) {
+      required.push(name);
+    }
+  }
+
+  const schema = prune({
+    type: 'object',
+    description: `The fields \`${controller}#${action}\` declared it accepts. A JSON body is checked and never parsed -- \`{"page": "2"}\` where a number was declared is refused -- while a form body is parsed into the declared type.`,
+    properties,
+    required: required.length > 0 ? required : undefined,
+    additionalProperties: true,
+  });
+
+  return {
+    description: `What the action declared (\`params\`), which is what henri checks: a request that does not match is refused with a 422 before the action runs.${
+      model
+        ? ` The columns of the ${model.globalId} model are \`${model.globalId}Input\`, and the action may permit one of them by name.`
+        : ''
+    } Other properties are allowed, because an undeclared key is dropped rather than refused; henri reads a declared field from the query string as well as from the body.`,
+    content: {
+      [JSON_MEDIA]: { schema },
+      'application/x-www-form-urlencoded': { schema },
+    },
+    required: required.length > 0,
+  };
+}
+
+/**
  * The schemas of one model: the record as it leaves, and the columns a
  * request may carry
  *
@@ -947,6 +1145,12 @@ function responsesOf(settings) {
         settings.policyStatus === 403 ? ', or a policy that said no' : ''
       }.`
     ),
+    IdempotencyMismatch: named(
+      'The `Idempotency-Key` was already used for a different method, url or body (base/idempotency.js). The first answer is not replayed to a request that is not the same one.'
+    ),
+    InvalidParameters: named(
+      'The request does not match what the action declared it accepts (`params`, base/params-schema.js): `code` is `HENRI_PARAMS_INVALID` and `data.errors` holds one message per field. The check runs behind the role and the policy guards and ahead of the action, on every verb -- a `GET` declaring its query string answers this too.'
+    ),
     NotAcceptable: named(
       'The client asked for an API version this route does not serve (`Accept: application/vnd.henri.vN+json`).'
     ),
@@ -974,7 +1178,10 @@ function responsesOf(settings) {
       'Nobody is signed in. A browser asking for HTML is redirected to `config.user.loginPath` instead.'
     ),
     UnprocessableEntity: named(
-      'The `Idempotency-Key` was already used for a different method, url or body (base/idempotency.js), or a form could not be accepted.'
+      'Either of the two henri answers on this operation, and `code` says which: the parameter check refused the request (`HENRI_PARAMS_INVALID`, one message per field in `data.errors`), or the `Idempotency-Key` was already used for a different method, url or body.'
+    ),
+    ValidationFailed: named(
+      'A value one of the account handlers henri mounts could not accept: an address that is already registered, a password the user model refused, a form that did not validate. `data.errors` holds one message per field when henri has them.'
     ),
   };
 }
@@ -1056,12 +1263,16 @@ function template(route) {
  * identifier of the record when the model carries one, because that is the
  * only identifier `findById()` resolves (`externalIds.lookup`).
  *
+ * A name the action also declared in `params` is typed by the declaration
+ * instead: that is the rule henri checks, and it is checked on the path like
+ * anywhere else.
+ *
  * @param {Array<string>} names the parameter names
- * @param {object} context `{ findModel, route, settings }`
+ * @param {object} context `{ declared, findModel, route, settings }`
  * @returns {Array<object>} the parameter objects
  */
-function pathParameters(names, { findModel, route, settings }) {
-  const controller = String(route.controller || '').split('#')[0];
+function pathParameters(names, { declared = {}, findModel, route, settings }) {
+  const [controller, action] = String(route.controller || '').split('#');
 
   return names.map((name) => {
     const owner =
@@ -1069,23 +1280,29 @@ function pathParameters(names, { findModel, route, settings }) {
         ? findModel(controller)
         : findModel(name.replace(/_id$/u, ''));
     const external = owner && objectOf(owner.options).externalId !== false;
+    const rule = Object.prototype.hasOwnProperty.call(declared, name)
+      ? declared[name]
+      : null;
     const schema =
       external && settings.lookup === 'external'
         ? { type: 'string', format: 'uuid' }
         : { type: 'string' };
+    const description = owner
+      ? `The externalId of the ${owner.globalId}${
+          external && settings.lookup === 'external'
+            ? ': the primary key does not resolve (base/references.js)'
+            : ''
+        }.`
+      : 'A path parameter henri knows the name of and nothing else.';
 
     return {
       name,
       in: 'path',
       required: true,
-      description: owner
-        ? `The externalId of the ${owner.globalId}${
-            external && settings.lookup === 'external'
-              ? ': the primary key does not resolve (base/references.js)'
-              : ''
-          }.`
-        : 'A path parameter henri knows the name of and nothing else.',
-      schema,
+      description: rule
+        ? `${description} ${declaredDescription('path', { action, controller })}`
+        : description,
+      schema: rule ? ruleSchema(rule) : schema,
     };
   });
 }
@@ -1108,17 +1325,27 @@ function operationId(route, taken) {
 }
 
 /**
- * The failures henri answers on this route, from its own options
+ * The failures henri answers on this route, from its own options and from
+ * what the action declared it accepts.
+ *
+ * The 422 is the one status two of them can produce, and which of the two it
+ * is matters to whoever reads this: an idempotency replay and a parameter
+ * refused are not the same failure and are not fixed the same way. So the
+ * status names the cause it can have here, and the shared component only
+ * when it can have both.
  *
  * @param {object} route the route
  * @param {object} settings the settings
+ * @param {?object} rules what the action declared, or null
  * @returns {object} the responses, by status
  */
-function guardResponses(route, settings) {
+function guardResponses(route, settings, rules) {
   const responses = {};
   const reference = (name) => ({ $ref: `#/components/responses/${name}` });
   const roles = route.roles ? [].concat(route.roles) : null;
   const mutating = MUTATING.has(route.verb);
+  const idempotent =
+    mutating && settings.idempotency && route.idempotent !== false;
 
   if (roles || route.policy) {
     responses['401'] = reference('Unauthorized');
@@ -1140,10 +1367,17 @@ function guardResponses(route, settings) {
     responses['406'] = reference('NotAcceptable');
   }
 
-  if (mutating && settings.idempotency && route.idempotent !== false) {
+  if (idempotent) {
     responses['400'] = reference('BadRequest');
     responses['409'] = reference('Conflict');
+  }
+
+  if (idempotent && rules) {
     responses['422'] = reference('UnprocessableEntity');
+  } else if (idempotent) {
+    responses['422'] = reference('IdempotencyMismatch');
+  } else if (rules) {
+    responses['422'] = reference('InvalidParameters');
   }
 
   if (settings.rateLimit) {
@@ -1158,12 +1392,12 @@ function guardResponses(route, settings) {
  * not
  *
  * @param {object} route the route
- * @param {object} context `{ answer, known, model, policy, settings }`
+ * @param {object} context `{ answer, known, model, params, policy, settings }`
  * @returns {string} the description
  */
 function operationDescription(
   route,
-  { answer, known, model, policy, settings }
+  { answer, known, model, params, policy, settings }
 ) {
   const [controller, action] = String(route.controller).split('#');
   const lines = [
@@ -1198,6 +1432,25 @@ function operationDescription(
   if (route.version) {
     lines.push(
       `Version: \`${route.version}\`. A client asking for another \`application/vnd.henri.vN+json\` gets a 406; one asking for none is served this version.`
+    );
+  }
+
+  if (params.rules) {
+    lines.push(
+      `Parameters: \`${controller}#${action}\` declares ${Object.keys(
+        params.rules
+      )
+        .sort()
+        .map((field) => `\`${field}\``)
+        .join(
+          ', '
+        )} (\`params\`). henri checks them behind the guards and ahead of the action, and answers 422 with one message per field when a request does not match; what it accepts is coerced, so the action reads the declared type.`
+    );
+  }
+
+  if (params.read === false) {
+    lines.push(
+      `Parameters: henri could not read the \`params\` export of \`app/controllers/${controller}.js\` -- the file did not load outside a booted application, or its declaration would fail the boot. If the action declares any, they are checked at runtime and are **not** in this operation; nothing was guessed in their place.`
     );
   }
 
@@ -1402,15 +1655,35 @@ function operationFor(route, context) {
   const isResource = route.resource === true;
   const answer = isResource ? ANSWERS[action] || 'unknown' : 'unknown';
   const known = context.actionKnown(route.controller);
+  const params = context.declared(route.controller);
   const { names } = template(route.route);
-  const parameters = pathParameters(names, { findModel, route, settings });
+  const declared = params.rules
+    ? splitDeclaration(params.rules, { names, verb: route.verb })
+    : { body: {}, path: {}, query: {} };
+  const parameters = pathParameters(names, {
+    declared: declared.path,
+    findModel,
+    route,
+    settings,
+  });
   const responses = {};
 
+  parameters.push(
+    ...declaredParameters(declared.query, { action, controller })
+  );
+
   if (answer === 'collection') {
-    parameters.push(
-      { $ref: '#/components/parameters/Page' },
-      { $ref: '#/components/parameters/PerPage' }
-    );
+    // The paging parameters, unless the action declared one of them itself:
+    // two parameters of the same name in the same place is not a document,
+    // and the declaration is the one henri enforces
+    for (const [name, id] of [
+      ['page', 'Page'],
+      ['per_page', 'PerPage'],
+    ]) {
+      if (!Object.prototype.hasOwnProperty.call(declared.query, name)) {
+        parameters.push({ $ref: `#/components/parameters/${id}` });
+      }
+    }
   }
 
   if (MUTATING.has(route.verb)) {
@@ -1433,7 +1706,7 @@ function operationFor(route, context) {
     );
   }
 
-  Object.assign(responses, guardResponses(route, settings));
+  Object.assign(responses, guardResponses(route, settings, params.rules));
 
   if (answer === 'unknown' || known === false) {
     responses.default = {
@@ -1450,6 +1723,14 @@ function operationFor(route, context) {
   // A form page is a route henri guards and an answer it does not write:
   // it counts with the ones henri cannot describe
   const described = answer === 'collection' || answer === 'resource';
+  // What henri itself checks on this route, and nothing an application does
+  const enforced = []
+    .concat(described || answer === 'page' ? ['_links'] : [])
+    .concat(params.rules ? ['params'] : []);
+  const marks = prune({
+    fields: params.rules ? Object.keys(params.rules).sort() : undefined,
+    read: params.read === false ? false : undefined,
+  });
   const operation = {
     operationId: operationId(route, ids),
     summary: `${controller}#${action}`,
@@ -1457,6 +1738,7 @@ function operationFor(route, context) {
       answer,
       known,
       model,
+      params,
       policy,
       settings,
     }),
@@ -1467,9 +1749,10 @@ function operationFor(route, context) {
       action,
       answer: known === false ? 'unknown' : answer,
       controller,
-      enforced: described || answer === 'page' ? '_links' : undefined,
+      enforced: enforced.length > 0 ? enforced : undefined,
       known: known !== false && described,
       model: answer !== 'unknown' && model ? model.globalId : undefined,
+      params: Object.keys(marks).length > 0 ? marks : undefined,
       pathHelper: route.path,
       policy: route.policy ? policy || false : undefined,
       roles: route.roles ? [].concat(route.roles) : undefined,
@@ -1478,7 +1761,13 @@ function operationFor(route, context) {
     }),
   };
 
-  if (
+  if (Object.keys(declared.body).length > 0) {
+    operation.requestBody = declaredBody(declared.body, {
+      action,
+      controller,
+      model,
+    });
+  } else if (
     MUTATING.has(route.verb) &&
     model &&
     (action === 'create' || action === 'update')
@@ -1651,7 +1940,7 @@ function builtins(context) {
           },
           'The account was created.'
         ),
-        422: { $ref: '#/components/responses/UnprocessableEntity' },
+        422: { $ref: '#/components/responses/ValidationFailed' },
         429: { $ref: '#/components/responses/TooManyRequests' },
         default: errors,
       },
@@ -1689,7 +1978,7 @@ function builtins(context) {
           },
           'Accepted, whatever the address was.'
         ),
-        422: { $ref: '#/components/responses/UnprocessableEntity' },
+        422: { $ref: '#/components/responses/ValidationFailed' },
         429: { $ref: '#/components/responses/TooManyRequests' },
         default: errors,
       },
@@ -1747,7 +2036,7 @@ function builtins(context) {
           'The password was changed.'
         ),
         400: { $ref: '#/components/responses/BadRequest' },
-        422: { $ref: '#/components/responses/UnprocessableEntity' },
+        422: { $ref: '#/components/responses/ValidationFailed' },
         default: errors,
       },
       'x-henri': { answer: 'session', known: true, source: 'built-in' },
@@ -1802,7 +2091,7 @@ function builtins(context) {
           },
           'Accepted, whatever the address was.'
         ),
-        422: { $ref: '#/components/responses/UnprocessableEntity' },
+        422: { $ref: '#/components/responses/ValidationFailed' },
         default: errors,
       },
       'x-henri': { answer: 'acknowledgement', known: true, source: 'built-in' },
@@ -1839,7 +2128,7 @@ function builtins(context) {
           'The link is on its way to the new address.'
         ),
         401: { $ref: '#/components/responses/Unauthorized' },
-        422: { $ref: '#/components/responses/UnprocessableEntity' },
+        422: { $ref: '#/components/responses/ValidationFailed' },
         default: errors,
       },
       security: [{ session: [] }, { bearer: [] }],
@@ -1990,6 +2279,12 @@ function overview(settings) {
  * The OpenAPI 3.1 description of an application
  *
  * @param {object} input what to describe
+ * @param {?object} [input.accepts=null] what each action declared it accepts,
+ *   compiled, as `{ 'tasks#index': rules }` -- `henri.controllers.accepts()`
+ *   on a booted application, `declarations()` over the controller files
+ *   otherwise. An entry that is `null` is a controller whose declaration
+ *   could not be read; a missing entry is one that declares nothing; `null`
+ *   for the whole map is a caller that could not find out at all
  * @param {*} [input.config={}] henri's config module, or the plain object a
  *   command read from `config/<env>.json`
  * @param {Array<object>} [input.models=[]] the model files, with `globalId`
@@ -2006,6 +2301,7 @@ function overview(settings) {
  * @returns {object} the document
  */
 function build({
+  accepts = null,
   actions = null,
   config = {},
   info = {},
@@ -2028,9 +2324,42 @@ function build({
     subject: userModel ? userModel.globalId : null,
   });
   const hidden = new Set(privacy.private);
+  const unread = new Set();
   const context = {
     actionKnown: (controller) =>
       actions === null ? null : Boolean(actions[controller]),
+    /**
+     * What an action declared it accepts, and whether henri got to read it
+     *
+     * @param {string} controller the `controller#action` key
+     * @returns {{read: boolean, rules: ?object}} the declaration
+     */
+    declared: (controller) => {
+      if (!accepts || typeof accepts !== 'object') {
+        unread.add(controller);
+
+        return { read: false, rules: null };
+      }
+
+      if (!Object.prototype.hasOwnProperty.call(accepts, controller)) {
+        return { read: true, rules: null };
+      }
+
+      const written = accepts[controller];
+
+      if (!written || typeof written !== 'object') {
+        unread.add(controller);
+
+        return { read: false, rules: null };
+      }
+
+      const rules = objectOf(written);
+
+      return {
+        read: true,
+        rules: Object.keys(rules).length > 0 ? rules : null,
+      };
+    },
     findModel,
     findPolicy,
     hasUserModel: Boolean(userModel),
@@ -2173,6 +2502,11 @@ function build({
         excluded: excluded.length > 0 ? excluded : undefined,
         generator: 'henri openapi',
         models: files.map((model) => String(model.globalId)).sort(),
+        // The one place the two ways of building this document can differ:
+        // an action whose controller could not be read declares whatever it
+        // declares, and this document does not say so anywhere else
+        params:
+          unread.size > 0 ? { unread: Array.from(unread).sort() } : undefined,
       }),
     },
     servers: servers || serversOf(settings),
@@ -2188,6 +2522,7 @@ module.exports = {
   OPENAPI_VERSION,
   build,
   columnsOf,
+  ruleSchema,
   settingsOf,
   template,
 };

--- a/packages/core/src/base/params-schema.js
+++ b/packages/core/src/base/params-schema.js
@@ -98,8 +98,19 @@
  * validates documents), no cross-field rules (`endsAt` after `startsAt` is
  * the action's business, and it needs both values), no date bounds, no
  * message of one's own per field, and no trimming -- henri hands over
- * exactly what was sent. `henri openapi` does not read these declarations
- * yet.
+ * exactly what was sent.
+ *
+ * ## What reads them besides the middleware
+ *
+ * `henri openapi` (base/openapi.js): a declaration is a description of the
+ * request an action accepts, which is what an OpenAPI operation wants, so
+ * the fields become its query, path and body parameters and the 422 below
+ * becomes a response it names. Two things follow from that, and this file
+ * is where they are true: `declarations()` is the only compiler -- the
+ * command runs it over the controller files and a booted application hands
+ * over what it already compiled, so both write the same document -- and the
+ * check is registered whatever the verb, which is why a `GET` that declares
+ * anything is described as answering 422.
  */
 
 const { fail } = require('./errors');

--- a/showcase/AGENTS.md
+++ b/showcase/AGENTS.md
@@ -106,6 +106,14 @@ The global is the model of the `drizzle` store, and what the generators write: t
 - An action that returns without answering renders its own page with what it returned: `show: async (req) => ({ post: req.post })` renders `/posts/show`, `index` renders `/posts`.
 - `req.permit('title', 'body')` picks the allowed fields from query, body and
   params (later wins). Never pass `req.body` to a model.
+- `params: { index: { state: { type: 'string', enum: [...] } }, 'create,update':
+{ title: { type: 'string', maxLength: 120 } } }` says what each action
+  accepts: checked and coerced ahead of the action on every verb, 422 with one
+  message per field otherwise, and `henri openapi` writes the operation's
+  parameters and request body from it. `app/controllers/proposals.js` is the
+  one that declares them. What may arrive over HTTP goes here; what makes a
+  record (a title of at least eight characters) stays in the model, so the
+  form gets that message next to the field.
 - `res.negotiate({ html: () => res.render('/posts/show', { data: { post } }),
 json: () => res.resource(post) })`: the page for browsers, HAL for API
   clients. An index is one query, `Post.paginate(req.pagination())`, then

--- a/showcase/app/controllers/proposals.js
+++ b/showcase/app/controllers/proposals.js
@@ -125,6 +125,38 @@ module.exports = {
     { only: ['edit', 'submit', 'update', 'withdraw'], run: mustOwnIt },
   ],
 
+  // What each action accepts, checked before it runs and coerced into the
+  // declared type. The check is registered whatever the verb, so the filters
+  // of `index` are refused with a 422 exactly the way the body of `create`
+  // is, and `henri openapi` describes both from this block: the query
+  // parameters of GET /proposals and the request body of POST /proposals are
+  // this, and not a guess made from the model.
+  //
+  // Where the line between this and the model is: here is what may arrive
+  // over HTTP -- the shape, the size, the values that exist at all -- and
+  // there is what makes a proposal (a title of at least eight characters, an
+  // abstract of sixty). The second is a sentence a speaker reads next to the
+  // field they are filling, which is `henri.model.errors()` rendered back
+  // into the form below; the first is a request nobody meant to send.
+  params: {
+    'create,update': {
+      abstract: { maxLength: 4000, type: 'text' },
+      // The public id of an edition or a track, or the empty string the form
+      // posts for "none": `resolveReferences` turns either into what the
+      // column holds, so this says string and not uuid
+      eventId: { type: 'string' },
+      title: { maxLength: 120, type: 'string' },
+      trackId: { type: 'string' },
+    },
+    index: {
+      event: { type: 'uuid' },
+      // The same list the query below filters on: a state that is nobody's
+      // business is a 422 rather than a filter quietly ignored
+      state: { enum: PUBLIC_STATES, type: 'string' },
+    },
+  },
+
+  // eslint-disable-next-line sort-keys -- the hooks and the declaration first
   create: async (req, res) => {
     const attributes = req.permit(...FIELDS);
     let proposal;

--- a/showcase/test/openapi.test.js
+++ b/showcase/test/openapi.test.js
@@ -225,14 +225,33 @@ describe('the OpenAPI description of the showcase', () => {
       ).toEqual(expect.arrayContaining(['IdempotencyKey', 'CsrfToken']));
     });
 
-    test('the request body it declares is what the action accepts', () => {
+    test('the request body it declares is what the action declared', () => {
+      // The controller declares `params`, so the body is that -- what henri
+      // itself checks -- rather than the writable columns of the model
       const schema =
         document.paths['/proposals'].post.requestBody.content[
           'application/json'
         ].schema;
+
+      expect(Object.keys(schema.properties).sort()).toEqual([
+        'abstract',
+        'eventId',
+        'title',
+        'trackId',
+      ]);
+      expect(schema.properties.title).toEqual({
+        maxLength: 120,
+        type: 'string',
+      });
+      // Open, because an undeclared key is dropped rather than refused and
+      // the action still permits the model's other columns by name
+      expect(schema.additionalProperties).toBe(true);
+      expect(schema.required).toBeUndefined();
+    });
+
+    test('the columns of the model are still described, untouched', () => {
       const input = document.components.schemas.ProposalInput;
 
-      expect(schema).toEqual({ $ref: '#/components/schemas/ProposalInput' });
       // The FIELDS of app/helpers/proposals.js
       for (const field of [
         'abstract',
@@ -247,6 +266,117 @@ describe('the OpenAPI description of the showcase', () => {
       // Nothing is required: the speaker is the session, never the body
       expect(input.required).toBeUndefined();
       expect(input.properties.speakerId.type).toBeUndefined();
+    });
+  });
+
+  describe('what an action declared it accepts', () => {
+    test('GET /proposals declares its filters and refuses what it says', async () => {
+      const operation = document.paths['/proposals'].get;
+      const named = Object.fromEntries(
+        operation.parameters
+          .filter((parameter) => !parameter.$ref)
+          .map((parameter) => [parameter.name, parameter])
+      );
+
+      // A GET answers 422 -- the check is registered whatever the verb --
+      // and the document says which 422 it is
+      expect(operation.responses['422']).toEqual({
+        $ref: '#/components/responses/InvalidParameters',
+      });
+      expect(named.state.schema).toEqual({
+        enum: ['accepted', 'submitted'],
+        type: 'string',
+      });
+      expect(named.event.schema).toEqual({ format: 'uuid', type: 'string' });
+      expect(operation['x-henri'].params).toEqual({
+        fields: ['event', 'state'],
+      });
+      expect(operation['x-henri'].enforced).toEqual(['_links', 'params']);
+
+      // ... and the application answers exactly that
+      const refused = await request()
+        .get('/proposals?state=draft')
+        .set('Accept', HAL);
+
+      expect(refused.status).toBe(422);
+      expect(refused.body.code).toBe('HENRI_PARAMS_INVALID');
+      expect(Object.keys(refused.body.data.errors)).toEqual(['state']);
+
+      const valid = compile({ $ref: '#/components/schemas/Error' });
+
+      expect([valid(refused.body), valid.errors]).toEqual([true, null]);
+
+      // The paging parameters are still there: the declaration names
+      // neither, so neither is replaced
+      expect(
+        operation.parameters.filter((parameter) => parameter.$ref)
+      ).toEqual([
+        { $ref: '#/components/parameters/Page' },
+        { $ref: '#/components/parameters/PerPage' },
+      ]);
+      expect((await request().get('/proposals?state=accepted')).status).toBe(
+        200
+      );
+    });
+
+    test('POST /proposals names both 422s it can answer, and answers both', async () => {
+      const operation = document.paths['/proposals'].post;
+      const { browser, csrf } = await signIn(speaker);
+
+      // The route honours Idempotency-Key *and* the action declares
+      // parameters: one status, two failures, and the component says so
+      expect(operation.responses['422']).toEqual({
+        $ref: '#/components/responses/UnprocessableEntity',
+      });
+      expect(
+        document.components.responses.UnprocessableEntity.description
+      ).toContain('HENRI_PARAMS_INVALID');
+
+      const refused = await browser
+        .post('/proposals')
+        .set('Accept', HAL)
+        .set('X-CSRF-Token', csrf)
+        .send({ abstract: ABSTRACT, eventId: event.externalId, title: 42 });
+
+      expect(refused.status).toBe(422);
+      expect(refused.body.code).toBe('HENRI_PARAMS_INVALID');
+      expect(Object.keys(refused.body.data.errors)).toEqual(['title']);
+
+      const replayed = await browser
+        .post('/proposals')
+        .set('Accept', HAL)
+        .set('X-CSRF-Token', csrf)
+        .set('Idempotency-Key', 'the-document-key')
+        .send({
+          abstract: ABSTRACT,
+          eventId: event.externalId,
+          title: 'A proposal that takes the key',
+        });
+      const mismatch = await browser
+        .post('/proposals')
+        .set('Accept', HAL)
+        .set('X-CSRF-Token', csrf)
+        .set('Idempotency-Key', 'the-document-key')
+        .send({
+          abstract: ABSTRACT,
+          eventId: event.externalId,
+          title: 'Another proposal on the same key',
+        });
+
+      expect(replayed.status).toBe(201);
+      expect(mismatch.status).toBe(422);
+      expect(mismatch.body.code).not.toBe('HENRI_PARAMS_INVALID');
+    });
+
+    test('an action with no declaration says nothing about one', () => {
+      // The admin controller declares no `params`, and the document does
+      // not pretend it does
+      const operation = document.paths['/admin/proposals'].get;
+
+      expect(operation['x-henri'].params).toBeUndefined();
+      expect(operation.responses['422']).toBeUndefined();
+      // Nothing anywhere in this document went unread
+      expect(document.info['x-henri'].params).toBeUndefined();
     });
   });
 
@@ -270,7 +400,7 @@ describe('the OpenAPI description of the showcase', () => {
       expect([asPage(answer.body), asPage.errors]).toEqual([true, null]);
       // And still the envelope henri enforces, which is why both are named
       expect(asCollection(answer.body)).toBe(true);
-      expect(operation['x-henri'].enforced).toBe('_links');
+      expect(operation['x-henri'].enforced).toEqual(['_links']);
     });
   });
 

--- a/website/src/content/docs/guides/controllers.md
+++ b/website/src/content/docs/guides/controllers.md
@@ -166,7 +166,11 @@ The action never runs. The answer is a `422` carrying one message per field, neg
 
 `data.errors` is the `{ field: message }` shape [`henri.model.errors()`](/guides/models/) normalizes an ORM's validation failure to, so a form reads one thing whether the request was refused at the boundary or by the model. A browser that posted a form is sent back to the page it came from (`303`) with the messages in the flash, where a page reads them as `errors`; the values are not flashed, because henri cannot tell a password from a title. A browser that asked for anything else gets the `422` page.
 
-The check runs once the route is allowed — behind the [role guard](/guides/routes/#roles) and the [policy](/guides/policies/) — and **ahead of the `before` hooks**, so a hook that loads a record already sees the coerced value. An action that declares nothing behaves exactly as it did: nothing is checked, nothing is coerced, and `req.permit(...)` is unchanged.
+The check runs once the route is allowed — behind the [role guard](/guides/routes/#roles) and the [policy](/guides/policies/) — and **ahead of the `before` hooks**, so a hook that loads a record already sees the coerced value. It is registered whatever the verb, so an `index` declaring its query string answers `422` the same way a `create` declaring its body does. An action that declares nothing behaves exactly as it did: nothing is checked, nothing is coerced, and `req.permit(...)` is unchanged.
+
+### It is also the description of the request
+
+[`henri openapi`](/guides/openapi/) reads this block: the fields become the query, path and body parameters of the operation, with the types, the bounds and the enums declared here, and the `422` becomes a response the document names. Declaring `params` is how an action gets a request body in the description that is the one it actually accepts, rather than the writable columns of its model.
 
 ## Implicit rendering
 

--- a/website/src/content/docs/guides/openapi.md
+++ b/website/src/content/docs/guides/openapi.md
@@ -25,6 +25,7 @@ Everything below comes from the application, never from a convention henri hopes
 | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | The paths and the verbs           | `config/routes.js`, expanded by [`base/routes.js`](/guides/routes/) — the same table `henri routes` prints                                                                |
 | The path parameters               | The `:id` of the route, typed as the record's `externalId` when the model carries one                                                                                     |
+| The query and body parameters     | The [`params`](/guides/controllers/#params-what-an-action-accepts) an action declared, where it declared any — the types, the bounds, the enums and what is required      |
 | The schemas                       | `app/models`, plus the columns the adapters add (`externalId`, `createdAt`/`updatedAt`, `deletedAt`, and the user's `email`, `roles`, `confirmedAt`, `passwordChangedAt`) |
 | The HAL envelopes                 | [`res.resource()` and `res.collection()`](/guides/api/#answering-hal), for the routes expanded from `resources` and `crud`                                                |
 | The error envelope                | [`res.boom.*`](/guides/api/) and the 404/500 handlers, with the `code` of the [error catalogue](/reference/errors/)                                                       |
@@ -34,9 +35,41 @@ Everything below comes from the application, never from a convention henri hopes
 | `POST /login`, the account flows  | `config.user`: they are in the document only when henri actually mounts them                                                                                              |
 | `/livez`, `/readyz`, `/healthz`   | Always: every henri application answers them                                                                                                                              |
 
-Every operation also carries `x-henri.enforced`, which names what henri actually checks on that route (`_links`, on the ones expanded from `resources` and `crud`) as opposed to what it expects.
+Every operation also carries `x-henri.enforced`, a list naming what henri actually checks on that route — `_links` on the ones expanded from `resources` and `crud`, `params` on the ones whose action declared any — as opposed to what it expects.
 
 A field marked `personal: { expose: false }` is in **no** schema, because [privacy](/guides/privacy/) strips that name from every answer henri builds, at every depth. Neither is `password`. A declared foreign key is typed as the `externalId` of the row it names, because that is what [`base/references.js`](/guides/models/#identifiers) publishes — and `null`, because a key that names no row resolves to nothing.
+
+## What an action declared it accepts
+
+A controller that declares [`params`](/guides/controllers/#params-what-an-action-accepts) has told henri the shape of the request it takes, which is exactly what an OpenAPI operation wants. So the document is built from it rather than around it:
+
+- a field the route templates (`:id`) is that **path parameter**, typed by the rule;
+- on a verb with no body, everything else is a **query parameter**;
+- on a mutating verb, everything else is the **request body** — the declaration, not the model's columns — with `required` where the rule says so and `additionalProperties: true`, because an undeclared key is dropped rather than refused and the action may still permit one of the model's columns by name;
+- and the operation answers **422**, on every verb.
+
+That last one is the reason this exists. The check is registered next to the guards whatever the verb, so an `index` declaring `page: { type: 'integer', min: 1 }` answers `422` on `?page=banana` — an answer the document used to deny, because it tied `422` to the idempotency of a mutating route. Which `422` it is now has a name of its own:
+
+| Component             | What answered it                                                                     |
+| --------------------- | ------------------------------------------------------------------------------------ |
+| `InvalidParameters`   | The parameter check: `HENRI_PARAMS_INVALID`, one message per field in `data.errors`  |
+| `IdempotencyMismatch` | The `Idempotency-Key` was already used for a different method, url or body           |
+| `UnprocessableEntity` | Both can happen on this operation; `code` says which                                 |
+| `ValidationFailed`    | A value one of the account endpoints henri mounts refused (a duplicate address, say) |
+
+A generated client reading a parameter refusal as a replayed key is exactly the kind of drift this document exists not to have.
+
+### Where the declarations are read
+
+They live in a controller file, and the block holds regular expressions and functions, so there is nothing to scan for. **`henri openapi` loads the controller with `require()`** — which is what reading the action names already did — and compiles the block with the same `declarations()` the boot compiles it with. A booted application hands over what `henri.controllers.accepts()` already holds. One compiler, one answer: `GET /_openapi.json` and `henri openapi` agree operation for operation, and the suites check that.
+
+The command still starts no server and opens no database, but loading a controller does run whatever that file runs at import time. A henri controller is a plain object of handlers, so that is normally nothing; a file that reaches for a model global while it loads throws, and then:
+
+```json
+"x-henri": { "params": { "read": false } }
+```
+
+The operation declares no parameters of its own and no `422` for them, its description says why, and `info.x-henri.params.unread` lists every such action — `henri openapi --summary` prints them. That is the one place the two ways of building this document can differ, so it is in the document rather than left to be discovered.
 
 ## What it refuses to say
 
@@ -71,9 +104,11 @@ Nothing in a response schema is `required`, and every schema is open (`additiona
 
 The one exception is `_links`, and only when `config.api.strict` is on: with it, henri refuses a `resources` JSON answer that has none, so `required` is the truth.
 
-### A request body
+### A request body an action did not declare
 
-`req.permit()` names the fields an action accepts, and henri never sees that list; a controller that declares [`params`](/guides/controllers/#params-what-an-action-accepts) does hand henri the shape, and this document is not built from it yet. The input schema is the model's writable columns — no `required`, `additionalProperties: true` — because a column the model requires may well be set by the server (the speaker of a proposal is the session, never the body). A **foreign key gets no type at all**: whether a form posts an `externalId`, a primary key or nothing is the application's decision.
+`req.permit('title')` names the fields and henri never sees that list. Without a [`params`](/guides/controllers/#params-what-an-action-accepts) declaration the input schema is the model's writable columns — no `required`, `additionalProperties: true` — because a column the model requires may well be set by the server (the speaker of a proposal is the session, never the body). A **foreign key gets no type at all**: whether a form posts an `externalId`, a primary key or nothing is the application's decision.
+
+With a declaration the body is the declaration, which is the shape henri itself checks; the model's columns stay in `components.schemas` as `<Model>Input` and the operation says so.
 
 ### An action that does not exist
 
@@ -113,7 +148,7 @@ The [MCP server](/guides/agents/) exposes it as the `openapi` tool. It is the fa
 ## What is out of scope
 
 - **A UI.** No Swagger UI, no Redoc, no bundled viewer. The document is a file; point whatever you like at it.
-- **Request validation.** henri does not validate a request against the document. The model validates a write and `req.permit()` decides what a request may set; a second, generated gate in front of them would be a second source of truth.
+- **Request validation.** henri does not validate a request against the document, and the arrow points the other way: [`params`](/guides/controllers/#params-what-an-action-accepts) is the gate and the document is written from it. A second, generated gate reading this file back would be a second source of truth.
 - **Client generation.** The document is standard; the generators for it already exist and are better than anything shipped here would be.
 - **GraphQL.** It has a schema of its own. `config.graphql` names where to ask for it, and the description says so in `info.description` rather than describing the endpoint.
 

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -128,9 +128,11 @@ GET     /tasks/:id       tasks#show     show_tasks_path
 henri openapi [--out <file>] [--summary]
 ```
 
-Writes the [OpenAPI 3.1](/guides/openapi/) description of what the application exposes, built from `config/routes.js`, `app/models` and the configuration. It starts no server and opens no database. JSON on stdout by default; `--out <file>` writes it instead and prints what it covers, `--summary` prints only that.
+Writes the [OpenAPI 3.1](/guides/openapi/) description of what the application exposes, built from `config/routes.js`, `app/models`, the `params` an action declared and the configuration. It starts no server and opens no database. JSON on stdout by default; `--out <file>` writes it instead and prints what it covers, `--summary` prints only that.
 
-It describes the answers henri produces itself — the HAL collection and resource of every `resources`/`crud` route, the error envelope, the paging, the versioned media type, `Idempotency-Key`, the roles and the policy of each route, and the endpoints henri mounts (`POST /login`, the account flows, the health probes). What a controller writes itself it does not describe: those operations carry the statuses henri answers, `x-henri.known: false`, and no success status at all.
+It describes the answers henri produces itself — the HAL collection and resource of every `resources`/`crud` route, the error envelope, the paging, the versioned media type, `Idempotency-Key`, the roles and the policy of each route, the parameters an action [declared](/guides/controllers/#params-what-an-action-accepts) with the 422 they answer, and the endpoints henri mounts (`POST /login`, the account flows, the health probes). What a controller writes itself it does not describe: those operations carry the statuses henri answers, `x-henri.known: false`, and no success status at all.
+
+Reading a declaration means loading the controller (`require()`, the way the action names are read); a file that will not load outside a booted application, or whose `params` would fail the boot, is named under `x-henri.params.read: false` and in the summary rather than described as accepting nothing.
 
 ```text
 $ henri openapi --summary


### PR DESCRIPTION
`henri openapi` was breaking its own contract in two directions, and the contract is the whole point of the command: it describes what henri answers and marks what it cannot know, rather than guessing.

**It denied an answer the application gives.** The parameter gate is registered per route regardless of verb, so a `GET` declaring `page: { type: 'integer', min: 1 }` answers 422 on `?page=banana` — and the builder attached 422 only under `mutating && idempotency && route.idempotent !== false`.

**And where a 422 did appear, its provenance was wrong**: one component saying the `Idempotency-Key` was replayed *or* a form was refused, so a generated client read a parameter refusal as a conflict.

## What it does now

Four components instead of one, each with a single meaning: `InvalidParameters` (the parameter check, `HENRI_PARAMS_INVALID`, one message per field), `IdempotencyMismatch` (the key was reused), `UnprocessableEntity` (both are possible on that operation, and `code` says which), and `ValidationFailed` (an account endpoint henri mounts). The account flows used to point at the idempotency wording and now have their own.

**The parameters and the request body are built from the declaration**, not deferred: a declared field the route templates is that path parameter, typed by the rule; on a verb with no body the rest are query parameters; on a mutating verb the rest are the request body, with `required` where the rule says so. `enum`, `default`, `min`/`max`, lengths and `pattern` carry across, and a declared `page` replaces the paging component rather than doubling it — with a structural test asserting no operation declares one parameter twice.

## The design question, and the answer

The document is built **without booting**, so reading a controller's `params` meant choosing between parsing and loading. It `require()`s the controller — which is what it already did to read the action names — and compiles the block with core's own `declarations()`. No second parser, no second source of truth: a rule holds regular expressions and functions, and a scanner able to read one would be a JavaScript evaluator kept in step with the compiler forever.

The cost is stated rather than implied: loading a controller runs whatever that file runs at import time. It is the status quo for the action names, it is caught, and the command still starts no server and opens no database — and the guide now says "without booting" does not mean "without executing".

**When the command cannot load a controller, that is in the document rather than swallowed**: `x-henri.params.read: false` on the operation, a sentence in its description, the list in `info.x-henri.params.unread`, and a section in `--summary`. Such an operation declares no parameters and no parameter 422; nothing is invented in their place.

## Verified here, not on report

The claim that the two build paths agree is a test — the file-built document is compared operation by operation against the booted router's. What I checked myself is the thing the branch exists for, against a running application:

```
document:     GET /proposals → 422 → #/components/responses/InvalidParameters
              parameters: event (string/uuid), state (enum accepted, submitted)
application:  GET /proposals?state=nonsense
              422 {"code":"HENRI_PARAMS_INVALID",
                   "data":{"errors":{"state":"must be one of accepted, submitted"}}}
              GET /proposals?state=accepted → 200
```

Before this branch the document said that route could not answer 422 at all.

The showcase now declares parameters on a `GET` and on a mutating route, which is what makes its openapi suite able to catch this class: it missed the original bug only because nothing there declared any.

`pnpm test` (148 files), `pnpm test:types`, `pnpm lint --max-warnings 0`, `pnpm format:check`, the showcase suite (11 files) and `scripts/smoke.sh` pass.

## Left out on purpose

The declaration does not close the body (`additionalProperties: true`): an undeclared key is dropped, not refused, and `req.permit()` may still name a column the declaration says nothing about. Declared fields on a mutating verb appear in the body only rather than being listed twice. No `style`/`explode` annotations, because OpenAPI's query default is already what henri parses. And the showcase's lower bounds stayed in the model, because moving them would change that application's error UX in a branch about the document.
