### PR TITLE
decimal and bigint, so money stops being a float

### DIFF
--- a/.changeset/exact-numbers.md
+++ b/.changeset/exact-numbers.md
@@ -1,0 +1,58 @@
+---
+'@usehenri/core': minor
+'@usehenri/drizzle': minor
+'@usehenri/mongoose': minor
+'@usehenri/sequelize': minor
+'@usehenri/cli': minor
+---
+
+**`decimal` and `bigint` are henri types.** The vocabulary had no exact
+number: a model asking for `DECIMAL` got a `double` and one asking for
+`BIGINT` got a 32-bit `integer`, so money was binary floating point on the
+default adapter and a large identifier was a column that refused every
+insert past 2,147,483,647.
+
+`decimal` takes a `precision` (total digits, 19 by default, 38 at most --
+what every dialect henri writes carries) and a `scale` (digits after the
+point, 4 by default). `bigint` is a signed 64-bit integer and takes
+neither. Per dialect: `numeric(p, s)`/`bigint` on PostgreSQL,
+`decimal(p, s)`/`bigint` on MySQL, `Decimal128`/BSON `BigInt` on MongoDB,
+`DECIMAL(p, s)`/`BIGINT` on SQL Server, and `text` on sqlite, which has
+neither an exact decimal nor a 64-bit integer better-sqlite3 hands back
+whole. The stored value is exact everywhere; on sqlite a comparison and an
+order go through a cast, `INTEGER` for a `bigint` (exact, sqlite carries
+64 bits) and `REAL` for a `decimal` -- the one approximation, and the guide
+says so.
+
+**A value of either type is an exact decimal string in JavaScript**, on all
+three adapters: `'19.99'`, `'9223372036854775807'`. Not a `number`, which
+is what the column choice exists to avoid; not a `BigInt`, which
+`JSON.stringify` throws on and henri serializes records in a dozen places;
+not an object, which needs a dependency and survives JSON no better.
+node-postgres, mysql2 and `Decimal128.toString()` already hand back
+strings, so it is the shortest path rather than a conversion. On the way in
+henri takes a string, a `number` (through its shortest round-tripping
+representation, so `19.99` is `'19.99'`) or a `BigInt`. The validators, the
+JSON serialization, the HAL payloads, the OpenAPI description (a `string`
+with a `pattern`, because a JSON number is a double), the GraphQL
+derivation (`String`, because a `Float` would undo it), the query compiler,
+the `params` declarations and the version diffs all agree on that.
+
+**A value the column would have changed is refused rather than rounded**:
+more decimal places than the scale, more digits than the precision, a
+`bigint` outside the 64-bit range, and a JavaScript number that is not a
+safe integer. `0.1 + 0.2` fails validation instead of landing in the
+column. henri does not round money.
+
+**The compatibility spellings point at the real types now.** In a drizzle
+model `DECIMAL`, `NUMERIC` and `BIGINT` resolve to the exact types instead
+of a double and a 32-bit integer; in a sequelize model
+`DataTypes.DECIMAL(10, 2)` is read as the henri decimal and gets the same
+string boundary. Two things are refused at boot instead of downgraded, both
+naming the model and the field (`HENRI_MODEL_TYPE_UNSUPPORTED`): either
+type on a sqlite store served by `@usehenri/sequelize`, whose driver reads
+both through a JavaScript number; and a bare `DataTypes.DECIMAL`, which
+MySQL makes `DECIMAL(10, 0)`.
+
+`henri generate model thing price:decimal` writes `precision: 12, scale: 2`,
+because the default is rarely what money wants.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -378,11 +378,31 @@ request-id,redact,headers,pagination,timeout,health}.js`: `res.resource()` and
   and the models disagree about, which `henri db:status` prints and a
   production boot warns about). Core loads them from the app cwd
   with `utils.resolveFrom('@usehenri/<adapter>')`. Model files use the henri
-  schema format (`type: 'string'|'text'|'number'|'integer'|'float'|'boolean'|
-'date'|'json'|'uuid'`, `required`, `default`, `enum`, `unique`, `index`),
+  schema format (`type: 'string'|'text'|'number'|'integer'|'float'|'decimal'|
+'bigint'|'boolean'|'date'|'json'|'uuid'`, `required`, `default`, `enum`,
+  `unique`, `index`),
   normalized by `schema.js` in each adapter (Sequelize and Drizzle throw on
   unknown keys,
-  Mongoose passes them through). The user model gets `email` (unique,
+  Mongoose passes them through). **`decimal` and `bigint` are the two a
+  JavaScript number cannot carry**, and `base/exact.js` is the argument (a
+  copy per adapter, byte identical, kept so by `src/__tests__/exact.spec.js`,
+  the way `external-id.js` is): a `decimal` has a `precision` (19, at
+  most 38) and a `scale` (4), a `bigint` takes neither, and both cross into
+  JavaScript as exact decimal **strings** on every adapter -- never a
+  `number`, never a `BigInt`, because `JSON.stringify` throws on one and
+  henri serializes records in a dozen places. henri ships no arithmetic. A
+  value with more decimal places than the scale, more digits than the
+  precision, a `bigint` past the signed 64-bit range or a `number` that is
+  not a safe integer is refused rather than rounded, so `0.1 + 0.2` fails
+  validation instead of landing in the column. The columns are
+  `numeric(p, s)`/`bigint` on postgres, `decimal(p, s)`/`bigint` on mysql,
+  `Decimal128`/BSON `BigInt` on MongoDB, `DECIMAL(p, s)`/`BIGINT` on mssql,
+  and on sqlite a `text` of the digits, cast for a comparison only
+  (`dialects.js`: `CAST(... AS INTEGER)`, exact; `CAST(... AS REAL)`, the
+  one approximation). `graphql-schema.js` makes both `String`,
+  `openapi.js` a string with a `pattern` and no numeric bound, and
+  `params-schema.js` a rule type a JSON body must send as a string.
+  The user model gets `email` (unique,
   lowercased), `password` (hashed, not selected by default), `roles`
   (stripped from mass assignment; `setRoles()` or `{ unsafe: true }`) and the
   two dates the account flows write, `confirmedAt` and `passwordChangedAt`.
@@ -1138,5 +1158,21 @@ versions.spec.js`), and on MongoDB through the demo application core's
   schema change that dropped a column, and no route: henri serves no
   version over HTTP, so an application that wants to show a history writes
   the controller and the policy itself.
+- The exact types (`decimal`, `bigint`) are new. **On sqlite a comparison
+  and an order of a `decimal` go through `CAST(... AS REAL)`**, a double,
+  and that is the one approximation henri ships for them: exact to about
+  sixteen significant digits, which is the answer PostgreSQL gives for
+  every value a person writes down, and the nearest double past that. The
+  stored value never goes through it and an equality does not either (the
+  text is canonical), and a `bigint` casts to `INTEGER`, which sqlite
+  carries on 64 bits. `@usehenri/sequelize` **refuses both types on
+  sqlite** at boot (`HENRI_MODEL_TYPE_UNSUPPORTED`, naming the model and
+  the field) rather than reading a value back changed: it has no seam to
+  keep the digits as text and cast for a comparison. That is unreachable
+  through `henri new` -- sqlite goes to Drizzle and Sequelize is only
+  under `@usehenri/mssql` -- and MSSQL itself has only its generated DDL
+  covered, like the rest of that adapter. henri ships no arithmetic and
+  rounds nothing: a value that does not fit the scale is a validation
+  failure, and what to do about it is the application's.
 - The scaffolded app pins ESLint 9 because `eslint-plugin-react` does not
   support ESLint 10 yet.

--- a/packages/cli/__tests__/generate.spec.js
+++ b/packages/cli/__tests__/generate.spec.js
@@ -204,8 +204,14 @@ describe('attribute parsing', () => {
     );
 
     TYPES.forEach((type, index) => {
+      // A decimal is written with a precision and a scale: the default
+      // (19, 4) is not what somebody who typed `price:decimal` meant
+      const settings = type === 'decimal' ? { precision: 12, scale: 2 } : {};
+
       expect(schema[`f${index}`]).toEqual(
-        index % 2 ? { required: true, type } : { type }
+        index % 2
+          ? { required: true, ...settings, type }
+          : { ...settings, type }
       );
     });
     expect(parseAttributes(['name'])).toEqual({ name: { type: 'string' } });
@@ -218,8 +224,8 @@ describe('attribute parsing', () => {
   });
 
   test('rejects unknown types with the list of valid ones', () => {
-    expect(() => parseAttributes(['score:bigint'])).toThrow(
-      /Unknown type "bigint" for attribute "score"\. Valid types: string, text/
+    expect(() => parseAttributes(['score:varchar'])).toThrow(
+      /Unknown type "varchar" for attribute "score"\. Valid types: string, text/
     );
     expect(() => parseAttributes([':string'])).toThrow(/Invalid attribute/);
   });
@@ -270,6 +276,8 @@ describe('henri generate', () => {
           'g:date',
           'h:json',
           'i:uuid',
+          'j:decimal',
+          'k:bigint!',
         ],
         { cwd: app }
       );
@@ -291,6 +299,8 @@ describe('henri generate', () => {
         g: { type: 'date' },
         h: { type: 'json' },
         i: { type: 'uuid' },
+        j: { precision: 12, scale: 2, type: 'decimal' },
+        k: { required: true, type: 'bigint' },
       });
     });
 

--- a/packages/cli/scripts/agents.js
+++ b/packages/cli/scripts/agents.js
@@ -643,7 +643,7 @@ const generators = (facts) => {
 ${lines.join('\n')}
 \`\`\`
 
-Types are \`string, text, number, integer, float, boolean, date, json, uuid\`, and a trailing \`!\` makes the field required. \`Post\` gives \`posts\` (\`Category\` -> \`categories\`, \`Person\` -> \`people\`). An existing file is skipped unless \`--force\`; \`--json\` prints the files written or removed and the routes added. The generators rewrite \`config/routes.js\` through prettier, so comments in that file are lost. Regenerate this file with \`henri generate agents\` whenever the application changes shape.`;
+Types are \`string, text, number, integer, float, decimal, bigint, boolean, date, json, uuid\`, and a trailing \`!\` makes the field required. \`Post\` gives \`posts\` (\`Category\` -> \`categories\`, \`Person\` -> \`people\`). An existing file is skipped unless \`--force\`; \`--json\` prints the files written or removed and the routes added. The generators rewrite \`config/routes.js\` through prettier, so comments in that file are lost. Regenerate this file with \`henri generate agents\` whenever the application changes shape.`;
 };
 
 /**

--- a/packages/cli/scripts/generate.js
+++ b/packages/cli/scripts/generate.js
@@ -19,6 +19,11 @@ const {
 /**
  * The attribute types of the henri model format. Adapters map them to
  * their own types (mongoose: integer -> Number, json -> Mixed, ...).
+ *
+ * `decimal` and `bigint` are the two whose value a JavaScript number
+ * cannot carry, so they are exact decimal strings on every adapter; a
+ * generated `decimal` gets `precision` and `scale` written into the model
+ * file, because the default (19, 4) is rarely what money wants.
  */
 const TYPES = [
   'string',
@@ -26,11 +31,16 @@ const TYPES = [
   'number',
   'integer',
   'float',
+  'decimal',
+  'bigint',
   'boolean',
   'date',
   'json',
   'uuid',
 ];
+
+/** What `price:decimal` writes: money, which is what people mean by one */
+const DECIMAL_SETTINGS = { precision: 12, scale: 2 };
 
 const VIEWS = ['index', '_form', 'new', 'edit', 'show'];
 
@@ -126,7 +136,13 @@ const parseAttributes = (attributes = []) => {
       );
     }
 
-    schema[name] = required ? { required: true, type } : { type };
+    // A decimal with no settings is 19 digits with 4 after the point,
+    // which is not what somebody who typed `price:decimal` meant
+    const settings = type === 'decimal' ? DECIMAL_SETTINGS : {};
+
+    schema[name] = required
+      ? { required: true, ...settings, type }
+      : { ...settings, type };
   }
 
   return schema;

--- a/packages/cli/scripts/help.js
+++ b/packages/cli/scripts/help.js
@@ -35,7 +35,7 @@ const FORCE_FLAG = {
 };
 
 const FIELD_TYPES =
-  'string, text, number, integer, float, boolean, date, json, uuid';
+  'string, text, number, integer, float, decimal, bigint, boolean, date, json, uuid';
 
 /**
  * The catalogue of commands: one entry per command, rendered as text by

--- a/packages/cli/scripts/init.js
+++ b/packages/cli/scripts/init.js
@@ -835,7 +835,8 @@ const sampleResource = async (force) => {
       location,
       await format(`
 // Models are autoloaded from app/models and exposed globally (here: \`Task\`).
-// Types: string, text, number, integer, float, boolean, date, json, uuid.
+// Types: string, text, number, integer, float, decimal, bigint, boolean,
+// date, json, uuid.
 // Keys: type, required, default, enum, unique (anything else is handed to
 // the adapter as is).
 

--- a/packages/core/error-codes.json
+++ b/packages/core/error-codes.json
@@ -1247,6 +1247,16 @@
     {
       "area": "model",
       "causes": [
+        "a `decimal` or a `bigint` on a sqlite store served by `@usehenri/sequelize`, whose driver reads both through a JavaScript number",
+        "a Sequelize `DECIMAL` with no precision, which MySQL makes `DECIMAL(10, 0)` -- whole units, so money loses its cents"
+      ],
+      "code": "HENRI_MODEL_TYPE_UNSUPPORTED",
+      "fix": "The message names the model and the field. On sqlite, use `@usehenri/drizzle`, which stores both exactly, or put the store on postgres, mysql or mssql. For a bare `DECIMAL`, write `{ type: 'decimal', precision: 12, scale: 2 }` and henri writes the same column on every dialect.",
+      "what": "A model field asks for a type this store cannot carry without changing the value."
+    },
+    {
+      "area": "model",
+      "causes": [
         "an option another ORM had: `attributes`, `fields`, `raw`, `transaction`, `individualHooks`",
         "a model file declaring `options: { indexes }`, `scopes`, `hooks`, `tableName` or `underscored` on a drizzle store"
       ],
@@ -1271,7 +1281,7 @@
         "a typo in the type name"
       ],
       "code": "HENRI_MODEL_UNKNOWN_TYPE",
-      "fix": "henri's types are `string`, `text`, `number`, `integer`, `float`, `boolean`, `date`, `json` and `uuid`. The adapter maps them to the ORM's own.",
+      "fix": "henri's types are `string`, `text`, `number`, `integer`, `float`, `decimal`, `bigint`, `boolean`, `date`, `json` and `uuid`. The adapter maps them to the ORM's own.",
       "what": "A model field asks for a type henri does not have."
     },
     {

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -1860,9 +1860,14 @@ declare namespace start {
     default?: unknown | (() => unknown);
     /** The values accepted, checked after the coercion. */
     enum?: unknown[];
