### PR TITLE
The client's address in the call log, and when henri believes it

### DIFF
--- a/.changeset/call-log-client-address.md
+++ b/.changeset/call-log-client-address.md
@@ -1,0 +1,42 @@
+---
+'@usehenri/core': minor
+'@usehenri/cli': minor
+---
+
+The call log records the address the request came from, and says how sure it is.
+
+An inbound row gains three columns: `client`, the address henri believes the
+request came from; `peer`, the address that actually opened the socket; and
+`source`, how `client` was decided. Every forwarding header is text a client
+typed, so henri believes one only when the configuration can support it:
+`X-Forwarded-For` through express' `trustProxy`, and a header express will
+not read (`cf-connecting-ip` and friends) through the new
+`calls.address.header` **and** `calls.address.from`, which lists the proxies
+allowed to set it. Naming a header without `from` fails the boot
+(`HENRI_CALLS_ADDRESS_UNVERIFIABLE`).
+
+A blanket `trustProxy: true` in front of a forwarded request records **no
+client address at all** and says `unverified`, keeping the peer. An address
+that is a guess is worse than an empty column: an operator reading a call log
+is answering "who did this", and the empty column asks a question where the
+guess answers one. `henri audit` reports the combination
+(`calls.address-unverified`), and reports a `from` covering every address
+(`calls.address-from-any`).
+
+An address is personal data, so it gets the care the rest of that table gets.
+It lives in columns of its own and the forwarding headers are masked out of
+the stored header blob, which is the one place an erasure cannot reach.
+`calls.address.anonymize` truncates it to a `/24` or a `/48`, keeping the
+prefix length in the value; it is off by default, because the column exists
+to answer "who did this" and a `/24` answers "somebody in this city".
+
+A person's rows now answer a data subject request: `henri privacy:export`
+carries them under a `calls` key and `henri privacy:erase` writes over the
+`actor`, both addresses and the four payload columns, leaving the moment, the
+method, the route, the status and the request id. The access trail is
+unchanged and records no address on purpose -- it holds no values, which is
+what lets it outlive the erasure it recorded -- and `henri.reporter` still
+carries nothing from the client.
+
+A `henri_calls` table created before this release gains the three columns on
+the next boot; the store adds what is missing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -532,8 +532,29 @@ model }` or Mongoose's `ref` -- which `res.render()`, `res.resource()`,
   `calls.always` keeping the failures sampling dropped (without their
   bodies). Everything stored goes through `redactor(henri)` and, on top of
   it, `authorization`/`cookie`/`set-cookie`/`x-csrf-token`/`x-api-key`/
-  `webhook-signature` are masked whatever `filterParameters` says, a url
-  loses its userinfo and the person is their `externalId`. `calls.keep`
+  `webhook-signature` and every forwarding header are masked whatever
+  `filterParameters` says, a url
+  loses its userinfo and the person is their `externalId`. An inbound row
+  also records where the request came from (`base/address.js`,
+  `config.calls.address`), in three columns rather than one: `client_ip`,
+  what henri believes; `peer_ip`, the socket; and `ip_source`, how it was
+  decided. `X-Forwarded-For` is believed through `config.trustProxy`, which
+  express already applies, and a header express will not read
+  (`cf-connecting-ip`) only through `calls.address.header` **and**
+  `calls.address.from`, the proxies allowed to set it -- a header without
+  `from` fails the boot (`HENRI_CALLS_ADDRESS_UNVERIFIABLE`). A blanket
+  `trustProxy: true` in front of a forwarded request records **no client
+  address at all** and says `unverified`, because an address that is a
+  guess is worse than an empty column; `henri audit` reports that
+  (`calls.address-unverified`) and a `from` covering everything
+  (`calls.address-from-any`). `calls.address.anonymize` truncates to a /24
+  or a /48 keeping the prefix length in the value, and is off by default.
+  An address is personal data, so it is in columns of its own rather than
+  the header blob and a person's rows answer `henri privacy:export` and
+  `henri privacy:erase` (`henri.calls.forPerson()`/`forget()`, best effort,
+  joined on the `externalId`) -- the trail records no address on purpose,
+  because it holds no values and is hash-chained, and `henri.reporter`
+  still carries nothing from the client. `calls.keep`
   (30d) is pruned by the retention sweep, and where the dialect has ranges
   (`calls.partition`, PostgreSQL and MySQL) the sweep drops whole periods
   instead of rows -- with a catch-all partition so no row is ever refused,

--- a/packages/cli/__tests__/audit.spec.js
+++ b/packages/cli/__tests__/audit.spec.js
@@ -675,6 +675,95 @@ describe('henri audit', () => {
     ).not.toContain('calls.kept-forever');
   });
 
+  test('reports a client address the configuration cannot verify', () => {
+    // This is henri's own default. It records no client address rather
+    // than a forged one, which is the point -- but an empty column nobody
+    // was told about is a surprise in an incident
+    const { findings: found, names } = withConfig(
+      app,
+      'config/production.json',
+      { calls: {}, trustProxy: true }
+    );
+
+    expect(names).toContain('calls.address-unverified');
+    expect(found).toContainEqual(
+      expect.objectContaining({
+        check: 'calls.address-unverified',
+        file: 'config/production.json',
+        message: expect.stringContaining('unverified'),
+        owasp: 'A09:2021 Security Logging and Monitoring Failures',
+        severity: 'low',
+      })
+    );
+
+    // A hop count is the fix, no call log is nothing to report, an address
+    // nobody asked to record is nobody's problem, and a named header is
+    // its own mechanism with its own rules
+    for (const config of [
+      { calls: {}, trustProxy: 1 },
+      { calls: {}, trustProxy: false },
+      { trustProxy: true },
+      { calls: { address: false }, trustProxy: true },
+      {
+        calls: {
+          address: { from: ['10.0.0.0/8'], header: 'cf-connecting-ip' },
+        },
+        trustProxy: true,
+      },
+    ]) {
+      expect(
+        withConfig(app, 'config/production.json', config).names
+      ).not.toContain('calls.address-unverified');
+    }
+
+    // A laptop is not a deployment
+    expect(
+      withConfig(app, 'config/dev.json', { calls: {}, trustProxy: true }).names
+    ).not.toContain('calls.address-unverified');
+  });
+
+  test('reports a header believed from anybody, which is the dangerous one', () => {
+    // This is the shape that lets a client choose the address its own
+    // requests are recorded under, so an operator asking "who did this"
+    // reads back what the client typed
+    const { findings: found, names } = withConfig(
+      app,
+      'config/production.json',
+      {
+        calls: {
+          address: { from: ['10.0.0.0/8', '0.0.0.0/0'], header: 'x-real-ip' },
+        },
+      }
+    );
+
+    expect(names).toContain('calls.address-from-any');
+    expect(found).toContainEqual(
+      expect.objectContaining({
+        check: 'calls.address-from-any',
+        message: expect.stringContaining('x-real-ip'),
+        owasp: 'A05:2021 Security Misconfiguration',
+        severity: 'high',
+      })
+    );
+
+    // ... in a development configuration too: a header believed from
+    // anywhere is wrong wherever it is written
+    expect(
+      withConfig(app, 'config/dev.json', {
+        calls: { address: { from: ['::/0'], header: 'x-real-ip' } },
+      }).names
+    ).toContain('calls.address-from-any');
+
+    // Real ranges are the whole point of the setting
+    expect(
+      withConfig(app, 'config/production.json', {
+        calls: {
+          address: { from: ['173.245.48.0/20'], header: 'cf-connecting-ip' },
+        },
+      }).names
+    ).not.toContain('calls.address-from-any');
+  });
+
   test('reports password hashes that are not bound to their row', () => {
     // An application that turned the binding off is telling anyone who can
     // write its database that a hash copied onto another row still works

--- a/packages/cli/__tests__/calls.spec.js
+++ b/packages/cli/__tests__/calls.spec.js
@@ -120,6 +120,31 @@ describe('henri calls', () => {
       expect(stderr).toContain('HENRI_CALLS_DISABLED');
     });
 
+    test('a header a client could have typed is never printed as an answer', () => {
+      const { addressOf } = calls;
+
+      expect(
+        addressOf({ client: '203.0.113.9', peer: '10.1.2.3', source: 'proxy' })
+      ).toBe('from 203.0.113.9 through 10.1.2.3');
+      expect(
+        addressOf({
+          client: '203.0.113.9',
+          peer: '203.0.113.9',
+          source: 'socket',
+        })
+      ).toBe('from 203.0.113.9');
+      // The word an operator has to be able to tell from an address: the
+      // configuration could not support an answer, and here is the hop
+      // that can
+      expect(
+        addressOf({ client: null, peer: '10.1.2.3', source: 'unverified' })
+      ).toBe('from unverified, peer 10.1.2.3');
+      // An outbound call has no address, and says nothing rather than
+      // printing an empty note
+      expect(addressOf({ client: null, peer: null, source: null })).toBeNull();
+      expect(addressOf(null)).toBeNull();
+    });
+
     test('an unknown subcommand prints the usage and exits 2', () => {
       const { status, stderr } = run(['calls:nope', '--json']);
 

--- a/packages/cli/scripts/audit.js
+++ b/packages/cli/scripts/audit.js
@@ -74,6 +74,20 @@ const STANDARDS = { asvs: '4.0.3', owasp: 'Top 10:2021' };
  */
 const CHECKS = [
   {
+    asvs: null,
+    check: 'calls.address-from-any',
+    level: null,
+    owasp: 'A05',
+    what: 'calls.address.from covers every address, so any client may choose the address recorded for it',
+  },
+  {
+    asvs: null,
+    check: 'calls.address-unverified',
+    level: null,
+    owasp: 'A09',
+    what: '"trustProxy": true with a call log: the client address cannot be believed, so the column stays empty',
+  },
+  {
     asvs: 'V7.1.1',
     check: 'calls.kept-forever',
     level: 1,
@@ -1040,6 +1054,51 @@ const configFindings = (config, { file, hasUser }) => {
       'calls.keep is false, so the call log keeps every request and response body it captured for as long as the database lasts: it is a copy of what users sent, growing without a sweep',
       `Give it a period in ${file} ("calls": { "keep": "30d" }), which the retention sweep enforces`,
       'V7.1.1'
+    );
+  }
+
+  // Two ways a call log ends up with an address column that is worse than
+  // useless. The first is the dangerous one: a range covering everything
+  // says "believe this header from anybody", which is a client choosing
+  // what an operator reads when they ask who did something. The second is
+  // only a disappointment -- henri refuses to believe a forwarded address
+  // under a blanket trustProxy, so the column is empty rather than forged
+  // -- but an empty column nobody was told about is a surprise in an
+  // incident, which is the worst time to find out
+  if (isObject(config.calls) && isObject(config.calls.address)) {
+    const from = config.calls.address.from;
+    const everything = Array.isArray(from)
+      ? from.filter((entry) =>
+          /^(?:0\.0\.0\.0\/0|::\/0)$/u.test(String(entry).trim())
+        )
+      : [];
+
+    if (everything.length > 0) {
+      add(
+        'high',
+        'calls.address-from-any',
+        OWASP.A05,
+        `calls.address.from includes ${everything.join(', ')}, so henri believes ${config.calls.address.header || 'the named header'} from any peer: a client can choose the address its own requests are recorded under`,
+        'List the addresses or ranges of the proxies actually in front of henri ("from": ["10.0.0.0/8"]); a header from anywhere else is text the client typed',
+        null
+      );
+    }
+  }
+
+  if (
+    isObject(config.calls) &&
+    config.calls.address !== false &&
+    config.trustProxy === true &&
+    !(isObject(config.calls.address) && config.calls.address.header) &&
+    PRODUCTION_CONFIGS.includes(file)
+  ) {
+    add(
+      'low',
+      'calls.address-unverified',
+      OWASP.A09,
+      '"trustProxy": true means a forwarded address could have been sent by anyone, so the call log records no client address at all and says "unverified": the column an incident is read with will be empty',
+      `Set trustProxy to the number of proxies in front of henri in ${file} ("trustProxy": 1), or to false when nothing is, and the address becomes believable`,
+      null
     );
   }
 

--- a/packages/cli/scripts/calls.js
+++ b/packages/cli/scripts/calls.js
@@ -132,6 +132,32 @@ const took = (duration) =>
   duration === null ? '     -' : `${String(duration).padStart(4)}ms`;
 
 /**
+ * Where a call came from, as one note.
+ *
+ * A client address henri could not believe is printed as `unverified`
+ * rather than left out: an operator reading a call log to answer "who did
+ * this" has to be able to tell "nobody was recorded" from "the
+ * configuration could not support an answer". The peer is shown next to it
+ * whenever it is not the client itself, because it is the hop that can.
+ *
+ * @param {?object} address What the row holds (`client`, `peer`, `source`)
+ * @returns {?string} The note, or null for an outbound call
+ */
+const addressOf = (address) => {
+  if (!address || (!address.client && !address.peer)) {
+    return null;
+  }
+
+  if (!address.client) {
+    return address.peer ? `from unverified, peer ${address.peer}` : null;
+  }
+
+  return address.peer && address.peer !== address.client
+    ? `from ${address.client} through ${address.peer}`
+    : `from ${address.client}`;
+};
+
+/**
  * Prints a listing
  *
  * @param {object} result What list() answered
@@ -169,6 +195,7 @@ const printList = ({ calls, requestId }) => {
     const notes = [
       call.service ? `service ${call.service}` : null,
       call.actor ? `actor ${call.actor}` : null,
+      addressOf(call.address),
       call.error ? `error ${call.error}` : null,
       call.truncated.length > 0
         ? `truncated ${call.truncated.join(', ')}`
@@ -330,6 +357,7 @@ const main = async (args) => {
 
 module.exports = main;
 module.exports.COMMANDS = COMMANDS;
+module.exports.addressOf = addressOf;
 module.exports.list = list;
 module.exports.stats = stats;
 module.exports.sweep = sweep;

--- a/packages/core/error-codes.json
+++ b/packages/core/error-codes.json
@@ -455,6 +455,15 @@
     {
       "area": "calls",
       "causes": [
+        "`calls.address.header` names a header and `calls.address.from` names nobody allowed to set it"
+      ],
+      "code": "HENRI_CALLS_ADDRESS_UNVERIFIABLE",
+      "fix": "Any client can send a header, so henri only believes a named one from a proxy the application listed. Add the addresses or the ranges of the proxies in front of henri: `{ \"calls\": { \"address\": { \"header\": \"cf-connecting-ip\", \"from\": [\"10.0.0.0/8\"] } } }`. Remove the header to fall back to `X-Forwarded-For`, which `config.trustProxy` already governs.",
+      "what": "The call log was asked to read the client address out of a header it has no way to verify."
+    },
+    {
+      "area": "calls",
+      "causes": [
         "`config.calls` is absent or false",
         "the call log could not be started"
       ],

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -894,7 +894,37 @@ declare namespace start {
    * It holds **values**, which the access trail deliberately does not. See
    * the guide before turning it on.
    */
+  /**
+   * What the call log records about the client's address, and when it
+   * believes a forwarded one. `false` records none.
+   */
+  interface CallsAddressConfig {
+    /**
+     * `true` drops the last octet of an IPv4 and the last 80 bits of an
+     * IPv6, keeping the prefix length in the value (`203.0.113.0/24`).
+     * `false` by default: the column exists to answer "who did this".
+     */
+    anonymize?: boolean;
+    /**
+     * The proxies allowed to set `header`, as addresses or ranges. Naming
+     * a header without this fails the boot
+     * (`HENRI_CALLS_ADDRESS_UNVERIFIABLE`).
+     */
+    from?: string[];
+    /**
+     * A header express will not read on its own (`"cf-connecting-ip"`),
+     * believed only when the peer is one of `from`. henri names none.
+     */
+    header?: string;
+  }
+
   interface CallsConfig {
+    /**
+     * The client address: `{ anonymize, header, from }`, or `false` to
+     * record none. `X-Forwarded-For` is `trustProxy`'s business, and a
+     * blanket `trustProxy: true` records no client address at all.
+     */
+    address?: false | CallsAddressConfig;
     /**
      * The outcomes sampling never drops (`["error"]`). They are recorded
      * without their bodies: the decision not to capture one was made before
@@ -2822,6 +2852,15 @@ declare namespace start {
     duration: number | null;
     /** The `externalId` of the person, never an address. */
     actor: string | null;
+    /**
+     * Who made the call, for an inbound one. `client` is `null` when the
+     * configuration could not support an answer and `source` says so.
+     */
+    address: {
+      client: string | null;
+      peer: string | null;
+      source: 'header' | 'proxy' | 'socket' | 'unverified' | null;
+    };
     outcome: 'aborted' | 'failed' | 'ok';
     error: string | null;
     request: { headers: Record<string, string> | null; body: unknown };
@@ -2925,6 +2964,20 @@ declare namespace start {
       requestId: string,
       filter?: Record<string, unknown>
     ): Promise<CallRecord[]>;
+    /**
+     * Everything the log holds about one person, by their `externalId`.
+     * What `henri privacy:export` reads.
+     */
+    forPerson(
+      actor: string,
+      filter?: Record<string, unknown>
+    ): Promise<CallRecord[]>;
+    /**
+     * Takes one person out of the rows that named them: the `actor`, the
+     * addresses and the payloads are written over and the row survives.
+     * What `henri privacy:erase` runs.
+     */
+    forget(actor: string): Promise<number>;
     /**
      * Takes the calls past `config.calls.keep` away. Drops whole partitions
      * where the dialect has them, and deletes rows in bounded batches for

--- a/packages/core/src/3.privacy.js
+++ b/packages/core/src/3.privacy.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const debug = require('debug')('henri:privacy');
 
+const { EXTERNAL_ID } = require('./base/external-id');
 const { check } = require('./base/arguments');
 const { fail } = require('./base/errors');
 const { userConfig } = require('./base/auth');
@@ -37,6 +38,29 @@ const {
  *
  * The person is the user model. `henri.privacy.subject(who)` finds one by
  * email address, by external id or by primary key.
+ *
+ * ## The two framework tables, and why only one of them answers
+ *
+ * The walk of `base/erasure.js` is over *models*, and the tables henri owns
+ * itself are not models. Two of them hold something about a person, and
+ * they answer differently on purpose:
+ *
+ * - **the call log** does, through `henri.calls`. It holds values -- the
+ *   bodies of a request, and now the address it came from -- so there is
+ *   something to hand over and something to write over, and "wait for
+ *   `calls.keep` to come round" is a deadline rather than an answer to a
+ *   data subject request. Its rows join on the `externalId`, so only the
+ *   requests a person was signed in for are theirs;
+ * - **the access trail** does not, and `base/trail.js` argues it where it
+ *   lives: it holds field *names*, counts, public identifiers and digests
+ *   and refuses a value, which is what lets it outlive the erasure it
+ *   recorded. It is also hash-chained, so a row written over would break
+ *   the chain that makes it evidence. Its retention is its own clock.
+ *
+ * The call log is best effort here and says so in the receipt: an erasure
+ * that already wrote over a person's records must not fail because a
+ * debugging log was unreachable, and a receipt that says the log was not
+ * reached is better than no receipt at all.
  *
  * @class Privacy
  * @extends {BaseModule}
@@ -350,6 +374,8 @@ class Privacy extends BaseModule {
       return exportOf(context, subject);
     });
 
+    document.calls = await this.callsOf(subject);
+
     await this.tell(subject, {
       action: 'privacy.export',
       meta: { models: Object.keys(document.records).length },
@@ -506,6 +532,7 @@ class Privacy extends BaseModule {
       throw error;
     }
 
+    receipt.calls = await this.forgetCalls(subject, options);
     receipt.file = options.dryRun ? null : this.record(receipt);
 
     await this.tell(subject, {
@@ -531,6 +558,83 @@ class Privacy extends BaseModule {
     );
 
     return receipt;
+  }
+
+  /**
+   * The person's own rows of the call log, for an export.
+   *
+   * Best effort, like the erasure below: a person is entitled to what the
+   * application holds about them, and a debugging log that is off or
+   * unreachable is not a reason to refuse them the rest of it. What
+   * happened is in the answer either way.
+   *
+   * @async
+   * @param {object} subject The person, as a plain object
+   * @returns {Promise<?object>} `{ records }`, `{ problem }`, or null when
+   *   this application keeps no call log
+   * @memberof Privacy
+   */
+  async callsOf(subject) {
+    const { calls } = this.henri;
+    const actor = subject && subject[EXTERNAL_ID];
+
+    if (!calls || !calls.enabled || typeof actor !== 'string') {
+      return null;
+    }
+
+    try {
+      return { records: await calls.forPerson(actor, { limit: 1000 }) };
+    } catch (error) {
+      debug('unable to read the call log: %s', error.message);
+
+      return { problem: error.code || 'unreadable' };
+    }
+  }
+
+  /**
+   * Takes the person out of the call log.
+   *
+   * The row survives and the person does not (`base/call-store.js` says
+   * exactly which columns are written over). A dry run counts and writes
+   * nothing, the way every other step of a plan does.
+   *
+   * @async
+   * @param {object} subject The person, as a plain object
+   * @param {object} options `dryRun`
+   * @returns {Promise<?object>} `{ action, count, written }`, `{ problem }`,
+   *   or null when this application keeps no call log
+   * @memberof Privacy
+   */
+  async forgetCalls(subject, options) {
+    const { calls } = this.henri;
+    const actor = subject && subject[EXTERNAL_ID];
+
+    if (!calls || !calls.enabled || typeof actor !== 'string') {
+      return null;
+    }
+
+    try {
+      const count = options.dryRun
+        ? await calls.count({ actor })
+        : await calls.forget(actor);
+
+      return {
+        action: 'anonymize',
+        count,
+        written: options.dryRun ? 0 : count,
+      };
+    } catch (error) {
+      // An erasure that has already written over a person's records must
+      // not fail because a debugging log was unreachable; the receipt is
+      // what says it was not reached
+      this.henri.pen.warn(
+        'privacy',
+        'the call log was not reached; its rows still name this person',
+        error.message
+      );
+
+      return { problem: error.code || 'unreachable' };
+    }
   }
 
   /**

--- a/packages/core/src/4.calls.js
+++ b/packages/core/src/4.calls.js
@@ -4,6 +4,7 @@ const debug = require('debug')('henri:calls');
 const { randomUUID } = require('node:crypto');
 
 const { check } = require('./base/arguments');
+const { describeAddress } = require('./base/address');
 const { fail } = require('./base/errors');
 const { currentRequestId } = require('./base/request-id');
 const { storeFor } = require('./base/call-store');
@@ -93,6 +94,8 @@ class Calls extends BaseModule {
     this.track = this.track.bind(this);
     this.list = this.list.bind(this);
     this.about = this.about.bind(this);
+    this.forPerson = this.forPerson.bind(this);
+    this.forget = this.forget.bind(this);
     this.prune = this.prune.bind(this);
 
     debug('constructor initialized');
@@ -154,7 +157,13 @@ class Calls extends BaseModule {
       this.settings.partition
         ? `${this.settings.partition} partitions`
         : 'swept by deleting rows',
-      `sample ${this.settings.sample}, at most ${this.settings.maxPerSecond}/s`
+      `sample ${this.settings.sample}, at most ${this.settings.maxPerSecond}/s`,
+      // Where an address comes from is a decision an operator has to be
+      // able to read back without opening the configuration
+      describeAddress(
+        this.settings.address,
+        config.has('trustProxy') ? config.get('trustProxy') : true
+      )
     );
 
     return this.name;
@@ -282,6 +291,8 @@ class Calls extends BaseModule {
 
     return this.record({
       actor: actorOf(req.user),
+      // Read by the middleware, while the socket was still open
+      address: state.address,
       at: state.at,
       direction: 'in',
       duration,
@@ -550,6 +561,53 @@ class Calls extends BaseModule {
       since: moment(filter.since),
       until: moment(filter.until),
     };
+  }
+
+  /**
+   * Everything the log holds about one person.
+   *
+   * The call log holds **values**, which is the whole difference between
+   * it and the access trail: the trail can outlive an erasure because it
+   * holds field names and digests, and this one cannot. So a person's rows
+   * answer a data subject request like any other record about them --
+   * `henri privacy:export` reads them here and `henri privacy:erase`
+   * writes over them.
+   *
+   * A row is theirs when it carries their `externalId` as its `actor`,
+   * which is the only join there is: an anonymous request is an address
+   * and nothing henri can tie to a person.
+   *
+   * @async
+   * @param {string} actor the person's `externalId`
+   * @param {object} [filter={}] the rest of the filter (`limit`, `since`)
+   * @returns {Promise<Array<object>>} their calls
+   * @memberof Calls
+   */
+  async forPerson(actor, filter = {}) {
+    check('henri.calls.forPerson', [actor, filter]);
+
+    return this.list({ ...filter, actor });
+  }
+
+  /**
+   * Takes one person out of the rows that named them.
+   *
+   * The row survives and the person does not: the `actor`, the two
+   * addresses and the four payload columns are written over, and the
+   * moment, the method, the url, the route, the status and the request id
+   * are left, because a request did happen and that record names nobody.
+   *
+   * @async
+   * @param {string} actor the person's `externalId`
+   * @returns {Promise<number>} how many rows named them
+   * @memberof Calls
+   */
+  async forget(actor) {
+    check('henri.calls.forget', [actor]);
+
+    await this.flush();
+
+    return this.ready().forget(actor);
   }
 
   /**

--- a/packages/core/src/__tests__/calls.spec.js
+++ b/packages/core/src/__tests__/calls.spec.js
@@ -373,6 +373,23 @@ describe('the client address', () => {
     expect(answer.peer).toBe('172.16.0.9');
   });
 
+  // Node joins duplicate headers into one string, so a forwarding header
+  // is a string today. Reading an array as "no header at all" would, under
+  // a blanket trustProxy, record the forged address as though it had come
+  // off the socket -- so the shape is not what the answer rests on
+  test('a forwarding header that arrived as a list is still a forwarded one', () => {
+    expect(
+      addressOf(
+        asking({
+          headers: { 'x-forwarded-for': ['1.2.3.4', '5.6.7.8'] },
+          ip: '1.2.3.4',
+          trust: true,
+        }),
+        addressConfig({})
+      )
+    ).toEqual({ client: null, peer: '172.16.0.9', source: 'unverified' });
+  });
+
   test('a blanket trustProxy with nothing forwarded is still the socket', () => {
     expect(
       addressOf(asking({ ip: '172.16.0.9', trust: true }), addressConfig({}))

--- a/packages/core/src/__tests__/calls.spec.js
+++ b/packages/core/src/__tests__/calls.spec.js
@@ -25,6 +25,35 @@ const {
   startOf,
 } = require('../base/call-store');
 const { redactor, urlRedactor } = require('../base/redact');
+const {
+  addressConfig,
+  addressOf,
+  anonymize,
+  describeAddress,
+  normalize,
+} = require('../base/address');
+
+/** The code a call refused with, without an expect() inside a catch */
+const refused = (work) => {
+  try {
+    work();
+
+    return null;
+  } catch (error) {
+    return error.code;
+  }
+};
+
+/**
+ * A request, as this file needs one: what express would have decided, the
+ * headers a client actually sent, and the socket underneath
+ */
+const asking = (over = {}) => ({
+  app: { get: () => over.trust },
+  headers: over.headers || {},
+  ip: over.ip,
+  socket: { remoteAddress: over.peer || '::ffff:172.16.0.9' },
+});
 
 /** A configuration module standing in for the real one */
 const config = (calls) => ({
@@ -274,6 +303,243 @@ describe('what never reaches a row', () => {
   });
 });
 
+describe('the client address', () => {
+  test('a stored address has one spelling', () => {
+    expect(normalize('::ffff:203.0.113.9')).toBe('203.0.113.9');
+    expect(normalize('fe80::1%lo0')).toBe('fe80::1');
+    expect(normalize('  203.0.113.9  ')).toBe('203.0.113.9');
+    expect(normalize('not-an-address')).toBeNull();
+    expect(normalize(undefined)).toBeNull();
+  });
+
+  test('anonymizing keeps the prefix length in the value', () => {
+    expect(anonymize('203.0.113.9')).toBe('203.0.113.0/24');
+    expect(anonymize('2001:db8:85a3:1234::1')).toBe('2001:db8:85a3::/48');
+    expect(anonymize('::1')).toBe('::/48');
+    expect(anonymize(null)).toBeNull();
+  });
+
+  test('with nothing in front, the peer is the client and a forged header changes nothing', () => {
+    const forged = { 'x-forwarded-for': '1.2.3.4' };
+
+    expect(
+      addressOf(
+        asking({ headers: forged, ip: '172.16.0.9', trust: false }),
+        addressConfig({})
+      )
+    ).toEqual({
+      client: '172.16.0.9',
+      peer: '172.16.0.9',
+      source: 'socket',
+    });
+  });
+
+  test('with a hop count, express decides and henri says a proxy vouched', () => {
+    expect(
+      addressOf(
+        asking({
+          headers: { 'x-forwarded-for': '203.0.113.9' },
+          ip: '203.0.113.9',
+          trust: 1,
+        }),
+        addressConfig({})
+      )
+    ).toEqual({
+      client: '203.0.113.9',
+      peer: '172.16.0.9',
+      source: 'proxy',
+    });
+  });
+
+  // The whole point of the feature: `trustProxy: true` is express'
+  // "believe whoever sent it", so an address taken from it is a value the
+  // client chose. An empty column asks a question; a forged one answers it
+  test('a forged header under a blanket trustProxy records no client at all', () => {
+    const answer = addressOf(
+      asking({
+        headers: { 'x-forwarded-for': '1.2.3.4' },
+        ip: '1.2.3.4',
+        trust: true,
+      }),
+      addressConfig({})
+    );
+
+    expect(answer).toEqual({
+      client: null,
+      peer: '172.16.0.9',
+      source: 'unverified',
+    });
+    // And the row keeps the hop that can answer
+    expect(answer.peer).toBe('172.16.0.9');
+  });
+
+  test('a blanket trustProxy with nothing forwarded is still the socket', () => {
+    expect(
+      addressOf(asking({ ip: '172.16.0.9', trust: true }), addressConfig({}))
+    ).toEqual({ client: '172.16.0.9', peer: '172.16.0.9', source: 'socket' });
+  });
+
+  test('a named header is believed from a listed proxy and from nobody else', () => {
+    const settings = addressConfig({
+      from: ['10.0.0.0/8'],
+      header: 'CF-Connecting-IP',
+    });
+    const headers = {
+      'cf-connecting-ip': '198.51.100.7',
+      'x-forwarded-for': '1.2.3.4',
+    };
+
+    expect(
+      addressOf(asking({ headers, peer: '10.1.2.3', trust: true }), settings)
+    ).toEqual({
+      client: '198.51.100.7',
+      peer: '10.1.2.3',
+      source: 'header',
+    });
+
+    // The same header, sent straight at the application by anybody
+    expect(
+      addressOf(
+        asking({ headers, peer: '203.0.113.200', trust: true }),
+        settings
+      )
+    ).toEqual({
+      client: null,
+      peer: '203.0.113.200',
+      source: 'unverified',
+    });
+  });
+
+  test('a listed proxy that sent no usable header is unverified, never itself', () => {
+    const settings = addressConfig({
+      from: ['10.0.0.0/8'],
+      header: 'cf-connecting-ip',
+    });
+
+    for (const headers of [{}, { 'cf-connecting-ip': 'nonsense' }]) {
+      // The peer is a proxy, so answering with it would be the guess the
+      // whole file exists to refuse
+      expect(
+        addressOf(
+          asking({ headers, ip: '10.1.2.3', peer: '10.1.2.3' }),
+          settings
+        )
+      ).toEqual({ client: null, peer: '10.1.2.3', source: 'unverified' });
+    }
+  });
+
+  test('naming a header with nobody allowed to set it fails, loudly', () => {
+    expect(() => addressConfig({ header: 'cf-connecting-ip' })).toThrow(
+      /names nobody allowed to set it/u
+    );
+    expect(refused(() => addressConfig({ header: 'cf-connecting-ip' }))).toBe(
+      'HENRI_CALLS_ADDRESS_UNVERIFIABLE'
+    );
+
+    expect(() => addressConfig({ from: ['nonsense'] })).toThrow(
+      /neither an address nor a range/u
+    );
+    expect(() => addressConfig({ from: ['10.0.0.0/44'] })).toThrow(
+      /neither an address nor a range/u
+    );
+  });
+
+  test('anonymizing applies to both halves', () => {
+    expect(
+      addressOf(
+        asking({
+          headers: { 'x-forwarded-for': '203.0.113.9' },
+          ip: '203.0.113.9',
+          trust: 1,
+        }),
+        addressConfig({ anonymize: true })
+      )
+    ).toEqual({
+      client: '203.0.113.0/24',
+      peer: '172.16.0.0/24',
+      source: 'proxy',
+    });
+  });
+
+  test('false records none of it', () => {
+    expect(
+      addressOf(asking({ ip: '203.0.113.9', trust: 1 }), addressConfig(false))
+    ).toEqual({ client: null, peer: null, source: null });
+    expect(callsConfig(config({ address: false })).address).toBeNull();
+  });
+
+  test('a row carries the three columns and a call reads them back', () => {
+    const row = toRow(
+      {
+        address: { client: '203.0.113.9', peer: '10.1.2.3', source: 'proxy' },
+        at: 1,
+        direction: 'in',
+        id: 'x',
+        method: 'GET',
+        status: 200,
+        url: '/orders',
+      },
+      context()
+    );
+
+    expect(row.client_ip).toBe('203.0.113.9');
+    expect(row.peer_ip).toBe('10.1.2.3');
+    expect(row.ip_source).toBe('proxy');
+    expect(toCall(row).address).toEqual({
+      client: '203.0.113.9',
+      peer: '10.1.2.3',
+      source: 'proxy',
+    });
+  });
+
+  // The address must not reach the table through the one blob an erasure
+  // cannot write into
+  test('a forwarded header is masked in the stored headers whatever the filters say', () => {
+    const row = toRow(
+      {
+        address: { client: '203.0.113.9', peer: '10.1.2.3', source: 'proxy' },
+        at: 1,
+        direction: 'in',
+        id: 'x',
+        method: 'GET',
+        request: {
+          headers: {
+            'cf-connecting-ip': '203.0.113.9',
+            'true-client-ip': '203.0.113.9',
+            'x-forwarded-for': '203.0.113.9, 10.1.2.3',
+            'x-real-ip': '203.0.113.9',
+          },
+        },
+        status: 200,
+        url: '/orders',
+      },
+      context()
+    );
+
+    expect(JSON.parse(row.request_headers)).toEqual({
+      'cf-connecting-ip': '[FILTERED]',
+      'true-client-ip': '[FILTERED]',
+      'x-forwarded-for': '[FILTERED]',
+      'x-real-ip': '[FILTERED]',
+    });
+    // ... and the address is still in the column that can be truncated,
+    // exported and erased
+    expect(row.client_ip).toBe('203.0.113.9');
+  });
+
+  test('the boot line says where an address comes from', () => {
+    expect(describeAddress(addressConfig({}), true)).toMatch(/unverified/u);
+    expect(describeAddress(addressConfig({}), 1)).toMatch(/X-Forwarded-For/u);
+    expect(describeAddress(addressConfig({}), false)).toBe(
+      'addresses from the socket'
+    );
+    expect(describeAddress(addressConfig({ anonymize: true }), false)).toMatch(
+      /truncated/u
+    );
+    expect(describeAddress(addressConfig(false), true)).toBe('no addresses');
+  });
+});
+
 describe('the four bounds', () => {
   test('an outcome is what decides whether sampling gets to drop it', () => {
     expect(outcomeOf({ status: 200 })).toBe('ok');
@@ -340,6 +606,11 @@ describe('the table, per dialect', () => {
       const statements = install(dialect, 'henri_calls').join('\n');
 
       expect(statements).toContain('request_id');
+      expect(statements).toContain('client_ip');
+      expect(statements).toContain('peer_ip');
+      expect(statements).toContain('ip_source');
+      // A table an older henri created is a no-op for the CREATE above
+      expect(statements).toContain('ADD');
       expect(statements).toContain('PRIMARY KEY (at, id)');
       expect(statements).toContain('henri_calls_request');
       expect(statements).toContain('henri_calls_at');
@@ -500,6 +771,87 @@ describe('the module, in the demo application', () => {
     expect(JSON.stringify(call)).not.toMatch(/called@demo\.test/u);
     // ... and the session cookie the request carried is not in it either
     expect(call.request.headers.cookie).toBe('[FILTERED]');
+  });
+
+  // The demo application sets no trustProxy, so it is henri's default of
+  // `true` -- which is exactly the configuration that cannot tell a real
+  // forwarded address from one a client typed
+  test('a request over the loopback records the address it came from', async () => {
+    const id = `spec-addr-${Date.now()}`;
+
+    await request.post('/echo').set('X-Request-Id', id).send({ title: 'x' });
+    await henri.calls.flush();
+
+    const [call] = await henri.calls.about(id);
+
+    expect(call.address.client).toBe('127.0.0.1');
+    expect(call.address.peer).toBe('127.0.0.1');
+    expect(call.address.source).toBe('socket');
+  });
+
+  test('a forged X-Forwarded-For buys no address at all', async () => {
+    const id = `spec-forged-${Date.now()}`;
+
+    await request
+      .post('/echo')
+      .set('X-Request-Id', id)
+      .set('X-Forwarded-For', '198.51.100.23')
+      .set('CF-Connecting-IP', '198.51.100.99')
+      .send({ title: 'x' });
+    await henri.calls.flush();
+
+    const [call] = await henri.calls.about(id);
+
+    // Not 198.51.100.23, and not the peer pretending to be the client
+    expect(call.address.client).toBeNull();
+    expect(call.address.source).toBe('unverified');
+    expect(call.address.peer).toBe('127.0.0.1');
+    // ... and the address it claimed is nowhere in the row, because the
+    // forwarding headers are masked out of the stored blob
+    expect(JSON.stringify(call)).not.toMatch(/198\.51\.100/u);
+    expect(call.request.headers['x-forwarded-for']).toBe('[FILTERED]');
+  });
+
+  test('a person can be handed their calls, and taken out of them', async () => {
+    const agent = supertest.agent(henri.server.app);
+    const email = 'erased-call@demo.test';
+    const password = 'difference-engine';
+
+    await agent.post('/register').send({ email, name: 'Erased', password });
+    await agent.post('/login').send({ email, password });
+
+    const id = `spec-erase-${Date.now()}`;
+
+    await agent.get('/profile').set('X-Request-Id', id);
+    await henri.calls.flush();
+
+    const [call] = await henri.calls.about(id);
+    const actor = call.actor;
+
+    expect(actor).toEqual(expect.any(String));
+    expect(call.address.client).toBe('127.0.0.1');
+
+    // What `henri privacy:export` hands a person
+    const mine = await henri.calls.forPerson(actor);
+
+    expect(mine.length).toBeGreaterThan(0);
+    expect(mine.every((one) => one.actor === actor)).toBe(true);
+
+    // ... and what `henri privacy:erase` writes over. The row survives and
+    // the person does not
+    expect(await henri.calls.forget(actor)).toBe(mine.length);
+    expect(await henri.calls.forPerson(actor)).toEqual([]);
+
+    const [after] = await henri.calls.about(id);
+
+    expect(after.actor).toBeNull();
+    expect(after.address.client).toBeNull();
+    expect(after.address.peer).toBeNull();
+    expect(after.request.headers).toBeNull();
+    // The operational record of a request that did happen, naming nobody
+    expect(after.route).toBe('/profile');
+    expect(after.status).toBe(200);
+    expect(after.requestId).toBe(id);
   });
 
   test('the health probes are not in it', async () => {

--- a/packages/core/src/base/address.js
+++ b/packages/core/src/base/address.js
@@ -323,6 +323,27 @@ function addressConfig(raw) {
 }
 
 /**
+ * One header's value as text, whatever shape it arrived in.
+ *
+ * Node joins duplicate headers into one string for everything except
+ * `set-cookie`, so a forwarding header is a string today. This does not
+ * depend on that table staying what it is: an array would otherwise read
+ * as "no header at all", which under a blanket `trustProxy` is the
+ * difference between refusing to believe a forged address and recording
+ * it as though it came off the socket.
+ *
+ * @param {object} headers the request headers
+ * @param {?string} name the header
+ * @returns {?string} the value, or null when there is none
+ */
+function valueOf(headers, name) {
+  const value = name && headers ? headers[name] : null;
+  const text = Array.isArray(value) ? value[0] : value;
+
+  return typeof text === 'string' && text !== '' ? text : null;
+}
+
+/**
  * Does this request carry an address somebody forwarded?
  *
  * @param {object} headers the request headers
@@ -334,9 +355,7 @@ function forwarded(headers, named) {
     return false;
   }
 
-  return [...FORWARDING, named].some(
-    (name) => name && typeof headers[name] === 'string' && headers[name] !== ''
-  );
+  return [...FORWARDING, named].some((name) => Boolean(valueOf(headers, name)));
 }
 
 /**
@@ -348,13 +367,9 @@ function forwarded(headers, named) {
  * @returns {?string} the address, or null
  */
 function claimed(headers, name) {
-  const value = headers && headers[name];
+  const value = valueOf(headers, name);
 
-  if (typeof value !== 'string') {
-    return null;
-  }
-
-  return normalize(value.split(',')[0]);
+  return value ? normalize(value.split(',')[0]) : null;
 }
 
 /**
@@ -465,4 +480,5 @@ module.exports = {
   normalize,
   trustOf,
   trustedProxies,
+  valueOf,
 };

--- a/packages/core/src/base/address.js
+++ b/packages/core/src/base/address.js
@@ -1,0 +1,468 @@
+/**
+ * Who connected, and how sure henri is about it.
+ *
+ * The call log records the address of the client that made a request. The
+ * hard part is not reading a header: every one of `X-Forwarded-For`,
+ * `CF-Connecting-IP`, `True-Client-IP` and `X-Real-IP` is text a client
+ * typed, and whether any of it can be believed depends entirely on whether
+ * the request really arrived through the proxy that sets it.
+ *
+ * So this file answers one question -- *what does henri believe, and how
+ * sure is it* -- and writes the answer down rather than guessing. A row
+ * carries three things:
+ *
+ * - `client`, the address henri believes the request came from, or **null**
+ *   when it cannot tell;
+ * - `peer`, the address that actually opened the socket, which is never a
+ *   guess and is worth having even when `client` is known: it is the
+ *   difference between "the client says it is 1.2.3.4" and "1.2.3.4 reached
+ *   us through 172.16.0.9";
+ * - `source`, how `client` was decided, so nobody has to reconstruct it
+ *   from the configuration six months later.
+ *
+ * ## What henri believes, and when
+ *
+ * There are two mechanisms, they answer to two different settings, and
+ * neither of them is a default:
+ *
+ * 1. **`X-Forwarded-For` is `config.trustProxy`'s business.** It is
+ *    express' `trust proxy` and express already applies it: `req.ip` is the
+ *    leftmost address the setting says to believe. henri does not
+ *    re-implement that walk and does not second-guess it -- with one
+ *    exception, below.
+ * 2. **A named header is `calls.address`'s business.** `CF-Connecting-IP`
+ *    is not an `X-Forwarded-For` and express will never read it. Believing
+ *    one takes two statements from the application, and henri requires
+ *    *both*: `calls.address.header` names it, and `calls.address.from`
+ *    lists the proxies allowed to set it. A header named without `from` is
+ *    a configuration that would have henri believe forgeable text, so it
+ *    fails the boot (`HENRI_CALLS_ADDRESS_UNVERIFIABLE`) rather than
+ *    quietly working.
+ *
+ * The exception in the first mechanism is the one that matters, and it is
+ * the reason this file exists. **`trustProxy: true` is not an answer.** It
+ * is express' "believe the leftmost entry, whoever sent it", it is henri's
+ * default, and the boot already warns that it lets anyone forge the address
+ * an ip-based rate limit counts. A rate limit that can be escaped is a
+ * degraded rate limit; an *address column* filled from the same header is
+ * worse than degraded, because it looks like an answer. So: with
+ * `trustProxy: true` and a forwarding header on the request, henri records
+ * no client address at all and says `unverified`.
+ *
+ * That is the whole decision table:
+ *
+ * | trustProxy          | request carries a forwarding header | client          | source        |
+ * | ------------------- | ----------------------------------- | --------------- | ------------- |
+ * | anything            | a named header, from a listed proxy | the header      | `header`      |
+ * | `false`             | either way                          | the peer        | `socket`      |
+ * | a hop count, a list | no                                  | the peer        | `socket`      |
+ * | a hop count, a list | yes                                 | `req.ip`        | `proxy`       |
+ * | `true`              | no                                  | the peer        | `socket`      |
+ * | `true`              | yes                                 | **null**        | `unverified`  |
+ *
+ * `socket` and `proxy` are the same rule read twice: the client is
+ * `req.ip`, and the source says whether that turned out to be the peer or
+ * something a proxy henri was told about vouched for. A request that
+ * carried a forged `X-Forwarded-For` to an application with nothing in
+ * front of it (`trustProxy: false`) is `socket` and the peer, which is
+ * correct rather than lenient -- the operator said nothing is in front.
+ *
+ * ## Why null rather than something plausible
+ *
+ * An operator reading a call log is usually answering "who did this". An
+ * address that is a guess is worse than an empty column there, because the
+ * empty column asks a question and the guess answers one. `unverified` is a
+ * row saying, in the row, that the configuration could not support an
+ * answer -- and the peer is still in it, which is often enough to find the
+ * hop that can answer.
+ *
+ * ## An address is personal data
+ *
+ * In most of the jurisdictions `guides/privacy.md` is written for it is,
+ * so it gets the care the rest of that table gets rather than an exception:
+ * it lives in columns of its own (never inside the header blob, which is
+ * how it would slip past the `personal` marks), `calls.address.anonymize`
+ * truncates it, the forwarding headers are masked in the stored headers,
+ * and a person's rows answer to `henri privacy:export` and
+ * `henri privacy:erase`.
+ *
+ * The anonymisation is the standard one -- the last octet of an IPv4, the
+ * last 80 bits of an IPv6 -- and henri keeps the prefix length in the
+ * value (`203.0.113.0/24`), because `203.0.113.0` and `203.0.113.0/24` are
+ * different claims and a column that cannot tell them apart is a column
+ * that lies once a year.
+ *
+ * **It is off by default, and that is a decision.** The column exists to
+ * answer "who did this"; a /24 answers "somebody in this city". A default
+ * that quietly answers a different question than the one asked is the same
+ * failure as recording a guess. What makes the whole address safe to hold
+ * is not truncation but the rules the table already has -- off unless
+ * configured, swept at `calls.keep`, masked in the logs, and erasable --
+ * and an application whose retention or whose jurisdiction says otherwise
+ * turns it on in one line.
+ *
+ * @module base/address
+ */
+
+const net = require('node:net');
+
+const { fail } = require('./errors');
+
+/** How `client` was decided */
+const SOURCES = Object.freeze([
+  'header',
+  'proxy',
+  'socket',
+  'unverified',
+  null,
+]);
+
+/**
+ * The headers that carry a forwarded address.
+ *
+ * Their presence is what turns `trustProxy: true` from "nothing is in
+ * front of me" into "something might be, and I cannot tell": a request
+ * without any of them was not forwarded by anybody, so the peer is the
+ * client and henri is sure of it.
+ *
+ * They are also masked in a stored row's headers, whatever
+ * `filterParameters` says, so the address cannot reach the table through
+ * the one blob the erasure does not reach into.
+ */
+const FORWARDING = Object.freeze([
+  'cf-connecting-ip',
+  'fastly-client-ip',
+  'forwarded',
+  'true-client-ip',
+  'x-client-ip',
+  'x-forwarded-for',
+  'x-real-ip',
+]);
+
+/** How many bits of an address survive `anonymize` */
+const KEEP = Object.freeze({ ipv4: 24, ipv6: 48 });
+
+/** The longest a stored address can be: a full IPv6 and its prefix */
+const MAX = 45;
+
+/**
+ * An address as henri stores it: no IPv4-in-IPv6 wrapper, no zone.
+ *
+ * `req.socket.remoteAddress` answers `::ffff:203.0.113.9` for an IPv4
+ * client on a dual-stack listener and `fe80::1%lo0` for a link-local one.
+ * Neither spelling is wrong and both make a column impossible to group by,
+ * so they are normalized on the way in.
+ *
+ * @param {*} value an address, or anything
+ * @returns {?string} the address, or null when it is not one
+ */
+function normalize(value) {
+  if (typeof value !== 'string' || value === '') {
+    return null;
+  }
+
+  const text = value.trim().replace(/%.*$/u, '');
+  const mapped = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/iu.exec(text);
+  const address = mapped ? mapped[1] : text;
+
+  return net.isIP(address) === 0 ? null : address;
+}
+
+/**
+ * The eight groups of an IPv6 address, expanded
+ *
+ * @param {string} address an IPv6 address
+ * @returns {?Array<number>} the groups, or null when it will not parse
+ */
+function groupsOf(address) {
+  const halves = address.split('::');
+
+  if (halves.length > 2) {
+    return null;
+  }
+
+  const parse = (half) =>
+    half === '' ? [] : half.split(':').map((part) => parseInt(part, 16));
+  const head = parse(halves[0]);
+  const tail = halves.length === 2 ? parse(halves[1]) : [];
+  const missing = 8 - head.length - tail.length;
+
+  if (missing < 0 || (halves.length === 1 && missing !== 0)) {
+    return null;
+  }
+
+  const groups = [...head, ...new Array(Math.max(missing, 0)).fill(0), ...tail];
+
+  return groups.every((group) => Number.isInteger(group) && group >= 0)
+    ? groups
+    : null;
+}
+
+/**
+ * An address with the host part dropped, carrying its prefix length.
+ *
+ * The last octet of an IPv4 and the last 80 bits of an IPv6, which is the
+ * truncation every analytics tool and every data protection authority
+ * means by "anonymized ip". The `/24` and the `/48` are part of the value
+ * on purpose: without them a truncated address is indistinguishable from a
+ * network address somebody really connected from.
+ *
+ * @param {?string} address a normalized address
+ * @returns {?string} the truncated address, or null
+ */
+function anonymize(address) {
+  if (!address) {
+    return null;
+  }
+
+  if (net.isIPv4(address)) {
+    const octets = address.split('.');
+
+    return `${octets[0]}.${octets[1]}.${octets[2]}.0/${KEEP.ipv4}`;
+  }
+
+  const groups = groupsOf(address);
+
+  if (!groups) {
+    return null;
+  }
+
+  const kept = groups.slice(0, 3);
+
+  // `::1` truncated is `::/48`, not `0:0:0::/48`: the whole point of the
+  // value is that a person can read it back
+  return kept.every((group) => group === 0)
+    ? `::/${KEEP.ipv6}`
+    : `${kept.map((group) => group.toString(16)).join(':')}::/${KEEP.ipv6}`;
+}
+
+/**
+ * The list of proxies allowed to set a named header.
+ *
+ * A `net.BlockList`, which is the same thing `@usehenri/webhooks` checks
+ * an outbound address against: the ranges are the standard ones and the
+ * matching is the kernel's idea of a subnet rather than a string compare.
+ *
+ * @param {Array<string>} entries `calls.address.from`
+ * @returns {?object} `{ check, entries }`, or null when the list is empty
+ * @throws HENRI_CONFIG_INVALID on an entry that is not an address or a
+ *   range
+ */
+function trustedProxies(entries) {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return null;
+  }
+
+  const list = new net.BlockList();
+
+  for (const entry of entries) {
+    const [address, prefix] = String(entry).trim().split('/');
+    const family = net.isIPv4(address) ? 'ipv4' : 'ipv6';
+    const bits = prefix === undefined ? null : Number(prefix);
+    const widest = family === 'ipv4' ? 32 : 128;
+
+    if (
+      net.isIP(address) === 0 ||
+      (bits !== null && (!Number.isInteger(bits) || bits < 0 || bits > widest))
+    ) {
+      throw fail(
+        'HENRI_CONFIG_INVALID',
+        `calls.address.from: "${entry}" is neither an address nor a range (10.0.0.0/8, 2400:cb00::/32)`
+      );
+    }
+
+    if (bits === null) {
+      list.addAddress(address, family);
+    } else {
+      list.addSubnet(address, bits, family);
+    }
+  }
+
+  return {
+    check: (address) =>
+      Boolean(address) &&
+      list.check(address, net.isIPv4(address) ? 'ipv4' : 'ipv6'),
+    entries: entries.map((entry) => String(entry)),
+  };
+}
+
+/**
+ * `config.calls.address`, normalized.
+ *
+ * @param {*} raw what the configuration said
+ * @returns {?object} `{ anonymize, header, from }`, or null for "record no
+ *   address"
+ * @throws HENRI_CALLS_ADDRESS_UNVERIFIABLE when a header is named with no
+ *   proxies to believe it from
+ * @throws HENRI_CONFIG_INVALID on a range henri cannot read
+ */
+function addressConfig(raw) {
+  if (raw === false) {
+    return null;
+  }
+
+  const settings = raw && typeof raw === 'object' ? raw : {};
+  const header =
+    typeof settings.header === 'string' && settings.header !== ''
+      ? settings.header.toLowerCase()
+      : null;
+  const from = trustedProxies(settings.from);
+
+  if (header && !from) {
+    const error = fail(
+      'HENRI_CALLS_ADDRESS_UNVERIFIABLE',
+      `calls.address.header names "${header}", and calls.address.from names nobody allowed to set it`
+    );
+
+    error.hint = `Any client can send ${header}. List the addresses or ranges of the proxies in front of henri: { "calls": { "address": { "header": "${header}", "from": ["10.0.0.0/8"] } } }`;
+
+    throw error;
+  }
+
+  return { anonymize: settings.anonymize === true, from, header };
+}
+
+/**
+ * Does this request carry an address somebody forwarded?
+ *
+ * @param {object} headers the request headers
+ * @param {?string} named `calls.address.header`
+ * @returns {boolean} whether one of them is there
+ */
+function forwarded(headers, named) {
+  if (!headers || typeof headers !== 'object') {
+    return false;
+  }
+
+  return [...FORWARDING, named].some(
+    (name) => name && typeof headers[name] === 'string' && headers[name] !== ''
+  );
+}
+
+/**
+ * The address a named header claims: the first entry, and only when it is
+ * an address
+ *
+ * @param {object} headers the request headers
+ * @param {string} name the header
+ * @returns {?string} the address, or null
+ */
+function claimed(headers, name) {
+  const value = headers && headers[name];
+
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  return normalize(value.split(',')[0]);
+}
+
+/**
+ * What express was told to trust, as this file cares about it.
+ *
+ * Only one distinction matters here: a blanket `true` believes whoever
+ * sent the header and everything else -- `false`, a hop count, a list of
+ * addresses, express' own `'loopback'` shorthands, a function -- is a
+ * statement about a topology somebody thought about.
+ *
+ * @param {object} req the request
+ * @returns {*} what `app.set('trust proxy', ...)` was given
+ */
+function trustOf(req) {
+  return req && req.app && typeof req.app.get === 'function'
+    ? req.app.get('trust proxy')
+    : undefined;
+}
+
+/**
+ * Who made this request, and how sure henri is.
+ *
+ * The table in the header of this file, as code. Never throws and never
+ * reads a body: it is called once per recorded request, after the answer
+ * has gone out.
+ *
+ * @param {object} req the request
+ * @param {?object} settings the normalized `calls.address`
+ * @returns {{client: ?string, peer: ?string, source: ?string}} the answer
+ */
+function addressOf(req, settings) {
+  if (!settings || !req) {
+    return { client: null, peer: null, source: null };
+  }
+
+  const headers = req.headers || {};
+  const peer = normalize(req.socket && req.socket.remoteAddress);
+  const { from, header } = settings;
+  const dress = (answer) => ({
+    client: settings.anonymize ? anonymize(answer.client) : answer.client,
+    peer: settings.anonymize ? anonymize(peer) : peer,
+    source: answer.source,
+  });
+
+  // A named header, from a peer the application listed: the one case where
+  // henri reads a header express will not, and it takes both statements
+  if (header && from && from.check(peer)) {
+    const address = claimed(headers, header);
+
+    // The peer is a proxy, so it is not the client -- answering with it
+    // would be the guess this whole file exists to refuse
+    return dress({
+      client: address,
+      source: address ? 'header' : 'unverified',
+    });
+  }
+
+  if (trustOf(req) === true && forwarded(headers, header)) {
+    return dress({ client: null, source: 'unverified' });
+  }
+
+  const client = normalize(req.ip) || peer;
+
+  return dress({ client, source: client === peer ? 'socket' : 'proxy' });
+}
+
+/**
+ * What the boot line says about where an address comes from
+ *
+ * @param {?object} settings the normalized `calls.address`
+ * @param {*} trust `config.trustProxy`
+ * @returns {string} one line
+ */
+function describeAddress(settings, trust) {
+  if (!settings) {
+    return 'no addresses';
+  }
+
+  const shortened = settings.anonymize ? 'truncated addresses' : 'addresses';
+
+  if (settings.header) {
+    return `${shortened} from ${settings.header}, and only from a listed proxy`;
+  }
+
+  if (trust === true) {
+    return `${shortened} from the socket; a forwarded one is unverified while trustProxy is true`;
+  }
+
+  if (trust === false) {
+    return `${shortened} from the socket`;
+  }
+
+  return `${shortened} from the socket, or from X-Forwarded-For as trustProxy allows`;
+}
+
+module.exports = {
+  FORWARDING,
+  KEEP,
+  MAX,
+  SOURCES,
+  addressConfig,
+  addressOf,
+  anonymize,
+  claimed,
+  describeAddress,
+  forwarded,
+  groupsOf,
+  normalize,
+  trustOf,
+  trustedProxies,
+};

--- a/packages/core/src/base/arguments.js
+++ b/packages/core/src/base/arguments.js
@@ -60,6 +60,7 @@
  * `fetch`), `henri.privacy` (`fields`, `strip`, `subject`, `export`,
  * `plan`, `erase`), `henri.retention` (`plan`, `sweep`), `henri.trail`
  * (`list`, `count`, `about`, `prune`), `henri.calls` (`list`, `count`,
+ * `forPerson`, `forget`,
  * `about`, `prune`, `outbound`, `track`), `henri.encryption` (`markOf`,
  * `encrypt`, `decrypt`, `candidates`, `tolerate`, `rotate`),
  * `henri.user` (`compare`, `encrypt`, `publicUser`), `henri.accounts`
@@ -621,6 +622,13 @@ const SIGNATURES = {
   ],
 
   'henri.calls.count': [{ name: 'filter', optional: true, ...CALL_FILTER }],
+
+  'henri.calls.forPerson': [
+    { name: 'actor', ...NAME },
+    { name: 'filter', optional: true, ...CALL_FILTER },
+  ],
+
+  'henri.calls.forget': [{ name: 'actor', ...NAME }],
 
   'henri.calls.list': [{ name: 'filter', optional: true, ...CALL_FILTER }],
 

--- a/packages/core/src/base/call-store.js
+++ b/packages/core/src/base/call-store.js
@@ -70,6 +70,9 @@ const COLUMNS = [
   'status',
   'duration',
   'actor',
+  'client_ip',
+  'peer_ip',
+  'ip_source',
   'outcome',
   'error',
   'request_headers',
@@ -82,6 +85,49 @@ const COLUMNS = [
 
 /** A day, in milliseconds */
 const DAY = 86400000;
+
+/**
+ * How wide an address column is: a full IPv6 and the `/48` an anonymized
+ * one carries (`base/address.js`)
+ */
+const ADDRESS = 45;
+
+/**
+ * The columns henri adds to a table that was created before they existed.
+ *
+ * `CREATE TABLE IF NOT EXISTS` is a no-op on a table that is already
+ * there, so a call log written by an older henri would keep its old shape
+ * and refuse every `INSERT` naming a column it has not got. These run
+ * after it, and a dialect that already has the column answers with an
+ * error `ALREADY_THERE` recognises, which is the same way this file
+ * handles two processes installing at once.
+ *
+ * PostgreSQL propagates an `ADD COLUMN` to every partition of a
+ * partitioned table and MySQL rebuilds it, so the partitioned path needs
+ * nothing of its own.
+ */
+/**
+ * What an erasure writes over in a row that named a person.
+ *
+ * Everything in a row that was about them: who they were, where they
+ * connected from, and the four payload columns, which hold whatever they
+ * sent and whatever the application answered them.
+ */
+const ERASED = [
+  'actor',
+  'client_ip',
+  'peer_ip',
+  'request_headers',
+  'request_body',
+  'response_headers',
+  'response_body',
+];
+
+const ADDED = [
+  `client_ip VARCHAR(${ADDRESS}) NULL`,
+  `peer_ip VARCHAR(${ADDRESS}) NULL`,
+  'ip_source VARCHAR(16) NULL',
+];
 
 /**
  * The column definitions of the table.
@@ -105,6 +151,9 @@ const columnsFor = (dialect) => [
   `status ${dialect.int} NULL`,
   `duration ${dialect.int} NULL`,
   'actor VARCHAR(64) NULL',
+  `client_ip VARCHAR(${ADDRESS}) NULL`,
+  `peer_ip VARCHAR(${ADDRESS}) NULL`,
+  'ip_source VARCHAR(16) NULL',
   'outcome VARCHAR(16) NOT NULL',
   'error VARCHAR(190) NULL',
   `request_headers ${dialect.text} NULL`,
@@ -289,6 +338,17 @@ const install = (name, table, options = {}) => {
     dialect.guardTable ? dialect.guardTable(table, create) : create
   );
 
+  // A table created by an older henri keeps its old shape: the CREATE
+  // above was a no-op on it, so the columns it has not got are added here
+  // and a column it already has answers with an error ALREADY_THERE knows
+  for (const definition of ADDED) {
+    statements.push(
+      `ALTER TABLE ${quoted} ADD ${name === 'mssql' ? '' : 'COLUMN '}${
+        name === 'postgres' ? 'IF NOT EXISTS ' : ''
+      }${definition}`
+    );
+  }
+
   if (!dialect.inlineIndexes) {
     for (const index of indexes) {
       const statement = [
@@ -409,7 +469,7 @@ const listPartitions = (name) => {
 
 /** Errors that mean the object was created by another process first */
 const ALREADY_THERE =
-  /already exists|duplicate key|duplicate table|there is already an object named|Duplicate partition name/iu;
+  /already exists|duplicate key|duplicate table|duplicate column|there is already an object named|Duplicate partition name/iu;
 
 /**
  * The SQL backend
@@ -740,6 +800,39 @@ class SqlCalls {
   }
 
   /**
+   * Takes one person out of the rows that named them.
+   *
+   * The row survives and the person does not: what is written over is the
+   * `actor`, the two addresses and the four payload columns, which is
+   * everything in a row that was about them. What is left -- the moment,
+   * the method, the url, the route, the status, the duration and the
+   * request id -- is the operational record of a request that did happen,
+   * and it names nobody.
+   *
+   * This is `onErase: 'anonymize'`, henri's own verb for "the record
+   * survives while the person is anonymized in place", applied to a table
+   * henri owns rather than to a model.
+   *
+   * @param {string} actor the person's `externalId`
+   * @returns {Promise<number>} how many rows named them
+   * @memberof SqlCalls
+   */
+  async forget(actor) {
+    const total = await this.count({ actor });
+
+    if (total === 0) {
+      return 0;
+    }
+
+    await this.run(
+      `UPDATE ${this.table} SET ${ERASED.map((column) => `${column} = NULL`).join(', ')} WHERE actor = ?`,
+      [actor]
+    );
+
+    return total;
+  }
+
+  /**
    * Takes the rows past `before` away.
    *
    * The partitioned path drops whole periods and then runs the bounded
@@ -970,6 +1063,22 @@ class MongoCalls {
   }
 
   /**
+   * Takes one person out of the rows that named them
+   *
+   * @param {string} actor the person's `externalId`
+   * @returns {Promise<number>} how many rows named them
+   * @memberof MongoCalls
+   */
+  async forget(actor) {
+    const result = await this.collection().updateMany(
+      { actor },
+      { $unset: Object.fromEntries(ERASED.map((column) => [column, ''])) }
+    );
+
+    return (result && result.matchedCount) || 0;
+  }
+
+  /**
    * Takes the rows past `before` away, a batch at a time
    *
    * @param {number} before a timestamp in milliseconds
@@ -1069,8 +1178,11 @@ const storeFor = (adapter, settings) => {
 };
 
 module.exports = {
+  ADDED,
+  ADDRESS,
   COLUMNS,
   DAY,
+  ERASED,
   MongoCalls,
   SqlCalls,
   boundsOf,

--- a/packages/core/src/base/calls.js
+++ b/packages/core/src/base/calls.js
@@ -111,7 +111,14 @@
  *   before it is serialized -- rather than by tapping the socket;
  * - the person is the `externalId` and nothing else. Not the primary key,
  *   not the email address: `publicUser()` already decided what a person
- *   looks like when they leave the server and this follows it.
+ *   looks like when they leave the server and this follows it;
+ * - **the client's address is three columns of its own, never a header.**
+ *   What henri believes, when it refuses to believe anything, and why the
+ *   forwarding headers are masked out of the stored blob is the header of
+ *   `base/address.js`. The short version: `X-Forwarded-For` is believed
+ *   through `config.trustProxy` and a named header through
+ *   `calls.address.from`, and a blanket `trustProxy: true` in front of a
+ *   forwarded request records no client address at all.
  *
  * ## How it is swept
  *
@@ -126,6 +133,13 @@
  */
 
 const { EXTERNAL_ID } = require('./external-id');
+const {
+  FORWARDING,
+  MAX,
+  SOURCES,
+  addressConfig,
+  addressOf,
+} = require('./address');
 const { currentRequestId } = require('./request-id');
 const { isFiltered, redactor, urlRedactor } = require('./redact');
 const { fail } = require('./errors');
@@ -153,6 +167,13 @@ const PARTITIONABLE = ['mysql', 'postgres'];
  * The headers whose value is never stored, whatever `filterParameters`
  * says. They are the credentials of the exchange, and a list an
  * application has to remember to write down is a list it forgets.
+ *
+ * The forwarding headers (`base/address.js`) are in it for a different
+ * reason: they carry addresses, an address is personal data, and the stored
+ * headers are one blob the erasure cannot reach inside. Masking them here
+ * is what keeps the address in the columns that *can* be truncated,
+ * exported and erased, rather than in two places with one of them out of
+ * reach.
  */
 const DENIED = Object.freeze([
   'authorization',
@@ -162,6 +183,7 @@ const DENIED = Object.freeze([
   'webhook-signature',
   'x-api-key',
   'x-csrf-token',
+  ...FORWARDING,
 ]);
 
 /** What a row says when a body was longer than `calls.maxBody` */
@@ -276,6 +298,7 @@ function callsConfig(config) {
 
   if (raw === false || raw === null || typeof raw === 'undefined') {
     return {
+      address: null,
       always: [],
       batch: 500,
       buffer: 1000,
@@ -303,6 +326,7 @@ function callsConfig(config) {
       : 1;
 
   return {
+    address: addressConfig(settings.address),
     always: Array.isArray(settings.always)
       ? settings.always.filter((name) => ALWAYS.includes(name))
       : ['error'],
@@ -638,7 +662,14 @@ function inbound(henri) {
     const at = Date.now();
     const started = process.hrtime.bigint();
     const keep = calls.samples(req.id);
-    const state = { body: undefined, keep };
+    // The address is read here rather than at `close`: an aborted request
+    // has no `remoteAddress` left by the time the socket has gone, and an
+    // aborted request is exactly what `calls.always` keeps
+    const state = {
+      address: addressOf(req, calls.settings.address),
+      body: undefined,
+      keep,
+    };
 
     // The response body is taken as a *value* from `res.json`, never off
     // the socket: a value can be walked and redacted, bytes cannot. Only a
@@ -738,18 +769,23 @@ function toRow(call, context) {
     response.truncated ? 'response' : null,
   ].filter(Boolean);
 
+  const address = call.address || {};
+
   return {
     actor: call.actor || null,
     at: call.at,
+    client_ip: text(address.client, MAX),
     direction: DIRECTIONS.includes(call.direction) ? call.direction : 'out',
     duration: Number.isFinite(call.duration) ? Math.round(call.duration) : null,
     error: call.error ? String(call.error).slice(0, 190) : null,
     id: call.id,
+    ip_source: SOURCES.includes(address.source) ? address.source || null : null,
     meta: metaOf(call, { request, response }, redact),
     method: String(call.method || 'GET')
       .toUpperCase()
       .slice(0, 12),
     outcome: OUTCOMES.includes(call.outcome) ? call.outcome : outcomeOf(call),
+    peer_ip: text(address.peer, MAX),
     request_body: request.body,
     request_headers: jsonOf(
       headers(call.request && call.request.headers, head)
@@ -765,6 +801,17 @@ function toRow(call, context) {
     truncated: truncated.length > 0 ? truncated.join(',') : null,
     url: safeUrl(call.url, mask),
   };
+}
+
+/**
+ * A string column, bounded, or null
+ *
+ * @param {*} value anything
+ * @param {number} max the longest the column takes
+ * @returns {?string} the value, or null
+ */
+function text(value, max) {
+  return typeof value === 'string' && value !== '' ? value.slice(0, max) : null;
 }
 
 /**
@@ -845,6 +892,13 @@ function toCall(row) {
 
   return {
     actor: row.actor || null,
+    address: {
+      // `client` is null when the configuration could not support an
+      // answer, and `source` says which of the two nulls this is
+      client: row.client_ip || null,
+      peer: row.peer_ip || null,
+      source: row.ip_source || null,
+    },
     at: Number.isFinite(at) ? new Date(at).toISOString() : null,
     direction: row.direction,
     duration: row.duration === null ? null : Number(row.duration),
@@ -960,6 +1014,7 @@ module.exports = {
   outcomeOf,
   safeUrl,
   seedOf,
+  text,
   toCall,
   toRow,
   track,

--- a/packages/core/src/base/config-schema.js
+++ b/packages/core/src/base/config-schema.js
@@ -1319,6 +1319,38 @@ const SCHEMA = {
       { const: false },
       {
         keys: {
+          address: {
+            default: {},
+            describe:
+              'an object ({ anonymize, header, from }), or false to record no address',
+            hint: 'What henri believes about the client address, and when. X-Forwarded-For is config.trustProxy\'s business; a named header needs "from" as well, and a blanket "trustProxy": true records no client address at all',
+            oneOf: [
+              { const: false },
+              {
+                keys: {
+                  anonymize: {
+                    default: false,
+                    describe: 'true or false',
+                    hint: 'true drops the last octet of an IPv4 and the last 80 bits of an IPv6, keeping the prefix length in the value (203.0.113.0/24)',
+                    type: 'boolean',
+                  },
+                  from: {
+                    describe:
+                      'a list of addresses or ranges (10.0.0.0/8, 2400:cb00::/32)',
+                    hint: 'The proxies allowed to set the named header. Without it a header is text any client can send, so naming one fails the boot',
+                    of: text(),
+                    type: 'array',
+                  },
+                  header: {
+                    describe: 'a header name (cf-connecting-ip)',
+                    hint: 'A header express will not read on its own; it is only believed when the peer is one of "from". henri names none by default',
+                    type: 'string',
+                  },
+                },
+                type: 'object',
+              },
+            ],
+          },
           always: {
             default: ['error'],
             describe: `a list of ${ALWAYS.join(', ')}, or an empty list`,

--- a/packages/drizzle/__tests__/calls.spec.js
+++ b/packages/drizzle/__tests__/calls.spec.js
@@ -11,7 +11,7 @@
 // offline and is the reason this suite exists at all.
 const { build, target } = require('./helpers');
 
-const { storeFor } = require('../../core/src/base/call-store');
+const { install, storeFor } = require('../../core/src/base/call-store');
 const { callsConfig, toCall, toRow } = require('../../core/src/base/calls');
 const { redact } = require('../../core/src/base/redact');
 
@@ -153,6 +153,111 @@ describe(`the call log on ${target.name}`, () => {
     expect(call.at).toMatch(/^\d{4}-/u);
   });
 
+  test('the address goes in and comes back, all three columns of it', async () => {
+    await store.insert([
+      row({
+        address: {
+          client: '203.0.113.9',
+          peer: '10.1.2.3',
+          source: 'proxy',
+        },
+        direction: 'in',
+        id: 'with-an-address',
+        requestId: 'addressed',
+        route: '/orders',
+        url: '/orders',
+      }),
+      row({
+        // What a row holds when the configuration could not support an
+        // answer: the peer, and a word saying why the client is empty
+        address: { client: null, peer: '10.1.2.3', source: 'unverified' },
+        direction: 'in',
+        id: 'without-an-address',
+        requestId: 'addressed',
+        url: '/orders',
+      }),
+      // An anonymized one keeps its prefix length, which is why the column
+      // is wide enough for a full IPv6 and a `/48`
+      row({
+        address: {
+          client: '2001:db8:85a3::/48',
+          peer: '2001:db8:1::/48',
+          source: 'header',
+        },
+        direction: 'in',
+        id: 'truncated-address',
+        requestId: 'addressed',
+        url: '/orders',
+      }),
+    ]);
+
+    const found = Object.fromEntries(
+      (await store.list({ requestId: 'addressed' }))
+        .map(toCall)
+        .map((call) => [call.id, call.address])
+    );
+
+    expect(found['with-an-address']).toEqual({
+      client: '203.0.113.9',
+      peer: '10.1.2.3',
+      source: 'proxy',
+    });
+    expect(found['without-an-address']).toEqual({
+      client: null,
+      peer: '10.1.2.3',
+      source: 'unverified',
+    });
+    expect(found['truncated-address'].client).toBe('2001:db8:85a3::/48');
+  });
+
+  test('a person is taken out of the rows that named them, and the rows stay', async () => {
+    await store.insert([
+      row({
+        actor: '018f5c2e-1f2a-7c31-9f0a-2b7c1d3e4f56',
+        address: { client: '203.0.113.9', peer: '10.1.2.3', source: 'proxy' },
+        direction: 'in',
+        id: 'theirs',
+        request: { body: { note: 'about them' }, headers: { accept: 'x' } },
+        requestId: 'erasure',
+        route: '/profile',
+        status: 200,
+        url: '/profile',
+      }),
+      row({
+        actor: '018f5c2e-1f2a-7c31-9f0a-000000000000',
+        address: { client: '198.51.100.4', peer: '10.1.2.3', source: 'proxy' },
+        direction: 'in',
+        id: 'somebody-elses',
+        requestId: 'erasure',
+        url: '/profile',
+      }),
+    ]);
+
+    expect(await store.forget('018f5c2e-1f2a-7c31-9f0a-2b7c1d3e4f56')).toBe(1);
+    // A person nobody's rows name is a clean, empty, successful run
+    expect(await store.forget('018f5c2e-0000-7c31-9f0a-2b7c1d3e4f56')).toBe(0);
+
+    const found = Object.fromEntries(
+      (await store.list({ requestId: 'erasure' }))
+        .map(toCall)
+        .map((call) => [call.id, call])
+    );
+
+    expect(found.theirs.actor).toBeNull();
+    expect(found.theirs.address).toEqual({
+      client: null,
+      peer: null,
+      source: 'proxy',
+    });
+    expect(found.theirs.request.body).toBeNull();
+    expect(found.theirs.request.headers).toBeNull();
+    // The operational record of a request that did happen, naming nobody
+    expect(found.theirs.route).toBe('/profile');
+    expect(found.theirs.status).toBe(200);
+    // ... and nobody else was touched
+    expect(found['somebody-elses'].address.client).toBe('198.51.100.4');
+  });
+
   test('a filter the store cannot use narrows rather than widening', async () => {
     const since = Date.now() + DAY;
 
@@ -181,6 +286,67 @@ describe(`the call log on ${target.name}`, () => {
     expect(await store.count({ requestId: 'bulk' })).toBe(25);
     // And a second pass finds nothing rather than looping
     expect((await store.sweep(before, { batch: 5 })).removed).toBe(0);
+  });
+});
+
+/**
+ * A call log an older henri created, which is the one henri will find in
+ * every application that turned the feature on before the address columns
+ * existed.
+ *
+ * `CREATE TABLE IF NOT EXISTS` is a no-op on it, so without the `ALTER`s
+ * every insert would name three columns the table has not got. This builds
+ * exactly what the previous version emitted -- the same statement with the
+ * three column definitions taken out -- and then lets `install()` catch it
+ * up.
+ */
+describe(`a table created before the address columns, on ${target.name}`, () => {
+  const table = 'henri_calls_old';
+  let adapter = null;
+  let store = null;
+
+  beforeAll(async () => {
+    ({ adapter } = build());
+    await adapter.start();
+    store = storeFor(adapter, settings({ table }));
+
+    const [create] = install(store.dialect, table);
+
+    await store.run(
+      create.replace(/\n\s*(?:client_ip|peer_ip|ip_source) [^,]+,/gu, '')
+    );
+  }, 60000);
+
+  afterAll(async () => {
+    await adapter.stop();
+  });
+
+  test('install adds what is missing, and says nothing when it is there', async () => {
+    await expect(store.install()).resolves.toBeDefined();
+    // Idempotent: the second pass meets its own columns and swallows it
+    await expect(store.install()).resolves.toBeDefined();
+
+    await store.insert([
+      row({
+        address: {
+          client: '203.0.113.9',
+          peer: '10.1.2.3',
+          source: 'proxy',
+        },
+        direction: 'in',
+        id: 'after-the-upgrade',
+        requestId: 'upgraded',
+        url: '/orders',
+      }),
+    ]);
+
+    const [call] = (await store.list({ requestId: 'upgraded' })).map(toCall);
+
+    expect(call.address).toEqual({
+      client: '203.0.113.9',
+      peer: '10.1.2.3',
+      source: 'proxy',
+    });
   });
 });
 
@@ -254,6 +420,29 @@ partitioned(`partitions on ${target.name}`, () => {
 
     expect(await store.count({ requestId: 'day-20' })).toBe(1);
     expect(await store.count({ requestId: 'day-22' })).toBe(1);
+  });
+
+  test('an address survives the partitioned path too', async () => {
+    await store.insert([
+      row({
+        address: { client: '203.0.113.9', peer: '10.1.2.3', source: 'proxy' },
+        at: Date.UTC(2026, 8, 22, 2),
+        direction: 'in',
+        id: 'partitioned-address',
+        requestId: 'day-22-address',
+        url: '/orders',
+      }),
+    ]);
+
+    const [call] = (await store.list({ requestId: 'day-22-address' })).map(
+      toCall
+    );
+
+    expect(call.address).toEqual({
+      client: '203.0.113.9',
+      peer: '10.1.2.3',
+      source: 'proxy',
+    });
   });
 
   test('a row outside every period is kept by the catch-all, not refused', async () => {

--- a/types/core.test-d.ts
+++ b/types/core.test-d.ts
@@ -421,6 +421,25 @@ henri.calls.list({ direction: 'sideways' });
 // @ts-expect-error a call log is read back by request id, never by address
 henri.calls.about({ email: 'someone@example.test' });
 
+// A person's own rows: what privacy:export reads and privacy:erase writes
+// over. The join is the externalId, so an anonymous request is nobody's
+expectType<Promise<CallRecord[]>>(
+  henri.calls.forPerson('018f5c2e-1f2a-7c31-9f0a-2b7c1d3e4f56')
+);
+expectType<Promise<number>>(
+  henri.calls.forget('018f5c2e-1f2a-7c31-9f0a-2b7c1d3e4f56')
+);
+
+// The address is three things a row holds, and `client` is nullable
+// because henri says so rather than guessing
+expectType<'header' | 'proxy' | 'socket' | 'unverified' | null>(
+  (null as unknown as CallRecord).address.source
+);
+
+// @ts-expect-error the address a call carries is read off the row, not
+// asked for in a filter
+henri.calls.list({ client: '203.0.113.9' });
+
 // --- controllers ------------------------------------------------------------
 
 const tasks: Controller = {

--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -412,6 +412,7 @@ turning it on.
 ```json
 {
   "calls": {
+    "address": { "header": "cf-connecting-ip", "from": ["10.0.0.0/8"] },
     "keep": "30d",
     "sample": 0.05,
     "maxPerSecond": 100,
@@ -427,6 +428,7 @@ turning it on.
 
 | Key               | Default         | Description                                                                                                                                                                                    |
 | ----------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `address`         | `{}`            | What is recorded about the client's address: `{ anonymize, header, from }`, or `false` for none. See [the client's address](/guides/calls/#the-clients-address).                               |
 | `keep`            | `"30d"`         | How long a row is kept. The retention sweep prunes them; `false` keeps them forever, which on this table is a decision to make on purpose.                                                     |
 | `sample`          | `1`             | The share of requests recorded, from `0` to `1`. The decision is a hash of the request id seeded with `secret`, so the inbound call and every outbound call it caused agree, in every process. |
 | `maxPerSecond`    | `100`           | The absolute per-process ceiling on rows a second, or `false` for none. Sampling is proportional and a burst is not, so this is what a spike runs into.                                        |

--- a/website/src/content/docs/guides/calls.md
+++ b/website/src/content/docs/guides/calls.md
@@ -23,7 +23,8 @@ means off: no table, no middleware, no allocation.
 
 - **inbound**, one row per call your application answered: the method, the
   path, the route, the status, how long it took, the person when one is
-  known, and the bodies henri can read;
+  known, [where it came from](#the-clients-address), and the bodies henri
+  can read;
 - **outbound**, one row per call your application made: the same, plus the
   service it went to.
 
@@ -127,6 +128,167 @@ still recorded when it failed. Without its bodies -- the decision not to
 capture them was made before the status was known, and there is nothing to go
 back for.
 
+## The client's address
+
+An inbound row records where the request came from, and the hard part is
+not reading a header. Every one of `X-Forwarded-For`, `CF-Connecting-IP`,
+`True-Client-IP` and `X-Real-IP` is text a client typed: whether any of it
+can be believed depends entirely on whether the request really arrived
+through the proxy that sets it.
+
+So a row carries three things rather than one:
+
+| Column   | What it holds                                                                       |
+| -------- | ----------------------------------------------------------------------------------- |
+| `client` | the address henri believes the request came from, or **`null`** when it cannot tell |
+| `peer`   | the address that actually opened the socket, which is never a guess                 |
+| `source` | how `client` was decided: `socket`, `proxy`, `header` or `unverified`               |
+
+The peer is worth keeping even when the client is known: it is the
+difference between _the client says it is 1.2.3.4_ and _1.2.3.4 reached us
+through 172.16.0.9_.
+
+### What henri believes, and when
+
+There are two mechanisms, they answer to two different settings, and neither
+is a default:
+
+1. **`X-Forwarded-For` is [`trustProxy`](/configuration/#keys)'s
+   business.** It is express' `trust proxy` and express already applies it:
+   `req.ip` is the leftmost address the setting says to believe. henri does
+   not re-implement that walk.
+2. **A named header is `calls.address`'s business.** `CF-Connecting-IP` is
+   not an `X-Forwarded-For` and express will never read it. Believing one
+   takes two statements and henri requires both: `header` names it, and
+   `from` lists the proxies allowed to set it.
+
+```json
+{
+  "calls": {
+    "address": {
+      "header": "cf-connecting-ip",
+      "from": ["173.245.48.0/20", "103.21.244.0/22"]
+    }
+  }
+}
+```
+
+Naming a header without `from` **fails the boot**
+(`HENRI_CALLS_ADDRESS_UNVERIFIABLE`), because any client can send a header
+and a configuration that would have henri believe one is a configuration
+worth refusing rather than quietly working.
+
+The whole decision, as a table:
+
+| `trustProxy`        | the request carries a forwarding header | `client`   | `source`     |
+| ------------------- | --------------------------------------- | ---------- | ------------ |
+| anything            | a named header, from a listed proxy     | the header | `header`     |
+| `false`             | either way                              | the peer   | `socket`     |
+| a hop count, a list | no                                      | the peer   | `socket`     |
+| a hop count, a list | yes                                     | `req.ip`   | `proxy`      |
+| `true`              | no                                      | the peer   | `socket`     |
+| `true`              | yes                                     | **`null`** | `unverified` |
+
+### `trustProxy: true` records no address, on purpose
+
+That last row is the one that matters, and it is henri's default setting.
+`trustProxy: true` is express' _believe the leftmost entry, whoever sent
+it_ — the boot already warns that it lets anyone forge the address an
+ip-based rate limit counts. A rate limit that can be escaped is degraded; an
+address column filled from the same header is worse, because it looks like
+an answer.
+
+**An address that is a guess is worse than an empty column.** An operator
+reading a call log is usually answering _who did this_: the empty column
+asks a question and the guess answers one. So the row says `unverified`,
+keeps the peer, and `henri calls` prints it as such:
+
+```
+  2026-09-06T14:22:31.004Z  <- 201        84ms  POST   /orders
+                              from unverified, peer 10.1.2.9
+```
+
+The fix is one line — tell henri how many proxies are in front of it:
+
+```json
+{ "trustProxy": 1 }
+```
+
+`henri audit` reports the combination in a production configuration
+(`calls.address-unverified`), and reports a `from` covering every address
+(`calls.address-from-any`), which is the shape that _would_ let a client
+choose what an operator reads.
+
+### An address is personal data
+
+It gets the same care as the rest of this table rather than an exception:
+
+- it lives in **columns of its own, never in the stored headers**. The
+  forwarding headers are masked in the header blob whatever
+  `filterParameters` says, precisely so the address cannot reach the table
+  through the one place an erasure cannot write into;
+- it is swept by `calls.keep` like every other column;
+- a person's rows answer `henri privacy:export` and `henri privacy:erase`
+  (below);
+- `calls.address.anonymize` truncates it — the last octet of an IPv4 and
+  the last 80 bits of an IPv6, with the prefix length kept in the value, so
+  `203.0.113.0/24` cannot be mistaken for an address somebody really
+  connected from.
+
+```json
+{ "calls": { "address": { "anonymize": true } } }
+```
+
+**It is off by default, and that is a decision.** The column exists to
+answer _who did this_; a `/24` answers _somebody in this city_. A default
+that quietly answers a different question than the one asked is the same
+failure as recording a guess. What makes the whole address safe to hold is
+not truncation but the rules this table already has — off unless
+configured, kept thirty days, masked in the logs, and erasable. Turn it on
+if you keep the log longer than a few weeks, or if your basis for holding
+an address does not stretch that far.
+
+`"address": false` records none of it.
+
+## A person's rows, and a data subject request
+
+The call log holds **values**, which is the whole difference between it and
+the trail — so it answers a data subject request like any other record about
+a person, rather than pointing at its own retention and calling that an
+answer:
+
+- `henri privacy:export <who>` includes the rows whose `actor` is theirs,
+  under a `calls` key of the document;
+- `henri privacy:erase <who>` writes over them: the `actor`, both
+  addresses and the four payload columns go, and the row survives holding
+  the moment, the method, the url, the route, the status, the duration and
+  the request id. That is `onErase: "anonymize"` — the record of a request
+  that did happen, naming nobody.
+
+A row is a person's when it carries their `externalId`, which is the only
+join there is: an anonymous request is an address and nothing henri can tie
+to anybody.
+
+The call log is **best effort** in both, and the receipt says so. An erasure
+that has already written over a person's records must not fail because a
+debugging log was unreachable, so a failure is a warning and a `problem` in
+the receipt rather than a refusal.
+
+### What the neighbours do, and why they are different
+
+- **[The access trail](/guides/trail/) records no address, and is not
+  changing.** It holds field _names_, counts, public identifiers and
+  digests, and refuses a value — which is exactly what lets it outlive the
+  erasure it recorded. It is also hash-chained, so a row written over would
+  break the chain that makes it evidence. An address in it would be
+  personal data in the one table that is kept for a year and cannot be
+  erased from.
+- **`henri.reporter` carries nothing from the client, and is not
+  changing.** A handler gets the method, the route pattern and the status
+  and nothing else — no url, no query, no body, no headers, no user. That
+  is the property that makes it safe to hand to a third-party error
+  service, and an address is from the client.
+
 ## What never reaches a row
 
 Everything stored goes through the same redactor as your logs:
@@ -139,6 +301,11 @@ bodies alike. On top of that:
   `filterParameters` says: `authorization`, `proxy-authorization`, `cookie`,
   `set-cookie`, `x-csrf-token`, `x-api-key` and `webhook-signature`. No
   application should have to remember to write those down;
+- **the forwarding headers are masked too** — `x-forwarded-for`,
+  `x-real-ip`, `cf-connecting-ip`, `true-client-ip` and the rest. They
+  carry addresses, an address is personal data, and the stored headers are
+  the one blob an erasure cannot reach inside: the address belongs in
+  [the columns that can be truncated and erased](#the-clients-address);
 - **a url loses its userinfo**: `https://key:secret@host/` is stored as
   `https://host/`, and the filtered query values are masked;
 - **the person is their `externalId`** and nothing else. Not the primary key,

--- a/website/src/content/docs/guides/logs.md
+++ b/website/src/content/docs/guides/logs.md
@@ -161,6 +161,13 @@ It is the shape `henri.mailers.onDeliverLater()` already established: one handle
 
 And what it never gets, which is the part worth reading twice: **nothing that came from the client and nothing about a person.** No url, no query string, no body, no params, no headers, no cookies, no session and no user. The method, the route pattern and the status are what henri chose; the path is not, because `/users/ada@example.com` is a path in some applications and a personal field in all of them. If you want the record, you have the request id and your own logs.
 
+That includes **the client's address**, which is deliberately not in a
+report and is not going to be: the property that makes a handler safe to
+point at a third-party error service is that henri hands it nothing the
+client chose, and an address is from the client. Where a request came from
+is recorded, under rules of its own, by [the call
+log](/guides/calls/#the-clients-address), and the request id joins the two.
+
 The two deliberate exceptions:
 
 - `error` is handed over as it is. A reporter exists for the stack, and a framework that rewrote your Error would be reporting something that never happened. What an error carries is your business; what henri _adds_ is what the rule governs.

--- a/website/src/content/docs/guides/privacy.md
+++ b/website/src/content/docs/guides/privacy.md
@@ -184,6 +184,34 @@ An application that wants a page rather than a command calls the same thing:
 const document = await henri.privacy.export(req.user);
 ```
 
+## The two framework tables
+
+The walk above is over your **models**, and the tables henri owns itself are
+not models. Two of them hold something about a person, and they answer
+differently on purpose.
+
+**[The call log](/guides/calls/) answers.** It holds values -- the bodies of
+a request, and the address it came from -- so there is something to hand
+over and something to write over, and _wait for `calls.keep` to come round_
+is a deadline rather than an answer to a data subject request. Its rows join
+on the `externalId`, so only the requests a person was signed in for are
+theirs; an anonymous request is an address and nothing henri can tie to
+anybody. The export carries them under a `calls` key, and the erasure writes
+over the `actor`, both addresses and the four payload columns, leaving the
+moment, the method, the url, the route, the status and the request id --
+the record of a request that did happen, naming nobody.
+
+It is **best effort** in both, and the receipt says so: an erasure that has
+already written over a person's records must not fail because a debugging
+log was unreachable.
+
+**[The access trail](/guides/trail/) does not, and that is deliberate.** It
+holds field _names_, counts, public identifiers and digests and refuses a
+value, which is exactly what lets it outlive the erasure it recorded -- it
+is the evidence that the erasure happened. It is also hash-chained, so a row
+written over would break the chain. Its retention is its own clock
+(`trail.keep`).
+
 ## Erasure
 
 ```bash

--- a/website/src/content/docs/guides/security.md
+++ b/website/src/content/docs/guides/security.md
@@ -349,6 +349,17 @@ false` (`calls.kept-forever`: a [call log](/guides/calls/) holds the bodies
 users sent, so a copy of them that nothing ever sweeps is not a setting but
 an accumulation).
 
+**A client address the configuration cannot support** — a
+[`calls.address.from`](/guides/calls/#the-clients-address) covering every
+address (`calls.address-from-any`), which says "believe this header from
+anybody" and lets a client choose the address its own requests are recorded
+under; and, in a configuration a production boot reads, a call log with
+`trustProxy: true` (`calls.address-unverified`). The second is a
+disappointment rather than a hole -- henri refuses to believe a forwarded
+address under a blanket `trustProxy` and records none, which is the point --
+but an empty column nobody was told about is a surprise in an incident, and
+an incident is the worst time to find out.
+
 **Schema changes nobody reviewed** — an `mssql` store with `"sync": true`
 in `config/default.json` or `config/production.json`, which makes a
 production boot run DDL of its own from whatever the models happen to say

--- a/website/src/content/docs/guides/trail.md
+++ b/website/src/content/docs/guides/trail.md
@@ -87,6 +87,15 @@ their `externalId` when they have one, and an HMAC of their address keyed
 with `config.secret`. The address itself is never in the table -- which is
 what makes the trail survive the erasure it recorded.
 
+### It records no address, and is not going to
+
+An IP address is a value about a person, and this table refuses values. It
+would also be the one place holding personal data that an erasure cannot
+reach: the entries are hash-chained, so a row written over breaks the chain
+that makes the trail evidence in the first place. Where a request came from
+belongs in [the call log](/guides/calls/#the-clients-address), which holds
+values on purpose, is kept for days rather than a year, and can be erased.
+
 ## How it stays append-only
 
 A database will happily let anyone `UPDATE` a row, so "append-only" is not a

--- a/website/src/content/docs/reference/errors.md
+++ b/website/src/content/docs/reference/errors.md
@@ -473,6 +473,16 @@ Usually:
 
 The call log of `henri.calls`: the table it owns, the store it lives in and the partitions it sweeps.
 
+### `HENRI_CALLS_ADDRESS_UNVERIFIABLE`
+
+The call log was asked to read the client address out of a header it has no way to verify.
+
+Usually:
+
+- `calls.address.header` names a header and `calls.address.from` names nobody allowed to set it
+
+**Fix.** Any client can send a header, so henri only believes a named one from a proxy the application listed. Add the addresses or the ranges of the proxies in front of henri: `{ "calls": { "address": { "header": "cf-connecting-ip", "from": ["10.0.0.0/8"] } } }`. Remove the header to fall back to `X-Forwarded-For`, which `config.trustProxy` already governs.
+
 ### `HENRI_CALLS_DISABLED`
 
 The call log was read back and this application keeps none.


### PR DESCRIPTION
The owner asked for the client's address in the inbound call log, correct behind Cloudflare or another reverse proxy. The call log had **no address column at all**, and the hard half was never reading a header — it is deciding when a header may be believed.

## What henri believes, and when

Two mechanisms, two settings, neither a default.

1. **`X-Forwarded-For` is `config.trustProxy`'s business.** Express already applies `trust proxy` to produce `req.ip`; henri does not re-implement that walk.
2. **A named header is `calls.address`'s business.** `CF-Connecting-IP` is not an XFF and Express will never read it. Believing one takes *both* `calls.address.header` and `calls.address.from`, the proxies allowed to set it — and a header named with no `from` **fails the boot** rather than quietly working.

The row that matters is the last one below. **`trustProxy: true` is henri's default and is Express's "believe whoever sent it".** A rate limit that can be escaped is a degraded rate limit; an address column filled from the same header is worse, because it reads as an answer.

| `trustProxy` | forwarding header | recorded client | source |
| --- | --- | --- | --- |
| anything | named header from a listed proxy | the header | `header` |
| `false` | either way | the peer | `socket` |
| hop count or list | no / yes | the peer / `req.ip` | `socket` / `proxy` |
| **`true`** | **present** | **null** | **`unverified`** |

The socket peer is kept either way — the difference between "the client says it is 1.2.3.4" and "1.2.3.4 reached us through 172.16.0.9".

## Verified here, not on report

Booted the showcase in production against a scratch database, with the call log on and the default `trustProxy: true`, and forged both headers:

```
request:  X-Forwarded-For: 198.51.100.23   CF-Connecting-IP: 198.51.100.99
row:      client_ip  (null)   ip_source  unverified   peer_ip  127.0.0.1
          the string "198.51.100" appears in 0 rows, anywhere in the row
```

Then configured `calls.address` with the header and `from: ["127.0.0.1/32"]`, so the peer really is a listed proxy:

```
row:      client_ip  198.51.100.99   ip_source  header   peer_ip  127.0.0.1
```

And the boot refusal, directly: `{ header: 'cf-connecting-ip' }` with no `from` throws `HENRI_CALLS_ADDRESS_UNVERIFIABLE` — *"Any client can send cf-connecting-ip. List the addresses or ranges of the proxies in front of henri"*. The boot line says which of the three cases is in force on every boot.

## An address is personal data, and this table already knew that

- The forwarding headers joined the always-masked header set, so the address does not also arrive inside the stored header blob where an erasure cannot reach it.
- **It is in `privacy:export` and `privacy:erase`**, joined on the actor's `externalId`. The trail's "we hold no values, so there is nothing to erase" argument does not transfer to a table that holds values on purpose, and "wait 30 days for the sweep" is a deadline, not an answer. An erasure anonymises in place — the actor, both addresses and the payload columns go; the moment, method, route, status and request id stay — and is best effort with a `problem` in the receipt, because an erasure that already rewrote a person's records must not fail on a debugging log.
- `calls.address.anonymize` truncates to `/24` and `/48` **keeping the prefix in the value** (`203.0.113.0/24`), so a truncated address cannot be mistaken for a real one. **Off by default**, and the argument is the same as for `unverified`: the column exists to answer "who did this", a /24 answers "somebody in this city", and a default that quietly answers a different question is the same failure as a guess.

## The neighbours, deliberately unchanged

The **trail** still records no address: it refuses values by construction and is hash-chained, so an address there would be personal data in the one table kept for a year that an erasure cannot rewrite without breaking the chain that makes it evidence. **`henri.reporter`** still carries nothing from the client, which is what makes it safe to point at a third-party error service. Both are now documented as decisions rather than omissions.

## Also

Two audit checks: `calls.address-from-any` (high, anywhere) for a `from` covering `0.0.0.0/0` — the genuinely dangerous shape, since it lets a client choose its own recorded address — and `calls.address-unverified` (low, production) for `trustProxy: true` with a call log. An existing table gets the three columns by `ALTER TABLE` after the create, idempotently, and PostgreSQL propagates to partitions.

One defensive fix rides along: the forwarding-header check no longer depends on Node joining duplicate headers into a string, because an array would have read as "no header" and recorded a forged address as `socket`.

`pnpm test` (151 files), `pnpm test:sql` against live PostgreSQL (38 files, partitions included), `pnpm test:types`, `pnpm lint --max-warnings 0`, `pnpm format:check` and `scripts/smoke.sh` pass.