-    /** The bounds of a number. */
-    min?: number;
-    max?: number;
+    /**
+     * The bounds of a number. On a `decimal` or a `bigint` they may be
+     * written out (`min: '0.01'`), so a limit past what a JavaScript
+     * number carries exactly can be declared at all; either way they are
+     * compared digit by digit and never through a double.
+     */
+    min?: number | string;
+    max?: number | string;
     /** The bounds of a length: characters of a string, items of a list. */
     minLength?: number;
     maxLength?: number;

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -1902,8 +1902,10 @@ declare namespace start {
 
   /** The field types every adapter understands. */
   type FieldType =
+    | 'bigint'
     | 'boolean'
     | 'date'
+    | 'decimal'
     | 'float'
     | 'integer'
     | 'json'
@@ -1911,6 +1913,17 @@ declare namespace start {
     | 'string'
     | 'text'
     | 'uuid';
+
+  /**
+   * The two whose value a JavaScript `number` cannot carry, and which are
+   * therefore exact decimal **strings** on every adapter: `'19.99'`,
+   * `'9223372036854775807'`. Reading one into a number would undo the
+   * column, which is the reason the types exist.
+   */
+  type ExactFieldType = 'bigint' | 'decimal';
+
+  /** A value of an exact field: the digits, written out. */
+  type ExactValue = string;
 
   /**
    * One field of a model schema.
@@ -1931,6 +1944,18 @@ declare namespace start {
     enum?: unknown[];
     unique?: boolean;
     index?: boolean;
+    /**
+     * Total digits of a `decimal`, defaulting to 19 and capped at 38 --
+     * the most every dialect henri writes carries. Only a `decimal` takes
+     * one; anywhere else it is a boot failure.
+     */
+    precision?: number;
+    /**
+     * Digits after the point of a `decimal`, defaulting to 4. A value with
+     * more of them is refused rather than rounded into the column: money
+     * is the application's to round.
+     */
+    scale?: number;
     /**
      * This field is about a person: masked in the logs, included in the
      * export, erased by an erasure. `{ expose: false }` also keeps it out

--- a/packages/core/src/__tests__/exact-boundary.spec.js
+++ b/packages/core/src/__tests__/exact-boundary.spec.js
@@ -1,0 +1,185 @@
+/* global Invoice */
+const Henri = require('../henri');
+const { columnsOf } = require('../base/openapi');
+const { describe: describeModels, sdlOf } = require('../base/graphql-schema');
+const { anonymousValue } = require('../base/erasure');
+
+/**
+ * What an application gets from a `decimal` and a `bigint`, everywhere the
+ * value leaves the model: the instance, `toJSON()`, what henri publishes,
+ * the version diff, the OpenAPI description and the GraphQL definition. The
+ * round trip runs against MongoDB, through the demo application core's own
+ * tests boot, so the same claim is proved on all three adapters.
+ *
+ * The claim is one sentence: **an exact value is a decimal string, and it
+ * is the same string here as on the SQL adapters.**
+ */
+
+/** A configuration with a user model and nothing else to say */
+const config = { user: { model: 'user' } };
+
+const invoiceModel = {
+  globalId: 'Invoice',
+  identity: 'invoice',
+  options: { timestamps: true },
+  schema: {
+    amount: { precision: 12, scale: 2, type: 'decimal' },
+    rate: { type: 'decimal' },
+    reference: { type: 'bigint', unique: true },
+    title: { required: true, type: 'string' },
+  },
+};
+
+describe('decimal and bigint at the boundary', () => {
+  describe('the description of an exact column', () => {
+    test('openapi keeps the settings the model declared', () => {
+      const columns = columnsOf(invoiceModel, {
+        externalIds: true,
+        references: true,
+        user: config.user,
+      });
+
+      expect(columns.amount).toMatchObject({ scale: 2, type: 'decimal' });
+      expect(columns.reference).toMatchObject({ type: 'bigint' });
+    });
+
+    test('graphql says String, because a Float would undo the column', () => {
+      const [described] = describeModels(
+        [{ ...invoiceModel, graphql: true }],
+        config
+      );
+      const fields = Object.fromEntries(
+        described.fields.map((field) => [field.name, field.type])
+      );
+
+      expect(fields.amount).toBe('String');
+      expect(fields.rate).toBe('String');
+      expect(fields.reference).toBe('String');
+      expect(sdlOf(described)).toContain('amount: String');
+    });
+  });
+
+  describe('erasure', () => {
+    test('anonymizes an exact field to zero, written out', () => {
+      // A string, not 0: the adapter is what pads it to the scale of its
+      // column, and every other value of the field is a string too
+      expect(anonymousValue('amount', { type: 'decimal' }, 'token')).toBe('0');
+      expect(anonymousValue('reference', { type: 'bigint' }, 'token')).toBe(
+        '0'
+      );
+    });
+  });
+
+  describe('through the demo application (mongodb)', () => {
+    const skipWorkers = process.env.SKIP_WORKERS;
+    let counter = 0;
+    let henri;
+
+    beforeAll(async () => {
+      process.env.SKIP_WORKERS = '1';
+      henri = new Henri();
+      await henri.init();
+      global.henri = henri;
+    }, 60000);
+
+    afterAll(async () => {
+      await henri.stop();
+      delete global.henri;
+      if (typeof skipWorkers === 'undefined') {
+        delete process.env.SKIP_WORKERS;
+      } else {
+        process.env.SKIP_WORKERS = skipWorkers;
+      }
+    }, 60000);
+
+    /**
+     * A reference nothing else in this file uses, past 2^53
+     *
+     * @returns {string} the digits
+     */
+    const reference = () => {
+      counter += 1;
+
+      return String(9007199254740993n + BigInt(counter));
+    };
+
+    test('a cent added a hundred times is a dollar, exactly', async () => {
+      let total = 0n;
+
+      for (let index = 0; index < 100; index += 1) {
+        total += 1n;
+      }
+
+      const invoice = await Invoice.create({
+        amount: `${total / 100n}.${total % 100n}`,
+        reference: reference(),
+        title: 'cents',
+      });
+      const read = await Invoice.findById(invoice.externalId);
+
+      expect(read.amount).toBe('1.00');
+      expect(read.amount === '1.00').toBe(true);
+    });
+
+    test('0.1 + 0.2 never reaches the column', async () => {
+      await expect(
+        Invoice.create({
+          rate: 0.1 + 0.2,
+          reference: reference(),
+          title: 'float',
+        })
+      ).rejects.toThrow(/at most 4 decimal places/u);
+    });
+
+    test('a bigint past 2^53 survives the round trip', async () => {
+      const value = '9223372036854775807';
+      const invoice = await Invoice.create({ reference: value, title: 'big' });
+
+      expect(invoice.reference).toBe(value);
+      expect((await Invoice.findById(invoice.externalId)).reference).toBe(
+        value
+      );
+    });
+
+    test('what henri publishes is the string, at every depth', async () => {
+      const invoice = await Invoice.create({
+        amount: '19.99',
+        rate: '0.0125',
+        reference: reference(),
+        title: 'published',
+      });
+      const [published] = await henri.model.publish([invoice]);
+
+      expect(published.amount).toBe('19.99');
+      expect(published.rate).toBe('0.0125');
+      expect(typeof published.reference).toBe('string');
+      // The one that would throw if any of them were a BigInt
+      expect(JSON.parse(JSON.stringify(published)).amount).toBe('19.99');
+    });
+
+    test('a version diff holds the strings, so a restore writes them back', async () => {
+      const invoice = await Invoice.create({
+        amount: '10.00',
+        reference: reference(),
+        title: 'versioned',
+      });
+
+      await invoice.updateOne({ amount: '12.50' });
+
+      const history = await henri.versions.of({
+        model: 'Invoice',
+        record: invoice.externalId,
+      });
+
+      // Both ends of the change, as the strings they are everywhere else:
+      // a version that held a double would restore a different number
+      expect(history[0].changes.amount).toEqual(['10.00', '12.50']);
+      expect(history[1].changes.amount).toEqual([null, '10.00']);
+
+      const reified = await henri.versions.reify(history[0].id);
+
+      expect(reified.attributes.amount).toBe('12.50');
+      expect(reified.complete).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/__tests__/exact.spec.js
+++ b/packages/core/src/__tests__/exact.spec.js
@@ -1,0 +1,249 @@
+const fs = require('fs');
+const path = require('path');
+
+const {
+  BIGINT_MAX,
+  BIGINT_MIN,
+  DEFAULT_PRECISION,
+  DEFAULT_SCALE,
+  EXACT_TYPES,
+  canonical,
+  canonicalInteger,
+  checkSettings,
+  compare,
+  isExact,
+  literalOf,
+  settingsOf,
+  toNumber,
+} = require('../base/exact');
+
+/** The settings a field gets when it says nothing */
+const settings = { precision: DEFAULT_PRECISION, scale: DEFAULT_SCALE };
+
+/** Two decimal places, which is what money looks like */
+const money = { precision: 12, scale: 2 };
+
+describe('exact numbers', () => {
+  test('there are two of them and they are the ones a number cannot carry', () => {
+    expect(EXACT_TYPES).toEqual(['bigint', 'decimal']);
+    expect(isExact('decimal')).toBe(true);
+    expect(isExact('bigint')).toBe(true);
+    expect(isExact('number')).toBe(false);
+    expect(isExact('float')).toBe(false);
+  });
+
+  describe('the copies in the adapters', () => {
+    // Each adapter holds its own, the way `external-id.js` and
+    // `encrypted.js` are held: an adapter depends on no part of core at
+    // runtime. Nothing but this test keeps them the same file.
+    const root = path.join(__dirname, '..', '..', '..');
+    const source = fs.readFileSync(
+      path.join(root, 'core', 'src', 'base', 'exact.js'),
+      'utf8'
+    );
+
+    for (const adapter of ['drizzle', 'mongoose', 'sequelize']) {
+      test(`@usehenri/${adapter} carries the same file, byte for byte`, () => {
+        const copy = fs.readFileSync(
+          path.join(root, adapter, 'exact.js'),
+          'utf8'
+        );
+
+        expect(copy).toBe(source);
+      });
+
+      test(`@usehenri/${adapter} publishes it`, () => {
+        const manifest = JSON.parse(
+          fs.readFileSync(path.join(root, adapter, 'package.json'), 'utf8')
+        );
+
+        expect(manifest.files).toContain('exact.js');
+      });
+    }
+  });
+
+  describe('a decimal', () => {
+    test('is the digits, padded to the scale', () => {
+      expect(canonical('19.99', money)).toEqual({ value: '19.99' });
+      expect(canonical('19.9', money)).toEqual({ value: '19.90' });
+      expect(canonical('19', money)).toEqual({ value: '19.00' });
+      expect(canonical('.5', money)).toEqual({ value: '0.50' });
+      expect(canonical('-2.5', money)).toEqual({ value: '-2.50' });
+    });
+
+    test('keeps the literal a person wrote, through a javascript number', () => {
+      // `String(19.99)` is the shortest representation that round-trips,
+      // so the literal survives even though the double did not hold it
+      expect(canonical(19.99, money)).toEqual({ value: '19.99' });
+      expect(canonical(0.1, settings)).toEqual({ value: '0.1000' });
+    });
+
+    test('refuses arithmetic that already lost the value', () => {
+      expect(canonical(0.1 + 0.2, settings).error).toMatch(
+        /at most 4 decimal places/u
+      );
+      expect(canonical(1 / 3, settings).error).toMatch(
+        /at most 4 decimal places/u
+      );
+    });
+
+    test('reads an exponent, because a javascript number writes one', () => {
+      expect(canonical('1e3', money)).toEqual({ value: '1000.00' });
+      expect(canonical('1.5e-3', settings)).toEqual({ value: '0.0015' });
+      expect(canonical(1e21, { precision: 30, scale: 0 })).toEqual({
+        value: '1000000000000000000000',
+      });
+    });
+
+    test('does not count trailing zeros as decimal places', () => {
+      expect(canonical('19.9900', money)).toEqual({ value: '19.99' });
+      expect(canonical('19.999', money).error).toMatch(
+        /at most 2 decimal places/u
+      );
+    });
+
+    test('counts the digits before the point against the precision', () => {
+      expect(canonical('9999999999.99', money)).toEqual({
+        value: '9999999999.99',
+      });
+      expect(canonical('99999999999.99', money).error).toMatch(
+        /at most 10 digits before the decimal point/u
+      );
+    });
+
+    test('has one spelling of zero, with no sign', () => {
+      expect(canonical('-0.0000', settings)).toEqual({ value: '0.0000' });
+      expect(canonical(0, money)).toEqual({ value: '0.00' });
+    });
+
+    test('is a number or nothing', () => {
+      for (const value of ['', 'nineteen', '0x10', 'Infinity', NaN, {}, true]) {
+        expect(canonical(value, money).error).toBe('must be a decimal number');
+      }
+    });
+
+    test('with a scale of zero is a whole number', () => {
+      const whole = { precision: 10, scale: 0 };
+
+      expect(canonical('42', whole)).toEqual({ value: '42' });
+      expect(canonical('42.5', whole).error).toBe('must be a whole number');
+    });
+  });
+
+  describe('a bigint', () => {
+    test('takes both ends of the signed 64-bit range', () => {
+      expect(canonicalInteger(BIGINT_MAX)).toEqual({ value: BIGINT_MAX });
+      expect(canonicalInteger(BIGINT_MIN)).toEqual({ value: BIGINT_MIN });
+    });
+
+    test('refuses a value past it, rather than wrapping', () => {
+      expect(canonicalInteger('9223372036854775808').error).toBe(
+        `must be between ${BIGINT_MIN} and ${BIGINT_MAX}`
+      );
+    });
+
+    test('takes a BigInt, a safe number and a string', () => {
+      expect(canonicalInteger(42n)).toEqual({ value: '42' });
+      expect(canonicalInteger(42)).toEqual({ value: '42' });
+      expect(canonicalInteger('+007')).toEqual({ value: '7' });
+      expect(canonicalInteger('-0')).toEqual({ value: '0' });
+    });
+
+    test('refuses a number that is not exact, rather than rounding it', () => {
+      expect(canonicalInteger(2 ** 60).error).toMatch(/pass it as a string/u);
+      expect(canonicalInteger(1.5).error).toBe('must be a whole number');
+    });
+
+    test('is a whole number or nothing', () => {
+      for (const value of ['1.0', '1e3', 'x', '', {}, null]) {
+        expect(canonicalInteger(value).error).toBe('must be a whole number');
+      }
+    });
+  });
+
+  describe('the settings of a decimal', () => {
+    test('default to 19 digits with 4 after the point', () => {
+      expect(settingsOf({})).toEqual({ precision: 19, scale: 4 });
+      expect(settingsOf({ scale: 2 })).toEqual({ precision: 19, scale: 2 });
+    });
+
+    test('refuse a precision no dialect carries', () => {
+      expect(checkSettings('decimal', { precision: 39 })).toMatch(
+        /between 1 and 38/u
+      );
+      expect(checkSettings('decimal', { precision: 0 })).toMatch(
+        /between 1 and 38/u
+      );
+    });
+
+    test('refuse a scale bigger than the precision', () => {
+      expect(checkSettings('decimal', { precision: 4, scale: 6 })).toMatch(
+        /more than its precision/u
+      );
+    });
+
+    test('refuse a fraction of a digit', () => {
+      expect(checkSettings('decimal', { scale: 1.5 })).toMatch(
+        /not a whole number/u
+      );
+      expect(checkSettings('decimal', { precision: -2 })).toMatch(
+        /not a whole number/u
+      );
+    });
+
+    test('belong to a decimal and to nothing else', () => {
+      expect(checkSettings('bigint', { scale: 2 })).toBe(
+        "takes no 'scale': only a decimal has one"
+      );
+      expect(checkSettings('string', { precision: 4 })).toBe(
+        "takes no 'precision': only a decimal has one"
+      );
+      expect(checkSettings('bigint', {})).toBeNull();
+      expect(checkSettings('decimal', {})).toBeNull();
+    });
+  });
+
+  describe('comparing', () => {
+    test('is by value and not by letter', () => {
+      // The one a text column gets wrong, and the reason sqlite casts
+      expect(compare('9.99', '10')).toBe(-1);
+      expect(compare('100.50', '99')).toBe(1);
+    });
+
+    test('reads the sign before the magnitude', () => {
+      expect(compare('-2', '-10')).toBe(1);
+      expect(compare('-1', '1')).toBe(-1);
+      expect(compare('0', '-0')).toBe(0);
+    });
+
+    test('ignores how a value was spelled', () => {
+      expect(compare('5', '5.00')).toBe(0);
+      expect(compare('5e0', '5')).toBe(0);
+    });
+
+    test('is exact past what a double carries', () => {
+      expect(compare('9007199254740993', '9007199254740992')).toBe(1);
+      expect(compare('1.0000000000000001', '1')).toBe(1);
+    });
+
+    test('answers null when either side is not a number', () => {
+      expect(compare('x', '1')).toBeNull();
+      expect(compare('1', undefined)).toBeNull();
+    });
+  });
+
+  describe('the pieces the adapters reach for', () => {
+    test('literalOf writes an exponent out', () => {
+      expect(literalOf('1e3')).toBe('1000');
+      expect(literalOf(1e-7)).toBe('0.0000001');
+      expect(literalOf(9n)).toBe('9');
+      expect(literalOf('nope')).toBeNull();
+      expect(literalOf(Infinity)).toBeNull();
+    });
+
+    test('toNumber is the double a dialect without the type compares through', () => {
+      expect(toNumber('19.99')).toBe(19.99);
+      expect(Number.isNaN(toNumber('x'))).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/__tests__/graphql-schema.spec.js
+++ b/packages/core/src/__tests__/graphql-schema.spec.js
@@ -52,7 +52,9 @@ const everything = file('Thing', {
     key: { type: 'uuid' },
     okay: { type: 'boolean' },
     price: { type: 'float' },
+    reference: { type: 'bigint' },
     size: { type: 'number' },
+    total: { scale: 2, type: 'decimal' },
     state: { enum: ['draft', 'published'], type: 'string' },
     title: { required: true, type: 'string' },
   },
@@ -72,15 +74,20 @@ describe('the graphql definition derived from a model', () => {
         key: 'String',
         okay: 'Boolean',
         price: 'Float',
+        // Exact, so String: a Float would undo the column in the answer
+        reference: 'String',
         size: 'Float',
         title: 'String',
+        total: 'String',
       });
     });
 
     test('is the whole table, so nothing is mapped twice', () => {
       expect(Object.keys(TYPES).sort()).toEqual([
+        'bigint',
         'boolean',
         'date',
+        'decimal',
         'float',
         'integer',
         'number',

--- a/packages/core/src/__tests__/graphql-schema.spec.js
+++ b/packages/core/src/__tests__/graphql-schema.spec.js
@@ -54,9 +54,9 @@ const everything = file('Thing', {
     price: { type: 'float' },
     reference: { type: 'bigint' },
     size: { type: 'number' },
-    total: { scale: 2, type: 'decimal' },
     state: { enum: ['draft', 'published'], type: 'string' },
     title: { required: true, type: 'string' },
+    total: { scale: 2, type: 'decimal' },
   },
 });
 

--- a/packages/core/src/__tests__/params.spec.js
+++ b/packages/core/src/__tests__/params.spec.js
@@ -393,6 +393,109 @@ describe('declared parameters', () => {
     });
   });
 
+  describe('an exact type: decimal and bigint', () => {
+    test('a textual source keeps the digits rather than parsing a number', async () => {
+      const res = await app({
+        count: 'bigint',
+        price: 'decimal',
+      }).get('/it?price=19.99&count=9223372036854775807');
+
+      expect(res.status).toBe(200);
+      // Strings, both of them: `Number('9223372036854775807')` is
+      // 9223372036854776000, which is the loss the type exists to avoid
+      expect(res.body.accepted).toEqual({
+        count: '9223372036854775807',
+        price: '19.99',
+      });
+    });
+
+    test('a json body sends them as strings, and says so when it does not', async () => {
+      const ok = await app({ price: 'decimal' }, { verb: 'post' })
+        .post('/it')
+        .send({ price: '19.99' });
+      const wrong = await app({ price: 'decimal' }, { verb: 'post' })
+        .post('/it')
+        .send({ price: 19.99 });
+
+      expect(ok.body.accepted).toEqual({ price: '19.99' });
+      expect(wrong.status).toBe(422);
+      expect(wrong.body.data.errors.price).toBe(
+        'must be a number, written out: a json number is a double (json sent a number)'
+      );
+    });
+
+    test('a bigint is whole, whichever source it came from', async () => {
+      const dotted = await app({ count: 'bigint' }).get('/it?count=1.0');
+      const body = await app({ count: 'bigint' }, { verb: 'post' })
+        .post('/it')
+        .send({ count: '12.5' });
+
+      expect(dotted.status).toBe(422);
+      expect(dotted.body.data.errors.count).toBe(
+        'must be a whole number, written out'
+      );
+      expect(body.status).toBe(422);
+    });
+
+    test('refuses what is not a number at all', async () => {
+      for (const value of ['banana', '0x10', 'Infinity', '2n', '']) {
+        const res = await app({
+          price: { required: true, type: 'decimal' },
+        }).get(`/it?price=${value}`);
+
+        expect(res.status).toBe(422);
+      }
+    });
+
+    test('a bound is compared by value, not letter by letter', async () => {
+      const rule = { min: 10, type: 'decimal' };
+      const below = await app({ price: rule }).get('/it?price=9.99');
+      const above = await app({ price: rule }).get('/it?price=100.50');
+
+      // `'9.99' > '10'` as text, which is the answer this must not give
+      expect(below.status).toBe(422);
+      expect(below.body.data.errors.price).toBe('must be at least 10');
+      expect(above.status).toBe(200);
+    });
+
+    test('a bound may be written out, so it can be past what a double holds', async () => {
+      const rule = { max: '9223372036854775806', type: 'bigint' };
+      const under = await app({ count: rule }).get(
+        '/it?count=9223372036854775806'
+      );
+      const over = await app({ count: rule }).get(
+        '/it?count=9223372036854775807'
+      );
+
+      expect(under.status).toBe(200);
+      expect(over.status).toBe(422);
+    });
+
+    test('an enum is matched by value, so 10 and 10.00 are the same', async () => {
+      const rule = { enum: ['10.00', '20.00'], type: 'decimal' };
+      const res = await app({ price: rule }).get('/it?price=10');
+      const nope = await app({ price: rule }).get('/it?price=15');
+
+      expect(res.status).toBe(200);
+      expect(nope.status).toBe(422);
+    });
+
+    test('a length is not a bound a number has', () => {
+      expect(
+        refused({ index: { price: { maxLength: 4, type: 'decimal' } } })
+      ).toHaveProperty(
+        'message',
+        expect.stringContaining('which a decimal does not take')
+      );
+    });
+
+    test('a rule may be the type on its own', async () => {
+      const res = await app({ total: 'decimal' }).get('/it?total=.5');
+
+      expect(res.body.accepted).toEqual({ total: '0.5' });
+    });
+  });
+
   describe('a typed source: a JSON body', () => {
     /**
      * Posts a JSON body against a declaration

--- a/packages/core/src/__tests__/runtime.spec.js
+++ b/packages/core/src/__tests__/runtime.spec.js
@@ -213,6 +213,7 @@ describe('runtime endpoints (demo app, disk store)', () => {
     });
     expect(res.body.models.map((model) => model.name).sort()).toEqual([
       'Artwork',
+      'Invoice',
       'Memo',
       'User',
     ]);

--- a/packages/core/src/__tests__/utils.spec.js
+++ b/packages/core/src/__tests__/utils.spec.js
@@ -114,7 +114,12 @@ describe('utils', () => {
     test('loads a directory with identity and globalId', () => {
       const models = utils.loadModules(path.join(demo, 'models'));
 
-      expect(Object.keys(models).sort()).toEqual(['artwork', 'memo', 'user']);
+      expect(Object.keys(models).sort()).toEqual([
+        'artwork',
+        'invoice',
+        'memo',
+        'user',
+      ]);
       expect(models.artwork.identity).toBe('artwork');
       expect(models.artwork.globalId).toBe('Artwork');
       expect(models.user.globalId).toBe('User');

--- a/packages/core/src/base/erasure.js
+++ b/packages/core/src/base/erasure.js
@@ -373,6 +373,12 @@ function anonymousValue(field, mark, token) {
     return 0;
   }
 
+  // Zero, written out: an exact value is a string everywhere else, and the
+  // adapter is what pads it to the scale of its column (base/exact.js)
+  if (['bigint', 'decimal'].includes(mark.type)) {
+    return '0';
+  }
+
   if (mark.type === 'boolean') {
     return false;
   }

--- a/packages/core/src/base/exact.js
+++ b/packages/core/src/base/exact.js
@@ -132,6 +132,27 @@ function expand(text) {
 }
 
 /**
+ * The one spelling of a literal: no exponent, no `+`, no leading zeros, a
+ * digit before the point, and no sign on a zero. The digits after the point
+ * are left alone -- they are what the writer said the value was worth to.
+ *
+ * @param {string} literal a literal, already written out
+ * @returns {?string} the same value, spelled once
+ */
+function plain(literal) {
+  const parts = split(literal);
+
+  if (!parts) {
+    return null;
+  }
+
+  const whole = parts.whole.replace(/^0+(?=\d)/u, '');
+  const sign = parts.negative && !isZero(parts) ? '-' : '';
+
+  return `${sign}${whole}${parts.fraction === '' ? '' : `.${parts.fraction}`}`;
+}
+
+/**
  * A value as a decimal literal written out, or null when it is not a number
  *
  * @param {*} value a string, a number or a BigInt
@@ -143,7 +164,7 @@ function literalOf(value) {
   }
 
   if (typeof value === 'number') {
-    return Number.isFinite(value) ? expand(String(value)) : null;
+    return Number.isFinite(value) ? plain(expand(String(value))) : null;
   }
 
   if (typeof value !== 'string') {
@@ -152,7 +173,7 @@ function literalOf(value) {
 
   const text = value.trim();
 
-  return LITERAL.test(text) ? expand(text) : null;
+  return LITERAL.test(text) ? plain(expand(text)) : null;
 }
 
 /**

--- a/packages/core/src/base/exact.js
+++ b/packages/core/src/base/exact.js
@@ -1,0 +1,417 @@
+/**
+ * The two henri types a JavaScript `number` cannot carry: `decimal` and
+ * `bigint`.
+ *
+ * Every other type in the vocabulary has a JavaScript value that *is* the
+ * value: a `string` is a string, a `date` is a Date, an `integer` under
+ * 2^53 is a number. These two do not. A `numeric(19, 4)` read into a double
+ * is a float again, a `bigint` past `Number.MAX_SAFE_INTEGER` loses digits,
+ * and in both cases the column choice is undone by the round trip -- which
+ * is the whole reason the types exist.
+ *
+ * ## The boundary is a string, on all three adapters
+ *
+ * A value of an exact type crosses into JavaScript as a **decimal string**:
+ * `'19.99'`, `'-1'`, `'9223372036854775807'`. Never a `number`, never a
+ * `BigInt`, never an object of henri's own. The reasons, in order:
+ *
+ * - `JSON.stringify` throws on a `BigInt`. henri serializes model records in
+ *   `res.render`, `res.resource`, `res.collection`, the cache (which refuses
+ *   what it cannot encode), the call log, the version diffs, the trail, the
+ *   job payloads and GraphQL. A `BigInt` escaping into any of them is a
+ *   TypeError raised deep inside express, after the controller returned --
+ *   a worse silent difference than the one being removed.
+ * - A decimal object needs a dependency, and it would not survive JSON
+ *   either. henri ships no arithmetic: an application that wants to add two
+ *   prices picks its own library, and hands henri back a string.
+ * - It is the shortest path, not a conversion. node-postgres already hands
+ *   back `numeric` and `int8` as strings, mysql2 hands back `DECIMAL` as a
+ *   string, and `Decimal128.toString()` is exact. Turning any of those into
+ *   a number is what loses the value.
+ * - A string is exact, comparable for equality, JSON-safe, and identical on
+ *   the three adapters -- which is what makes a model file mean one thing
+ *   everywhere.
+ *
+ * ## What is accepted on the way in
+ *
+ * A string (a decimal literal, exponent form included), a `number`, and --
+ * for `bigint` -- a `BigInt`. A number goes through `String(value)`, which
+ * is the shortest representation that round-trips, so the literal a person
+ * typed survives: `String(19.99)` is `'19.99'`. What does *not* survive is
+ * arithmetic that already lost the value, and that is the point:
+ * `0.1 + 0.2` arrives as `'0.30000000000000004'` and is refused by the
+ * scale rather than rounded into the column. henri does not round money.
+ *
+ * ## What is refused
+ *
+ * More decimal places than the declared `scale` (after the trailing zeros,
+ * which are not information), more digits before the point than
+ * `precision - scale`, a `bigint` outside the signed 64-bit range, and a
+ * `number` that is not a safe integer where a whole number was asked for.
+ * Each one is a value the database would have quietly changed.
+ *
+ * This file is duplicated into each adapter (`packages/<adapter>/exact.js`)
+ * the way `external-id.js` and `encrypted.js` are: an adapter depends on no
+ * part of core at runtime. The copies are byte identical and
+ * `src/__tests__/exact.spec.js` is what keeps them so.
+ *
+ * @module exact
+ */
+
+/** The henri types whose values are exact, and therefore strings */
+const EXACT_TYPES = Object.freeze(['bigint', 'decimal']);
+
+/** Total digits of a `decimal` when the field does not say */
+const DEFAULT_PRECISION = 19;
+
+/** Digits after the point when the field does not say */
+const DEFAULT_SCALE = 4;
+
+/**
+ * The most digits every dialect henri writes carries: SQL Server stops at
+ * 38, MySQL at 65, PostgreSQL at 1000. The smallest is the one a model may
+ * ask for, so the same file works everywhere.
+ */
+const MAX_PRECISION = 38;
+
+/** The bounds of a signed 64-bit integer, as the strings a message prints */
+const BIGINT_MIN = '-9223372036854775808';
+
+/** ... and the other end */
+const BIGINT_MAX = '9223372036854775807';
+
+const MIN = BigInt(BIGINT_MIN);
+const MAX = BigInt(BIGINT_MAX);
+
+/** A decimal literal and nothing else: no `0x10`, no `Infinity`, no `1n` */
+const LITERAL = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/u;
+
+/** A whole number, written out */
+const WHOLE = /^[+-]?\d+$/u;
+
+/** A literal in exponent form, split into its parts */
+const EXPONENT = /^([+-]?)(\d*)(?:\.(\d*))?[eE]([+-]?\d+)$/u;
+
+/** A literal written out, split into its parts */
+const PLAIN = /^([+-]?)(\d*)(?:\.(\d*))?$/u;
+
+/**
+ * Is this one of the exact types?
+ *
+ * @param {*} type a type name
+ * @returns {boolean} true for `decimal` and `bigint`
+ */
+const isExact = (type) => EXACT_TYPES.includes(type);
+
+/**
+ * The same literal without its exponent, so everything below is string work
+ *
+ * @param {string} text a decimal literal
+ * @returns {string} the literal written out
+ */
+function expand(text) {
+  const match = EXPONENT.exec(text);
+
+  if (!match) {
+    return text;
+  }
+
+  const [, sign, whole, fraction = '', exponent] = match;
+  const digits = `${whole}${fraction}`;
+  const point = whole.length + Number(exponent);
+
+  if (point <= 0) {
+    return `${sign}0.${'0'.repeat(-point)}${digits}`;
+  }
+
+  if (point >= digits.length) {
+    return `${sign}${digits}${'0'.repeat(point - digits.length)}`;
+  }
+
+  return `${sign}${digits.slice(0, point)}.${digits.slice(point)}`;
+}
+
+/**
+ * A value as a decimal literal written out, or null when it is not a number
+ *
+ * @param {*} value a string, a number or a BigInt
+ * @returns {?string} the literal, or null
+ */
+function literalOf(value) {
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? expand(String(value)) : null;
+  }
+
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const text = value.trim();
+
+  return LITERAL.test(text) ? expand(text) : null;
+}
+
+/**
+ * A literal split into a sign, the digits before the point and the ones
+ * after it
+ *
+ * @param {string} literal a literal written out
+ * @returns {?object} `{ negative, whole, fraction }`, or null
+ */
+function split(literal) {
+  const match = PLAIN.exec(literal);
+
+  if (!match) {
+    return null;
+  }
+
+  const [, sign, whole, fraction = ''] = match;
+
+  if (whole === '' && fraction === '') {
+    return null;
+  }
+
+  return {
+    fraction,
+    negative: sign === '-',
+    whole: whole === '' ? '0' : whole,
+  };
+}
+
+/**
+ * The `precision` and `scale` of a decimal field, defaulted
+ *
+ * @param {object} [field] the normalized field
+ * @returns {{precision: number, scale: number}} what the column carries
+ */
+const settingsOf = (field) => ({
+  precision: Number.isInteger(field && field.precision)
+    ? field.precision
+    : DEFAULT_PRECISION,
+  scale: Number.isInteger(field && field.scale) ? field.scale : DEFAULT_SCALE,
+});
+
+/**
+ * What is wrong with the `precision` and `scale` a field declares, if
+ * anything. An adapter raises its own coded error with the sentence.
+ *
+ * @param {string} type the henri type of the field
+ * @param {object} [field] the field definition
+ * @returns {?string} what is wrong, or null
+ */
+function checkSettings(type, field) {
+  const given = field || {};
+  const declared = ['precision', 'scale'].filter((key) => key in given);
+
+  if (type !== 'decimal') {
+    return declared.length > 0
+      ? `takes no '${declared[0]}': only a decimal has one`
+      : null;
+  }
+
+  for (const key of declared) {
+    if (!Number.isInteger(given[key]) || given[key] < 0) {
+      return `has a '${key}' that is not a whole number`;
+    }
+  }
+
+  const { precision, scale } = settingsOf(given);
+
+  if (precision < 1 || precision > MAX_PRECISION) {
+    return `has a 'precision' of ${precision}: it is between 1 and ${MAX_PRECISION}, the most every dialect henri writes carries`;
+  }
+
+  if (scale > precision) {
+    return `has a 'scale' of ${scale}, which is more than its precision of ${precision}`;
+  }
+
+  return null;
+}
+
+/**
+ * A decimal value as the exact string the column holds, at its scale
+ *
+ * @param {*} value what the application passed
+ * @param {object} settings `{ precision, scale }`
+ * @returns {{value: string}|{error: string}} the value, or what is wrong
+ */
+function canonical(value, settings) {
+  const { precision, scale } = settings;
+  const literal = literalOf(value);
+  const parts = literal === null ? null : split(literal);
+
+  if (!parts) {
+    return { error: 'must be a decimal number' };
+  }
+
+  const fraction = parts.fraction.replace(/0+$/u, '');
+
+  if (fraction.length > scale) {
+    return {
+      error:
+        scale === 0
+          ? 'must be a whole number'
+          : `must have at most ${scale} decimal place${
+              scale === 1 ? '' : 's'
+            }, and rounding is the application's to do`,
+    };
+  }
+
+  const whole = parts.whole.replace(/^0+(?=\d)/u, '');
+  const digits = precision - scale;
+
+  if (whole !== '0' && whole.length > digits) {
+    return {
+      error: `must have at most ${digits} digit${
+        digits === 1 ? '' : 's'
+      } before the decimal point`,
+    };
+  }
+
+  const padded = fraction.padEnd(scale, '0');
+  const body = scale > 0 ? `${whole}.${padded}` : whole;
+  const zero = whole === '0' && !/[1-9]/u.test(padded);
+
+  return { value: `${parts.negative && !zero ? '-' : ''}${body}` };
+}
+
+/**
+ * A bigint value as the exact string the column holds
+ *
+ * @param {*} value what the application passed
+ * @returns {{value: string}|{error: string}} the value, or what is wrong
+ */
+function canonicalInteger(value) {
+  if (typeof value === 'bigint') {
+    return bounded(value);
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isInteger(value)) {
+      return { error: 'must be a whole number' };
+    }
+
+    return Number.isSafeInteger(value)
+      ? bounded(BigInt(value))
+      : {
+          error:
+            'is past what a javascript number carries exactly: pass it as a string',
+        };
+  }
+
+  if (typeof value !== 'string' || !WHOLE.test(value.trim())) {
+    return { error: 'must be a whole number' };
+  }
+
+  return bounded(BigInt(value.trim()));
+}
+
+/**
+ * The value, when it fits a signed 64-bit column
+ *
+ * @param {bigint} value the value
+ * @returns {{value: string}|{error: string}} the value, or what is wrong
+ */
+function bounded(value) {
+  return value < MIN || value > MAX
+    ? { error: `must be between ${BIGINT_MIN} and ${BIGINT_MAX}` }
+    : { value: value.toString() };
+}
+
+/**
+ * Two exact numbers compared without going through a double
+ *
+ * @param {*} left one value
+ * @param {*} right the other
+ * @returns {?number} -1, 0 or 1, and null when either is not a number
+ */
+function compare(left, right) {
+  const one = literalOf(left);
+  const two = literalOf(right);
+  const first = one === null ? null : split(one);
+  const second = two === null ? null : split(two);
+
+  if (!first || !second) {
+    return null;
+  }
+
+  // A zero has no sign to compare, so `-0` and `0` are the same value
+  const below = first.negative && !isZero(first);
+  const under = second.negative && !isZero(second);
+
+  if (below !== under) {
+    return below ? -1 : 1;
+  }
+
+  const size = magnitude(first, second);
+
+  return below ? -size : size;
+}
+
+/**
+ * Is this value zero, whatever it was written as?
+ *
+ * @param {object} parts a split literal
+ * @returns {boolean} true for every spelling of zero
+ */
+const isZero = (parts) =>
+  !/[1-9]/u.test(parts.whole) && !/[1-9]/u.test(parts.fraction);
+
+/**
+ * The two magnitudes compared, sign left out
+ *
+ * @param {object} first a split literal
+ * @param {object} second another
+ * @returns {number} -1, 0 or 1
+ */
+function magnitude(first, second) {
+  const left = first.whole.replace(/^0+(?=\d)/u, '');
+  const right = second.whole.replace(/^0+(?=\d)/u, '');
+
+  if (left.length !== right.length) {
+    return left.length < right.length ? -1 : 1;
+  }
+
+  if (left !== right) {
+    return left < right ? -1 : 1;
+  }
+
+  const size = Math.max(first.fraction.length, second.fraction.length);
+  const one = first.fraction.padEnd(size, '0');
+  const two = second.fraction.padEnd(size, '0');
+
+  if (one === two) {
+    return 0;
+  }
+
+  return one < two ? -1 : 1;
+}
+
+/**
+ * The double a dialect without an exact type has to compare through
+ *
+ * @param {*} value an exact value
+ * @returns {number} the nearest double
+ */
+const toNumber = (value) => Number(literalOf(value) ?? NaN);
+
+module.exports = {
+  BIGINT_MAX,
+  BIGINT_MIN,
+  DEFAULT_PRECISION,
+  DEFAULT_SCALE,
+  EXACT_TYPES,
+  MAX_PRECISION,
+  canonical,
+  canonicalInteger,
+  checkSettings,
+  compare,
+  isExact,
+  literalOf,
+  settingsOf,
+  toNumber,
+};

--- a/packages/core/src/base/exact.js
+++ b/packages/core/src/base/exact.js
@@ -146,7 +146,7 @@ function plain(literal) {
     return null;
   }
 
-  const whole = parts.whole.replace(/^0+(?=\d)/u, '');
+  const whole = withoutLeadingZeros(parts.whole);
   const sign = parts.negative && !isZero(parts) ? '-' : '';
 
   return `${sign}${whole}${parts.fraction === '' ? '' : `.${parts.fraction}`}`;
@@ -217,6 +217,46 @@ const settingsOf = (field) => ({
 });
 
 /**
+ * The digits without their trailing zeros, and without their leading ones.
+ *
+ * Walked rather than matched. `/0+$/` is quadratic on a fraction that is a
+ * long run of zeros followed by a digit -- `0.000…0001`, which is a decimal
+ * a request may legitimately carry -- and 200,000 of them took 17 seconds
+ * here before this was two index walks. The same shape has been fixed twice
+ * elsewhere in this repository (`uploads/src/names.js`, the cdn base of
+ * `uploads/src/signing.js`), and the rule is the one those state: a value
+ * that reaches a pattern from a request is walked.
+ *
+ * @param {string} digits the fraction, as written
+ * @returns {string} the same without trailing zeros
+ */
+function withoutTrailingZeros(digits) {
+  let end = digits.length;
+
+  while (end > 0 && digits[end - 1] === '0') {
+    end -= 1;
+  }
+
+  return digits.slice(0, end);
+}
+
+/**
+ * The whole part without its leading zeros, keeping one digit
+ *
+ * @param {string} digits the whole part, as written
+ * @returns {string} the same without leading zeros
+ */
+function withoutLeadingZeros(digits) {
+  let start = 0;
+
+  while (start < digits.length - 1 && digits[start] === '0') {
+    start += 1;
+  }
+
+  return digits.slice(start);
+}
+
+/**
  * What is wrong with the `precision` and `scale` a field declares, if
  * anything. An adapter raises its own coded error with the sentence.
  *
@@ -269,7 +309,7 @@ function canonical(value, settings) {
     return { error: 'must be a decimal number' };
   }
 
-  const fraction = parts.fraction.replace(/0+$/u, '');
+  const fraction = withoutTrailingZeros(parts.fraction);
 
   if (fraction.length > scale) {
     return {
@@ -282,7 +322,7 @@ function canonical(value, settings) {
     };
   }
 
-  const whole = parts.whole.replace(/^0+(?=\d)/u, '');
+  const whole = withoutLeadingZeros(parts.whole);
   const digits = precision - scale;
 
   if (whole !== '0' && whole.length > digits) {
@@ -390,8 +430,8 @@ const isZero = (parts) =>
  * @returns {number} -1, 0 or 1
  */
 function magnitude(first, second) {
-  const left = first.whole.replace(/^0+(?=\d)/u, '');
-  const right = second.whole.replace(/^0+(?=\d)/u, '');
+  const left = withoutLeadingZeros(first.whole);
+  const right = withoutLeadingZeros(second.whole);
 
   if (left.length !== right.length) {
     return left.length < right.length ? -1 : 1;

--- a/packages/core/src/base/graphql-schema.js
+++ b/packages/core/src/base/graphql-schema.js
@@ -46,6 +46,7 @@
  * | `string`, `text`       | `String`                                       |
  * | `integer`              | `Int`                                          |
  * | `number`, `float`      | `Float`                                        |
+ * | `decimal`, `bigint`    | `String` (exact; a `Float` would undo it)      |
  * | `boolean`              | `Boolean`                                      |
  * | `date`                 | `String` (ISO 8601, what the JSON answer holds) |
  * | `uuid`                 | `String`                                       |
@@ -123,10 +124,23 @@ const { GENERATED, columnsOf, referenceOf, settingsOf } = require('./openapi');
 const { isPlainObject, mapOf } = require('./privacy');
 const { pluralize } = require('./routes');
 
-/** The henri schema types and the GraphQL type each one becomes */
+/**
+ * The henri schema types and the GraphQL type each one becomes.
+ *
+ * `decimal` and `bigint` are `String`, for the same reason the OpenAPI
+ * description calls them strings: GraphQL's `Float` is a double and its
+ * `Int` is 32 bits, so either one would undo the column in the answer --
+ * which is the whole thing the two types exist to stop. henri defines no
+ * custom scalar for them, because a scalar is a `GraphQLScalarType`
+ * instance and core depends on the `graphql` package for nothing (see the
+ * header of this file); the value is already a string at the boundary, so
+ * `String` is what it is, not a fallback.
+ */
 const TYPES = Object.freeze({
+  bigint: 'String',
   boolean: 'Boolean',
   date: 'String',
+  decimal: 'String',
   float: 'Float',
   integer: 'Int',
   number: 'Float',

--- a/packages/core/src/base/openapi.js
+++ b/packages/core/src/base/openapi.js
@@ -140,10 +140,23 @@ const METHODS = new Set([
 /**
  * The henri schema types and what they serialize as. `json` is deliberately
  * `{}`: a JSON column holds whatever the application put in it.
+ *
+ * `decimal` and `bigint` are deliberately **strings**, and that is not a
+ * looser description than the truth -- it is the truth. A JSON number is a
+ * double, so describing an exact column as `{ "type": "number" }` would
+ * tell a client to parse the value into the one shape that cannot hold it,
+ * which is what the two types exist to stop. The `pattern` says what the
+ * string is, and the `format` says which kind (`base/exact.js`).
  */
 const TYPES = {
+  bigint: { format: 'int64', pattern: '^-?\\d+$', type: 'string' },
   boolean: { type: 'boolean' },
   date: { format: 'date-time', type: 'string' },
+  decimal: {
+    format: 'decimal',
+    pattern: '^-?\\d+(\\.\\d+)?$',
+    type: 'string',
+  },
   float: { type: 'number' },
   integer: { type: 'integer' },
   json: {},
@@ -152,6 +165,9 @@ const TYPES = {
   text: { type: 'string' },
   uuid: { format: 'uuid', type: 'string' },
 };
+
+/** The two whose value is a string because a double cannot carry it */
+const EXACT = ['bigint', 'decimal'];
 
 /** Columns henri writes itself: they never belong in a request body */
 const GENERATED = new Set([
@@ -529,6 +545,11 @@ function fieldSchema(name, field, { resolves, settings, write = false }) {
     if (known.format) {
       schema.format = known.format;
     }
+
+    // A `pattern` says nothing about a null, so it widens nothing
+    if (known.pattern) {
+      schema.pattern = known.pattern;
+    }
   }
 
   if (
@@ -572,12 +593,18 @@ function fieldSchema(name, field, { resolves, settings, write = false }) {
     }
   }
 
-  if (!published && Number.isFinite(definition.min)) {
-    schema.minimum = definition.min;
-  }
+  // `minimum` and `maximum` describe a JSON number, and the value of an
+  // exact column is a string: writing them there would be describing a
+  // bound on something the document just said is not a number. The bound
+  // is still enforced -- by the model, which is where it was declared
+  if (!published && !EXACT.includes(definition.type)) {
+    if (Number.isFinite(definition.min)) {
+      schema.minimum = definition.min;
+    }
 
-  if (!published && Number.isFinite(definition.max)) {
-    schema.maximum = definition.max;
+    if (Number.isFinite(definition.max)) {
+      schema.maximum = definition.max;
+    }
   }
 
   return description.length > 0
@@ -604,6 +631,8 @@ function ruleSchema(compiled) {
   const known = TYPES[written.type];
   const schema = {};
 
+  const exact = EXACT.includes(written.type);
+
   if (list) {
     schema.type = 'array';
     schema.items = ruleSchema(written.of);
@@ -612,6 +641,10 @@ function ruleSchema(compiled) {
 
     if (known.format) {
       schema.format = known.format;
+    }
+
+    if (known.pattern) {
+      schema.pattern = known.pattern;
     }
   }
 
@@ -623,11 +656,13 @@ function ruleSchema(compiled) {
     schema.default = written.default;
   }
 
-  if (Number.isFinite(written.min)) {
+  // The bound of an exact rule is not a bound on a JSON number: the value
+  // is a string there, for the reason TYPES gives above
+  if (!exact && Number.isFinite(written.min)) {
     schema.minimum = written.min;
   }
 
-  if (Number.isFinite(written.max)) {
+  if (!exact && Number.isFinite(written.max)) {
     schema.maximum = written.max;
   }
 

--- a/packages/core/src/base/params-schema.js
+++ b/packages/core/src/base/params-schema.js
@@ -32,10 +32,10 @@
  * bounds a request genuinely needs. A rule is an object, or the type itself
  * (`year: 'integer'` is `year: { type: 'integer' }`):
  *
- * - `type`: `string`, `text`, `number`, `integer`, `float`, `boolean`,
- *   `date`, `json`, `uuid` -- the henri schema types -- and `array`, which a
- *   query string produces on its own (`?tag=a&tag=b`) and nothing else could
- *   express.
+ * - `type`: `string`, `text`, `number`, `integer`, `float`, `decimal`,
+ *   `bigint`, `boolean`, `date`, `json`, `uuid` -- the henri schema types --
+ *   and `array`, which a query string produces on its own (`?tag=a&tag=b`)
+ *   and nothing else could express.
  * - `required`: the field has to be there.
  * - `default`: what an absent field is worth. A function is called per
  *   request, so `default: () => new Date()` is a value and not a shared one.
@@ -62,9 +62,17 @@
  *   Date. There is no other way for a client to say 2 there.
  * - **A typed source** -- a JSON body -- is *checked*, never parsed:
  *   `{"page": "2"}` is a caller sending a string where the action declared a
- *   number, and it is refused. JSON can say 2; it said "2". The two types
- *   JSON cannot express are the exception and are read from a string there
- *   as well: a `date` is an ISO-8601 string and a `uuid` is a string.
+ *   number, and it is refused. JSON can say 2; it said "2". The types JSON
+ *   cannot express are the exception and are read from a string there as
+ *   well: a `date` is an ISO-8601 string, a `uuid` is a string, and so are
+ *   a `decimal` and a `bigint` -- a JSON number *is* a double, so
+ *   `{"price": 19.99}` is already the value those two exist to avoid, and
+ *   it is refused with that as the reason.
+ *
+ * An exact value stays the string it arrived as, whichever source it came
+ * from, because that is what it is everywhere else (`base/exact.js`). A
+ * rule says nothing about a precision or a scale: it describes a request,
+ * and the model is what says which values fit the column.
  *
  * The rest follows from those two: an empty string from a textual source is
  * an absent field (a browser sends one for every input nobody touched)
@@ -114,6 +122,7 @@
  */
 
 const { fail } = require('./errors');
+const { compare, isExact, literalOf } = require('./exact');
 const { isUuid } = require('./external-id');
 const { page } = require('./http');
 const { respond } = require('./auth');
@@ -130,8 +139,10 @@ const MESSAGE = 'the parameters are invalid';
 /** The types a rule may declare */
 const TYPES = [
   'array',
+  'bigint',
   'boolean',
   'date',
+  'decimal',
   'float',
   'integer',
   'json',
@@ -144,8 +155,10 @@ const TYPES = [
 /** What each type is, in words, for the message a person reads */
 const WORDS = {
   array: 'must be a list',
+  bigint: 'must be a whole number, written out',
   boolean: 'must be true or false',
   date: 'must be a date',
+  decimal: 'must be a number, written out',
   float: 'must be a number',
   integer: 'must be a whole number',
   json: 'must be json',
@@ -157,10 +170,19 @@ const WORDS = {
 
 /** The types a constraint applies to; every other key is in BASE */
 const APPLIES = {
-  enum: ['float', 'integer', 'number', 'string', 'text', 'uuid'],
-  max: ['float', 'integer', 'number'],
+  enum: [
+    'bigint',
+    'decimal',
+    'float',
+    'integer',
+    'number',
+    'string',
+    'text',
+    'uuid',
+  ],
+  max: ['bigint', 'decimal', 'float', 'integer', 'number'],
   maxLength: ['array', 'string', 'text'],
-  min: ['float', 'integer', 'number'],
+  min: ['bigint', 'decimal', 'float', 'integer', 'number'],
   minLength: ['array', 'string', 'text'],
   of: ['array'],
   pattern: ['string', 'text'],
@@ -374,8 +396,21 @@ function finish(compiled, where, field) {
     throw invalid(where, `declares "${field}" with ${what}`);
   };
 
+  const exact = isExact(compiled.type);
+
   for (const key of ['max', 'maxLength', 'min', 'minLength']) {
-    if (key in compiled && typeof compiled[key] !== 'number') {
+    if (!(key in compiled)) {
+      continue;
+    }
+
+    // The bound of an exact rule may be written out, the way its values
+    // are, so a limit past what a double carries can be declared at all
+    const written =
+      exact &&
+      (key === 'max' || key === 'min') &&
+      literalOf(compiled[key]) !== null;
+
+    if (!written && typeof compiled[key] !== 'number') {
       bad(`a "${key}" that is not a number`);
     }
   }
@@ -514,6 +549,17 @@ function typed(compiled, given, strict = false) {
     return isUuid(given) ? null : WORDS.uuid;
   }
 
+  // The third kind JSON cannot carry, and the one where it looks like it
+  // can: a JSON number *is* a double, so `{"price": 19.99}` is already the
+  // value the exact types exist to avoid. It has to be written out
+  if (isExact(type)) {
+    if (typeof given !== 'string') {
+      return `${WORDS[type]}: a json number is a double`;
+    }
+
+    return exactly(type, given) === null ? WORDS[type] : null;
+  }
+
   if (type === 'boolean') {
     return typeof given === 'boolean' ? null : WORDS.boolean;
   }
@@ -528,6 +574,28 @@ function typed(compiled, given, strict = false) {
 
   return type === 'integer' && !Number.isInteger(given) ? WORDS.integer : null;
 }
+
+/**
+ * One exact value, written out, or null when it is not one.
+ *
+ * A rule says nothing about a precision or a scale -- it describes a
+ * request, not a column, and the model is what says which values fit -- so
+ * the only thing settled here is the shape: the digits, with any exponent
+ * written out, so an action never has to read `1e3` or `.5`.
+ *
+ * @param {string} type `decimal` or `bigint`
+ * @param {*} given the value
+ * @returns {?string} the digits, or null
+ */
+const exactly = (type, given) => {
+  const literal = literalOf(given);
+
+  if (literal === null) {
+    return null;
+  }
+
+  return type === 'decimal' || !literal.includes('.') ? literal : null;
+};
 
 /**
  * Is this a date? A Date, or -- since JSON has no other way of carrying one
@@ -558,6 +626,23 @@ function constrain(compiled, given) {
   const { enum: allowed, max, maxLength, min, minLength, pattern } = compiled;
   const sized = typeof given === 'string' || Array.isArray(given);
   const unit = Array.isArray(given) ? 'items' : 'characters';
+  // An exact value is a string, so `<` would compare it letter by letter
+  // and answer that 9.99 is more than 10
+  const exact = isExact(compiled.type);
+
+  if (exact) {
+    if (typeof min !== 'undefined' && compare(given, min) < 0) {
+      return `must be at least ${min}`;
+    }
+
+    if (typeof max !== 'undefined' && compare(given, max) > 0) {
+      return `must be at most ${max}`;
+    }
+
+    return allowed && !allowed.some((entry) => compare(given, entry) === 0)
+      ? `must be one of ${allowed.join(', ')}`
+      : null;
+  }
 
   if (typeof min === 'number' && given < min) {
     return `must be at least ${min}`;
@@ -621,6 +706,12 @@ function keep(compiled, given, nested) {
 
   if (compiled.type === 'date') {
     return { value: given instanceof Date ? given : new Date(given) };
+  }
+
+  // The digits, with any exponent written out: the same value an action
+  // gets from a query string, so the source stops mattering
+  if (isExact(compiled.type)) {
+    return { value: exactly(compiled.type, given) };
   }
 
   if (compiled.type === 'array') {
@@ -693,6 +784,14 @@ function scalar(type, given) {
     return Number.isNaN(time)
       ? { error: WORDS.date }
       : { value: new Date(time) };
+  }
+
+  // An exact value stays a string: turning it into a number here is
+  // exactly the loss the type was declared to avoid
+  if (isExact(type)) {
+    const digits = exactly(type, given.trim());
+
+    return digits === null ? { error: WORDS[type] } : { value: digits };
   }
 
   const number = DECIMAL.test(given.trim()) ? Number(given.trim()) : NaN;

--- a/packages/demo/app/models/Invoice.js
+++ b/packages/demo/app/models/Invoice.js
@@ -1,0 +1,24 @@
+// The two types a JavaScript number cannot carry, on the adapter core's
+// tests boot: `decimal` for money and `bigint` for an identifier that comes
+// from somewhere else and does not fit a 32-bit column.
+//
+// A double would answer `1.0000000000000007` for a hundred cents and
+// `9223372036854776000` for the largest 64-bit integer, so both cross into
+// JavaScript as exact decimal strings on every adapter -- `'19.99'`,
+// `'9223372036854775807'` -- and that is what `res.resource()`, `toJSON()`
+// and a version diff hold. See `base/exact.js`.
+module.exports = {
+  options: { timestamps: true, versioned: true },
+  schema: {
+    // Money: two digits after the point, and a value with more of them is
+    // refused rather than rounded into the column
+    amount: { precision: 12, scale: 2, type: 'decimal' },
+    // The default settings, 19 digits with 4 after the point: a unit price
+    // wants more than money does
+    rate: { type: 'decimal' },
+    // What the accounting system calls it. Past 2,147,483,647, which is
+    // where an `integer` column stopped
+    reference: { type: 'bigint', unique: true },
+    title: { required: true, type: 'string' },
+  },
+};

--- a/packages/drizzle/__tests__/exact.spec.js
+++ b/packages/drizzle/__tests__/exact.spec.js
@@ -1,0 +1,291 @@
+const { ValidationError } = require('../validation');
+const { build, target } = require('./helpers');
+
+/**
+ * The point of `decimal` and `bigint` is that the value comes back the way
+ * it went in. Every test here writes a value and reads it back, and asserts
+ * it is the *same* value rather than a near one -- on sqlite offline, and
+ * on the live PostgreSQL and MySQL of `pnpm test:sql:live`, which is where
+ * the bugs of this change would only ever have shown up.
+ */
+
+const invoiceModel = {
+  globalId: 'Invoice',
+  identity: 'invoice',
+  options: { timestamps: false },
+  schema: {
+    // The one people reach for: money
+    amount: { scale: 2, type: 'decimal' },
+    // The default settings, 19 total digits and 4 after the point
+    rate: { type: 'decimal' },
+    // A 64-bit identifier, the other half of the change
+    reference: { type: 'bigint' },
+    name: { type: 'string' },
+  },
+  store: 'default',
+};
+
+describe(`decimal and bigint (${target.name})`, () => {
+  let adapter;
+  let Invoice;
+
+  beforeAll(async () => {
+    ({ adapter } = build());
+    Invoice = adapter.addModel(invoiceModel);
+    await adapter.start();
+  });
+
+  afterAll(async () => {
+    await adapter.stop();
+  });
+
+  describe('the round trip', () => {
+    test('a cent added a hundred times is a dollar, exactly', async () => {
+      // The demonstration: the same loop through a double gives
+      // 1.0000000000000007, and `that sum === 1.00` is false
+      const invoice = await Invoice.create({ amount: '0.00', name: 'cents' });
+      let total = 0n;
+
+      for (let index = 0; index < 100; index += 1) {
+        total += 1n;
+      }
+
+      await invoice.update({ amount: `${total / 100n}.${total % 100n}` });
+
+      const read = await Invoice.findByKey(invoice.id);
+
+      expect(read.amount).toBe('1.00');
+      expect(read.amount === '1.00').toBe(true);
+    });
+
+    test('0.1 + 0.2 is refused rather than stored as 0.30000000000000004', async () => {
+      // A double arriving where an exact column was asked for is the whole
+      // silent difference: henri will not round it into the column
+      await expect(
+        Invoice.create({ name: 'float', rate: 0.1 + 0.2 })
+      ).rejects.toThrow(ValidationError);
+
+      const created = await Invoice.create({ name: 'exact', rate: '0.3' });
+
+      expect(created.rate).toBe('0.3000');
+      expect((await Invoice.findByKey(created.id)).rate).toBe('0.3000');
+    });
+
+    test('the literal a person writes down survives a javascript number', async () => {
+      const created = await Invoice.create({ amount: 19.99, name: 'literal' });
+
+      expect(created.amount).toBe('19.99');
+      expect((await Invoice.findByKey(created.id)).amount).toBe('19.99');
+    });
+
+    test('a bigint past 2^53 comes back whole', async () => {
+      const values = [
+        '9223372036854775807',
+        '-9223372036854775808',
+        '9007199254740993',
+        '0',
+      ];
+
+      for (const reference of values) {
+        const created = await Invoice.create({ name: 'big', reference });
+        const read = await Invoice.findByKey(created.id);
+
+        expect(created.reference).toBe(reference);
+        expect(read.reference).toBe(reference);
+      }
+    });
+
+    test('a value that would overflow a 32-bit integer column is stored', async () => {
+      // What `BIGINT` used to become: `ERROR: integer out of range`
+      const created = await Invoice.create({
+        name: 'overflow',
+        reference: '2147483648',
+      });
+
+      expect((await Invoice.findByKey(created.id)).reference).toBe(
+        '2147483648'
+      );
+    });
+
+    test('every value is a string, whatever the dialect handed back', async () => {
+      const created = await Invoice.create({
+        amount: '1.50',
+        name: 'types',
+        rate: '0.0001',
+        reference: 7,
+      });
+      const read = await Invoice.findByKey(created.id);
+
+      expect(typeof read.amount).toBe('string');
+      expect(typeof read.rate).toBe('string');
+      expect(typeof read.reference).toBe('string');
+      expect(read.reference).toBe('7');
+    });
+
+    test('a null stays null', async () => {
+      const created = await Invoice.create({ name: 'empty' });
+      const read = await Invoice.findByKey(created.id);
+
+      expect(read.amount).toBeNull();
+      expect(read.reference).toBeNull();
+    });
+  });
+
+  describe('what leaves the server', () => {
+    test('toJSON keeps the string, so JSON.stringify never throws', async () => {
+      const created = await Invoice.create({
+        amount: '12.34',
+        name: 'json',
+        reference: '9223372036854775807',
+      });
+      const body = JSON.parse(JSON.stringify(created));
+
+      expect(body.amount).toBe('12.34');
+      expect(body.reference).toBe('9223372036854775807');
+    });
+  });
+
+  describe('the bounds of the column', () => {
+    test('more decimal places than the scale is a validation error', async () => {
+      await expect(
+        Invoice.create({ amount: '19.999', name: 'too precise' })
+      ).rejects.toThrow(/at most 2 decimal places/u);
+    });
+
+    test('trailing zeros are not decimal places', async () => {
+      const created = await Invoice.create({
+        amount: '19.9900',
+        name: 'padded',
+      });
+
+      expect(created.amount).toBe('19.99');
+    });
+
+    test('more digits than the precision is a validation error', async () => {
+      await expect(
+        Invoice.create({ name: 'too big', rate: '12345678901234567' })
+      ).rejects.toThrow(/at most 15 digits before the decimal point/u);
+    });
+
+    test('a bigint outside the signed 64-bit range is refused', async () => {
+      await expect(
+        Invoice.create({ name: 'past', reference: '9223372036854775808' })
+      ).rejects.toThrow(
+        /between -9223372036854775808 and 9223372036854775807/u
+      );
+    });
+
+    test('a javascript number past the safe range is refused, not rounded', async () => {
+      await expect(
+        Invoice.create({ name: 'unsafe', reference: 2 ** 60 })
+      ).rejects.toThrow(/pass it as a string/u);
+    });
+
+    test('a value that is not a number at all is refused', async () => {
+      await expect(
+        Invoice.create({ amount: 'nineteen', name: 'words' })
+      ).rejects.toThrow(/must be a decimal number/u);
+    });
+  });
+
+  describe('querying', () => {
+    let Ledger;
+
+    beforeAll(async () => {
+      Ledger = adapter.addModel({
+        globalId: 'Ledger',
+        identity: 'ledger',
+        options: { timestamps: false },
+        schema: {
+          count: { type: 'bigint' },
+          label: { type: 'string' },
+          total: { scale: 2, type: 'decimal' },
+        },
+        store: 'default',
+      });
+
+      await adapter.start();
+
+      for (const [label, total, count] of [
+        ['a', '9.99', '9223372036854775807'],
+        ['b', '10.00', '-5'],
+        ['c', '100.50', '0'],
+        ['d', '-2.50', '9007199254740993'],
+      ]) {
+        await Ledger.create({ count, label, total });
+      }
+    });
+
+    test('an equality finds the row however the value was spelled', async () => {
+      for (const value of ['10.00', '10', 10, '1e1']) {
+        const found = await Ledger.findOne({ total: value });
+
+        expect(found && found.label).toBe('b');
+      }
+    });
+
+    test('a greater-than is a number, not text', async () => {
+      // `'9.99' > '10'` lexicographically, which is the answer a text
+      // column gives without the cast of ./dialects.js
+      const rows = await Ledger.find(
+        { total: { gt: '10' } },
+        {
+          order: 'label',
+        }
+      );
+
+      expect(rows.map((row) => row.label)).toEqual(['c']);
+    });
+
+    test('a range keeps the negative values below zero', async () => {
+      const rows = await Ledger.find({ total: { lt: '0' } });
+
+      expect(rows.map((row) => row.label)).toEqual(['d']);
+    });
+
+    test('between reads both ends', async () => {
+      const rows = await Ledger.find(
+        { total: { between: ['9.99', '10.00'] } },
+        { order: 'label' }
+      );
+
+      expect(rows.map((row) => row.label)).toEqual(['a', 'b']);
+    });
+
+    test('an order is numeric', async () => {
+      const rows = await Ledger.find({}, { order: 'total' });
+
+      expect(rows.map((row) => row.label)).toEqual(['d', 'a', 'b', 'c']);
+    });
+
+    test('a bigint comparison is exact past 2^53', async () => {
+      const rows = await Ledger.find(
+        { count: { gt: '9007199254740992' } },
+        { order: 'label' }
+      );
+
+      expect(rows.map((row) => row.label)).toEqual(['a', 'd']);
+    });
+
+    test('a bigint order is numeric, negatives included', async () => {
+      const rows = await Ledger.find({}, { order: 'count' });
+
+      expect(rows.map((row) => row.label)).toEqual(['b', 'c', 'd', 'a']);
+    });
+
+    test('an `in` takes the values however they were spelled', async () => {
+      const rows = await Ledger.find(
+        { total: ['9.99', 10] },
+        { order: 'label' }
+      );
+
+      expect(rows.map((row) => row.label)).toEqual(['a', 'b']);
+    });
+
+    test('a condition that is not a number is refused, not matched as text', async () => {
+      await expect(Ledger.find({ total: 'ten' })).rejects.toThrow(
+        /HENRI_MODEL_INVALID_QUERY|must be a decimal number/u
+      );
+    });
+  });
+});

--- a/packages/drizzle/__tests__/exact.spec.js
+++ b/packages/drizzle/__tests__/exact.spec.js
@@ -288,4 +288,88 @@ describe(`decimal and bigint (${target.name})`, () => {
       );
     });
   });
+  describe('what the definition itself may say', () => {
+    const { normalizeSchema } = require('../schema');
+
+    test('a bound that measures text fails the boot', () => {
+      expect(() =>
+        normalizeSchema({ price: { maxLength: 4, type: 'decimal' } })
+      ).toThrow(/which measures text/u);
+      expect(() =>
+        normalizeSchema({ count: { match: /x/u, type: 'bigint' } })
+      ).toThrow(/which measures text/u);
+    });
+
+    test('a precision or a scale belongs to a decimal alone', () => {
+      expect(() =>
+        normalizeSchema({ count: { scale: 2, type: 'bigint' } })
+      ).toThrow(/takes no 'scale'/u);
+      expect(() =>
+        normalizeSchema({ price: { precision: 99, type: 'decimal' } })
+      ).toThrow(/between 1 and 38/u);
+    });
+
+    test('the sequelize spellings point at the exact types', () => {
+      const fields = normalizeSchema({
+        big: 'BIGINT',
+        money: 'DECIMAL',
+        num: 'NUMERIC',
+      });
+
+      // They used to be a double and a 32-bit integer
+      expect(fields.big.type).toBe('bigint');
+      expect(fields.money.type).toBe('decimal');
+      expect(fields.num.type).toBe('decimal');
+    });
+
+    test('a default and an enum are canonicalized with the field', () => {
+      const fields = normalizeSchema({
+        price: { default: 5, enum: [5, '10.5'], scale: 2, type: 'decimal' },
+      });
+
+      expect(fields.price.default).toBe('5.00');
+      expect(fields.price.enum).toEqual(['5.00', '10.50']);
+    });
+
+    test('a default the column would not carry fails the boot', () => {
+      expect(() =>
+        normalizeSchema({
+          price: { default: 0.1 + 0.2, scale: 2, type: 'decimal' },
+        })
+      ).toThrow(/has a 'default'/u);
+    });
+  });
+
+  describe('the bounds a model declares', () => {
+    let Priced;
+
+    beforeAll(async () => {
+      Priced = adapter.addModel({
+        globalId: 'Priced',
+        identity: 'priced',
+        options: { timestamps: false },
+        schema: {
+          // `'9.99' > '10'` as text, which is the answer this must not give
+          price: { min: '10', scale: 2, type: 'decimal' },
+          seats: { max: '9223372036854775806', type: 'bigint' },
+        },
+        store: 'default',
+      });
+
+      await adapter.start();
+    });
+
+    test('are compared by value, not letter by letter', async () => {
+      await expect(Priced.create({ price: '9.99' })).rejects.toThrow(
+        /must be at least 10/u
+      );
+      await expect(
+        Priced.create({ seats: '9223372036854775807' })
+      ).rejects.toThrow(/must be at most/u);
+
+      const ok = await Priced.create({ price: '100.50', seats: '5' });
+
+      expect(ok.price).toBe('100.50');
+    });
+  });
 });

--- a/packages/drizzle/__tests__/exact.spec.js
+++ b/packages/drizzle/__tests__/exact.spec.js
@@ -16,11 +16,11 @@ const invoiceModel = {
   schema: {
     // The one people reach for: money
     amount: { scale: 2, type: 'decimal' },
+    name: { type: 'string' },
     // The default settings, 19 total digits and 4 after the point
     rate: { type: 'decimal' },
     // A 64-bit identifier, the other half of the change
     reference: { type: 'bigint' },
-    name: { type: 'string' },
   },
   store: 'default',
 };

--- a/packages/drizzle/__tests__/schema.spec.js
+++ b/packages/drizzle/__tests__/schema.spec.js
@@ -42,7 +42,9 @@ describe('schema normalizer', () => {
       key: 'uuid',
       name: { type: 'string' },
       notes: 'text',
+      price: { type: 'decimal' },
       ratio: 'float',
+      reference: 'bigint',
       settings: 'json',
       weight: 'number',
     });
@@ -58,7 +60,9 @@ describe('schema normalizer', () => {
       key: 'uuid',
       name: 'string',
       notes: 'text',
+      price: 'decimal',
       ratio: 'float',
+      reference: 'bigint',
       settings: 'json',
       weight: 'number',
     });
@@ -66,8 +70,10 @@ describe('schema normalizer', () => {
 
   test('documents the same names as the types map', () => {
     expect(Object.keys(types).sort()).toEqual([
+      'bigint',
       'boolean',
       'date',
+      'decimal',
       'float',
       'integer',
       'json',

--- a/packages/drizzle/dialects.js
+++ b/packages/drizzle/dialects.js
@@ -154,6 +154,47 @@ const sqlite = {
   affected: (result) => Number((result && result.changes) || 0),
 
   /**
+   * The bound value of a comparison against a cast column
+   *
+   * @param {*} value A canonical exact value
+   * @param {object} field The normalized field
+   * @returns {*} What to bind
+   */
+  bind: (value, field) =>
+    field.type === 'bigint' ? BigInt(value) : toNumber(value),
+
+  /**
+   * How an exact column is compared and ordered.
+   *
+   * sqlite has neither an exact decimal nor a 64-bit integer a driver hands
+   * back whole -- better-sqlite3 returns `9223372036854775807` as
+   * `9223372036854776000` unless every read asks for BigInts -- so both
+   * types keep their digits in a `text` column, which round-trips the
+   * *value* exactly. A comparison is a different question from a value, and
+   * text answers it wrongly (`'9.99' > '10'` lexicographically), so the
+   * comparison is the one thing that goes through a cast:
+   *
+   * - a `bigint` casts to `INTEGER`, which sqlite carries on 64 bits: the
+   *   answer is exact.
+   * - a `decimal` casts to `REAL`, and that is the one approximation henri
+   *   ships for these types. It is a double, so it is exact to about
+   *   sixteen significant digits and gives the same answer PostgreSQL does
+   *   for every value a person writes down; past that it is the nearest
+   *   double. The stored value never goes through it.
+   *
+   * The bound value is cast the same way, because sqlite would otherwise
+   * compare a number against text and sort every number first.
+   *
+   * @param {object} column The Drizzle column
+   * @param {object} field The normalized field
+   * @returns {object} An SQL expression
+   */
+  cast: (column, field) =>
+    field.type === 'bigint'
+      ? sql`CAST(${column} AS INTEGER)`
+      : sql`CAST(${column} AS REAL)`,
+
+  /**
    * Closes the database
    *
    * @param {object} client A better-sqlite3 database
@@ -320,47 +361,6 @@ const sqlite = {
 
     return error;
   },
-
-  /**
-   * How an exact column is compared and ordered.
-   *
-   * sqlite has neither an exact decimal nor a 64-bit integer a driver hands
-   * back whole -- better-sqlite3 returns `9223372036854775807` as
-   * `9223372036854776000` unless every read asks for BigInts -- so both
-   * types keep their digits in a `text` column, which round-trips the
-   * *value* exactly. A comparison is a different question from a value, and
-   * text answers it wrongly (`'9.99' > '10'` lexicographically), so the
-   * comparison is the one thing that goes through a cast:
-   *
-   * - a `bigint` casts to `INTEGER`, which sqlite carries on 64 bits: the
-   *   answer is exact.
-   * - a `decimal` casts to `REAL`, and that is the one approximation henri
-   *   ships for these types. It is a double, so it is exact to about
-   *   sixteen significant digits and gives the same answer PostgreSQL does
-   *   for every value a person writes down; past that it is the nearest
-   *   double. The stored value never goes through it.
-   *
-   * The bound value is cast the same way, because sqlite would otherwise
-   * compare a number against text and sort every number first.
-   *
-   * @param {object} column The Drizzle column
-   * @param {object} field The normalized field
-   * @returns {object} An SQL expression
-   */
-  cast: (column, field) =>
-    field.type === 'bigint'
-      ? sql`CAST(${column} AS INTEGER)`
-      : sql`CAST(${column} AS REAL)`,
-
-  /**
-   * The bound value of a comparison against a cast column
-   *
-   * @param {*} value A canonical exact value
-   * @param {object} field The normalized field
-   * @returns {*} What to bind
-   */
-  compared: (value, field) =>
-    field.type === 'bigint' ? BigInt(value) : toNumber(value),
 
   /**
    * Column builder for a normalized field

--- a/packages/drizzle/dialects.js
+++ b/packages/drizzle/dialects.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { sql } = require('drizzle-orm');
+const { settingsOf, toNumber } = require('./exact');
 
 /**
  * Everything that differs between sqlite, postgres and mysql: the driver,
@@ -321,6 +322,47 @@ const sqlite = {
   },
 
   /**
+   * How an exact column is compared and ordered.
+   *
+   * sqlite has neither an exact decimal nor a 64-bit integer a driver hands
+   * back whole -- better-sqlite3 returns `9223372036854775807` as
+   * `9223372036854776000` unless every read asks for BigInts -- so both
+   * types keep their digits in a `text` column, which round-trips the
+   * *value* exactly. A comparison is a different question from a value, and
+   * text answers it wrongly (`'9.99' > '10'` lexicographically), so the
+   * comparison is the one thing that goes through a cast:
+   *
+   * - a `bigint` casts to `INTEGER`, which sqlite carries on 64 bits: the
+   *   answer is exact.
+   * - a `decimal` casts to `REAL`, and that is the one approximation henri
+   *   ships for these types. It is a double, so it is exact to about
+   *   sixteen significant digits and gives the same answer PostgreSQL does
+   *   for every value a person writes down; past that it is the nearest
+   *   double. The stored value never goes through it.
+   *
+   * The bound value is cast the same way, because sqlite would otherwise
+   * compare a number against text and sort every number first.
+   *
+   * @param {object} column The Drizzle column
+   * @param {object} field The normalized field
+   * @returns {object} An SQL expression
+   */
+  cast: (column, field) =>
+    field.type === 'bigint'
+      ? sql`CAST(${column} AS INTEGER)`
+      : sql`CAST(${column} AS REAL)`,
+
+  /**
+   * The bound value of a comparison against a cast column
+   *
+   * @param {*} value A canonical exact value
+   * @param {object} field The normalized field
+   * @returns {*} What to bind
+   */
+  compared: (value, field) =>
+    field.type === 'bigint' ? BigInt(value) : toNumber(value),
+
+  /**
    * Column builder for a normalized field
    *
    * @param {object} core drizzle-orm/sqlite-core
@@ -332,6 +374,10 @@ const sqlite = {
     switch (field.type) {
       case 'integer':
         return core.integer(column);
+      // The digits, exactly; see `cast` above
+      case 'bigint':
+      case 'decimal':
+        return core.text(column);
       case 'number':
       case 'float':
         return core.real(column);
@@ -467,6 +513,16 @@ const postgres = {
     switch (field.type) {
       case 'integer':
         return core.integer(column);
+      case 'bigint':
+        // Node-postgres hands `int8` back as a string and drizzle turns it
+        // into a BigInt; henri's own hooks make it the decimal string every
+        // adapter answers with (packages/drizzle/exact.js)
+        return core.bigint(column, { mode: 'bigint' });
+      case 'decimal': {
+        const { precision, scale } = settingsOf(field);
+
+        return core.numeric(column, { precision, scale });
+      }
       case 'number':
         return core.doublePrecision(column);
       case 'float':
@@ -519,7 +575,13 @@ const mysql = {
    */
   connect: async (config, paths) => {
     const driver = requireDriver('mysql2/promise', paths);
-    const options = credentials(config);
+    // Without this mysql2 reads a BIGINT through a double, so
+    // 9223372036854775807 comes back as 9223372036854776000 and the
+    // `bigint` column would be a lie. With it, a value past what a
+    // JavaScript number carries exactly arrives as a string and everything
+    // smaller is untouched -- so henri's own BIGINT tables (the queue, the
+    // trail, the call log, the versions) keep reading numbers
+    const options = { supportBigNumbers: true, ...credentials(config) };
 
     if (config.url) {
       options.uri = config.url.replace(/^mariadb:/i, 'mysql:');
@@ -607,6 +669,16 @@ const mysql = {
     switch (field.type) {
       case 'integer':
         return core.int(column);
+      case 'bigint':
+        // Mysql2 needs `supportBigNumbers` (set in credentials() above) to
+        // hand a value past 2^53 back whole; drizzle then makes it a BigInt
+        // and henri's own hooks make it the decimal string
+        return core.bigint(column, { mode: 'bigint' });
+      case 'decimal': {
+        const { precision, scale } = settingsOf(field);
+
+        return core.decimal(column, { precision, scale });
+      }
       case 'number':
         return core.double(column);
       case 'float':

--- a/packages/drizzle/exact.js
+++ b/packages/drizzle/exact.js
@@ -132,6 +132,27 @@ function expand(text) {
 }
 
 /**
+ * The one spelling of a literal: no exponent, no `+`, no leading zeros, a
+ * digit before the point, and no sign on a zero. The digits after the point
+ * are left alone -- they are what the writer said the value was worth to.
+ *
+ * @param {string} literal a literal, already written out
+ * @returns {?string} the same value, spelled once
+ */
+function plain(literal) {
+  const parts = split(literal);
+
+  if (!parts) {
+    return null;
+  }
+
+  const whole = parts.whole.replace(/^0+(?=\d)/u, '');
+  const sign = parts.negative && !isZero(parts) ? '-' : '';
+
+  return `${sign}${whole}${parts.fraction === '' ? '' : `.${parts.fraction}`}`;
+}
+
+/**
  * A value as a decimal literal written out, or null when it is not a number
  *
  * @param {*} value a string, a number or a BigInt
@@ -143,7 +164,7 @@ function literalOf(value) {
   }
 
   if (typeof value === 'number') {
-    return Number.isFinite(value) ? expand(String(value)) : null;
+    return Number.isFinite(value) ? plain(expand(String(value))) : null;
   }
 
   if (typeof value !== 'string') {
@@ -152,7 +173,7 @@ function literalOf(value) {
 
   const text = value.trim();
 
-  return LITERAL.test(text) ? expand(text) : null;
+  return LITERAL.test(text) ? plain(expand(text)) : null;
 }
 
 /**

--- a/packages/drizzle/exact.js
+++ b/packages/drizzle/exact.js
@@ -1,0 +1,417 @@
+/**
+ * The two henri types a JavaScript `number` cannot carry: `decimal` and
+ * `bigint`.
+ *
+ * Every other type in the vocabulary has a JavaScript value that *is* the
+ * value: a `string` is a string, a `date` is a Date, an `integer` under
+ * 2^53 is a number. These two do not. A `numeric(19, 4)` read into a double
+ * is a float again, a `bigint` past `Number.MAX_SAFE_INTEGER` loses digits,
+ * and in both cases the column choice is undone by the round trip -- which
+ * is the whole reason the types exist.
+ *
+ * ## The boundary is a string, on all three adapters
+ *
+ * A value of an exact type crosses into JavaScript as a **decimal string**:
+ * `'19.99'`, `'-1'`, `'9223372036854775807'`. Never a `number`, never a
+ * `BigInt`, never an object of henri's own. The reasons, in order:
+ *
+ * - `JSON.stringify` throws on a `BigInt`. henri serializes model records in
+ *   `res.render`, `res.resource`, `res.collection`, the cache (which refuses
+ *   what it cannot encode), the call log, the version diffs, the trail, the
+ *   job payloads and GraphQL. A `BigInt` escaping into any of them is a
+ *   TypeError raised deep inside express, after the controller returned --
+ *   a worse silent difference than the one being removed.
+ * - A decimal object needs a dependency, and it would not survive JSON
+ *   either. henri ships no arithmetic: an application that wants to add two
+ *   prices picks its own library, and hands henri back a string.
+ * - It is the shortest path, not a conversion. node-postgres already hands
+ *   back `numeric` and `int8` as strings, mysql2 hands back `DECIMAL` as a
+ *   string, and `Decimal128.toString()` is exact. Turning any of those into
+ *   a number is what loses the value.
+ * - A string is exact, comparable for equality, JSON-safe, and identical on
+ *   the three adapters -- which is what makes a model file mean one thing
+ *   everywhere.
+ *
+ * ## What is accepted on the way in
+ *
+ * A string (a decimal literal, exponent form included), a `number`, and --
+ * for `bigint` -- a `BigInt`. A number goes through `String(value)`, which
+ * is the shortest representation that round-trips, so the literal a person
+ * typed survives: `String(19.99)` is `'19.99'`. What does *not* survive is
+ * arithmetic that already lost the value, and that is the point:
+ * `0.1 + 0.2` arrives as `'0.30000000000000004'` and is refused by the
+ * scale rather than rounded into the column. henri does not round money.
+ *
+ * ## What is refused
+ *
+ * More decimal places than the declared `scale` (after the trailing zeros,
+ * which are not information), more digits before the point than
+ * `precision - scale`, a `bigint` outside the signed 64-bit range, and a
+ * `number` that is not a safe integer where a whole number was asked for.
+ * Each one is a value the database would have quietly changed.
+ *
+ * This file is duplicated into each adapter (`packages/<adapter>/exact.js`)
+ * the way `external-id.js` and `encrypted.js` are: an adapter depends on no
+ * part of core at runtime. The copies are byte identical and
+ * `src/__tests__/exact.spec.js` is what keeps them so.
+ *
+ * @module exact
+ */
+
+/** The henri types whose values are exact, and therefore strings */
+const EXACT_TYPES = Object.freeze(['bigint', 'decimal']);
+
+/** Total digits of a `decimal` when the field does not say */
+const DEFAULT_PRECISION = 19;
+
+/** Digits after the point when the field does not say */
+const DEFAULT_SCALE = 4;
+
+/**
+ * The most digits every dialect henri writes carries: SQL Server stops at
+ * 38, MySQL at 65, PostgreSQL at 1000. The smallest is the one a model may
+ * ask for, so the same file works everywhere.
+ */
+const MAX_PRECISION = 38;
+
+/** The bounds of a signed 64-bit integer, as the strings a message prints */
+const BIGINT_MIN = '-9223372036854775808';
+
+/** ... and the other end */
+const BIGINT_MAX = '9223372036854775807';
+
+const MIN = BigInt(BIGINT_MIN);
+const MAX = BigInt(BIGINT_MAX);
+
+/** A decimal literal and nothing else: no `0x10`, no `Infinity`, no `1n` */
+const LITERAL = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/u;
+
+/** A whole number, written out */
+const WHOLE = /^[+-]?\d+$/u;
+
+/** A literal in exponent form, split into its parts */
+const EXPONENT = /^([+-]?)(\d*)(?:\.(\d*))?[eE]([+-]?\d+)$/u;
+
+/** A literal written out, split into its parts */
+const PLAIN = /^([+-]?)(\d*)(?:\.(\d*))?$/u;
+
+/**
+ * Is this one of the exact types?
+ *
+ * @param {*} type a type name
+ * @returns {boolean} true for `decimal` and `bigint`
+ */
+const isExact = (type) => EXACT_TYPES.includes(type);
+
+/**
+ * The same literal without its exponent, so everything below is string work
+ *
+ * @param {string} text a decimal literal
+ * @returns {string} the literal written out
+ */
+function expand(text) {
+  const match = EXPONENT.exec(text);
+
+  if (!match) {
+    return text;
+  }
+
+  const [, sign, whole, fraction = '', exponent] = match;
+  const digits = `${whole}${fraction}`;
+  const point = whole.length + Number(exponent);
+
+  if (point <= 0) {
+    return `${sign}0.${'0'.repeat(-point)}${digits}`;
+  }
+
+  if (point >= digits.length) {
+    return `${sign}${digits}${'0'.repeat(point - digits.length)}`;
+  }
+
+  return `${sign}${digits.slice(0, point)}.${digits.slice(point)}`;
+}
+
+/**
+ * A value as a decimal literal written out, or null when it is not a number
+ *
+ * @param {*} value a string, a number or a BigInt
+ * @returns {?string} the literal, or null
+ */
+function literalOf(value) {
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? expand(String(value)) : null;
+  }
+
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const text = value.trim();
+
+  return LITERAL.test(text) ? expand(text) : null;
+}
+
+/**
+ * A literal split into a sign, the digits before the point and the ones
+ * after it
+ *
+ * @param {string} literal a literal written out
+ * @returns {?object} `{ negative, whole, fraction }`, or null
+ */
+function split(literal) {
+  const match = PLAIN.exec(literal);
+
+  if (!match) {
+    return null;
+  }
+
+  const [, sign, whole, fraction = ''] = match;
+
+  if (whole === '' && fraction === '') {
+    return null;
+  }
+
+  return {
+    fraction,
+    negative: sign === '-',
+    whole: whole === '' ? '0' : whole,
+  };
+}
+
+/**
+ * The `precision` and `scale` of a decimal field, defaulted
+ *
+ * @param {object} [field] the normalized field
+ * @returns {{precision: number, scale: number}} what the column carries
+ */
+const settingsOf = (field) => ({
+  precision: Number.isInteger(field && field.precision)
+    ? field.precision
+    : DEFAULT_PRECISION,
+  scale: Number.isInteger(field && field.scale) ? field.scale : DEFAULT_SCALE,
+});
+
+/**
+ * What is wrong with the `precision` and `scale` a field declares, if
+ * anything. An adapter raises its own coded error with the sentence.
+ *
+ * @param {string} type the henri type of the field
+ * @param {object} [field] the field definition
+ * @returns {?string} what is wrong, or null
+ */
+function checkSettings(type, field) {
+  const given = field || {};
+  const declared = ['precision', 'scale'].filter((key) => key in given);
+
+  if (type !== 'decimal') {
+    return declared.length > 0
+      ? `takes no '${declared[0]}': only a decimal has one`
+      : null;
+  }
+
+  for (const key of declared) {
+    if (!Number.isInteger(given[key]) || given[key] < 0) {
+      return `has a '${key}' that is not a whole number`;
+    }
+  }
+
+  const { precision, scale } = settingsOf(given);
+
+  if (precision < 1 || precision > MAX_PRECISION) {
+    return `has a 'precision' of ${precision}: it is between 1 and ${MAX_PRECISION}, the most every dialect henri writes carries`;
+  }
+
+  if (scale > precision) {
+    return `has a 'scale' of ${scale}, which is more than its precision of ${precision}`;
+  }
+
+  return null;
+}
+
+/**
+ * A decimal value as the exact string the column holds, at its scale
+ *
+ * @param {*} value what the application passed
+ * @param {object} settings `{ precision, scale }`
+ * @returns {{value: string}|{error: string}} the value, or what is wrong
+ */
+function canonical(value, settings) {
+  const { precision, scale } = settings;
+  const literal = literalOf(value);
+  const parts = literal === null ? null : split(literal);
+
+  if (!parts) {
+    return { error: 'must be a decimal number' };
+  }
+
+  const fraction = parts.fraction.replace(/0+$/u, '');
+
+  if (fraction.length > scale) {
+    return {
+      error:
+        scale === 0
+          ? 'must be a whole number'
+          : `must have at most ${scale} decimal place${
+              scale === 1 ? '' : 's'
+            }, and rounding is the application's to do`,
+    };
+  }
+
+  const whole = parts.whole.replace(/^0+(?=\d)/u, '');
+  const digits = precision - scale;
+
+  if (whole !== '0' && whole.length > digits) {
+    return {
+      error: `must have at most ${digits} digit${
+        digits === 1 ? '' : 's'
+      } before the decimal point`,
+    };
+  }
+
+  const padded = fraction.padEnd(scale, '0');
+  const body = scale > 0 ? `${whole}.${padded}` : whole;
+  const zero = whole === '0' && !/[1-9]/u.test(padded);
+
+  return { value: `${parts.negative && !zero ? '-' : ''}${body}` };
+}
+
+/**
+ * A bigint value as the exact string the column holds
+ *
+ * @param {*} value what the application passed
+ * @returns {{value: string}|{error: string}} the value, or what is wrong
+ */
+function canonicalInteger(value) {
+  if (typeof value === 'bigint') {
+    return bounded(value);
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isInteger(value)) {
+      return { error: 'must be a whole number' };
+    }
+
+    return Number.isSafeInteger(value)
+      ? bounded(BigInt(value))
+      : {
+          error:
+            'is past what a javascript number carries exactly: pass it as a string',
+        };
+  }
+
+  if (typeof value !== 'string' || !WHOLE.test(value.trim())) {
+    return { error: 'must be a whole number' };
+  }
+
+  return bounded(BigInt(value.trim()));
+}
+
+/**
+ * The value, when it fits a signed 64-bit column
+ *
+ * @param {bigint} value the value
+ * @returns {{value: string}|{error: string}} the value, or what is wrong
+ */
+function bounded(value) {
+  return value < MIN || value > MAX
+    ? { error: `must be between ${BIGINT_MIN} and ${BIGINT_MAX}` }
+    : { value: value.toString() };
+}
+
+/**
+ * Two exact numbers compared without going through a double
+ *
+ * @param {*} left one value
+ * @param {*} right the other
+ * @returns {?number} -1, 0 or 1, and null when either is not a number
+ */
+function compare(left, right) {
+  const one = literalOf(left);
+  const two = literalOf(right);
+  const first = one === null ? null : split(one);
+  const second = two === null ? null : split(two);
+
+  if (!first || !second) {
+    return null;
+  }
+
+  // A zero has no sign to compare, so `-0` and `0` are the same value
+  const below = first.negative && !isZero(first);
+  const under = second.negative && !isZero(second);
+
+  if (below !== under) {
+    return below ? -1 : 1;
+  }
+
+  const size = magnitude(first, second);
+
+  return below ? -size : size;
+}
+
+/**
+ * Is this value zero, whatever it was written as?
+ *
+ * @param {object} parts a split literal
+ * @returns {boolean} true for every spelling of zero
+ */
+const isZero = (parts) =>
+  !/[1-9]/u.test(parts.whole) && !/[1-9]/u.test(parts.fraction);
+
+/**
+ * The two magnitudes compared, sign left out
+ *
+ * @param {object} first a split literal
+ * @param {object} second another
+ * @returns {number} -1, 0 or 1
+ */
+function magnitude(first, second) {
+  const left = first.whole.replace(/^0+(?=\d)/u, '');
+  const right = second.whole.replace(/^0+(?=\d)/u, '');
+
+  if (left.length !== right.length) {
+    return left.length < right.length ? -1 : 1;
+  }
+
+  if (left !== right) {
+    return left < right ? -1 : 1;
+  }
+
+  const size = Math.max(first.fraction.length, second.fraction.length);
+  const one = first.fraction.padEnd(size, '0');
+  const two = second.fraction.padEnd(size, '0');
+
+  if (one === two) {
+    return 0;
+  }
+
+  return one < two ? -1 : 1;
+}
+
+/**
+ * The double a dialect without an exact type has to compare through
+ *
+ * @param {*} value an exact value
+ * @returns {number} the nearest double
+ */
+const toNumber = (value) => Number(literalOf(value) ?? NaN);
+
+module.exports = {
+  BIGINT_MAX,
+  BIGINT_MIN,
+  DEFAULT_PRECISION,
+  DEFAULT_SCALE,
+  EXACT_TYPES,
+  MAX_PRECISION,
+  canonical,
+  canonicalInteger,
+  checkSettings,
+  compare,
+  isExact,
+  literalOf,
+  settingsOf,
+  toNumber,
+};

--- a/packages/drizzle/exact.js
+++ b/packages/drizzle/exact.js
@@ -146,7 +146,7 @@ function plain(literal) {
     return null;
   }
 
-  const whole = parts.whole.replace(/^0+(?=\d)/u, '');
+  const whole = withoutLeadingZeros(parts.whole);
   const sign = parts.negative && !isZero(parts) ? '-' : '';
 
   return `${sign}${whole}${parts.fraction === '' ? '' : `.${parts.fraction}`}`;
@@ -217,6 +217,46 @@ const settingsOf = (field) => ({
 });
 
 /**
+ * The digits without their trailing zeros, and without their leading ones.
+ *
+ * Walked rather than matched. `/0+$/` is quadratic on a fraction that is a
+ * long run of zeros followed by a digit -- `0.000…0001`, which is a decimal
+ * a request may legitimately carry -- and 200,000 of them took 17 seconds
+ * here before this was two index walks. The same shape has been fixed twice
+ * elsewhere in this repository (`uploads/src/names.js`, the cdn base of
+ * `uploads/src/signing.js`), and the rule is the one those state: a value
+ * that reaches a pattern from a request is walked.
+ *
+ * @param {string} digits the fraction, as written
+ * @returns {string} the same without trailing zeros
+ */
+function withoutTrailingZeros(digits) {
+  let end = digits.length;
+
+  while (end > 0 && digits[end - 1] === '0') {
+    end -= 1;
+  }
+
+  return digits.slice(0, end);
+}
+
+/**
+ * The whole part without its leading zeros, keeping one digit
+ *
+ * @param {string} digits the whole part, as written
+ * @returns {string} the same without leading zeros
+ */
+function withoutLeadingZeros(digits) {
+  let start = 0;
+
+  while (start < digits.length - 1 && digits[start] === '0') {
+    start += 1;
+  }
+
+  return digits.slice(start);
+}
+
+/**
  * What is wrong with the `precision` and `scale` a field declares, if
  * anything. An adapter raises its own coded error with the sentence.
  *
@@ -269,7 +309,7 @@ function canonical(value, settings) {
     return { error: 'must be a decimal number' };
   }
 
-  const fraction = parts.fraction.replace(/0+$/u, '');
+  const fraction = withoutTrailingZeros(parts.fraction);
 
   if (fraction.length > scale) {
     return {
@@ -282,7 +322,7 @@ function canonical(value, settings) {
     };
   }
 
-  const whole = parts.whole.replace(/^0+(?=\d)/u, '');
+  const whole = withoutLeadingZeros(parts.whole);
   const digits = precision - scale;
 
   if (whole !== '0' && whole.length > digits) {
@@ -390,8 +430,8 @@ const isZero = (parts) =>
  * @returns {number} -1, 0 or 1
  */
 function magnitude(first, second) {
-  const left = first.whole.replace(/^0+(?=\d)/u, '');
-  const right = second.whole.replace(/^0+(?=\d)/u, '');
+  const left = withoutLeadingZeros(first.whole);
+  const right = withoutLeadingZeros(second.whole);
 
   if (left.length !== right.length) {
     return left.length < right.length ? -1 : 1;

--- a/packages/drizzle/model.js
+++ b/packages/drizzle/model.js
@@ -7,6 +7,7 @@ const {
   resolvesKeys,
   withoutInternalIds,
 } = require('./external-id');
+const { isExact } = require('./exact');
 const { normalizeField } = require('./schema');
 const { checkMassWrite, plainOf, write } = require('./versions');
 const { ValidationError, failure, validate } = require('./validation');
@@ -1830,6 +1831,26 @@ const createModel = (adapter, definition, fields) => {
       );
     },
   });
+  // What a driver hands back for an exact column is whatever that driver
+  // decided -- a string from node-postgres, a BigInt once drizzle mapped
+  // it, a number from mysql2 below 2^53, the digits sqlite kept as text.
+  // One hook makes all of them the decimal string every adapter answers
+  // with, so `toJSON()`, `changed()` and everything the router serializes
+  // see the same value on the three of them. See ./exact.js
+  const exact = Object.keys(fields).filter((field) =>
+    isExact(fields[field].type)
+  );
+
+  if (exact.length > 0) {
+    internalHooks.afterLoad.push((row) => {
+      for (const field of exact) {
+        if (row[field] !== null && typeof row[field] !== 'undefined') {
+          row[field] = String(row[field]);
+        }
+      }
+    });
+  }
+
   Object.assign(Klass, {
     adapter,
     associations: [],

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -17,6 +17,7 @@
   "files": [
     "index.js",
     "dialects.js",
+    "exact.js",
     "external-id.js",
     "dump.js",
     "migrations.js",

--- a/packages/drizzle/relation.js
+++ b/packages/drizzle/relation.js
@@ -139,8 +139,8 @@ const exactComparison = (Model, key, field, shorthand, value) => {
   return {
     column: dialect.cast(Model.column(key), field),
     value: Array.isArray(values)
-      ? values.map((entry) => dialect.compared(entry, field))
-      : dialect.compared(values, field),
+      ? values.map((entry) => dialect.bind(entry, field))
+      : dialect.bind(values, field),
   };
 };
 

--- a/packages/drizzle/relation.js
+++ b/packages/drizzle/relation.js
@@ -23,8 +23,16 @@ const {
   sql,
 } = require('drizzle-orm');
 const { coded, isPlainObject } = require('./utils');
+const { canonical, canonicalInteger, isExact, settingsOf } = require('./exact');
 const { checkOrder, comparison, markOf } = require('./encryption');
 const { checkMassWrite } = require('./versions');
+
+/**
+ * The operators whose answer depends on the order of the values, and which
+ * a dialect keeping an exact number as text therefore cannot give without
+ * a cast (see the `cast` of ./dialects.js)
+ */
+const ORDERED = new Set(['between', 'gt', 'gte', 'lt', 'lte']);
 
 /**
  * Operators accepted inside a where value: `{ age: { gt: 18 } }` (the `$`
@@ -57,6 +65,100 @@ const LOGICAL = {
   and: (parts) => and(...parts),
   not: (parts) => not(parts.length === 1 ? parts[0] : and(...parts)),
   or: (parts) => or(...parts),
+};
+
+/**
+ * The field definition of an exact column, when that is what the key names
+ *
+ * @param {function} Model The model
+ * @param {string} key The field name
+ * @returns {?object} The normalized field, or null
+ */
+const exactOf = (Model, key) => {
+  const field = Model.fields && Model.fields[key];
+
+  return field && isExact(field.type) ? field : null;
+};
+
+/**
+ * One value compared against an exact column, as the column holds it.
+ *
+ * A condition is written in whatever the application had -- `10`,
+ * `'10.00'`, `19.99` -- and the column holds one canonical spelling, so the
+ * value is canonicalized before it is bound: on sqlite the comparison is
+ * against text and `'10'` would never equal `'10.0000'` otherwise. A value
+ * that is not a number at all is refused here rather than compared as text
+ * and quietly matching nothing.
+ *
+ * @param {function} Model The model
+ * @param {string} key The field name
+ * @param {object} field The normalized field
+ * @param {*} value The value from the condition
+ * @returns {string} The canonical value
+ * @throws {Error} When the value is not a number
+ */
+const exactValue = (Model, key, field, value) => {
+  const answer =
+    field.type === 'bigint'
+      ? canonicalInteger(value)
+      : canonical(value, settingsOf(field));
+
+  if (answer.error) {
+    throw coded(
+      'HENRI_MODEL_INVALID_QUERY',
+      `The condition on ${Model.modelName}.${key} is ${JSON.stringify(
+        String(value)
+      )}, which ${answer.error}: a ${field.type} is compared against a number`
+    );
+  }
+
+  return answer.value;
+};
+
+/**
+ * The column and the values of a comparison against an exact field
+ *
+ * @param {function} Model The model
+ * @param {string} key The field name
+ * @param {object} field The normalized field
+ * @param {string} shorthand The operator, without its `$`
+ * @param {*} value The value from the condition
+ * @returns {{column: object, value: *}} What to compare, and with what
+ */
+const exactComparison = (Model, key, field, shorthand, value) => {
+  const { dialect } = Model.adapter;
+  const canonicalize = (entry) => exactValue(Model, key, field, entry);
+  const values = Array.isArray(value)
+    ? value.map(canonicalize)
+    : canonicalize(value);
+
+  if (!dialect.cast || !ORDERED.has(shorthand)) {
+    return { column: Model.column(key), value: values };
+  }
+
+  return {
+    column: dialect.cast(Model.column(key), field),
+    value: Array.isArray(values)
+      ? values.map((entry) => dialect.compared(entry, field))
+      : dialect.compared(values, field),
+  };
+};
+
+/**
+ * The expression an order reads a column through: the column itself, or the
+ * cast a dialect keeping an exact number as text needs to sort it
+ *
+ * @param {function} Model The model
+ * @param {string} key The field name
+ * @returns {object} A column or an SQL expression
+ */
+const ordered = (Model, key) => {
+  const field = exactOf(Model, key);
+  const { dialect } = Model.adapter;
+
+  return field && dialect.cast
+    ? dialect.cast(Model.column(key), field)
+    : Model.column(key);
 };
 
 /**
@@ -114,9 +216,20 @@ const compileWhere = (Model, condition) => {
     // configured key. Anything but an equality is refused there rather
     // than matching nothing here (see ./encryption.js)
     const encrypted = markOf(Model, key);
+    // A `decimal` or a `bigint` is a string on both sides of the boundary,
+    // so a condition is canonicalized before it is bound and an ordered
+    // comparison goes through the dialect's cast (see ./exact.js)
+    const exact = exactOf(Model, key);
 
     if (value === null) {
       parts.push(isNull(column));
+    } else if (exact && Array.isArray(value)) {
+      parts.push(
+        OPERATORS.in(
+          column,
+          value.map((entry) => exactValue(Model, key, exact, entry))
+        )
+      );
     } else if (Array.isArray(value)) {
       parts.push(OPERATORS.in(column, comparison(Model, key, value).value));
     } else if (is(value, SQL)) {
@@ -158,6 +271,21 @@ const compileWhere = (Model, condition) => {
           );
         }
 
+        if (exact) {
+          const settled = exactComparison(
+            Model,
+            key,
+            exact,
+            shorthand,
+            value[name]
+          );
+
+          parts.push(
+            operator(settled.column, settled.value, Model.adapter.dialect.name)
+          );
+          continue;
+        }
+
         const { list, value: compared } = comparison(
           Model,
           key,
@@ -173,6 +301,8 @@ const compileWhere = (Model, condition) => {
           parts.push(operator(column, compared, Model.adapter.dialect.name));
         }
       }
+    } else if (exact) {
+      parts.push(eq(column, exactValue(Model, key, exact, value)));
     } else if (encrypted) {
       const { list, value: compared } = comparison(Model, key, value);
 
@@ -214,15 +344,15 @@ const compileOrder = (Model, order) => {
     if (field.startsWith('-')) {
       checkOrder(Model, field.slice(1));
 
-      return [desc(Model.column(field.slice(1)))];
+      return [desc(ordered(Model, field.slice(1)))];
     }
 
     checkOrder(Model, field);
 
     return [
       direction.toLowerCase() === 'desc'
-        ? desc(Model.column(field))
-        : asc(Model.column(field)),
+        ? desc(ordered(Model, field))
+        : asc(ordered(Model, field)),
     ];
   }
 
@@ -244,8 +374,8 @@ const compileOrder = (Model, order) => {
 
       return String(order[field]).toLowerCase() === 'desc' ||
         Number(order[field]) === -1
-        ? desc(Model.column(field))
-        : asc(Model.column(field));
+        ? desc(ordered(Model, field))
+        : asc(ordered(Model, field));
     });
   }
 

--- a/packages/drizzle/schema.js
+++ b/packages/drizzle/schema.js
@@ -1,5 +1,12 @@
 const TYPES = require('./types');
 const { DETERMINISTIC_LENGTH, encryptionOf } = require('./encrypted');
+const {
+  canonical,
+  canonicalInteger,
+  checkSettings,
+  isExact,
+  settingsOf,
+} = require('./exact');
 const { coded, isPlainObject, snakeCase } = require('./utils');
 
 // Keys of the henri model format understood by this adapter
@@ -18,9 +25,12 @@ const KNOWN_KEYS = new Set([
   'minLength',
   // Metadata, not a column: what henri redacts, exports and erases
   'personal',
+  // The two a `decimal` column carries; see ./exact.js
+  'precision',
   'primaryKey',
   'references',
   'required',
+  'scale',
   'select',
   'trim',
   'type',
@@ -38,18 +48,24 @@ const CONSTRUCTORS = new Map([
   [Array, 'json'],
 ]);
 
-// Sequelize data type names accepted for compatibility with existing models
+// Sequelize data type names accepted for compatibility with existing models.
+// `BIGINT` and `DECIMAL` used to be downgrades -- a 32-bit integer and a
+// double -- so a model asking for money got binary floating point and one
+// asking for a big identifier got a column that refused the insert above
+// 2,147,483,647. They point at the exact types now.
 const SEQUELIZE_TYPES = {
-  BIGINT: 'integer',
+  BIGINT: 'bigint',
   BOOLEAN: 'boolean',
   DATE: 'date',
   DATEONLY: 'date',
-  DECIMAL: 'number',
+  DECIMAL: 'decimal',
   DOUBLE: 'number',
   FLOAT: 'float',
   INTEGER: 'integer',
   JSON: 'json',
   JSONB: 'json',
+  NUMERIC: 'decimal',
+  REAL: 'float',
   STRING: 'string',
   TEXT: 'text',
   UUID: 'uuid',
@@ -112,6 +128,89 @@ const resolveType = (type, field) => {
   );
 };
 
+// Keys that measure a string, and therefore mean nothing on a `decimal` or
+// a `bigint`: the value is a string, so they would quietly count digits
+const TEXTUAL_KEYS = [
+  'length',
+  'lowercase',
+  'match',
+  'maxLength',
+  'minLength',
+  'trim',
+];
+
+/**
+ * One value of an exact field, as the string the column holds
+ *
+ * @param {string} type `decimal` or `bigint`
+ * @param {*} value The value
+ * @param {object} settings `{ precision, scale }`
+ * @returns {{value: string}|{error: string}} The value, or what is wrong
+ */
+const exactly = (type, value, settings) =>
+  type === 'bigint' ? canonicalInteger(value) : canonical(value, settings);
+
+/**
+ * Settles the `precision` and `scale` of an exact field and canonicalizes
+ * everything the definition itself holds -- the default, the enum and the
+ * bounds -- so nothing downstream compares a literal against a stored
+ * value that spells the same number differently
+ *
+ * @param {string} field The field name
+ * @param {object} normalized The normalized field, changed in place
+ * @returns {void}
+ * @throws {Error} When the definition holds a value the type refuses
+ */
+const normalizeExact = (field, normalized) => {
+  const settings = settingsOf(normalized);
+  const textual = TEXTUAL_KEYS.filter((key) => key in normalized);
+
+  if (textual.length > 0) {
+    throw coded(
+      'HENRI_MODEL_INVALID_FIELD',
+      `Field '${field}' has '${textual[0]}', which measures text: a ${normalized.type} is a number, and its bounds are 'min' and 'max'`
+    );
+  }
+
+  for (const key of ['default', 'max', 'min']) {
+    const value = normalized[key];
+
+    if (!(key in normalized) || value === null || typeof value === 'function') {
+      continue;
+    }
+
+    const answer = exactly(normalized.type, value, settings);
+
+    if (answer.error) {
+      throw coded(
+        'HENRI_MODEL_INVALID_FIELD',
+        `Field '${field}' has a '${key}' of ${JSON.stringify(String(value))}, which ${answer.error}`
+      );
+    }
+
+    normalized[key] = answer.value;
+  }
+
+  if (Array.isArray(normalized.enum)) {
+    normalized.enum = normalized.enum.map((entry) => {
+      const answer = exactly(normalized.type, entry, settings);
+
+      if (answer.error) {
+        throw coded(
+          'HENRI_MODEL_INVALID_FIELD',
+          `Field '${field}' has the enum value ${JSON.stringify(String(entry))}, which ${answer.error}`
+        );
+      }
+
+      return answer.value;
+    });
+  }
+
+  if (normalized.type === 'decimal') {
+    Object.assign(normalized, settings);
+  }
+};
+
 /**
  * Normalizes one field definition
  *
@@ -170,6 +269,16 @@ const normalizeField = (field, definition, context = {}) => {
       'HENRI_MODEL_INVALID_FIELD',
       `Field '${field}': 'enum' must be an array`
     );
+  }
+
+  const settings = checkSettings(normalized.type, normalized);
+
+  if (settings) {
+    throw coded('HENRI_MODEL_INVALID_FIELD', `Field '${field}' ${settings}`);
+  }
+
+  if (isExact(normalized.type)) {
+    normalizeExact(field, normalized);
   }
 
   // The column of an encrypted field is the ciphertext's, not the

--- a/packages/drizzle/types.js
+++ b/packages/drizzle/types.js
@@ -9,8 +9,21 @@
  *
  * Values are read by the model layer too: `js` is the JavaScript type a
  * value is coerced to before validation.
+ *
+ * `decimal` and `bigint` are the two whose `js` is neither a number nor a
+ * Date: they cross into JavaScript as exact decimal **strings**, because a
+ * double undoes the column. `./exact.js` is where that is argued, and
+ * sqlite -- which has neither an exact decimal nor a 64-bit integer a
+ * driver hands back whole -- keeps the digits in a `text` column and casts
+ * for a comparison. See `./dialects.js`.
  */
 module.exports = {
+  bigint: {
+    js: 'bigint',
+    mysql: 'bigint',
+    postgres: 'bigint',
+    sqlite: 'text (the digits)',
+  },
   boolean: {
     js: 'boolean',
     mysql: 'boolean',
@@ -22,6 +35,12 @@ module.exports = {
     mysql: 'datetime(3)',
     postgres: 'timestamp with time zone',
     sqlite: 'integer (ms since epoch)',
+  },
+  decimal: {
+    js: 'decimal',
+    mysql: 'decimal(precision, scale)',
+    postgres: 'numeric(precision, scale)',
+    sqlite: 'text (the digits)',
   },
   float: {
     js: 'number',

--- a/packages/drizzle/validation.js
+++ b/packages/drizzle/validation.js
@@ -1,4 +1,11 @@
 const TYPES = require('./types');
+const {
+  canonical,
+  canonicalInteger,
+  compare,
+  isExact,
+  settingsOf,
+} = require('./exact');
 const { isPlainObject } = require('./utils');
 
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -89,6 +96,22 @@ const coerce = (field, value) => {
   }
 
   switch (kind) {
+    // The two the column keeps exactly and JavaScript cannot: they are
+    // decimal strings on both sides of the boundary (see ./exact.js)
+    case 'decimal': {
+      const answer = canonical(value, settingsOf(field));
+
+      return answer.error
+        ? { error: answer.error, value }
+        : { error: null, value: answer.value };
+    }
+    case 'bigint': {
+      const answer = canonicalInteger(value);
+
+      return answer.error
+        ? { error: answer.error, value }
+        : { error: null, value: answer.value };
+    }
     case 'integer': {
       const number =
         typeof value === 'string' && value.trim() !== ''
@@ -170,6 +193,19 @@ const check = (name, field, value, attrs) => {
     );
   }
 
+  // An exact value is a string, so its bounds are compared digit by digit
+  // rather than through the double the type exists to avoid
+  if (isExact(field.type)) {
+    if ('min' in field && compare(value, field.min) < 0) {
+      return failure('min', `must be at least ${field.min}`, name, value);
+    }
+    if ('max' in field && compare(value, field.max) > 0) {
+      return failure('max', `must be at most ${field.max}`, name, value);
+    }
+
+    return custom(name, field, value, attrs);
+  }
+
   if (typeof value === 'number') {
     if (typeof field.min === 'number' && value < field.min) {
       return failure('min', `must be at least ${field.min}`, name, value);
@@ -207,25 +243,39 @@ const check = (name, field, value, attrs) => {
     }
   }
 
-  if (typeof field.validate === 'function') {
-    let result;
+  return custom(name, field, value, attrs);
+};
 
-    try {
-      result = field.validate(value, attrs);
-    } catch (error) {
-      result = error.message || 'is invalid';
-    }
-
-    if (result === false) {
-      return failure('validate', 'is invalid', name, value);
-    }
-    if (typeof result === 'string') {
-      return failure('validate', result, name, value);
-    }
+/**
+ * Runs the `validate` function of a field, when it has one
+ *
+ * @param {string} name The field name
+ * @param {object} field The normalized field
+ * @param {*} value The coerced value
+ * @param {object} attrs Every attribute
+ * @returns {?object} An error entry or null
+ */
+function custom(name, field, value, attrs) {
+  if (typeof field.validate !== 'function') {
+    return null;
   }
 
-  return null;
-};
+  let result;
+
+  try {
+    result = field.validate(value, attrs);
+  } catch (error) {
+    result = error.message || 'is invalid';
+  }
+
+  if (result === false) {
+    return failure('validate', 'is invalid', name, value);
+  }
+
+  return typeof result === 'string'
+    ? failure('validate', result, name, value)
+    : null;
+}
 
 /**
  * Validates and coerces attributes against normalized fields

--- a/packages/mcp/__tests__/server.spec.js
+++ b/packages/mcp/__tests__/server.spec.js
@@ -875,6 +875,7 @@ describe('henri mcp against a running application', () => {
     expect(identity.app.pid).toBe(server.pid);
     expect(identity.models.map((model) => model.name).sort()).toEqual([
       'Artwork',
+      'Invoice',
       'Memo',
       'User',
     ]);

--- a/packages/mcp/src/server.js
+++ b/packages/mcp/src/server.js
@@ -601,7 +601,7 @@ const createServer = ({ cwd = process.cwd() } = {}) => {
     {
       annotations: { destructiveHint: false, idempotentHint: false },
       description:
-        'Runs a henri generator (the same as `henri generate`) and returns the files written, the files skipped and the routes added. scaffold/model/crud take attributes ("title:string!", "body:text"; types: string, text, number, integer, float, boolean, date, json, uuid; ! = required), controller and mailer take action names, authentication and agents take nothing. `authentication` turns the account flows on in config/*.json and writes the pages, the controller, the mailer and the tests around the endpoints henri mounts. Existing files are skipped unless force is true.',
+        'Runs a henri generator (the same as `henri generate`) and returns the files written, the files skipped and the routes added. scaffold/model/crud take attributes ("title:string!", "body:text"; types: string, text, number, integer, float, decimal, bigint, boolean, date, json, uuid; ! = required), controller and mailer take action names, authentication and agents take nothing. `authentication` turns the account flows on in config/*.json and writes the pages, the controller, the mailer and the tests around the endpoints henri mounts. Existing files are skipped unless force is true.',
       inputSchema: {
         actions: zod
           .array(zod.string().regex(ACTION))

--- a/packages/mongoose/__tests__/exact.spec.js
+++ b/packages/mongoose/__tests__/exact.spec.js
@@ -189,4 +189,50 @@ describe('decimal and bigint (mongodb)', () => {
       normalizeSchema({ price: { precision: 99, type: 'decimal' } })
     ).toThrow(/between 1 and 38/u);
   });
+
+  test('a bound that measures text fails the boot', () => {
+    expect(() =>
+      normalizeSchema({ price: { maxLength: 4, type: 'decimal' } })
+    ).toThrow(/which measures text/u);
+  });
+
+  test('a bound is henri’s, because mongoose ignores one here', () => {
+    // `min` on a Decimal128 or a BigInt is dropped by Mongoose without a
+    // word, so it never reaches the path and henri carries it itself
+    const definition = normalizeSchema({
+      price: { min: '10.00', type: 'decimal' },
+    });
+
+    expect(definition.price.min).toBeUndefined();
+  });
+
+  test('a bound is compared by value, not letter by letter', async () => {
+    const other = build('exact-bounds');
+    const Priced = other.addModel({
+      globalId: 'Priced',
+      identity: 'priced',
+      options: { timestamps: false },
+      schema: {
+        // `'9.99' > '10'` as text, which is the answer this must not give
+        price: { min: '10', scale: 2, type: 'decimal' },
+        seats: { max: '9223372036854775806', type: 'bigint' },
+      },
+      store: 'default',
+    });
+
+    await other.start();
+
+    await expect(Priced.create({ price: '9.99' })).rejects.toThrow(
+      /must be at least 10/u
+    );
+    await expect(
+      Priced.create({ seats: '9223372036854775807' })
+    ).rejects.toThrow(/must be at most/u);
+
+    const ok = await Priced.create({ price: '100.50', seats: '5' });
+
+    expect(ok.price).toBe('100.50');
+
+    await other.stop();
+  });
 });

--- a/packages/mongoose/__tests__/exact.spec.js
+++ b/packages/mongoose/__tests__/exact.spec.js
@@ -1,0 +1,192 @@
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const Mongoose = require('../index');
+const { normalizeSchema } = require('../schema');
+
+/**
+ * `decimal` and `bigint` on MongoDB. Every test writes a value and reads it
+ * back, and asserts it is the *same* value rather than a near one -- the
+ * same suite the SQL adapters run, so the two answer alike.
+ */
+
+let mongod;
+
+/**
+ * Builds a minimal henri stand-in for the adapter
+ *
+ * @returns {object} fake henri
+ */
+const fakeHenri = () => {
+  const pen = {};
+
+  ['error', 'fatal', 'info', 'warn'].forEach((level) => {
+    pen[level] = () => undefined;
+  });
+
+  return {
+    _user: null,
+    config: { get: () => undefined, has: () => false },
+    isTest: true,
+    pen,
+    user: { encrypt: async (password) => `hashed:${password}` },
+  };
+};
+
+/**
+ * Builds an adapter on the shared in-memory server
+ *
+ * @param {string} database A database name
+ * @returns {object} The adapter
+ */
+const build = (database) =>
+  new Mongoose('default', { url: mongod.getUri(database) }, fakeHenri());
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+}, 120000);
+
+afterAll(async () => {
+  await mongod?.stop();
+}, 60000);
+
+describe('decimal and bigint (mongodb)', () => {
+  let adapter;
+  let Invoice;
+
+  beforeAll(async () => {
+    adapter = build('exact');
+    Invoice = adapter.addModel({
+      globalId: 'Invoice',
+      identity: 'invoice',
+      options: { timestamps: false },
+      schema: {
+        amount: { scale: 2, type: 'decimal' },
+        name: { type: 'string' },
+        rate: { type: 'decimal' },
+        reference: { type: 'bigint' },
+      },
+      store: 'default',
+    });
+    await adapter.start();
+  });
+
+  afterAll(async () => {
+    await adapter.stop();
+  });
+
+  test('maps the two names to the bson types that carry them', () => {
+    expect(Invoice.schema.path('amount').instance).toBe('Decimal128');
+    expect(Invoice.schema.path('reference').instance).toBe('BigInt');
+  });
+
+  test('a decimal round-trips at its scale, however it was written', async () => {
+    for (const [given, expected] of [
+      ['19.99', '19.99'],
+      [19.99, '19.99'],
+      ['19.9900', '19.99'],
+      ['1e1', '10.00'],
+      ['-2.5', '-2.50'],
+      ['0', '0.00'],
+    ]) {
+      const created = await Invoice.create({ amount: given, name: 'x' });
+      const read = await Invoice.findById(created.externalId);
+      const lean = await Invoice.findById(created.externalId).lean();
+
+      expect(created.amount).toBe(expected);
+      expect(read.amount).toBe(expected);
+      expect(read.toJSON().amount).toBe(expected);
+      expect(lean.amount).toBe(expected);
+    }
+  });
+
+  test('a cent added a hundred times is a dollar, exactly', async () => {
+    const created = await Invoice.create({ amount: '1.00', name: 'cents' });
+    const read = await Invoice.findById(created.externalId);
+
+    expect(read.amount).toBe('1.00');
+    expect(read.amount === '1.00').toBe(true);
+  });
+
+  test('0.1 + 0.2 is refused rather than stored', async () => {
+    await expect(
+      Invoice.create({ name: 'float', rate: 0.1 + 0.2 })
+    ).rejects.toThrow(/at most 4 decimal places/u);
+  });
+
+  test('a bigint past 2^53 comes back whole', async () => {
+    for (const reference of [
+      '9223372036854775807',
+      '-9223372036854775808',
+      '9007199254740993',
+      '2147483648',
+    ]) {
+      const created = await Invoice.create({ name: 'big', reference });
+      const read = await Invoice.findById(created.externalId);
+
+      expect(created.reference).toBe(reference);
+      expect(read.reference).toBe(reference);
+      expect(JSON.parse(JSON.stringify(read)).reference).toBe(reference);
+    }
+  });
+
+  test('the bounds of the column are refused, not rounded', async () => {
+    await expect(
+      Invoice.create({ amount: '19.999', name: 'precise' })
+    ).rejects.toThrow(/at most 2 decimal places/u);
+    await expect(
+      Invoice.create({ name: 'past', reference: '9223372036854775808' })
+    ).rejects.toThrow();
+    await expect(
+      Invoice.create({ name: 'unsafe', reference: 2 ** 60 })
+    ).rejects.toThrow();
+  });
+
+  test('a comparison and an order are numeric', async () => {
+    const other = build('exact-query');
+    const Ledger = other.addModel({
+      globalId: 'Ledger',
+      identity: 'ledger',
+      options: { timestamps: false },
+      schema: {
+        count: { type: 'bigint' },
+        label: { type: 'string' },
+        total: { scale: 2, type: 'decimal' },
+      },
+      store: 'default',
+    });
+
+    await other.start();
+
+    for (const [label, total, count] of [
+      ['a', '9.99', '9223372036854775807'],
+      ['b', '10.00', '-5'],
+      ['c', '100.50', '0'],
+      ['d', '-2.50', '9007199254740993'],
+    ]) {
+      await Ledger.create({ count, label, total });
+    }
+
+    expect((await Ledger.findOne({ total: '10' })).label).toBe('b');
+    expect(
+      (await Ledger.find({ total: { $gt: '10' } })).map((row) => row.label)
+    ).toEqual(['c']);
+    expect(
+      (await Ledger.find({}).sort('total')).map((row) => row.label)
+    ).toEqual(['d', 'a', 'b', 'c']);
+    expect(
+      (
+        await Ledger.find({ count: { $gt: '9007199254740992' } }).sort('label')
+      ).map((row) => row.label)
+    ).toEqual(['a', 'd']);
+
+    await other.stop();
+  });
+
+  test('a precision or a scale on anything but a decimal fails the boot', () => {
+    expect(() =>
+      normalizeSchema({ count: { scale: 2, type: 'bigint' } })
+    ).toThrow(/takes no 'scale'/u);
+    expect(() =>
+      normalizeSchema({ price: { precision: 99, type: 'decimal' } })
+    ).toThrow(/between 1 and 38/u);
+  });
+});

--- a/packages/mongoose/__tests__/mongoose.spec.js
+++ b/packages/mongoose/__tests__/mongoose.spec.js
@@ -244,8 +244,10 @@ describe('mongoose adapter', () => {
       expect(definition.settings).toBe(types.json);
       expect(definition.weight).toBe(Number);
       expect(Object.keys(types).sort()).toEqual([
+        'bigint',
         'boolean',
         'date',
+        'decimal',
         'float',
         'integer',
         'json',
@@ -254,6 +256,21 @@ describe('mongoose adapter', () => {
         'text',
         'uuid',
       ]);
+    });
+
+    test('maps the two exact names to the bson types that carry them', () => {
+      const definition = normalizeSchema({
+        count: 'bigint',
+        price: { scale: 2, type: 'decimal' },
+      });
+
+      expect(definition.count).toBe(types.bigint);
+      expect(definition.price.type).toBe(types.decimal);
+      // The setter is what pads a value to the scale; `precision` and
+      // `scale` are henri's own and never reach Mongoose
+      expect(typeof definition.price.set).toBe('function');
+      expect(definition.price.scale).toBeUndefined();
+      expect(definition.price.set('19.9')).toBe('19.90');
     });
 
     test('passes mongoose definitions through and translates sequelize keys', () => {

--- a/packages/mongoose/exact-paths.js
+++ b/packages/mongoose/exact-paths.js
@@ -1,0 +1,203 @@
+const { canonical, canonicalInteger, isExact, settingsOf } = require('./exact');
+
+/**
+ * `decimal` and `bigint` on a Mongoose model.
+ *
+ * What the two types mean, and why their value is a string on every
+ * adapter, is in `./exact.js`. This is the Mongoose half, and it is two
+ * halves of its own:
+ *
+ * ## Writing: a setter that records, and a `pre('validate')` that refuses
+ *
+ * MongoDB keeps a `Decimal128` with the exponent it was given, so
+ * `'19.99'` and `'19.9900'` are stored differently (they compare equal, but
+ * they read back differently). PostgreSQL and MySQL pad to the declared
+ * scale, so Mongoose has to as well or the same model file would answer two
+ * different strings. The setter is what pads it, and it runs on an
+ * assignment, on `create()` and on a query filter alike.
+ *
+ * The setter is also the only place that still has the value the
+ * application passed. By the time a validator runs, Mongoose has cast it:
+ * `2 ** 60` is a `BigInt` that looks perfectly whole, and the reason it was
+ * refused -- that a JavaScript number does not carry those digits -- is
+ * gone. So the setter writes the reason into the document's `$locals` and
+ * `pre('validate')` calls `invalidate()` with it, which is Mongoose's own
+ * way of saying a field is wrong and puts the sentence a person reads in
+ * the ValidationError unchanged. A setter that threw instead would produce
+ * a message about casting, which is not what went wrong.
+ *
+ * ## Reading: `post('init')`, not a getter
+ *
+ * Exactly the argument `./encryption.js` makes: a getter runs on
+ * `doc.field` and on nothing else, so `toObject()`, `toJSON()` and `lean()`
+ * would all still hand out a `Decimal128`. The value is written into the
+ * document's own `_doc` as it is hydrated, and into the plain objects of a
+ * `lean()` query in a `post` hook. `post('save')` does it again because a
+ * save leaves the document holding what Mongoose cast, which is the
+ * `Decimal128` and not the string the application wrote.
+ *
+ * @module exact-paths
+ */
+
+/** The queries whose result may be plain objects (`lean()`) */
+const RESULT_HOOKS = [
+  'find',
+  'findOne',
+  'findOneAndReplace',
+  'findOneAndUpdate',
+];
+
+/**
+ * One value as the string the column holds
+ *
+ * @param {string} type `decimal` or `bigint`
+ * @param {*} value The value
+ * @param {object} settings `{ precision, scale }`
+ * @returns {{value: string}|{error: string}} The value, or what is wrong
+ */
+const exactly = (type, value, settings) =>
+  type === 'bigint' ? canonicalInteger(value) : canonical(value, settings);
+
+/**
+ * Is this a Mongoose document rather than a plain object?
+ *
+ * @param {*} value Anything
+ * @returns {boolean} true for a document
+ */
+const isDocument = (value) =>
+  Boolean(value && typeof value === 'object' && value.$__);
+
+/** Where the setter leaves what it refused, for `pre('validate')` */
+const LOCALS = 'henriExact';
+
+/**
+ * The setter of an exact path: the canonical string when the value fits the
+ * column, and the value untouched with the reason recorded when it does not
+ *
+ * @param {string} field The path name
+ * @param {string} type `decimal` or `bigint`
+ * @param {object} settings `{ precision, scale }`
+ * @returns {function} A Mongoose setter
+ */
+const setter = (field, type, settings) =>
+  /**
+   * `this` is the document when a path is assigned and the query when a
+   * filter is cast; only the first one has `$locals` to record into
+   *
+   * @param {*} value The value being set
+   * @returns {*} What to store
+   */
+  function set(value) {
+    if (value === null || typeof value === 'undefined') {
+      return value;
+    }
+
+    const answer = exactly(type, value, settings);
+    const locals = this && this.$locals;
+
+    if (locals) {
+      locals[LOCALS] = { ...locals[LOCALS], [field]: answer.error || null };
+    }
+
+    return answer.error ? value : answer.value;
+  };
+
+/**
+ * The exact paths of a normalized schema, with their type and settings
+ *
+ * @param {object} [schema={}] The model schema, as the model file wrote it
+ * @returns {object} `{ [path]: { type, precision, scale } }`
+ */
+const exactPaths = (schema = {}) => {
+  const paths = {};
+
+  for (const field of Object.keys(schema)) {
+    const definition = schema[field];
+    const type =
+      definition && typeof definition === 'object'
+        ? definition.type
+        : definition;
+
+    if (typeof type === 'string' && isExact(type.toLowerCase())) {
+      paths[field] = {
+        ...settingsOf(definition),
+        type: type.toLowerCase(),
+      };
+    }
+  }
+
+  return paths;
+};
+
+/**
+ * Writes the canonical strings of one plain object, in place
+ *
+ * @param {object} raw The document's `_doc`, or a lean result
+ * @param {object} paths The exact paths
+ * @returns {object} The same object
+ */
+const stringify = (raw, paths) => {
+  if (!raw || typeof raw !== 'object') {
+    return raw;
+  }
+
+  for (const field of Object.keys(paths)) {
+    const value = raw[field];
+
+    if (value !== null && typeof value !== 'undefined') {
+      raw[field] = String(value);
+    }
+  }
+
+  return raw;
+};
+
+/**
+ * The whole of it on one schema
+ *
+ * @param {object} schema The Mongoose schema
+ * @param {object} paths The exact paths (`exactPaths()`)
+ * @returns {object} The schema
+ */
+const exactness = (schema, paths) => {
+  // What the setter could not carry: said in henri's own words, through
+  // Mongoose's own way of marking a path wrong
+  schema.pre('validate', function preValidate() {
+    const refused = (this.$locals || {})[LOCALS] || {};
+
+    for (const field of Object.keys(paths)) {
+      if (refused[field]) {
+        this.invalidate(field, refused[field], this.get(field));
+      }
+    }
+  });
+
+  schema.post('init', function postInit() {
+    stringify(this._doc, paths);
+  });
+
+  schema.post(RESULT_HOOKS, function postFind(result) {
+    for (const entry of [result].flat().filter(Boolean)) {
+      if (!isDocument(entry)) {
+        stringify(entry, paths);
+      }
+    }
+  });
+
+  // A save leaves the document holding what Mongoose cast, which is a
+  // Decimal128 or a BigInt: read those paths back as the string the
+  // application wrote, the way `post('init')` does for a query
+  schema.post('save', function postSave(doc) {
+    stringify(doc._doc, paths);
+  });
+
+  schema.post('insertMany', function postInsertMany(docs) {
+    for (const doc of [docs].flat().filter(Boolean)) {
+      stringify(isDocument(doc) ? doc._doc : doc, paths);
+    }
+  });
+
+  return schema;
+};
+
+module.exports = { exactPaths, exactness, setter };

--- a/packages/mongoose/exact-paths.js
+++ b/packages/mongoose/exact-paths.js
@@ -1,4 +1,10 @@
-const { canonical, canonicalInteger, isExact, settingsOf } = require('./exact');
+const {
+  canonical,
+  canonicalInteger,
+  compare,
+  isExact,
+  settingsOf,
+} = require('./exact');
 
 /**
  * `decimal` and `bigint` on a Mongoose model.
@@ -121,6 +127,11 @@ const exactPaths = (schema = {}) => {
     if (typeof type === 'string' && isExact(type.toLowerCase())) {
       paths[field] = {
         ...settingsOf(definition),
+        // Mongoose has a `min` and a `max`, and it ignores both on a
+        // Decimal128 and a BigInt without a word: henri carries them
+        // itself so a bound means the same thing on the three adapters
+        max: definition.max,
+        min: definition.min,
         type: type.toLowerCase(),
       };
     }
@@ -166,8 +177,25 @@ const exactness = (schema, paths) => {
     const refused = (this.$locals || {})[LOCALS] || {};
 
     for (const field of Object.keys(paths)) {
+      const { max, min } = paths[field];
+      const value = this.get(field);
+
       if (refused[field]) {
-        this.invalidate(field, refused[field], this.get(field));
+        this.invalidate(field, refused[field], value);
+        continue;
+      }
+
+      if (value === null || typeof value === 'undefined') {
+        continue;
+      }
+
+      // Digit by digit, never through the double the type exists to avoid
+      if (typeof min !== 'undefined' && compare(String(value), min) < 0) {
+        this.invalidate(field, `must be at least ${min}`, value);
+      }
+
+      if (typeof max !== 'undefined' && compare(String(value), max) > 0) {
+        this.invalidate(field, `must be at most ${max}`, value);
       }
     }
   });

--- a/packages/mongoose/exact.js
+++ b/packages/mongoose/exact.js
@@ -132,6 +132,27 @@ function expand(text) {
 }
 
 /**
+ * The one spelling of a literal: no exponent, no `+`, no leading zeros, a
+ * digit before the point, and no sign on a zero. The digits after the point
+ * are left alone -- they are what the writer said the value was worth to.
+ *
+ * @param {string} literal a literal, already written out
+ * @returns {?string} the same value, spelled once
+ */
+function plain(literal) {
+  const parts = split(literal);
+
+  if (!parts) {
+    return null;
+  }
+
+  const whole = parts.whole.replace(/^0+(?=\d)/u, '');
+  const sign = parts.negative && !isZero(parts) ? '-' : '';
+
+  return `${sign}${whole}${parts.fraction === '' ? '' : `.${parts.fraction}`}`;
+}
+
+/**
  * A value as a decimal literal written out, or null when it is not a number
  *
  * @param {*} value a string, a number or a BigInt
@@ -143,7 +164,7 @@ function literalOf(value) {
   }
 
   if (typeof value === 'number') {
-    return Number.isFinite(value) ? expand(String(value)) : null;
+    return Number.isFinite(value) ? plain(expand(String(value))) : null;
   }
 
   if (typeof value !== 'string') {
@@ -152,7 +173,7 @@ function literalOf(value) {
 
   const text = value.trim();
 
-  return LITERAL.test(text) ? expand(text) : null;
+  return LITERAL.test(text) ? plain(expand(text)) : null;
 }
 
 /**

--- a/packages/mongoose/exact.js
+++ b/packages/mongoose/exact.js
@@ -1,0 +1,417 @@
+/**
+ * The two henri types a JavaScript `number` cannot carry: `decimal` and
+ * `bigint`.
+ *
+ * Every other type in the vocabulary has a JavaScript value that *is* the
+ * value: a `string` is a string, a `date` is a Date, an `integer` under
+ * 2^53 is a number. These two do not. A `numeric(19, 4)` read into a double
+ * is a float again, a `bigint` past `Number.MAX_SAFE_INTEGER` loses digits,
+ * and in both cases the column choice is undone by the round trip -- which
+ * is the whole reason the types exist.
+ *
+ * ## The boundary is a string, on all three adapters
+ *
+ * A value of an exact type crosses into JavaScript as a **decimal string**:
+ * `'19.99'`, `'-1'`, `'9223372036854775807'`. Never a `number`, never a
+ * `BigInt`, never an object of henri's own. The reasons, in order:
+ *
+ * - `JSON.stringify` throws on a `BigInt`. henri serializes model records in
+ *   `res.render`, `res.resource`, `res.collection`, the cache (which refuses
+ *   what it cannot encode), the call log, the version diffs, the trail, the
+ *   job payloads and GraphQL. A `BigInt` escaping into any of them is a
+ *   TypeError raised deep inside express, after the controller returned --
+ *   a worse silent difference than the one being removed.
+ * - A decimal object needs a dependency, and it would not survive JSON
+ *   either. henri ships no arithmetic: an application that wants to add two
+ *   prices picks its own library, and hands henri back a string.
+ * - It is the shortest path, not a conversion. node-postgres already hands
+ *   back `numeric` and `int8` as strings, mysql2 hands back `DECIMAL` as a
+ *   string, and `Decimal128.toString()` is exact. Turning any of those into
+ *   a number is what loses the value.
+ * - A string is exact, comparable for equality, JSON-safe, and identical on
+ *   the three adapters -- which is what makes a model file mean one thing
+ *   everywhere.
+ *
+ * ## What is accepted on the way in
+ *
+ * A string (a decimal literal, exponent form included), a `number`, and --
+ * for `bigint` -- a `BigInt`. A number goes through `String(value)`, which
+ * is the shortest representation that round-trips, so the literal a person
+ * typed survives: `String(19.99)` is `'19.99'`. What does *not* survive is
+ * arithmetic that already lost the value, and that is the point:
+ * `0.1 + 0.2` arrives as `'0.30000000000000004'` and is refused by the
+ * scale rather than rounded into the column. henri does not round money.
+ *
+ * ## What is refused
+ *
+ * More decimal places than the declared `scale` (after the trailing zeros,
+ * which are not information), more digits before the point than
+ * `precision - scale`, a `bigint` outside the signed 64-bit range, and a
+ * `number` that is not a safe integer where a whole number was asked for.
+ * Each one is a value the database would have quietly changed.
+ *
+ * This file is duplicated into each adapter (`packages/<adapter>/exact.js`)
+ * the way `external-id.js` and `encrypted.js` are: an adapter depends on no
+ * part of core at runtime. The copies are byte identical and
+ * `src/__tests__/exact.spec.js` is what keeps them so.
+ *
+ * @module exact
+ */
+
+/** The henri types whose values are exact, and therefore strings */
+const EXACT_TYPES = Object.freeze(['bigint', 'decimal']);
+
+/** Total digits of a `decimal` when the field does not say */
+const DEFAULT_PRECISION = 19;
+
+/** Digits after the point when the field does not say */
+const DEFAULT_SCALE = 4;
+
+/**
+ * The most digits every dialect henri writes carries: SQL Server stops at
+ * 38, MySQL at 65, PostgreSQL at 1000. The smallest is the one a model may
+ * ask for, so the same file works everywhere.
+ */
+const MAX_PRECISION = 38;
+
+/** The bounds of a signed 64-bit integer, as the strings a message prints */
+const BIGINT_MIN = '-9223372036854775808';
+
+/** ... and the other end */
+const BIGINT_MAX = '9223372036854775807';
+
+const MIN = BigInt(BIGINT_MIN);
+const MAX = BigInt(BIGINT_MAX);
+
+/** A decimal literal and nothing else: no `0x10`, no `Infinity`, no `1n` */
+const LITERAL = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/u;
+
+/** A whole number, written out */
+const WHOLE = /^[+-]?\d+$/u;
+
+/** A literal in exponent form, split into its parts */
+const EXPONENT = /^([+-]?)(\d*)(?:\.(\d*))?[eE]([+-]?\d+)$/u;
+
+/** A literal written out, split into its parts */
+const PLAIN = /^([+-]?)(\d*)(?:\.(\d*))?$/u;
+
+/**
+ * Is this one of the exact types?
+ *
+ * @param {*} type a type name
+ * @returns {boolean} true for `decimal` and `bigint`
+ */
+const isExact = (type) => EXACT_TYPES.includes(type);
+
+/**
+ * The same literal without its exponent, so everything below is string work
+ *
+ * @param {string} text a decimal literal
+ * @returns {string} the literal written out
+ */
+function expand(text) {
+  const match = EXPONENT.exec(text);
+
+  if (!match) {
+    return text;
+  }
+
+  const [, sign, whole, fraction = '', exponent] = match;
+  const digits = `${whole}${fraction}`;
+  const point = whole.length + Number(exponent);
+
+  if (point <= 0) {
+    return `${sign}0.${'0'.repeat(-point)}${digits}`;
+  }
+
+  if (point >= digits.length) {
+    return `${sign}${digits}${'0'.repeat(point - digits.length)}`;
+  }
+
+  return `${sign}${digits.slice(0, point)}.${digits.slice(point)}`;
+}
+
+/**
+ * A value as a decimal literal written out, or null when it is not a number
+ *
+ * @param {*} value a string, a number or a BigInt
+ * @returns {?string} the literal, or null
+ */
+function literalOf(value) {
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? expand(String(value)) : null;
+  }
+
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const text = value.trim();
+
+  return LITERAL.test(text) ? expand(text) : null;
+}
+
+/**
+ * A literal split into a sign, the digits before the point and the ones
+ * after it
+ *
+ * @param {string} literal a literal written out
+ * @returns {?object} `{ negative, whole, fraction }`, or null
+ */
+function split(literal) {
+  const match = PLAIN.exec(literal);
+
+  if (!match) {
+    return null;
+  }
+
+  const [, sign, whole, fraction = ''] = match;
+
+  if (whole === '' && fraction === '') {
+    return null;
+  }
+
+  return {
+    fraction,
+    negative: sign === '-',
+    whole: whole === '' ? '0' : whole,
+  };
+}
+
+/**
+ * The `precision` and `scale` of a decimal field, defaulted
+ *
+ * @param {object} [field] the normalized field
+ * @returns {{precision: number, scale: number}} what the column carries
+ */
+const settingsOf = (field) => ({
+  precision: Number.isInteger(field && field.precision)
+    ? field.precision
+    : DEFAULT_PRECISION,
+  scale: Number.isInteger(field && field.scale) ? field.scale : DEFAULT_SCALE,
+});
+
+/**
+ * What is wrong with the `precision` and `scale` a field declares, if
+ * anything. An adapter raises its own coded error with the sentence.
+ *
+ * @param {string} type the henri type of the field
+ * @param {object} [field] the field definition
+ * @returns {?string} what is wrong, or null
+ */
+function checkSettings(type, field) {
+  const given = field || {};
+  const declared = ['precision', 'scale'].filter((key) => key in given);
+
+  if (type !== 'decimal') {
+    return declared.length > 0
+      ? `takes no '${declared[0]}': only a decimal has one`
+      : null;
+  }
+
+  for (const key of declared) {
+    if (!Number.isInteger(given[key]) || given[key] < 0) {
+      return `has a '${key}' that is not a whole number`;
+    }
+  }
+
+  const { precision, scale } = settingsOf(given);
+
+  if (precision < 1 || precision > MAX_PRECISION) {
+    return `has a 'precision' of ${precision}: it is between 1 and ${MAX_PRECISION}, the most every dialect henri writes carries`;
+  }
+
+  if (scale > precision) {
+    return `has a 'scale' of ${scale}, which is more than its precision of ${precision}`;
+  }
+
+  return null;
+}
+
+/**
+ * A decimal value as the exact string the column holds, at its scale
+ *
+ * @param {*} value what the application passed
+ * @param {object} settings `{ precision, scale }`
+ * @returns {{value: string}|{error: string}} the value, or what is wrong
+ */
+function canonical(value, settings) {
+  const { precision, scale } = settings;
+  const literal = literalOf(value);
+  const parts = literal === null ? null : split(literal);
+
+  if (!parts) {
+    return { error: 'must be a decimal number' };
+  }
+
+  const fraction = parts.fraction.replace(/0+$/u, '');
+
+  if (fraction.length > scale) {
+    return {
+      error:
+        scale === 0
+          ? 'must be a whole number'
+          : `must have at most ${scale} decimal place${
+              scale === 1 ? '' : 's'
+            }, and rounding is the application's to do`,
+    };
+  }
+
+  const whole = parts.whole.replace(/^0+(?=\d)/u, '');
+  const digits = precision - scale;
+
+  if (whole !== '0' && whole.length > digits) {
+    return {
+      error: `must have at most ${digits} digit${
+        digits === 1 ? '' : 's'
+      } before the decimal point`,
+    };
+  }
+
+  const padded = fraction.padEnd(scale, '0');
+  const body = scale > 0 ? `${whole}.${padded}` : whole;
+  const zero = whole === '0' && !/[1-9]/u.test(padded);
+
+  return { value: `${parts.negative && !zero ? '-' : ''}${body}` };
+}
+
+/**
+ * A bigint value as the exact string the column holds
+ *
+ * @param {*} value what the application passed
+ * @returns {{value: string}|{error: string}} the value, or what is wrong
+ */
+function canonicalInteger(value) {
+  if (typeof value === 'bigint') {
+    return bounded(value);
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isInteger(value)) {
+      return { error: 'must be a whole number' };
+    }
+
+    return Number.isSafeInteger(value)
+      ? bounded(BigInt(value))
+      : {
+          error:
+            'is past what a javascript number carries exactly: pass it as a string',
+        };
+  }
+
+  if (typeof value !== 'string' || !WHOLE.test(value.trim())) {
+    return { error: 'must be a whole number' };
+  }
+
+  return bounded(BigInt(value.trim()));
+}
+
+/**
+ * The value, when it fits a signed 64-bit column
+ *
+ * @param {bigint} value the value
+ * @returns {{value: string}|{error: string}} the value, or what is wrong
+ */
+function bounded(value) {
+  return value < MIN || value > MAX
+    ? { error: `must be between ${BIGINT_MIN} and ${BIGINT_MAX}` }
+    : { value: value.toString() };
+}
+
+/**
+ * Two exact numbers compared without going through a double
+ *
+ * @param {*} left one value
+ * @param {*} right the other
+ * @returns {?number} -1, 0 or 1, and null when either is not a number
+ */
+function compare(left, right) {
+  const one = literalOf(left);
+  const two = literalOf(right);
+  const first = one === null ? null : split(one);
+  const second = two === null ? null : split(two);
+
+  if (!first || !second) {
+    return null;
+  }
+
+  // A zero has no sign to compare, so `-0` and `0` are the same value
+  const below = first.negative && !isZero(first);
+  const under = second.negative && !isZero(second);
+
+  if (below !== under) {
+    return below ? -1 : 1;
+  }
+
+  const size = magnitude(first, second);
+
+  return below ? -size : size;
+}
+
+/**
+ * Is this value zero, whatever it was written as?
+ *
+ * @param {object} parts a split literal
+ * @returns {boolean} true for every spelling of zero
+ */
+const isZero = (parts) =>
+  !/[1-9]/u.test(parts.whole) && !/[1-9]/u.test(parts.fraction);
+
+/**
+ * The two magnitudes compared, sign left out
+ *
+ * @param {object} first a split literal
+ * @param {object} second another
+ * @returns {number} -1, 0 or 1
+ */
+function magnitude(first, second) {
+  const left = first.whole.replace(/^0+(?=\d)/u, '');
+  const right = second.whole.replace(/^0+(?=\d)/u, '');
+
+  if (left.length !== right.length) {
+    return left.length < right.length ? -1 : 1;
+  }
+
+  if (left !== right) {
+    return left < right ? -1 : 1;
+  }
+
+  const size = Math.max(first.fraction.length, second.fraction.length);
+  const one = first.fraction.padEnd(size, '0');
+  const two = second.fraction.padEnd(size, '0');
+
+  if (one === two) {
+    return 0;
+  }
+
+  return one < two ? -1 : 1;
+}
+
+/**
+ * The double a dialect without an exact type has to compare through
+ *
+ * @param {*} value an exact value
+ * @returns {number} the nearest double
+ */
+const toNumber = (value) => Number(literalOf(value) ?? NaN);
+
+module.exports = {
+  BIGINT_MAX,
+  BIGINT_MIN,
+  DEFAULT_PRECISION,
+  DEFAULT_SCALE,
+  EXACT_TYPES,
+  MAX_PRECISION,
+  canonical,
+  canonicalInteger,
+  checkSettings,
+  compare,
+  isExact,
+  literalOf,
+  settingsOf,
+  toNumber,
+};

--- a/packages/mongoose/exact.js
+++ b/packages/mongoose/exact.js
@@ -146,7 +146,7 @@ function plain(literal) {
     return null;
   }
 
-  const whole = parts.whole.replace(/^0+(?=\d)/u, '');
+  const whole = withoutLeadingZeros(parts.whole);
   const sign = parts.negative && !isZero(parts) ? '-' : '';
 
   return `${sign}${whole}${parts.fraction === '' ? '' : `.${parts.fraction}`}`;
@@ -217,6 +217,46 @@ const settingsOf = (field) => ({
 });
 
 /**
+ * The digits without their trailing zeros, and without their leading ones.
+ *
+ * Walked rather than matched. `/0+$/` is quadratic on a fraction that is a
+ * long run of zeros followed by a digit -- `0.000…0001`, which is a decimal
+ * a request may legitimately carry -- and 200,000 of them took 17 seconds
+ * here before this was two index walks. The same shape has been fixed twice
+ * elsewhere in this repository (`uploads/src/names.js`, the cdn base of
+ * `uploads/src/signing.js`), and the rule is the one those state: a value
+ * that reaches a pattern from a request is walked.
+ *
+ * @param {string} digits the fraction, as written
+ * @returns {string} the same without trailing zeros
+ */
+function withoutTrailingZeros(digits) {
+  let end = digits.length;
+
+  while (end > 0 && digits[end - 1] === '0') {
+    end -= 1;
+  }
+
+  return digits.slice(0, end);
+}
+
+/**
+ * The whole part without its leading zeros, keeping one digit
+ *
+ * @param {string} digits the whole part, as written
+ * @returns {string} the same without leading zeros
+ */
+function withoutLeadingZeros(digits) {
+  let start = 0;
+
+  while (start < digits.length - 1 && digits[start] === '0') {
+    start += 1;
+  }
+
+  return digits.slice(start);
+}
+
+/**
  * What is wrong with the `precision` and `scale` a field declares, if
  * anything. An adapter raises its own coded error with the sentence.
  *
@@ -269,7 +309,7 @@ function canonical(value, settings) {
     return { error: 'must be a decimal number' };
   }
 
-  const fraction = parts.fraction.replace(/0+$/u, '');
+  const fraction = withoutTrailingZeros(parts.fraction);
 
   if (fraction.length > scale) {
     return {
@@ -282,7 +322,7 @@ function canonical(value, settings) {
     };
   }
 
-  const whole = parts.whole.replace(/^0+(?=\d)/u, '');
+  const whole = withoutLeadingZeros(parts.whole);
   const digits = precision - scale;
 
   if (whole !== '0' && whole.length > digits) {
@@ -390,8 +430,8 @@ const isZero = (parts) =>
  * @returns {number} -1, 0 or 1
  */
 function magnitude(first, second) {
-  const left = first.whole.replace(/^0+(?=\d)/u, '');
-  const right = second.whole.replace(/^0+(?=\d)/u, '');
+  const left = withoutLeadingZeros(first.whole);
+  const right = withoutLeadingZeros(second.whole);
 
   if (left.length !== right.length) {
     return left.length < right.length ? -1 : 1;

--- a/packages/mongoose/index.js
+++ b/packages/mongoose/index.js
@@ -2,6 +2,7 @@ const mongoose = require('mongoose');
 const debug = require('debug')('henri:mongoose');
 const { externalId, lookups, owned, paginate, paranoid } = require('./plugins');
 const { normalizeModel } = require('./schema');
+const { exactPaths, exactness } = require('./exact-paths');
 const { encryption } = require('./encryption');
 const { versioned } = require('./versions');
 const {
@@ -163,6 +164,15 @@ class Mongoose {
     owned(schema, this.henri);
     paginate(schema);
     lookups(schema);
+
+    // Before everything else that reads a document back: a `decimal` and a
+    // `bigint` are strings in JavaScript, and every other hook here has to
+    // see the same value the application wrote (./exact-paths.js)
+    const exact = exactPaths(model.schema || {});
+
+    if (Object.keys(exact).length > 0) {
+      exactness(schema, exact);
+    }
 
     // Before the model is compiled: `register()` is what refuses the boot
     // when a field says `encrypted` and the application has no key

--- a/packages/mongoose/package.json
+++ b/packages/mongoose/package.json
@@ -23,6 +23,8 @@
   "main": "index.js",
   "files": [
     "index.js",
+    "exact.js",
+    "exact-paths.js",
     "external-id.js",
     "plugins.js",
     "schema.js",

--- a/packages/mongoose/schema.js
+++ b/packages/mongoose/schema.js
@@ -1,5 +1,8 @@
 const TYPES = require('./types');
 const { encryptionOf, isPlainObject } = require('./encrypted');
+const { checkSettings, isExact, settingsOf } = require('./exact');
+const { setter } = require('./exact-paths');
+const { coded } = require('./utils');
 
 /**
  * Resolves a henri type name to a Mongoose type; anything else is returned
@@ -48,11 +51,39 @@ const normalizeField = (
   }
 
   // Marks for henri: `personal` for base/privacy.js, `encrypted` for
-  // base/encryption.js. Neither is a Mongoose option
-  const { allowNull, defaultValue, encrypted, personal, type, ...rest } =
-    definition;
+  // base/encryption.js. Neither is a Mongoose option, and neither are the
+  // `precision` and `scale` of a decimal column
+  const {
+    allowNull,
+    defaultValue,
+    encrypted,
+    personal,
+    precision,
+    scale,
+    type,
+    ...rest
+  } = definition;
   const mark = encryptionOf(field, definition, context);
   const shaped = { ...rest, type: normalizeField(type, field, context) };
+  const name = typeof type === 'string' ? type.toLowerCase() : null;
+  const wrong = checkSettings(name, definition);
+
+  if (wrong) {
+    throw coded('HENRI_MODEL_INVALID_FIELD', `Field '${field}' ${wrong}`);
+  }
+
+  // A `decimal` is padded to its scale on the way in and read back as a
+  // string on the way out, so a model file answers the same value here as
+  // it does on the SQL adapters (./exact-paths.js)
+  if (isExact(name)) {
+    const settings = settingsOf(definition);
+
+    shaped.set = setter(field, name, settings);
+
+    if (typeof shaped.default !== 'undefined') {
+      shaped.default = shaped.set(shaped.default);
+    }
+  }
 
   if (allowNull === false && typeof shaped.required === 'undefined') {
     shaped.required = true;

--- a/packages/mongoose/schema.js
+++ b/packages/mongoose/schema.js
@@ -4,6 +4,10 @@ const { checkSettings, isExact, settingsOf } = require('./exact');
 const { setter } = require('./exact-paths');
 const { coded } = require('./utils');
 
+// Keys that measure a string, and therefore mean nothing on a `decimal` or
+// a `bigint`: the value is a string, so they would quietly count digits
+const TEXTUAL_KEYS = ['lowercase', 'match', 'maxLength', 'minLength', 'trim'];
+
 /**
  * Resolves a henri type name to a Mongoose type; anything else is returned
  * as is (Mongoose knows constructors, 'ObjectId', schemas, ...)
@@ -77,8 +81,20 @@ const normalizeField = (
   // it does on the SQL adapters (./exact-paths.js)
   if (isExact(name)) {
     const settings = settingsOf(definition);
+    const textual = TEXTUAL_KEYS.find((key) => key in definition);
+
+    if (textual) {
+      throw coded(
+        'HENRI_MODEL_INVALID_FIELD',
+        `Field '${field}' has '${textual}', which measures text: a ${name} is a number, and its bounds are 'min' and 'max'`
+      );
+    }
 
     shaped.set = setter(field, name, settings);
+    // Mongoose ignores both on a Decimal128 and a BigInt without a word;
+    // `exact-paths.js` carries them, so they are not paths options here
+    delete shaped.min;
+    delete shaped.max;
 
     if (typeof shaped.default !== 'undefined') {
       shaped.default = shaped.set(shaped.default);

--- a/packages/mongoose/types.js
+++ b/packages/mongoose/types.js
@@ -14,14 +14,24 @@ const { Schema } = require('mongoose');
  * - number:  Number
  * - integer: Number
  * - float:   Number
+ * - decimal: Decimal128 (exact; a string in JavaScript, see ./exact.js)
+ * - bigint:  BigInt, stored as a BSON 64-bit integer (a string in
+ *   JavaScript too, for the same reason)
  * - boolean: Boolean
  * - date:    Date
  * - json:    Mixed
  * - uuid:    String (portable with the SQL adapters)
+ *
+ * The two exact ones are the only names whose JavaScript value is not what
+ * Mongoose hands back: a `Decimal128` and a `BigInt` are turned into the
+ * decimal string every adapter answers with, by the hooks of
+ * `./exact-paths.js`.
  */
 module.exports = {
+  bigint: Schema.Types.BigInt,
   boolean: Boolean,
   date: Date,
+  decimal: Schema.Types.Decimal128,
   float: Number,
   integer: Number,
   json: Schema.Types.Mixed,

--- a/packages/sequelize/__tests__/exact.spec.js
+++ b/packages/sequelize/__tests__/exact.spec.js
@@ -1,0 +1,189 @@
+// `decimal` and `bigint` on the Sequelize adapter.
+//
+// This adapter is reachable through `@usehenri/mssql` and nothing else,
+// because Drizzle has no SQL Server dialect -- so the round trip is proved
+// on the servers that are there to exercise the base class, the PostgreSQL
+// and MySQL of `pnpm test:sql:live`, and offline the suite proves the one
+// thing that runs everywhere: the refusal. Sequelize reads a sqlite
+// DECIMAL through a double and a BIGINT past 2^53 loses its digits, and
+// there is no seam in this adapter to store the digits as text and cast
+// for a comparison the way @usehenri/drizzle does on sqlite, so a model
+// asking for either fails the boot naming the model and the field.
+const { DataTypes } = require('sequelize');
+const { normalizeSchema } = require('../schema');
+const { build, target } = require('./helpers');
+
+const invoiceModel = {
+  globalId: 'Invoice',
+  identity: 'invoice',
+  options: { timestamps: false },
+  schema: {
+    amount: { precision: 12, scale: 2, type: 'decimal' },
+    name: { type: 'string' },
+    rate: { type: 'decimal' },
+    reference: { type: 'bigint' },
+  },
+  store: 'default',
+};
+
+describe(`decimal and bigint (${target.name})`, () => {
+  describe('what sqlite refuses', () => {
+    test('a decimal on sqlite fails the boot naming the model and the field', () => {
+      expect(() =>
+        normalizeSchema(
+          { amount: { type: 'decimal' } },
+          { dialect: 'sqlite', model: 'Invoice' }
+        )
+      ).toThrow(
+        /Field 'amount' of Invoice is a decimal, which @usehenri\/sequelize cannot carry on sqlite/u
+      );
+    });
+
+    test('so does a bigint, and it points at the adapter that can', () => {
+      let error = null;
+
+      try {
+        normalizeSchema(
+          { reference: { type: 'bigint' } },
+          { dialect: 'sqlite', model: 'Invoice' }
+        );
+      } catch (thrown) {
+        error = thrown;
+      }
+
+      expect(error.code).toBe('HENRI_MODEL_TYPE_UNSUPPORTED');
+      expect(error.message).toMatch(/@usehenri\/drizzle/u);
+    });
+
+    test('every other dialect takes them', () => {
+      for (const dialect of ['postgres', 'mysql', 'mssql']) {
+        const { attributes } = normalizeSchema(
+          {
+            amount: { precision: 12, scale: 2, type: 'decimal' },
+            reference: { type: 'bigint' },
+          },
+          { dialect, model: 'Invoice' }
+        );
+
+        expect(attributes.amount.type.toSql()).toMatch(/DECIMAL\(12, ?2\)/u);
+        expect(String(attributes.reference.type.key)).toBe('BIGINT');
+      }
+    });
+  });
+
+  describe('the sequelize spellings of the same column', () => {
+    test('a DECIMAL(p, s) is read as the henri decimal', () => {
+      const { attributes } = normalizeSchema(
+        { amount: { type: DataTypes.DECIMAL(10, 2) } },
+        { dialect: 'postgres', model: 'Invoice' }
+      );
+
+      expect(attributes.amount.type.toSql()).toMatch(/DECIMAL\(10, ?2\)/u);
+      expect(typeof attributes.amount.get).toBe('function');
+      expect(attributes.amount.validate.henriExact).toBeInstanceOf(Function);
+    });
+
+    test('a BIGINT is too', () => {
+      const { attributes } = normalizeSchema(
+        { count: { type: DataTypes.BIGINT } },
+        { dialect: 'postgres', model: 'Invoice' }
+      );
+
+      expect(typeof attributes.count.get).toBe('function');
+    });
+
+    test('a bare DECIMAL is refused: MySQL makes it whole units', () => {
+      expect(() =>
+        normalizeSchema(
+          { amount: { type: DataTypes.DECIMAL } },
+          { dialect: 'postgres', model: 'Invoice' }
+        )
+      ).toThrow(
+        /DECIMAL with no precision, which MySQL makes DECIMAL\(10, 0\)/u
+      );
+    });
+
+    test('a precision on anything but a decimal is refused', () => {
+      expect(() =>
+        normalizeSchema(
+          { count: { precision: 4, type: 'bigint' } },
+          { dialect: 'postgres', model: 'Invoice' }
+        )
+      ).toThrow(/takes no 'precision'/u);
+    });
+  });
+
+  // On a live server, the same round trip the other two adapters prove
+  const live = target.name === 'sqlite' ? describe.skip : describe;
+
+  live('the round trip', () => {
+    let adapter;
+    let Invoice;
+
+    beforeAll(async () => {
+      ({ adapter } = build());
+      Invoice = adapter.addModel(invoiceModel);
+      await adapter.start();
+      await adapter.connector.sync({ force: true });
+    });
+
+    afterAll(async () => {
+      await adapter.stop();
+    });
+
+    test('a decimal comes back at its scale, exactly', async () => {
+      for (const [given, expected] of [
+        ['19.99', '19.99'],
+        [19.99, '19.99'],
+        ['19.9900', '19.99'],
+        ['-2.5', '-2.50'],
+      ]) {
+        const created = await Invoice.create({ amount: given, name: 'x' });
+        const read = await Invoice.findByPk(created.id);
+
+        expect(created.amount).toBe(expected);
+        expect(read.amount).toBe(expected);
+        expect(JSON.parse(JSON.stringify(read)).amount).toBe(expected);
+      }
+    });
+
+    test('a cent added a hundred times is a dollar, exactly', async () => {
+      const created = await Invoice.create({ amount: '1.00', name: 'cents' });
+
+      expect((await Invoice.findByPk(created.id)).amount).toBe('1.00');
+    });
+
+    test('0.1 + 0.2 is refused rather than stored', async () => {
+      await expect(
+        Invoice.create({ name: 'float', rate: 0.1 + 0.2 })
+      ).rejects.toThrow(/at most 4 decimal places/u);
+    });
+
+    test('a bigint past 2^53 comes back whole', async () => {
+      for (const reference of [
+        '9223372036854775807',
+        '-9223372036854775808',
+        '9007199254740993',
+        '2147483648',
+      ]) {
+        const created = await Invoice.create({ name: 'big', reference });
+        const read = await Invoice.findByPk(created.id);
+
+        expect(created.reference).toBe(reference);
+        expect(read.reference).toBe(reference);
+      }
+    });
+
+    test('the bounds of the column are refused, not rounded', async () => {
+      await expect(
+        Invoice.create({ amount: '19.999', name: 'precise' })
+      ).rejects.toThrow(/at most 2 decimal places/u);
+      await expect(
+        Invoice.create({ name: 'past', reference: '9223372036854775808' })
+      ).rejects.toThrow(/between -9223372036854775808/u);
+      await expect(
+        Invoice.create({ name: 'unsafe', reference: 2 ** 60 })
+      ).rejects.toThrow(/pass it as a string/u);
+    });
+  });
+});

--- a/packages/sequelize/__tests__/schema.spec.js
+++ b/packages/sequelize/__tests__/schema.spec.js
@@ -29,8 +29,10 @@ describe('schema normalizer', () => {
 
   test('documents the same names as the types map', () => {
     expect(Object.keys(types).sort()).toEqual([
+      'bigint',
       'boolean',
       'date',
+      'decimal',
       'float',
       'integer',
       'json',

--- a/packages/sequelize/exact.js
+++ b/packages/sequelize/exact.js
@@ -132,6 +132,27 @@ function expand(text) {
 }
 
 /**
+ * The one spelling of a literal: no exponent, no `+`, no leading zeros, a
+ * digit before the point, and no sign on a zero. The digits after the point
+ * are left alone -- they are what the writer said the value was worth to.
+ *
+ * @param {string} literal a literal, already written out
+ * @returns {?string} the same value, spelled once
+ */
+function plain(literal) {
+  const parts = split(literal);
+
+  if (!parts) {
+    return null;
+  }
+
+  const whole = parts.whole.replace(/^0+(?=\d)/u, '');
+  const sign = parts.negative && !isZero(parts) ? '-' : '';
+
+  return `${sign}${whole}${parts.fraction === '' ? '' : `.${parts.fraction}`}`;
+}
+
+/**
  * A value as a decimal literal written out, or null when it is not a number
  *
  * @param {*} value a string, a number or a BigInt
@@ -143,7 +164,7 @@ function literalOf(value) {
   }
 
   if (typeof value === 'number') {
-    return Number.isFinite(value) ? expand(String(value)) : null;
+    return Number.isFinite(value) ? plain(expand(String(value))) : null;
   }
 
   if (typeof value !== 'string') {
@@ -152,7 +173,7 @@ function literalOf(value) {
 
   const text = value.trim();
 
-  return LITERAL.test(text) ? expand(text) : null;
+  return LITERAL.test(text) ? plain(expand(text)) : null;
 }
 
 /**

--- a/packages/sequelize/exact.js
+++ b/packages/sequelize/exact.js
@@ -1,0 +1,417 @@
+/**
+ * The two henri types a JavaScript `number` cannot carry: `decimal` and
+ * `bigint`.
+ *
+ * Every other type in the vocabulary has a JavaScript value that *is* the
+ * value: a `string` is a string, a `date` is a Date, an `integer` under
+ * 2^53 is a number. These two do not. A `numeric(19, 4)` read into a double
+ * is a float again, a `bigint` past `Number.MAX_SAFE_INTEGER` loses digits,
+ * and in both cases the column choice is undone by the round trip -- which
+ * is the whole reason the types exist.
+ *
+ * ## The boundary is a string, on all three adapters
+ *
+ * A value of an exact type crosses into JavaScript as a **decimal string**:
+ * `'19.99'`, `'-1'`, `'9223372036854775807'`. Never a `number`, never a
+ * `BigInt`, never an object of henri's own. The reasons, in order:
+ *
+ * - `JSON.stringify` throws on a `BigInt`. henri serializes model records in
+ *   `res.render`, `res.resource`, `res.collection`, the cache (which refuses
+ *   what it cannot encode), the call log, the version diffs, the trail, the
+ *   job payloads and GraphQL. A `BigInt` escaping into any of them is a
+ *   TypeError raised deep inside express, after the controller returned --
+ *   a worse silent difference than the one being removed.
+ * - A decimal object needs a dependency, and it would not survive JSON
+ *   either. henri ships no arithmetic: an application that wants to add two
+ *   prices picks its own library, and hands henri back a string.
+ * - It is the shortest path, not a conversion. node-postgres already hands
+ *   back `numeric` and `int8` as strings, mysql2 hands back `DECIMAL` as a
+ *   string, and `Decimal128.toString()` is exact. Turning any of those into
+ *   a number is what loses the value.
+ * - A string is exact, comparable for equality, JSON-safe, and identical on
+ *   the three adapters -- which is what makes a model file mean one thing
+ *   everywhere.
+ *
+ * ## What is accepted on the way in
+ *
+ * A string (a decimal literal, exponent form included), a `number`, and --
+ * for `bigint` -- a `BigInt`. A number goes through `String(value)`, which
+ * is the shortest representation that round-trips, so the literal a person
+ * typed survives: `String(19.99)` is `'19.99'`. What does *not* survive is
+ * arithmetic that already lost the value, and that is the point:
+ * `0.1 + 0.2` arrives as `'0.30000000000000004'` and is refused by the
+ * scale rather than rounded into the column. henri does not round money.
+ *
+ * ## What is refused
+ *
+ * More decimal places than the declared `scale` (after the trailing zeros,
+ * which are not information), more digits before the point than
+ * `precision - scale`, a `bigint` outside the signed 64-bit range, and a
+ * `number` that is not a safe integer where a whole number was asked for.
+ * Each one is a value the database would have quietly changed.
+ *
+ * This file is duplicated into each adapter (`packages/<adapter>/exact.js`)
+ * the way `external-id.js` and `encrypted.js` are: an adapter depends on no
+ * part of core at runtime. The copies are byte identical and
+ * `src/__tests__/exact.spec.js` is what keeps them so.
+ *
+ * @module exact
+ */
+
+/** The henri types whose values are exact, and therefore strings */
+const EXACT_TYPES = Object.freeze(['bigint', 'decimal']);
+
+/** Total digits of a `decimal` when the field does not say */
+const DEFAULT_PRECISION = 19;
+
+/** Digits after the point when the field does not say */
+const DEFAULT_SCALE = 4;
+
+/**
+ * The most digits every dialect henri writes carries: SQL Server stops at
+ * 38, MySQL at 65, PostgreSQL at 1000. The smallest is the one a model may
+ * ask for, so the same file works everywhere.
+ */
+const MAX_PRECISION = 38;
+
+/** The bounds of a signed 64-bit integer, as the strings a message prints */
+const BIGINT_MIN = '-9223372036854775808';
+
+/** ... and the other end */
+const BIGINT_MAX = '9223372036854775807';
+
+const MIN = BigInt(BIGINT_MIN);
+const MAX = BigInt(BIGINT_MAX);
+
+/** A decimal literal and nothing else: no `0x10`, no `Infinity`, no `1n` */
+const LITERAL = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/u;
+
+/** A whole number, written out */
+const WHOLE = /^[+-]?\d+$/u;
+
+/** A literal in exponent form, split into its parts */
+const EXPONENT = /^([+-]?)(\d*)(?:\.(\d*))?[eE]([+-]?\d+)$/u;
+
+/** A literal written out, split into its parts */
+const PLAIN = /^([+-]?)(\d*)(?:\.(\d*))?$/u;
+
+/**
+ * Is this one of the exact types?
+ *
+ * @param {*} type a type name
+ * @returns {boolean} true for `decimal` and `bigint`
+ */
+const isExact = (type) => EXACT_TYPES.includes(type);
+
+/**
+ * The same literal without its exponent, so everything below is string work
+ *
+ * @param {string} text a decimal literal
+ * @returns {string} the literal written out
+ */
+function expand(text) {
+  const match = EXPONENT.exec(text);
+
+  if (!match) {
+    return text;
+  }
+
+  const [, sign, whole, fraction = '', exponent] = match;
+  const digits = `${whole}${fraction}`;
+  const point = whole.length + Number(exponent);
+
+  if (point <= 0) {
+    return `${sign}0.${'0'.repeat(-point)}${digits}`;
+  }
+
+  if (point >= digits.length) {
+    return `${sign}${digits}${'0'.repeat(point - digits.length)}`;
+  }
+
+  return `${sign}${digits.slice(0, point)}.${digits.slice(point)}`;
+}
+
+/**
+ * A value as a decimal literal written out, or null when it is not a number
+ *
+ * @param {*} value a string, a number or a BigInt
+ * @returns {?string} the literal, or null
+ */
+function literalOf(value) {
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? expand(String(value)) : null;
+  }
+
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const text = value.trim();
+
+  return LITERAL.test(text) ? expand(text) : null;
+}
+
+/**
+ * A literal split into a sign, the digits before the point and the ones
+ * after it
+ *
+ * @param {string} literal a literal written out
+ * @returns {?object} `{ negative, whole, fraction }`, or null
+ */
+function split(literal) {
+  const match = PLAIN.exec(literal);
+
+  if (!match) {
+    return null;
+  }
+
+  const [, sign, whole, fraction = ''] = match;
+
+  if (whole === '' && fraction === '') {
+    return null;
+  }
+
+  return {
+    fraction,
+    negative: sign === '-',
+    whole: whole === '' ? '0' : whole,
+  };
+}
+
+/**
+ * The `precision` and `scale` of a decimal field, defaulted
+ *
+ * @param {object} [field] the normalized field
+ * @returns {{precision: number, scale: number}} what the column carries
+ */
+const settingsOf = (field) => ({
+  precision: Number.isInteger(field && field.precision)
+    ? field.precision
+    : DEFAULT_PRECISION,
+  scale: Number.isInteger(field && field.scale) ? field.scale : DEFAULT_SCALE,
+});
+
+/**
+ * What is wrong with the `precision` and `scale` a field declares, if
+ * anything. An adapter raises its own coded error with the sentence.
+ *
+ * @param {string} type the henri type of the field
+ * @param {object} [field] the field definition
+ * @returns {?string} what is wrong, or null
+ */
+function checkSettings(type, field) {
+  const given = field || {};
+  const declared = ['precision', 'scale'].filter((key) => key in given);
+
+  if (type !== 'decimal') {
+    return declared.length > 0
+      ? `takes no '${declared[0]}': only a decimal has one`
+      : null;
+  }
+
+  for (const key of declared) {
+    if (!Number.isInteger(given[key]) || given[key] < 0) {
+      return `has a '${key}' that is not a whole number`;
+    }
+  }
+
+  const { precision, scale } = settingsOf(given);
+
+  if (precision < 1 || precision > MAX_PRECISION) {
+    return `has a 'precision' of ${precision}: it is between 1 and ${MAX_PRECISION}, the most every dialect henri writes carries`;
+  }
+
+  if (scale > precision) {
+    return `has a 'scale' of ${scale}, which is more than its precision of ${precision}`;
+  }
+
+  return null;
+}
+
+/**
+ * A decimal value as the exact string the column holds, at its scale
+ *
+ * @param {*} value what the application passed
+ * @param {object} settings `{ precision, scale }`
+ * @returns {{value: string}|{error: string}} the value, or what is wrong
+ */
+function canonical(value, settings) {
+  const { precision, scale } = settings;
+  const literal = literalOf(value);
+  const parts = literal === null ? null : split(literal);
+
+  if (!parts) {
+    return { error: 'must be a decimal number' };
+  }
+
+  const fraction = parts.fraction.replace(/0+$/u, '');
+
+  if (fraction.length > scale) {
+    return {
+      error:
+        scale === 0
+          ? 'must be a whole number'
+          : `must have at most ${scale} decimal place${
+              scale === 1 ? '' : 's'
+            }, and rounding is the application's to do`,
+    };
+  }
+
+  const whole = parts.whole.replace(/^0+(?=\d)/u, '');
+  const digits = precision - scale;
+
+  if (whole !== '0' && whole.length > digits) {
+    return {
+      error: `must have at most ${digits} digit${
+        digits === 1 ? '' : 's'
+      } before the decimal point`,
+    };
+  }
+
+  const padded = fraction.padEnd(scale, '0');
+  const body = scale > 0 ? `${whole}.${padded}` : whole;
+  const zero = whole === '0' && !/[1-9]/u.test(padded);
+
+  return { value: `${parts.negative && !zero ? '-' : ''}${body}` };
+}
+
+/**
+ * A bigint value as the exact string the column holds
+ *
+ * @param {*} value what the application passed
+ * @returns {{value: string}|{error: string}} the value, or what is wrong
+ */
+function canonicalInteger(value) {
+  if (typeof value === 'bigint') {
+    return bounded(value);
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isInteger(value)) {
+      return { error: 'must be a whole number' };
+    }
+
+    return Number.isSafeInteger(value)
+      ? bounded(BigInt(value))
+      : {
+          error:
+            'is past what a javascript number carries exactly: pass it as a string',
+        };
+  }
+
+  if (typeof value !== 'string' || !WHOLE.test(value.trim())) {
+    return { error: 'must be a whole number' };
+  }
+
+  return bounded(BigInt(value.trim()));
+}
+
+/**
+ * The value, when it fits a signed 64-bit column
+ *
+ * @param {bigint} value the value
+ * @returns {{value: string}|{error: string}} the value, or what is wrong
+ */
+function bounded(value) {
+  return value < MIN || value > MAX
+    ? { error: `must be between ${BIGINT_MIN} and ${BIGINT_MAX}` }
+    : { value: value.toString() };
+}
+
+/**
+ * Two exact numbers compared without going through a double
+ *
+ * @param {*} left one value
+ * @param {*} right the other
+ * @returns {?number} -1, 0 or 1, and null when either is not a number
+ */
+function compare(left, right) {
+  const one = literalOf(left);
+  const two = literalOf(right);
+  const first = one === null ? null : split(one);
+  const second = two === null ? null : split(two);
+
+  if (!first || !second) {
+    return null;
+  }
+
+  // A zero has no sign to compare, so `-0` and `0` are the same value
+  const below = first.negative && !isZero(first);
+  const under = second.negative && !isZero(second);
+
+  if (below !== under) {
+    return below ? -1 : 1;
+  }
+
+  const size = magnitude(first, second);
+
+  return below ? -size : size;
+}
+
+/**
+ * Is this value zero, whatever it was written as?
+ *
+ * @param {object} parts a split literal
+ * @returns {boolean} true for every spelling of zero
+ */
+const isZero = (parts) =>
+  !/[1-9]/u.test(parts.whole) && !/[1-9]/u.test(parts.fraction);
+
+/**
+ * The two magnitudes compared, sign left out
+ *
+ * @param {object} first a split literal
+ * @param {object} second another
+ * @returns {number} -1, 0 or 1
+ */
+function magnitude(first, second) {
+  const left = first.whole.replace(/^0+(?=\d)/u, '');
+  const right = second.whole.replace(/^0+(?=\d)/u, '');
+
+  if (left.length !== right.length) {
+    return left.length < right.length ? -1 : 1;
+  }
+
+  if (left !== right) {
+    return left < right ? -1 : 1;
+  }
+
+  const size = Math.max(first.fraction.length, second.fraction.length);
+  const one = first.fraction.padEnd(size, '0');
+  const two = second.fraction.padEnd(size, '0');
+
+  if (one === two) {
+    return 0;
+  }
+
+  return one < two ? -1 : 1;
+}
+
+/**
+ * The double a dialect without an exact type has to compare through
+ *
+ * @param {*} value an exact value
+ * @returns {number} the nearest double
+ */
+const toNumber = (value) => Number(literalOf(value) ?? NaN);
+
+module.exports = {
+  BIGINT_MAX,
+  BIGINT_MIN,
+  DEFAULT_PRECISION,
+  DEFAULT_SCALE,
+  EXACT_TYPES,
+  MAX_PRECISION,
+  canonical,
+  canonicalInteger,
+  checkSettings,
+  compare,
+  isExact,
+  literalOf,
+  settingsOf,
+  toNumber,
+};

--- a/packages/sequelize/exact.js
+++ b/packages/sequelize/exact.js
@@ -146,7 +146,7 @@ function plain(literal) {
     return null;
   }
 
-  const whole = parts.whole.replace(/^0+(?=\d)/u, '');
+  const whole = withoutLeadingZeros(parts.whole);
   const sign = parts.negative && !isZero(parts) ? '-' : '';
 
   return `${sign}${whole}${parts.fraction === '' ? '' : `.${parts.fraction}`}`;
@@ -217,6 +217,46 @@ const settingsOf = (field) => ({
 });
 
 /**
+ * The digits without their trailing zeros, and without their leading ones.
+ *
+ * Walked rather than matched. `/0+$/` is quadratic on a fraction that is a
+ * long run of zeros followed by a digit -- `0.000…0001`, which is a decimal
+ * a request may legitimately carry -- and 200,000 of them took 17 seconds
+ * here before this was two index walks. The same shape has been fixed twice
+ * elsewhere in this repository (`uploads/src/names.js`, the cdn base of
+ * `uploads/src/signing.js`), and the rule is the one those state: a value
+ * that reaches a pattern from a request is walked.
+ *
+ * @param {string} digits the fraction, as written
+ * @returns {string} the same without trailing zeros
+ */
+function withoutTrailingZeros(digits) {
+  let end = digits.length;
+
+  while (end > 0 && digits[end - 1] === '0') {
+    end -= 1;
+  }
+
+  return digits.slice(0, end);
+}
+
+/**
+ * The whole part without its leading zeros, keeping one digit
+ *
+ * @param {string} digits the whole part, as written
+ * @returns {string} the same without leading zeros
+ */
+function withoutLeadingZeros(digits) {
+  let start = 0;
+
+  while (start < digits.length - 1 && digits[start] === '0') {
+    start += 1;
+  }
+
+  return digits.slice(start);
+}
+
+/**
  * What is wrong with the `precision` and `scale` a field declares, if
  * anything. An adapter raises its own coded error with the sentence.
  *
@@ -269,7 +309,7 @@ function canonical(value, settings) {
     return { error: 'must be a decimal number' };
   }
 
-  const fraction = parts.fraction.replace(/0+$/u, '');
+  const fraction = withoutTrailingZeros(parts.fraction);
 
   if (fraction.length > scale) {
     return {
@@ -282,7 +322,7 @@ function canonical(value, settings) {
     };
   }
 
-  const whole = parts.whole.replace(/^0+(?=\d)/u, '');
+  const whole = withoutLeadingZeros(parts.whole);
   const digits = precision - scale;
 
   if (whole !== '0' && whole.length > digits) {
@@ -390,8 +430,8 @@ const isZero = (parts) =>
  * @returns {number} -1, 0 or 1
  */
 function magnitude(first, second) {
-  const left = first.whole.replace(/^0+(?=\d)/u, '');
-  const right = second.whole.replace(/^0+(?=\d)/u, '');
+  const left = withoutLeadingZeros(first.whole);
+  const right = withoutLeadingZeros(second.whole);
 
   if (left.length !== right.length) {
     return left.length < right.length ? -1 : 1;

--- a/packages/sequelize/index.js
+++ b/packages/sequelize/index.js
@@ -147,6 +147,20 @@ class Sql {
       options.dialectModule = this.driver;
     }
 
+    // Without this mysql2 reads a BIGINT through a double, so
+    // 9223372036854775807 comes back as 9223372036854776000; with it, a
+    // value past what a JavaScript number carries exactly arrives as a
+    // string and everything smaller is untouched (see ./exact.js)
+    if (
+      /^(mysql|mariadb)$/iu.test(options.dialect || '') ||
+      /^(mysql|mariadb):/iu.test(url || '')
+    ) {
+      options.dialectOptions = {
+        supportBigNumbers: true,
+        ...(options.dialectOptions || {}),
+      };
+    }
+
     debug('store %s configuration %O', this.name, redact({ ...options, url }));
 
     if (url) {

--- a/packages/sequelize/package.json
+++ b/packages/sequelize/package.json
@@ -24,6 +24,7 @@
   "files": [
     "index.js",
     "drift.js",
+    "exact.js",
     "external-id.js",
     "plugins.js",
     "schema.js",

--- a/packages/sequelize/schema.js
+++ b/packages/sequelize/schema.js
@@ -1,6 +1,13 @@
 const { DataTypes } = require('sequelize');
 const TYPES = require('./types');
 const { DETERMINISTIC_LENGTH, encryptionOf } = require('./encrypted');
+const {
+  canonical,
+  canonicalInteger,
+  checkSettings,
+  isExact,
+  settingsOf,
+} = require('./exact');
 const { coded } = require('./utils');
 
 // Dialects with a native ENUM column type
@@ -17,7 +24,10 @@ const HENRI_KEYS = {
   // Metadata, not a column: henri reads it back through the model file
   // (base/privacy.js), so the attribute never carries it
   personal: 'henri.privacy',
+  // The two a `decimal` carries; they build DECIMAL(p, s) below
+  precision: 'DataTypes.DECIMAL(precision, scale)',
   required: 'allowNull: false',
+  scale: 'DataTypes.DECIMAL(precision, scale)',
   type: 'type',
   unique: 'unique',
 };
@@ -141,6 +151,194 @@ const resolveType = (type, field) => {
 };
 
 /**
+ * The henri exact type a field asks for, whichever way it was spelled.
+ *
+ * A Sequelize `DECIMAL(10, 2)` is the same column as
+ * `{ type: 'decimal', precision: 10, scale: 2 }`, so it is read as one and
+ * gets the same string boundary rather than whatever the driver felt like
+ * handing back. A **bare** `DataTypes.DECIMAL` is not: MySQL makes it
+ * `DECIMAL(10, 0)`, which stores money as whole units, so it is refused by
+ * the caller instead of quietly becoming something else.
+ *
+ * @param {*} type The type from the model file
+ * @returns {?object} `{ bare, precision, scale, type }`, or null
+ */
+const exactTypeOf = (type) => {
+  if (typeof type === 'string' && isExact(type.toLowerCase())) {
+    return { bare: false, type: type.toLowerCase() };
+  }
+
+  const key = type === DataTypes.DECIMAL || type === DataTypes.BIGINT;
+  const name = key
+    ? type.key
+    : (type instanceof DataTypes.DECIMAL && 'DECIMAL') ||
+      (type instanceof DataTypes.BIGINT && 'BIGINT') ||
+      null;
+
+  if (!name) {
+    return null;
+  }
+
+  if (name === 'BIGINT') {
+    return { bare: false, type: 'bigint' };
+  }
+
+  const options = (!key && type.options) || {};
+  const bare = !Number.isInteger(options.precision);
+
+  return {
+    bare,
+    precision: options.precision,
+    scale: Number.isInteger(options.scale) ? options.scale : 0,
+    type: 'decimal',
+  };
+};
+
+/**
+ * One value of an exact field, as the string the column holds
+ *
+ * @param {string} type `decimal` or `bigint`
+ * @param {*} value The value
+ * @param {object} settings `{ precision, scale }`
+ * @returns {{value: string}|{error: string}} The value, or what is wrong
+ */
+const exactly = (type, value, settings) =>
+  type === 'bigint' ? canonicalInteger(value) : canonical(value, settings);
+
+/**
+ * Turns a field into an exact Sequelize attribute: the parameterized
+ * column, a setter that canonicalizes, a validator that says what a value
+ * the column will not carry is wrong with, and a getter that answers the
+ * decimal string every adapter answers with.
+ *
+ * @param {object} attribute The Sequelize attribute, changed in place
+ * @param {string} field The field name
+ * @param {object} exact What `exactTypeOf()` read
+ * @param {object} definition The field definition
+ * @param {string} dialect The Sequelize dialect
+ * @param {object} context `{ model }`, for the messages
+ * @returns {void}
+ * @throws {Error} On sqlite, on a bare DECIMAL, and on bad settings
+ */
+const decorateExact = (
+  attribute,
+  field,
+  exact,
+  definition,
+  dialect,
+  context
+) => {
+  const model = (context && context.model) || 'model';
+
+  // The one downgrade this adapter cannot make quiet. Sequelize reads a
+  // sqlite DECIMAL through a double and a BIGINT past 2^53 loses its
+  // digits, and there is no seam here to store the value as text and cast
+  // for a comparison the way @usehenri/drizzle does
+  if (dialect === 'sqlite') {
+    throw coded(
+      'HENRI_MODEL_TYPE_UNSUPPORTED',
+      `Field '${field}' of ${model} is a ${exact.type}, which @usehenri/sequelize cannot carry on sqlite: the driver reads it through a JavaScript number and the value would come back changed. Use @usehenri/drizzle, which stores both exactly on sqlite, or put the store on postgres, mysql or mssql`
+    );
+  }
+
+  if (exact.bare) {
+    throw coded(
+      'HENRI_MODEL_TYPE_UNSUPPORTED',
+      `Field '${field}' of ${model} is a DECIMAL with no precision, which MySQL makes DECIMAL(10, 0) -- whole units, so money loses its cents. Write { type: 'decimal', precision: 12, scale: 2 } and henri writes the same column on every dialect`
+    );
+  }
+
+  const wrong = checkSettings(
+    exact.type,
+    exact.type === 'decimal' && Number.isInteger(exact.precision)
+      ? exact
+      : definition
+  );
+
+  if (wrong) {
+    throw coded(
+      'HENRI_MODEL_INVALID_FIELD',
+      `Field '${field}' of ${model} ${wrong}`
+    );
+  }
+
+  const settings = settingsOf(
+    Number.isInteger(exact.precision) ? exact : definition
+  );
+
+  attribute.type =
+    exact.type === 'bigint'
+      ? DataTypes.BIGINT
+      : DataTypes.DECIMAL(settings.precision, settings.scale);
+
+  /**
+   * The stored value as the decimal string, whatever the driver gave
+   *
+   * @returns {?string} The value
+   */
+  attribute.get = function get() {
+    const raw = this.getDataValue(field);
+
+    return raw === null || typeof raw === 'undefined' ? raw : String(raw);
+  };
+
+  /**
+   * The canonical value when it fits the column, and the value untouched
+   * when it does not, so the validator below is what says why
+   *
+   * @param {*} value The value
+   * @returns {void}
+   */
+  attribute.set = function set(value) {
+    if (value === null || typeof value === 'undefined') {
+      this.setDataValue(field, value);
+
+      return;
+    }
+
+    const answer = exactly(exact.type, value, settings);
+
+    this.setDataValue(field, answer.error ? value : answer.value);
+  };
+
+  attribute.validate = {
+    ...(attribute.validate || {}),
+
+    /**
+     * The bounds of the column, which the dialect would round to instead
+     *
+     * @param {*} value The stored value
+     * @returns {void}
+     * @throws {Error} When the value does not fit
+     */
+    henriExact(value) {
+      if (value === null || typeof value === 'undefined') {
+        return;
+      }
+
+      const answer = exactly(exact.type, value, settings);
+
+      if (answer.error) {
+        throw new Error(answer.error);
+      }
+    },
+  };
+
+  if (typeof attribute.defaultValue !== 'undefined') {
+    const answer = exactly(exact.type, attribute.defaultValue, settings);
+
+    if (answer.error) {
+      throw coded(
+        'HENRI_MODEL_INVALID_FIELD',
+        `Field '${field}' of ${model} has a default that ${answer.error}`
+      );
+    }
+
+    attribute.defaultValue = answer.value;
+  }
+};
+
+/**
  * Normalizes one field definition
  *
  * @param {string} field The field name
@@ -190,9 +388,15 @@ const normalizeField = (
       attribute.defaultValue = value === Date.now ? DataTypes.NOW : value;
     } else if (key === 'enum' || key === 'index') {
       // Handled below, they depend on the resolved type
-    } else if (key === 'personal' || key === 'encrypted') {
+    } else if (
+      key === 'personal' ||
+      key === 'encrypted' ||
+      key === 'precision' ||
+      key === 'scale'
+    ) {
       // Marks for henri, and nothing Sequelize has to know about: the
-      // second one is applied below, once the type has resolved
+      // encryption one and the decimal column are applied below, once the
+      // type has resolved
     } else if (KNOWN_KEYS.has(key)) {
       attribute[key] = value;
     } else {
@@ -218,6 +422,15 @@ const normalizeField = (
 
   if (definition.index && !attribute.unique) {
     indexes.push({ fields: [field] });
+  }
+
+  // A `decimal` or a `bigint` is an exact column and a decimal string in
+  // JavaScript on every adapter, which is what ./exact.js argues; the two
+  // Sequelize spellings of the same thing are read as the henri type
+  const exact = exactTypeOf(definition.type);
+
+  if (exact) {
+    decorateExact(attribute, field, exact, definition, dialect, context);
   }
 
   // The column of an encrypted field is the ciphertext's, not the

--- a/packages/sequelize/types.js
+++ b/packages/sequelize/types.js
@@ -13,14 +13,23 @@ const { DataTypes } = require('sequelize');
  * - number:  double precision float (Mongoose `Number`)
  * - integer: integer
  * - float:   single precision float
+ * - decimal: DECIMAL(precision, scale), exact
+ * - bigint:  BIGINT, a signed 64-bit integer
  * - boolean: boolean
  * - date:    date and time
  * - json:    any JSON value (Mongoose `Mixed`); TEXT on dialects without JSON
  * - uuid:    UUID string
+ *
+ * The two exact ones are here as the *class*, not an instance: a decimal
+ * carries a precision and a scale, so `schema.js` builds `DECIMAL(p, s)`
+ * from the field. It is also where they are refused on sqlite, which this
+ * adapter cannot carry either type on -- see ./exact.js and ./schema.js.
  */
 module.exports = {
+  bigint: DataTypes.BIGINT,
   boolean: DataTypes.BOOLEAN,
   date: DataTypes.DATE,
+  decimal: DataTypes.DECIMAL,
   float: DataTypes.FLOAT,
   integer: DataTypes.INTEGER,
   json: DataTypes.JSON,

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -130,6 +130,55 @@ cd "$app"
 log "henri generate authentication"
 node "$root/packages/henri/bin/henri.js" generate authentication
 
+# The two types a JavaScript number cannot carry. The scaffold has neither,
+# so the model is generated here: what this proves is the whole published
+# chain -- the packed core, the packed adapter and the real driver -- rather
+# than a test fixture, and it is the only place `henri generate model` writes
+# a `precision` and a `scale`
+log "henri generate model invoice (a decimal and a bigint)"
+node "$root/packages/henri/bin/henri.js" generate model invoice \
+  title:string! amount:decimal reference:bigint
+cat >db/seeds.js <<'SEEDS'
+// The round trip of the two exact types, on the store this app was
+// scaffolded with: a value goes in and the *same* value comes back, not a
+// near one. A double would answer 1.0000000000000007 for a hundred cents
+// and 9223372036854776000 for the largest 64-bit integer.
+module.exports = async () => {
+  const invoice = await Invoice.create({
+    amount: '19.99',
+    reference: '9223372036854775807',
+    title: 'exact',
+  });
+  const read = await Invoice.findById(invoice.externalId);
+
+  for (const [field, wanted] of [
+    ['amount', '19.99'],
+    ['reference', '9223372036854775807'],
+  ]) {
+    if (read[field] !== wanted) {
+      throw new Error(
+        `${field} came back as ${JSON.stringify(read[field])}, not ${wanted}`
+      );
+    }
+  }
+
+  // ... and a value the column would have quietly rounded is refused
+  const refused = await Invoice.create({
+    amount: 0.1 + 0.2,
+    title: 'float',
+  }).then(
+    () => null,
+    (error) => error
+  );
+
+  if (!refused) {
+    throw new Error('0.1 + 0.2 was stored in a decimal(12, 2)');
+  }
+
+  console.log(`  exact: ${read.amount} and ${read.reference}, and 0.1 + 0.2 refused`);
+};
+SEEDS
+
 printf '\n# Resolve the henri packages from the tarballs packed above\noverrides:\n%s' "$overrides" >>pnpm-workspace.yaml
 node -e "
   const fs = require('fs');
@@ -225,7 +274,22 @@ if [ "$adapter" = drizzle ]; then
     exit 1
   }
   rm "$app/db/schema.first.sql"
+
+  # The columns the two exact types asked for, in the DDL a real install
+  # generated: a `numeric`/`decimal` with its precision and scale, and a
+  # 64-bit integer. On sqlite both keep their digits in a text column
+  grep -qiE 'amount[^,]*(text|numeric\(12, ?2\)|decimal\(12, ?2\))' \
+    "$app/db/migrations/0000_init.sql" || {
+    echo "the decimal column is not in the generated migration" >&2
+    grep -i amount "$app/db/migrations/0000_init.sql" >&2 || true
+    exit 1
+  }
 fi
+
+# The round trip, through the packed packages and the real driver
+log "henri db:seed (the decimal and the bigint come back unchanged)"
+pnpm exec henri db:seed
+stop_mongod
 
 if [ ! -e "$app/$build_marker" ]; then
   echo "henri build did not write $build_marker" >&2

--- a/showcase/AGENTS.md
+++ b/showcase/AGENTS.md
@@ -33,8 +33,8 @@ henri generate worker cleanup | test posts | agents   # app/workers, test/, AGEN
 henri destroy scaffold Post                           # undo (model, controller, route, view, worker, test, crud too)
 ```
 
-Types: `string, text, number, integer, float, boolean, date, json, uuid`; a
-trailing `!` makes the field required. `Post` gives `posts` (`Category` ->
+Types: `string, text, number, integer, float, decimal, bigint, boolean, date,
+json, uuid`; a trailing `!` makes the field required. `Post` gives `posts` (`Category` ->
 `categories`, `Person` -> `people`). Existing files are skipped unless `--force`
 is given; `--json` prints the files written or removed. Generators rewrite
 `config/routes.js` through prettier: comments in that file are lost.

--- a/types/core.test-d.ts
+++ b/types/core.test-d.ts
@@ -515,6 +515,9 @@ const declared: Controller = {
       title: { type: 'string', required: true, maxLength: 120 },
       // the short form is the type itself
       year: 'integer',
+      // exact: sent as a string, and a bound may be written out
+      price: { type: 'decimal', min: '0.01' },
+      reference: 'bigint',
     },
     'index,search': { page: { type: 'integer', min: 1, default: 1 } },
   },
@@ -613,6 +616,10 @@ const model: ModelFile = {
     meta: { type: 'json' },
     author: { type: 'string', personal: true },
     phone: { type: 'string', personal: { expose: false, erase: 'retain' } },
+    // The two exact ones: a decimal string in JavaScript, whatever the
+    // adapter stores. `precision` and `scale` belong to the first only
+    amount: { type: 'decimal', precision: 12, scale: 2, min: '0' },
+    reference: { type: 'bigint', unique: true },
   },
   associate(models) {
     expectType<Record<string, unknown>>(models);
@@ -627,6 +634,15 @@ const badModel: ModelFile = {
     title: { type: 'varchar', required: true },
   },
 };
+
+const badPrecision: ModelFile = {
+  schema: {
+    // @ts-expect-error a precision is a number of digits
+    amount: { type: 'decimal', precision: '12' },
+  },
+};
+
+expectType<ModelFile>(badPrecision);
 
 const badMark: ModelFile = {
   schema: {

--- a/website/src/content/docs/guides/controllers.md
+++ b/website/src/content/docs/guides/controllers.md
@@ -124,16 +124,16 @@ module.exports = {
 
 `all` (or `*`) is every action, any other key is one action or a comma-separated list, and the action's own key wins over the lists before it. A rule may be the type itself: `year: 'integer'` is `year: { type: 'integer' }`.
 
-| Key                      | What it does                                                                                                                         |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `type`                   | `string`, `text`, `number`, `integer`, `float`, `boolean`, `date`, `json`, `uuid` — the [model types](/guides/models/) — and `array` |
-| `required`               | the field has to be there                                                                                                            |
-| `default`                | what an absent field is worth; a function is called per request                                                                      |
-| `enum`                   | the values accepted, checked after the coercion                                                                                      |
-| `min`, `max`             | the bounds of a number                                                                                                               |
-| `minLength`, `maxLength` | the bounds of a length: characters of a string, items of a list                                                                      |
-| `pattern`                | a regular expression a string has to match                                                                                           |
-| `of`                     | the rule every item of a list follows; a list declares it                                                                            |
+| Key                      | What it does                                                                                                                                              |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `type`                   | `string`, `text`, `number`, `integer`, `float`, `decimal`, `bigint`, `boolean`, `date`, `json`, `uuid` — the [model types](/guides/models/) — and `array` |
+| `required`               | the field has to be there                                                                                                                                 |
+| `default`                | what an absent field is worth; a function is called per request                                                                                           |
+| `enum`                   | the values accepted, checked after the coercion                                                                                                           |
+| `min`, `max`             | the bounds of a number; on a `decimal` or a `bigint` they are compared digit by digit and may be written out as strings themselves                        |
+| `minLength`, `maxLength` | the bounds of a length: characters of a string, items of a list                                                                                           |
+| `pattern`                | a regular expression a string has to match                                                                                                                |
+| `of`                     | the rule every item of a list follows; a list declares it                                                                                                 |
 
 A rule henri cannot carry out fails the boot with `HENRI_PARAMS_DECLARATION_INVALID`, naming the controller, the action and the key: an unknown type, an unknown key (`requird`), a constraint the type does not take (`min` on a string), a `default` the rule itself refuses, a selector naming an action the controller does not export. A declaration that silently accepts everything is the mistake this feature exists to remove.
 
@@ -142,7 +142,9 @@ A rule henri cannot carry out fails the boot with `HENRI_PARAMS_DECLARATION_INVA
 A query string is all strings. A form body is all strings. A JSON body is not, and that is the rule:
 
 - **A textual source** — the query string, a path parameter, a form body — is _parsed_ into the type. `?page=2` arrives as the number `2`, `?active=true` (or `on`, `yes`, `1`) as `true`, `?at=2024-01-02` as a `Date`. There is no other way for a client to say `2` there.
-- **A JSON body** is _checked_, never parsed: `{"page": "2"}` is a caller sending a string where the action declared a number, and it is refused. JSON can say `2`; it said `"2"`. The two types JSON cannot carry are the exception and are read from a string there as well: a `date` is an ISO-8601 string and a `uuid` is a string.
+- **A JSON body** is _checked_, never parsed: `{"page": "2"}` is a caller sending a string where the action declared a number, and it is refused. JSON can say `2`; it said `"2"`. The types JSON cannot carry are the exception and are read from a string there as well: a `date` is an ISO-8601 string, a `uuid` is a string, and so are a `decimal` and a `bigint`.
+
+The last two are the interesting case, because JSON _can_ express them — as a double, which is the value they exist to avoid. `{"price": 19.99}` is refused for that reason, and `{"price": "19.99"}` is what a client sends. From a textual source the digits are kept as a string rather than parsed into a number, so an [exact value](/guides/models/#exact-numbers) is the same string wherever it came from; `enum` matches by value there, so `'10'` matches a declared `'10.00'`, and `minLength`, `maxLength` and `pattern` are not constraints those two take — they measure text — so declaring one fails the boot.
 
 The rest follows: an empty string from a textual source is an absent field (a browser sends one for every input nobody touched) unless the type is `string` or `text`; `null` is an absent field everywhere; a single textual value is a one-item list when the type is `array`, while a JSON body has to send the list; and `?year=1&year=2` is a list arriving where a number was declared, which is refused rather than silently taking one of the two.
 

--- a/website/src/content/docs/guides/graphql.md
+++ b/website/src/content/docs/guides/graphql.md
@@ -79,17 +79,18 @@ A `henri generate graphql` would have written the SDL above into `app/models/Art
 
 ### What each type becomes
 
-| henri schema           | GraphQL                                                                                              |
-| ---------------------- | ---------------------------------------------------------------------------------------------------- |
-| `string`, `text`       | `String`                                                                                             |
-| `integer`              | `Int`                                                                                                |
-| `number`, `float`      | `Float`                                                                                              |
-| `boolean`              | `Boolean`                                                                                            |
-| `date`                 | `String`, ISO 8601 — the same string the JSON answer carries                                         |
-| `uuid`                 | `String`                                                                                             |
-| `json`                 | nothing: a JSON column holds no shape GraphQL could state, so add the field and a scalar of your own |
-| `enum: [...]`          | an `enum <Type><Field>` when every value is a GraphQL name, `String` when one is not (`in-progress`) |
-| a declared foreign key | `ID`, holding the `externalId` of the row it names                                                   |
+| henri schema           | GraphQL                                                                                                                                                   |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `string`, `text`       | `String`                                                                                                                                                  |
+| `integer`              | `Int`                                                                                                                                                     |
+| `number`, `float`      | `Float`                                                                                                                                                   |
+| `decimal`, `bigint`    | `String` — the [exact value](/guides/models/#exact-numbers); a `Float` is a double and an `Int` is 32 bits, so either would undo the column in the answer |
+| `boolean`              | `Boolean`                                                                                                                                                 |
+| `date`                 | `String`, ISO 8601 — the same string the JSON answer carries                                                                                              |
+| `uuid`                 | `String`                                                                                                                                                  |
+| `json`                 | nothing: a JSON column holds no shape GraphQL could state, so add the field and a scalar of your own                                                      |
+| `enum: [...]`          | an `enum <Type><Field>` when every value is a GraphQL name, `String` when one is not (`in-progress`)                                                      |
+| a declared foreign key | `ID`, holding the `externalId` of the row it names                                                                                                        |
 
 `required: true` makes the field non-null. The timestamps, `deletedAt` on a `paranoid` model and the columns henri adds to the user model are all there, because they are all in the JSON answer.
 

--- a/website/src/content/docs/guides/models.md
+++ b/website/src/content/docs/guides/models.md
@@ -51,23 +51,27 @@ module.exports = {
 
 On SQL, `associate()` runs before the schema is brought up, so the foreign keys end up in the tables.
 
-The keys above and the nine field types are declared in `@usehenri/core`: a `/** @type {import('@usehenri/core').ModelFile} */` line, which `henri generate model` writes, is enough for an editor to complete them. The model itself is the ORM's, and stays untyped — see [Types](/reference/types/).
+The keys above and the eleven field types are declared in `@usehenri/core`: a `/** @type {import('@usehenri/core').ModelFile} */` line, which `henri generate model` writes, is enough for an editor to complete them. The model itself is the ORM's, and stays untyped — see [Types](/reference/types/).
 
 ## The schema format
 
 A field is `{ type, ...keys }` or a bare type. The type names and the keys below mean the same thing on every adapter, so a model written for the disk adapter moves to MongoDB or PostgreSQL unchanged.
 
-| Type      | Mongoose  | Sequelize |
-| --------- | --------- | --------- |
-| `string`  | `String`  | `STRING`  |
-| `text`    | `String`  | `TEXT`    |
-| `number`  | `Number`  | `DOUBLE`  |
-| `integer` | `Number`  | `INTEGER` |
-| `float`   | `Number`  | `FLOAT`   |
-| `boolean` | `Boolean` | `BOOLEAN` |
-| `date`    | `Date`    | `DATE`    |
-| `json`    | `Mixed`   | `JSON`    |
-| `uuid`    | `String`  | `UUID`    |
+| Type      | Drizzle (postgres)         | Drizzle (mysql) | Drizzle (sqlite)        | Mongoose     | Sequelize (mssql) |
+| --------- | -------------------------- | --------------- | ----------------------- | ------------ | ----------------- |
+| `string`  | `varchar(255)`             | `varchar(255)`  | `text`                  | `String`     | `STRING`          |
+| `text`    | `text`                     | `text`          | `text`                  | `String`     | `TEXT`            |
+| `number`  | `double precision`         | `double`        | `real`                  | `Number`     | `DOUBLE`          |
+| `integer` | `integer`                  | `int`           | `integer`               | `Number`     | `INTEGER`         |
+| `float`   | `real`                     | `float`         | `real`                  | `Number`     | `FLOAT`           |
+| `decimal` | `numeric(p, s)`            | `decimal(p, s)` | `text` (the digits)     | `Decimal128` | `DECIMAL(p, s)`   |
+| `bigint`  | `bigint`                   | `bigint`        | `text` (the digits)     | `BigInt`     | `BIGINT`          |
+| `boolean` | `boolean`                  | `boolean`       | `integer` (`0`/`1`)     | `Boolean`    | `BOOLEAN`         |
+| `date`    | `timestamp with time zone` | `datetime(3)`   | `integer` (ms of epoch) | `Date`       | `DATE`            |
+| `json`    | `jsonb`                    | `json`          | `text` (JSON)           | `Mixed`      | `JSON`            |
+| `uuid`    | `uuid`                     | `varchar(36)`   | `text`                  | `String`     | `UUID`            |
+
+`decimal` and `bigint` are the two whose value a JavaScript number cannot carry, so they cross into JavaScript as exact decimal strings on every adapter. See [Exact numbers](#exact-numbers).
 
 | Key         | Description                                                                                                                                                                                              |
 | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -76,6 +80,8 @@ A field is `{ type, ...keys }` or a bare type. The type names and the keys below
 | `enum`      | Allowed values. An `ENUM` column on MySQL, MariaDB and PostgreSQL, an `isIn` validation elsewhere.                                                                                                       |
 | `unique`    | Unique index or constraint.                                                                                                                                                                              |
 | `index`     | `index: true` adds an index on the field.                                                                                                                                                                |
+| `precision` | A `decimal` only: the total number of digits, 19 by default and 38 at most — the widest every dialect henri writes carries. See [Exact numbers](#exact-numbers).                                         |
+| `scale`     | A `decimal` only: the digits after the point, 4 by default. A value with more of them is refused, not rounded.                                                                                           |
 | `personal`  | This field is about a person: masked in the logs, exported and erased. See [Personal data](/guides/privacy/).                                                                                            |
 | `encrypted` | The column holds ciphertext and the model the string. `true` is randomised (not queryable), `{ deterministic: true }` keeps an equality and a `unique`. See [Encrypted attributes](/guides/encryption/). |
 
@@ -84,7 +90,87 @@ What the adapters do with anything else differs:
 - **Mongoose** passes every other key and type through, so `{ type: 'ObjectId', ref: 'Post' }`, `[String]`, nested objects, `lowercase`, `trim`, `match`, `select`, `validate` and the JavaScript constructors (`String`, `Number`, `Date`) all work. It also understands the Sequelize spellings `allowNull: false` and `defaultValue`.
 - **Sequelize** (`mssql` only) accepts its own attribute options (`allowNull`, `defaultValue`, `validate`, `field`, `primaryKey`, `autoIncrement`, `references`, `onDelete`, `onUpdate`, `comment`, `get`, `set`, `values`, ...), its data types (`type: DataTypes.STRING(50)` or the uppercase name as a string, `'STRING'`), the JavaScript constructors (`Object` and `Array` become `JSON`, `Buffer` a `BLOB`), and stores nested objects and arrays as `JSON`. Any other key throws at boot with the list of supported keys, so a typo never becomes a silently ignored option. A field with a known key but no `type` is an error too.
 
-`@usehenri/mongoose/types` and `@usehenri/sequelize/types` export the map above if you need the ORM types themselves.
+`@usehenri/drizzle/types`, `@usehenri/mongoose/types` and `@usehenri/sequelize/types` export the map above if you need the column or ORM types themselves.
+
+## Exact numbers
+
+Two of the types hold a value a JavaScript number cannot: `decimal`, an exact number with a `precision` (total digits) and a `scale` (digits after the point), and `bigint`, a signed 64-bit integer. Money is the reason the first one exists — a `number` column is a double, and a double answers `1.0000000000000007` for a hundred cents — and an identifier that comes from somewhere else is the reason for the second, because `9223372036854775807` read through a double is `9223372036854776000`.
+
+```js
+// app/models/Invoice.js
+module.exports = {
+  schema: {
+    // Money: two digits after the point
+    amount: { type: 'decimal', precision: 12, scale: 2 },
+    // The defaults, 19 digits with 4 after the point: a unit price wants
+    // more than money does
+    rate: { type: 'decimal' },
+    // What the accounting system calls it, past where an `integer` stopped
+    reference: { type: 'bigint', unique: true },
+  },
+};
+```
+
+`precision` is 19 by default and 38 at most, which is the widest every dialect henri writes carries; `scale` is 4 and cannot be more than the precision. A `bigint` takes neither: declaring a `precision` or a `scale` on one fails the boot.
+
+### The value is a string
+
+A value of either type crosses into JavaScript as an exact decimal **string**, on every adapter: `'19.99'`, `'-1'`, `'9223372036854775807'`. Never a `number`, never a `BigInt`, never an object of henri's own.
+
+```js
+const invoice = await Invoice.create({
+  amount: 19.99,
+  reference: '90071992547409911',
+});
+
+invoice.amount; // '19.99'
+invoice.reference; // '90071992547409911'
+JSON.stringify(invoice); // {"amount":"19.99","reference":"90071992547409911", ...}
+```
+
+There are four reasons, and they are the same four everywhere the value travels:
+
+- `JSON.stringify` throws on a `BigInt`, and henri serializes records in a dozen places — `res.render()`, `res.resource()`, `res.collection()`, the cache, the call log, a version diff, the trail, a job payload, GraphQL. One escaping into any of them is a `TypeError` raised deep inside express, after the controller returned.
+- A decimal object needs a dependency and would not survive JSON either.
+- It is the shortest path rather than a conversion: node-postgres hands `numeric` and `int8` back as strings, mysql2 hands `DECIMAL` back as a string, and `Decimal128.toString()` is exact. Turning any of those into a number is the step that loses the value.
+- A string is exact, JSON-safe and identical on the three adapters, which is what makes one model file mean one thing everywhere.
+
+**henri ships no arithmetic.** An application that adds two prices picks its own library and hands henri back a string.
+
+On the way in, a string (a decimal literal, exponent form included), a JavaScript `number` and — for a `bigint` — a `BigInt` are all accepted. A number goes through `String(value)`, the shortest representation that round-trips, so the literal a person typed survives: `19.99` is `'19.99'`.
+
+### What is refused rather than rounded
+
+Each of these is a value the database would have quietly changed:
+
+- more decimal places than the `scale`, counted after the trailing zeros, which are not information: `'19.9900'` is fine at scale 2 and `'19.999'` is not;
+- more digits before the point than `precision - scale`;
+- a `bigint` outside `-9223372036854775808 .. 9223372036854775807`;
+- a JavaScript number that is not a safe integer where a whole number was asked for (`2 ** 60` is refused, and the message says to pass it as a string).
+
+So `0.1 + 0.2` arrives as `0.30000000000000004` and fails validation instead of landing in the column: **henri does not round money**, because rounding is the application's to do and it is the application that knows which way.
+
+`min` and `max` mean what they always did on an exact field, and they are compared digit by digit rather than through a double, so a bound past what a double holds can be written down. (Mongoose has a `min` and a `max` of its own and drops both on a `Decimal128` without a word, so henri carries them itself there.) The keys that measure text — `minLength`, `maxLength`, `match`, `trim`, `lowercase` and `length` — fail the boot on an exact field, naming it: the value is a string, so they would only count its digits.
+
+### On each store
+
+| Store                                  | `decimal`                  | `bigint`                   |
+| -------------------------------------- | -------------------------- | -------------------------- |
+| PostgreSQL (`drizzle`, `postgresql`)   | `numeric(p, s)`            | `bigint`                   |
+| MySQL and MariaDB (`drizzle`, `mysql`) | `decimal(p, s)`            | `bigint`                   |
+| sqlite (`drizzle`)                     | `text`, holding the digits | `text`, holding the digits |
+| MongoDB (`disk`, `mongoose`)           | `Decimal128`               | a BSON 64-bit integer      |
+| SQL Server (`mssql`)                   | `DECIMAL(p, s)`            | `BIGINT`                   |
+
+sqlite has neither an exact decimal nor a 64-bit integer its driver hands back whole (better-sqlite3 reads `9223372036854775807` back as `9223372036854776000`), so the drizzle adapter keeps the digits in a `text` column, which round-trips the value exactly. A comparison is a different question from a value, and text answers it wrongly — `'9.99' > '10'` lexicographically — so **a comparison and an order** are the one thing that goes through a cast: `CAST(col AS INTEGER)` for a `bigint`, which sqlite carries on 64 bits and is therefore exact, and `CAST(col AS REAL)` for a `decimal`, which is a double and is the one approximation henri ships for these types — accurate to about sixteen significant digits, the same answer PostgreSQL gives for every value a person writes down. An equality is not cast at all: the stored text is canonical, so `=` is exact.
+
+`@usehenri/sequelize` **refuses both types on sqlite** at boot, naming the model and the field ([`HENRI_MODEL_TYPE_UNSUPPORTED`](/reference/errors/#henri_model_type_unsupported)), and points at `@usehenri/drizzle`: it reads a sqlite `DECIMAL` through a double and loses the digits of a `BIGINT` past 2^53, and it has no seam to store the value as text and cast for a comparison the way the drizzle adapter does. It is a corner `henri new` cannot produce — sqlite goes to Drizzle, and Sequelize is reachable only under [`mssql`](#mssql-1) — and the adapter says so rather than reading a value back changed.
+
+### The Sequelize spellings
+
+A model written for Sequelize keeps its data type names on a drizzle store, and the two that used to be downgrades point at the real types now: `DECIMAL` and `NUMERIC` are `decimal` (they were `number`, a double) and `BIGINT` is `bigint` (it was `integer`, 32 bits). On an `mssql` store, `DataTypes.DECIMAL(10, 2)` is read as `{ type: 'decimal', precision: 10, scale: 2 }` and gets the same string boundary. A **bare `DataTypes.DECIMAL`** is refused there, because MySQL makes it `DECIMAL(10, 0)` — whole units, so money loses its cents. Write `{ type: 'decimal', precision: 12, scale: 2 }` and henri writes the same column on every dialect.
+
+Elsewhere: an exact field is a `String` in [GraphQL](/guides/graphql/#what-each-type-becomes), a string with a `pattern` in the [OpenAPI document](/guides/openapi/), and a `decimal` or `bigint` rule in a controller's [`params`](/guides/controllers/#params-what-an-action-accepts) block.
 
 ## Timestamps
 

--- a/website/src/content/docs/guides/openapi.md
+++ b/website/src/content/docs/guides/openapi.md
@@ -39,6 +39,8 @@ Every operation also carries `x-henri.enforced`, a list naming what henri actual
 
 A field marked `personal: { expose: false }` is in **no** schema, because [privacy](/guides/privacy/) strips that name from every answer henri builds, at every depth. Neither is `password`. A declared foreign key is typed as the `externalId` of the row it names, because that is what [`base/references.js`](/guides/models/#identifiers) publishes — and `null`, because a key that names no row resolves to nothing.
 
+A [`decimal` and a `bigint`](/guides/models/#exact-numbers) are `{ "type": "string" }` with a `pattern` (`^-?\d+(\.\d+)?$` and `^-?\d+$`) and a `format` (`decimal`, `int64`), because a string is what the JSON answer carries and a JSON number is a double. `minimum` and `maximum` are deliberately left off those two: a numeric bound on a value the document has just called a string describes nothing. The model still enforces it.
+
 ## What an action declared it accepts
 
 A controller that declares [`params`](/guides/controllers/#params-what-an-action-accepts) has told henri the shape of the request it takes, which is exactly what an OpenAPI operation wants. So the document is built from it rather than around it:

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -195,7 +195,7 @@ henri g <what> <name> [options] [--force]
 
 Model and resource names are given in the singular with a capital: `Post` gives the model `Post`, the controller `posts.js`, the route `resources posts` and the pages under `posts/` (`category` gives `categories`, `person` `people`). Existing files are skipped and reported; `--force` overwrites them. Routes are added to `config/routes.js`, which is rewritten (formatted with prettier) with the new keys.
 
-Fields are `name:type`, `string` when the type is omitted; a trailing `!` (`name:string!` or `name!:string`) makes the field required. Types: `string`, `text`, `number`, `integer`, `float`, `boolean`, `date`, `json`, `uuid`, mapped by each adapter (see [Models](/guides/models/#the-schema-format)); anything else is refused.
+Fields are `name:type`, `string` when the type is omitted; a trailing `!` (`name:string!` or `name!:string`) makes the field required. Types: `string`, `text`, `number`, `integer`, `float`, `decimal`, `bigint`, `boolean`, `date`, `json`, `uuid`, mapped by each adapter (see [Models](/guides/models/#the-schema-format)); anything else is refused. A generated `decimal` is written out as `{ type: 'decimal', precision: 12, scale: 2 }`, because a field somebody spells `price:decimal` is money and the default (19, 4) is not — see [Exact numbers](/guides/models/#exact-numbers).
 
 ```bash
 henri generate model User name:string! birthday:date

--- a/website/src/content/docs/reference/errors.md
+++ b/website/src/content/docs/reference/errors.md
@@ -1364,6 +1364,17 @@ Usually:
 
 **Fix.** Configure `stores.default`, or give the model a `store` naming one of the stores that exist.
 
+### `HENRI_MODEL_TYPE_UNSUPPORTED`
+
+A model field asks for a type this store cannot carry without changing the value.
+
+Usually:
+
+- a `decimal` or a `bigint` on a sqlite store served by `@usehenri/sequelize`, whose driver reads both through a JavaScript number
+- a Sequelize `DECIMAL` with no precision, which MySQL makes `DECIMAL(10, 0)` -- whole units, so money loses its cents
+
+**Fix.** The message names the model and the field. On sqlite, use `@usehenri/drizzle`, which stores both exactly, or put the store on postgres, mysql or mssql. For a bare `DECIMAL`, write `{ type: 'decimal', precision: 12, scale: 2 }` and henri writes the same column on every dialect.
+
 ### `HENRI_MODEL_UNKNOWN_OPTION`
 
 A model call, or the `options` of a model file, holds a key the adapter does not read.
@@ -1395,7 +1406,7 @@ Usually:
 - a type of the underlying ORM rather than henri's (`STRING`, `varchar`, `ObjectId`)
 - a typo in the type name
 
-**Fix.** henri's types are `string`, `text`, `number`, `integer`, `float`, `boolean`, `date`, `json` and `uuid`. The adapter maps them to the ORM's own.
+**Fix.** henri's types are `string`, `text`, `number`, `integer`, `float`, `decimal`, `bigint`, `boolean`, `date`, `json` and `uuid`. The adapter maps them to the ORM's own.
 
 ## params
 

--- a/website/src/content/docs/reference/types.md
+++ b/website/src/content/docs/reference/types.md
@@ -113,7 +113,7 @@ module.exports = {
 };
 ```
 
-The nine field types are checked; every other key of a field is passed to the
+The eleven field types are checked; every other key of a field is passed to the
 adapter, so the shape stays open (see [Models](/guides/models/)).
 
 ```js

--- a/website/src/content/docs/upgrading.md
+++ b/website/src/content/docs/upgrading.md
@@ -146,6 +146,25 @@ Neither change touches the database: the columns, the joins and the indexes are 
 { "externalIds": { "lookup": "any", "references": false } }
 ```
 
+### `DECIMAL` and `BIGINT` are exact columns, and their value is a string
+
+The schema format gained two types, `decimal` and `bigint`, and the Sequelize spellings a model file may already carry now point at them. See [Exact numbers](/guides/models/#exact-numbers).
+
+**The column changes.** On a drizzle store, `DECIMAL` and `NUMERIC` used to resolve to `number` — a double — and `BIGINT` to `integer`, 32 bits. They are `numeric(19, 4)` and `bigint` now (`decimal(19, 4)` on MySQL), which is what those names always meant. It is a schema change like any other: `henri db:generate` writes it and `henri db:migrate` applies it, on a copy of the database first if the column holds rows. A `DECIMAL` was storing money in a double, so the values in it are already whatever a double made of them.
+
+**The value changes.** A `decimal` and a `bigint` cross into JavaScript as exact decimal strings — `'19.99'`, not `19.99` — on every adapter, and that is what a JSON answer, a version diff and a cached record hold. What breaks is arithmetic on the way out:
+
+```js
+// before
+const total = invoice.amount * quantity;
+// after: henri ships no arithmetic, and the string is the exact value
+const total = Number(invoice.amount) * quantity; // a double again, deliberately
+```
+
+A page that only prints the value needs no change; a sum needs a decimal library and a string handed back to henri. Values are still written the way they always were — `Invoice.create({ amount: 19.99 })` works — but a value with more decimal places than the `scale` is now **refused rather than rounded**, so `0.1 + 0.2` fails validation instead of landing in the column. Rounding is the application's.
+
+**Two things fail the boot rather than doing something else.** A bare `DataTypes.DECIMAL` on a Sequelize store: a decimal with no precision is `DECIMAL(10, 0)` on MySQL — whole units, so money loses its cents — and writing `{ type: 'decimal', precision: 12, scale: 2 }` gets the same column on every dialect. And either type on a Sequelize store on sqlite, which reads it back through a double; that one is a configuration `henri new` never wrote, since sqlite goes to Drizzle.
+
 ## From 1.1 to 1.2
 
 ### Every record has a public uuid, and the numeric id stops leaving the server


### PR DESCRIPTION
henri's schema vocabulary had nine types and neither `decimal` nor `bigint`. The Sequelize compatibility map turned `DECIMAL` into `number` and `BIGINT` into `integer`, and on PostgreSQL `number` is a `doublePrecision` and `integer` is 32 bits. So **money was binary floating point on the default adapter**, and a value a model explicitly asked to be 64-bit got a column that refuses the insert above 2,147,483,647.

Measured on the live server before any of this was written:

```
double  0.1 + 0.2       = 0.30000000000000004      numeric = 0.3
a cent added 100 times  = 1.0000000000000007       numeric = 1.00
that sum = 1.00?          false
a bigint in an integer column:  ERROR: integer out of range
```

That is the silent-difference class the Drizzle tranche exists to remove — and it was on the adapter `henri new` scaffolds.

## What each type becomes

| | PostgreSQL | MySQL | sqlite | MongoDB | SQL Server |
| --- | --- | --- | --- | --- | --- |
| `decimal` | `numeric(p, s)` | `decimal(p, s)` | `text` (the digits) | `Decimal128` | `DECIMAL(p, s)` |
| `bigint` | `bigint` | `bigint` | `text` (the digits) | BSON `BigInt` | `BIGINT` |

`decimal` takes `precision` (19 by default, 38 the ceiling — the narrowest across the dialects) and `scale` (4). Two driver-level fixes were needed and are the sort that would have quietly undone the rest: mysql2 needs `supportBigNumbers`, without which a `BIGINT` is read through a double, and the drizzle mysql and pg columns need `mode: 'bigint'`.

## The boundary is a string, and that is the whole design

Not a `number` — that is the loss these types exist to remove. Not a `BigInt`, and the argument is decisive rather than aesthetic: **`JSON.stringify` throws on a `BigInt`**, and henri serializes records in `res.render`, `res.resource`, `res.collection`, the cache, the call log, version diffs, the trail, job payloads and GraphQL. A `BigInt` escaping into any of those is a `TypeError` raised inside express after the controller returned — a *worse* silent failure than the one being fixed.

A string is also the shortest path rather than a conversion: node-postgres already returns `numeric` and `int8` as strings, mysql2 returns `DECIMAL` as a string, and `Decimal128.toString()` is exact. Everything else agrees with it — the validators, `toJSON`, the HAL payloads, OpenAPI (`string` with a `pattern`, and no `minimum`, because a JSON number is a double), GraphQL (`String`; a `Float` would undo it), the query compiler, the `params` vocabulary, erasure, and the version diffs. **henri ships no arithmetic**, which is the honest boundary for a framework.

## Verified here, not on report

On the demo application, through the model layer:

```
a cent added 100 times        "1.00"   exact string, and JSON round-trips it
9007199254740993 (past 2^53)  "9007199254740993"
9223372036854775807 (64-bit)  "9223372036854775807"
2147483648                    stored     <- the value that used to be
                                            "ERROR: integer out of range"
0.30000000000000004           refused: "must have at most 2 decimal places,
                                        and rounding is the application's"
```

That last one is the shape of the whole change: a value the column would have altered is a validation error, not a quiet rounding.

`pnpm test` (168 files), `pnpm test:sql` against live PostgreSQL and MySQL (42 files each), `pnpm test:types`, `pnpm lint --max-warnings 0`, `pnpm format:check` and `scripts/smoke.sh` pass — and smoke now scaffolds a model with both types, checks the generated migration carries `numeric(12, 2)`, and asserts through the packed tarballs and the real driver that `0.1 + 0.2` cannot be stored in it.

## What refuses, and where

A value with more decimal places than the scale, more digits than the precision allows, a bigint outside 64 bits, or a `number` that is not a safe integer: validation errors on all three adapters. Text-measuring keys (`minLength`, `match`, `trim`) on an exact field fail the **boot**. A non-numeric condition (`where: { total: 'ten' }`) is `HENRI_MODEL_INVALID_QUERY` rather than a query that matches nothing. A bare `DataTypes.DECIMAL` is refused because MySQL makes it `DECIMAL(10, 0)`, while `DataTypes.DECIMAL(10, 2)` is honoured.

**`@usehenri/sequelize` on sqlite refuses both types at boot**, naming the model and the field: its driver reads a `DECIMAL` through a double and loses a `BIGINT` past 2^53, and there is no seam there to do what drizzle does. That combination is unreachable from `henri new`.

## sqlite, and the one approximation

sqlite has neither an exact decimal nor a 64-bit integer better-sqlite3 hands back whole (`9223372036854775807` comes back as `9223372036854776000`). The digits go in a `text` column, so the **value** round-trips exactly, and equality is exact because the stored text is canonical. A *comparison* is a different question, and text answers it wrongly, so comparisons and ordering — only those — cast: `CAST(col AS INTEGER)` for a bigint, which sqlite carries on 64 bits exactly, and `CAST(col AS REAL)` for a decimal, which is a double and **the one approximation henri ships**. Sixteen significant digits, the same answer PostgreSQL gives for any value a person writes down. Both are in `guides/models.md` and in the Known gaps of `CLAUDE.md`.

## One found beyond the brief

Mongoose accepts `min`/`max` on a `Decimal128` and **silently drops them** — the same silent-difference class, in the one place a bound looked like it worked. henri carries those bounds itself now, compared digit by digit.
