### PR TITLE
The query seam, and an N+1 detector that counts model calls

### DIFF
--- a/.changeset/query-seam.md
+++ b/.changeset/query-seam.md
@@ -1,0 +1,39 @@
+---
+'@usehenri/core': minor
+'@usehenri/drizzle': minor
+'@usehenri/mongoose': minor
+'@usehenri/sequelize': minor
+'@usehenri/cli': minor
+---
+
+An adapter that says what it ran, and the N+1 detection that follows from it.
+
+`bullet` is the most-installed development tool in the Rails world after the linters, and henri had nothing like it. It had `include()`, a guide that told you to use it, and no way to find out when you had not. The reason nobody outside henri could write that check either was more basic: **no adapter emitted anything when it ran a query**, so there was nothing to listen to.
+
+So there are two halves, in that order. `henri.queries` is the seam — every adapter reports every model call — and the N+1 detector is a listener on it, on in development and in test, off in production.
+
+```
+warn  queries  GET /proposals/:id  Track.findById ran 24 times at
+               app/controllers/ProposalsController.js:41 (18.3ms) --
+               load them together: one Track.find({ id: [...] }) for the
+               whole set, or include('track') on the query that fetched
+               the parents
+```
+
+**The seam is at the model call, not the statement**, and that is the decision everything else follows from. It is the only level at which henri can give _advice_ — a driver instrumentation can already tell you forty statements ran, and `@opentelemetry/instrumentation-pg` does that better than henri would; only henri knows they were forty `Proposal.findById` calls and that one `Proposal.find({ id: [...] })` replaces them. It is also the only level whose number you can act on: `paginate()` is two statements and one decision, and on MySQL so is an insert, because the dialect has no `RETURNING`.
+
+And it is the level that matches what is actually wrong. Measuring the adapters rather than assuming: **`include()` on Drizzle compiles to a single correlated json subquery**, so the classic Rails lazy-association N+1 does not exist there at all. A detector written to `bullet`'s mental model would walk a Drizzle application, find nothing, and report success. What remains — a loop issuing one `find`/`findById` per record where one call for the set would do — is a count of model calls. So, said plainly everywhere because a person reading "40 queries" assumes the other thing: **the threshold counts model calls, never statements.**
+
+**An event carries names and numbers, and no SQL.** `{ at, store, adapter, dialect, model, operation, method, keys, shape, duration, rows, requestId, source, callsite }`. At the model call there is no statement to carry, which is the happy half; the unhappy half is why it would have been refused anyway. **Sequelize's query generator interpolates values into the text it runs** — `findAll({ where: { name: 'ada' } })` reaches the driver as `WHERE "name" = 'ada'`, on the ordinary path — while Drizzle parameterizes and Mongoose has no statement at all. A `sql` field would have been safe on two adapters and a copy of your rows on the third, which is worse than no field because it is the leak nobody would look for. `keys` is column **names**, which is the rule the access trail already established: a field name is schema, a field value is personal data.
+
+`callsite` is one frame, the first belonging to the application's own files. `bullet`'s value was never that it counted queries; it is that it names the line.
+
+**The join is the request id and there is only one.** The same `AsyncLocalStorage` the call log keys its rows by, every `pen` line carries, and a span carries as `henri.request_id`. There is no trace id, and **telemetry deliberately does not consume this seam**: statements stay the driver's own instrumentation to trace, `adapter.query()` keeps its span and gains an event, and no model call ever becomes a span. `base/telemetry.js` was amended to say where that line now sits.
+
+A finding goes to the log (one warning per request, at the end, when the count is final), to `X-Henri-Queries` in development, and — with `queries.detect.raise` — to a thrown `HENRI_QUERIES_N_PLUS_ONE` at the moment the threshold is crossed, so the stack names the call that went one too far. That last one is the CI gate, the way `Bullet.raise = true` is in a Rails suite. It does **not** go to `henri.reporter`: an N+1 is a slow answer, not a failure, and an application that wired Sentry to page someone should not be paged for a slow page. `henri audit` reports `queries.detect.raise` left on in a production configuration.
+
+Each adapter maps its own layer. Drizzle and Sequelize wrap their statics, because both answer promises, plus Drizzle's `Relation.prototype` once per process for the lazy `where().toArray()` path. Mongoose uses schema middleware instead, because `Model.find()` answers a lazy chainable `Query` and wrapping it would have executed it early and turned every `find().sort()` in every henri application into a promise; the cost is that an operation that fans out (`populate`) reports once per operation rather than once per model call, which the guide says out loud.
+
+**Off costs nothing**, the way the call log and telemetry mean it: no hook registered on any adapter, no middleware mounted, nothing allocated per query, and no flag tested on a hot path. Measured on Drizzle over in-memory sqlite — the harshest framing, since the call itself is only 26µs — the default adds 9.2µs per model call, two thirds of which is capturing the call site (`"callsites": false` drops it). Against a real database that is a fraction of a percent, and it is still off in production by default.
+
+`config.queries` is the whole configuration: absent means on outside production, `false` is off everywhere, `{ "enabled": true }` is the production opt-in. The guide is [N+1 detection](https://usehenri.io/guides/queries/).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,8 +144,9 @@ afterLogin, sessionMaxAge, signup, passwordReset, confirmation }`),
   `baseRole`, `externalIds`, `policies`, `trustProxy`, `csrf`, `graphql`,
   `mail`, `mailers`, `api`, `jobs`, `webhooks`, `rateLimit`, `shared`,
   `cache`, `helmet`, `csp`, `filterParameters`, `logs`, `telemetry`,
-  `encryption`, `privacy`, `retention`, `trail`, `calls`, `versions`, `i18n`,
-  `bodyLimit`, `uploads`, `requestTimeout`, `shutdown`, `errors`.
+  `encryption`, `privacy`, `retention`, `trail`, `calls`, `queries`,
+  `versions`, `i18n`, `bodyLimit`, `uploads`, `requestTimeout`, `shutdown`,
+  `errors`.
 - The configuration is validated at boot, before any other module starts:
   `base/config-schema.js` declares every key henri owns (as data, in the order
   of the documentation page) and `base/config-validate.js` walks it. A wrong
@@ -588,6 +589,42 @@ model }` or Mongoose's `ref` -- which `res.render()`, `res.resource()`,
   asynchronous delivery still joins. `henri calls <request-id>`,
   `henri calls:stats` and `henri calls:sweep` read it back, and the guide is
   `guides/calls.md`.
+- The query seam is `0.queries.js` (`henri.queries`) and `base/queries.js`,
+  on outside production. **Every adapter reports every model call** --
+  `{ at, store, adapter, dialect, model, operation, method, keys, shape,
+duration, rows, requestId, source, callsite }` -- and the N+1 detector is
+  a listener on it. It sits at the **model call and not the statement**, and
+  the header argues why: it is the only level at which henri can give advice
+  (a driver instrumentation counts statements better), a statement count is
+  not actionable (`paginate` is two, a MySQL insert is two), and -- the
+  measurement that settled it -- `include()` on Drizzle is one correlated
+  json subquery, so the Rails lazy-association N+1 **does not exist there**
+  and a detector written to `bullet`'s model would report success. So: **the
+  threshold counts model calls, never statements**, said out loud everywhere
+  because a person reading "40 queries" assumes the other thing. The event
+  carries **no SQL**, and the reason is `@usehenri/sequelize`: its query
+  generator interpolates values into the text it runs (`WHERE "name" =
+'ada'`), so a `sql` field would be safe on Drizzle and Mongoose and a copy
+  of the row there; `keys` is column **names**, the trail's rule. The join
+  is the request id and nothing else, off the same `AsyncLocalStorage`, and
+  **telemetry does not consume this seam** -- statements stay the driver's
+  own instrumentation to trace, `adapter.query()` keeps its span and gains
+  an event, and no model call becomes a span (`base/telemetry.js` was
+  amended to say where that line sits). Each adapter maps its own layer in
+  a `queries.js`: Drizzle and Sequelize **wrap** their statics (both answer
+  promises) plus `Relation.prototype` once per process for the lazy path,
+  Mongoose uses **schema middleware** because `Model.find()` answers a lazy
+  chainable `Query` and wrapping it would break `find().sort()` -- at the
+  cost that an operation that fans out (`populate`) reports twice, which the
+  header and the guide both say. `henri.queries.instrument()` is the one API
+  they call, and it owns the nesting rule (the outermost call wins, so
+  `findById` is one event and not the `first()` it is built out of).
+  A finding goes to the log, to `X-Henri-Queries` in development, or to a
+  thrown `HENRI_QUERIES_N_PLUS_ONE` with `detect.raise` (the test-suite
+  gate); **not** to `henri.reporter`, because an N+1 is a slow answer and
+  not a failure. Off means nothing installed: no hook, no middleware, no
+  allocation. `henri audit` reports `queries.raise-in-production` and the
+  guide is `guides/queries.md`.
 - Model versioning is `4.versions.js` (`henri.versions`),
   `base/versions.js` and `base/version-store.js`, and it is **opt-in per
   model**: `options: { versioned: true }` (or `{ only, except, events }`)
@@ -1174,5 +1211,20 @@ versions.spec.js`), and on MongoDB through the demo application core's
   covered, like the rest of that adapter. henri ships no arithmetic and
   rounds nothing: a value that does not fit the scale is a validation
   failure, and what to do about it is the application's.
+- The query seam and the N+1 detector (`config.queries`) are new. They are
+  covered on sqlite offline and on the live PostgreSQL and MySQL of
+  `pnpm test:sql:live` (`packages/{drizzle,sequelize}/__tests__/
+queries.spec.js`), on MongoDB by `packages/mongoose/__tests__/
+queries.spec.js`, and on a real application by the showcase's cost test.
+  MSSQL rides the Sequelize mapping and has no coverage of its own, like the
+  rest of that adapter. Three limits are deliberate and in the guide: the
+  detector counts **model calls**, so a statement count is a different
+  number and the showcase keeps one counter of each, labelled; a Mongoose
+  `populate` reports one event per operation rather than one per model call,
+  because `pre` and `post` are two callbacks with no scope between them; and
+  repetition is only ever counted **within one request**, so nothing is
+  detected in a job, in the console or across requests. There is no history
+  of findings, no span (the join is the request id and nothing more) and no
+  fix applied on anyone's behalf.
 - The scaffolded app pins ESLint 9 because `eslint-plugin-react` does not
   support ESLint 10 yet.

--- a/packages/cli/__tests__/analyze.spec.js
+++ b/packages/cli/__tests__/analyze.spec.js
@@ -35,7 +35,11 @@ describe('henri analyze', () => {
       expect(names[0]).toBe('config');
       expect(names).toContain('router');
       expect(names.indexOf('model')).toBeLessThan(names.indexOf('user'));
-      expect(analysis.chart[0].modules).toEqual(['config', 'telemetry']);
+      expect(analysis.chart[0].modules).toEqual([
+        'config',
+        'queries',
+        'telemetry',
+      ]);
       expect(analysis.chart[3].modules).toEqual([
         'cache',
         'model',

--- a/packages/cli/__tests__/audit.spec.js
+++ b/packages/cli/__tests__/audit.spec.js
@@ -582,6 +582,39 @@ describe('henri audit', () => {
     ).not.toContain('uploads.limits-disabled');
   });
 
+  test('reports a detector that raises in production, and only there', () => {
+    // Failing a test suite on an N+1 is the point of `raise`. Failing a
+    // real visitor's request is not: the page was slow, and now it is 500
+    const { findings: found, names } = withConfig(
+      app,
+      'config/production.json',
+      { queries: { detect: { raise: true } } }
+    );
+
+    expect(names).toContain('queries.raise-in-production');
+    expect(found).toContainEqual(
+      expect.objectContaining({
+        asvs: 'V14.1.1',
+        check: 'queries.raise-in-production',
+        file: 'config/production.json',
+        message: expect.stringContaining('500'),
+        severity: 'medium',
+      })
+    );
+
+    // Where it belongs, and what henri says nothing about
+    expect(
+      withConfig(app, 'config/test.json', {
+        queries: { detect: { raise: true } },
+      }).names
+    ).not.toContain('queries.raise-in-production');
+    expect(
+      withConfig(app, 'config/production.json', {
+        queries: { enabled: true, detect: { threshold: 10 } },
+      }).names
+    ).not.toContain('queries.raise-in-production');
+  });
+
   test('reports the webhook escape hatches, and only in production', () => {
     // A url an application was handed is the classic way into the metadata
     // service: turning the address rules off in production is a hole with a

--- a/packages/cli/__tests__/audit.spec.js
+++ b/packages/cli/__tests__/audit.spec.js
@@ -610,7 +610,7 @@ describe('henri audit', () => {
     ).not.toContain('queries.raise-in-production');
     expect(
       withConfig(app, 'config/production.json', {
-        queries: { enabled: true, detect: { threshold: 10 } },
+        queries: { detect: { threshold: 10 }, enabled: true },
       }).names
     ).not.toContain('queries.raise-in-production');
   });

--- a/packages/cli/scripts/audit.js
+++ b/packages/cli/scripts/audit.js
@@ -284,6 +284,13 @@ const CHECKS = [
     what: 'a model holds a field that is about a person and does not say so, so henri cannot redact, export or erase it',
   },
   {
+    asvs: 'V14.1.1',
+    check: 'queries.raise-in-production',
+    level: 1,
+    owasp: 'A05',
+    what: '"queries": { "detect": { "raise": true } } in a production configuration: a repeated model call answers 500 to a real visitor',
+  },
+  {
     asvs: 'V2.2.1',
     check: 'rate-limit.auth-disabled',
     level: 1,
@@ -1099,6 +1106,27 @@ const configFindings = (config, { file, hasUser }) => {
       '"trustProxy": true means a forwarded address could have been sent by anyone, so the call log records no client address at all and says "unverified": the column an incident is read with will be empty',
       `Set trustProxy to the number of proxies in front of henri in ${file} ("trustProxy": 1), or to false when nothing is, and the address becomes believable`,
       null
+    );
+  }
+
+  // The N+1 detector is a development instrument. Counting in production is
+  // a decision an application is allowed to make (`queries.enabled`), and
+  // henri says nothing about it: it costs time and tells nobody's secrets.
+  // Raising is different -- it turns a page that loops into a 500 for a real
+  // visitor, which is a worse outage than the slow page it was reporting.
+  if (
+    isObject(config.queries) &&
+    isObject(config.queries.detect) &&
+    config.queries.detect.raise === true &&
+    PRODUCTION_CONFIGS.includes(file)
+  ) {
+    add(
+      'medium',
+      'queries.raise-in-production',
+      OWASP.A05,
+      'queries.detect.raise is true, so the first request that makes the same model call often enough throws HENRI_QUERIES_N_PLUS_ONE and answers 500: a page that was merely slow now fails',
+      `Remove "raise": true from ${file} and keep it in config/test.json, where failing the suite on an N+1 is the point`,
+      'V14.1.1'
     );
   }
 

--- a/packages/core/error-codes.json
+++ b/packages/core/error-codes.json
@@ -70,6 +70,10 @@
       "what": "the personal data marked in the models, the export of one person and the erasure of them"
     },
     {
+      "area": "queries",
+      "what": "the query seam of `henri.queries`: what the adapters report running, and the repeated model calls the detector counts"
+    },
+    {
       "area": "retention",
       "what": "how long the models say they keep their records, and the sweep that enforces it"
     },
@@ -1371,6 +1375,26 @@
       "code": "HENRI_PRIVACY_UNKNOWN_SUBJECT",
       "fix": "Name the person by email address, by external id or by primary key. An erased person no longer answers to their address: look their receipt up by digest instead.",
       "what": "The person an export or an erasure was asked about does not exist."
+    },
+    {
+      "area": "queries",
+      "causes": [
+        "config.queries.detect.threshold is not a whole number of at least two",
+        "config.queries.detect.ignore holds something that is not a model or a Model.operation name"
+      ],
+      "code": "HENRI_QUERIES_INVALID_DETECT",
+      "fix": "A threshold is a whole number of at least two, because a call that ran once is not a repetition. An `ignore` entry is `Model`, `Model.operation` or `*.operation`, where the operation is one of count, delete, insert, other, raw, select, update.",
+      "what": "The N+1 detector was configured with something it cannot use."
+    },
+    {
+      "area": "queries",
+      "causes": [
+        "a loop made one model call per record where one call for the whole set would do",
+        "a view or a serializer read an association the query that fetched the parents did not include"
+      ],
+      "code": "HENRI_QUERIES_N_PLUS_ONE",
+      "fix": "Load the records together: one `Model.find({ id: [...] })` for the whole set, or `include()` on the query that fetched the parents. `config.queries.detect.raise` is what turned this into an error rather than a warning; `config.queries.detect.threshold` is how many repeats it takes, and `detect.ignore` silences a model or an operation.",
+      "what": "The same model call ran enough times in one request for the detector to call it an N+1."
     },
     {
       "area": "retention",

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -805,6 +805,12 @@ declare namespace start {
      */
     calls?: false | CallsConfig;
     /**
+     * What the adapters report running, and the repeated model calls the
+     * detector counts. On in development and in test, off in production;
+     * `false` records nothing anywhere.
+     */
+    queries?: false | QueriesConfig;
+    /**
      * Where the history of the versioned models lives and how long it is
      * kept. It does not turn versioning on: a model does, with
      * `options: { versioned: true }`.
@@ -989,6 +995,56 @@ declare namespace start {
      * believed only when the peer is one of `from`. henri names none.
      */
     header?: string;
+  }
+
+  /** `config.queries`: the query seam and the N+1 detector on top of it. */
+  interface QueriesConfig {
+    /**
+     * Whether an event carries the line the model call was made on. It
+     * costs an `Error` allocation per call, so it follows the detector
+     * unless this says otherwise.
+     */
+    callsites?: boolean;
+    /**
+     * The N+1 detector; `false` keeps the events and reports nothing, so
+     * `onQuery()` still works.
+     */
+    detect?: false | QueriesDetectConfig;
+    /**
+     * Absent means on outside production. `true` is the production opt-in:
+     * every model call is timed and counted.
+     */
+    enabled?: boolean;
+  }
+
+  /** `config.queries.detect`: what a repeated model call does. */
+  interface QueriesDetectConfig {
+    /**
+     * `X-Henri-Queries` on the answer, in development only (`true`): the
+     * counts and the names of the repeated calls, never a value.
+     */
+    header?: boolean;
+    /**
+     * Calls the detector never counts: `Model`, `Model.operation` or
+     * `*.operation`.
+     */
+    ignore?: string[];
+    /**
+     * One warning per request naming the call, the count, the line and
+     * what to do instead (`true`).
+     */
+    log?: boolean;
+    /**
+     * Throw `HENRI_QUERIES_N_PLUS_ONE` the moment the threshold is crossed,
+     * so the stack names the call (`false`). This is what makes a test
+     * suite fail on an N+1.
+     */
+    raise?: boolean;
+    /**
+     * How many times the same model call has to run in one request before
+     * it is reported (`5`). It counts **model calls, never statements**.
+     */
+    threshold?: number;
   }
 
   interface CallsConfig {
@@ -2284,6 +2340,67 @@ declare namespace start {
    * A handler that throws or hangs never takes the request or the boot with
    * it, and no handler at all costs nothing.
    */
+  /**
+   * One model call, as an adapter reported it.
+   *
+   * Names and numbers only: no statement, no filter values, no bound
+   * parameters, no rows, no person and nothing from the client. `keys` is the
+   * filter's column **names**.
+   */
+  interface QueryEvent {
+    /** Which adapter ran it. */
+    adapter: string;
+    /** When it finished, in epoch milliseconds. */
+    at: number;
+    /** The first frame of the application's own files, when captured. */
+    callsite: { column: number; file: number | string; line: number } | null;
+    /** The SQL dialect, or `null` on MongoDB. */
+    dialect: string | null;
+    /** How long the call took, in milliseconds. */
+    duration: number;
+    /** The filter's column names, never what they were compared against. */
+    keys: string[];
+    /** The adapter's own name for the call (`findById`, `paginate`). */
+    method: string;
+    /** The model, or `null` for a raw `adapter.query()`. */
+    model: string | null;
+    /** One vocabulary across the three adapters. */
+    operation:
+      'count' | 'delete' | 'insert' | 'other' | 'raw' | 'select' | 'update';
+    /** The request this happened in, or `null` outside one. */
+    requestId: string | null;
+    /** How many rows came back, or `null` when it cannot be told. */
+    rows: number | null;
+    /** A digest of (adapter, model, operation, keys): what "the same call" means. */
+    shape: string;
+    /** Whether henri asked on its own behalf, or the application did. */
+    source: 'application' | 'henri';
+    /** The store it went to. */
+    store: string | null;
+  }
+
+  /** `henri.queries`: the query seam and the N+1 detector. */
+  interface QueriesModule {
+    /** Whether an event carries the line the call was made on. */
+    readonly callsites: boolean;
+    /** Whether anything is recorded at all. Off means nothing is installed. */
+    readonly enabled: boolean;
+    /**
+     * Register the handler every query event is given to, replacing any
+     * previous one; `null` removes it. Follows `henri.reporter.onError()`.
+     * It is called synchronously, inside the call it describes.
+     */
+    onQuery(handler: ((event: QueryEvent) => unknown) | null): boolean;
+    /** What has been seen since the boot. */
+    stats(): {
+      detecting: boolean;
+      enabled: boolean;
+      events: number;
+      findings: number;
+      requests: number;
+    };
+  }
+
   interface Reporter {
     /** Is a handler registered? */
     readonly enabled: boolean;
@@ -4081,6 +4198,12 @@ declare namespace start {
      * the request id. Off unless `config.calls` says otherwise.
      */
     calls: CallsModule;
+    /**
+     * What the adapters report running, and the N+1 detector on top of it.
+     * On outside production; `enabled` is false when nothing is counted, and
+     * then nothing is installed either.
+     */
+    queries: QueriesModule;
     /**
      * The history of the models that asked for one. `enabled` is false
      * until a model says `options: { versioned: true }`, and nothing is

--- a/packages/core/src/0.queries.js
+++ b/packages/core/src/0.queries.js
@@ -1,0 +1,578 @@
+const BaseModule = require('./base/module');
+
+const debug = require('debug')('henri:queries');
+
+const {
+  Detector,
+  bucketOf,
+  callsiteOf,
+  currentRequestId,
+  describe,
+  keysOf,
+  nested,
+  outermost,
+  queriesConfig,
+  rowsOf,
+  shapeOf,
+} = require('./base/queries');
+const { fail } = require('./base/errors');
+
+/**
+ * `henri.queries`: what the adapters ran, and the N+1 that follows from it.
+ *
+ * The design -- why the seam is at the model call and not at the statement,
+ * what an event carries and what it refuses, and why the threshold counts
+ * model calls rather than statements -- is in the header of
+ * `base/queries.js`. This is the module: the adapters call `record()`, the
+ * detector counts, and this decides where a finding goes.
+ *
+ * It sits at runlevel 0, with the configuration, for the same reason
+ * telemetry does: everything that *installs* the instrumentation is above it.
+ * The three adapters ask `henri.queries.enabled` once, while they are
+ * building their models, and install nothing when the answer is no.
+ *
+ * ## Where a finding goes, and why each one is there
+ *
+ * Three destinations, each opting out on its own, and one that was
+ * considered and refused:
+ *
+ * - **The log** (`detect.log`, on). One `pen.warn` per request, at the end,
+ *   naming the call, the count, the line and what to do instead. This is the
+ *   one a developer actually reads, and end-of-request is when the count is
+ *   final: a warning at the moment the threshold is crossed would say "5
+ *   times" about something that ran forty.
+ * - **A response header** (`detect.header`, on, development only). `X-Henri-
+ *   Queries: 47; n+1 Track.findById x40`. It carries counts and the names of
+ *   models and methods -- the application's own vocabulary, never a value --
+ *   and it exists because a header is what a devtool, a browser extension or
+ *   an Inertia dev overlay can read without henri shipping a UI. It is
+ *   refused outside development, where an internal count is nobody's
+ *   business.
+ * - **A thrown error** (`detect.raise`, off). `HENRI_QUERIES_N_PLUS_ONE`,
+ *   thrown at the moment the threshold is crossed rather than at the end of
+ *   the request, because the point of raising is the stack: the developer
+ *   wants the frame that made the fortieth call, not a summary. This is what
+ *   turns the detector into a test-suite gate, which is what `Bullet.raise =
+ *   true` is for in a Rails suite.
+ *
+ * **The reporter is not one of them.** `henri.reporter` is the seam for
+ * failures henri caught (`base/reporting.js` says so in its own header), and
+ * an N+1 is not a failure -- it is an answer that was slower than it needed
+ * to be. Sending one there would put a performance note in the same stream as
+ * the 500s, and the application that wired Sentry to page someone would be
+ * paged for a slow page. An application that wants that anyway has
+ * `onQuery()` and four lines.
+ *
+ * `henri doctor` is not one either, for a duller reason: it does not boot the
+ * application and cannot run a request, so it has nothing to count. What it
+ * can say -- that the detector is configured on in production -- is
+ * `henri audit`'s job, and that is where it is.
+ *
+ * @class Queries
+ * @extends {BaseModule}
+ */
+class Queries extends BaseModule {
+  /**
+   * Creates an instance of Queries.
+   * @memberof Queries
+   */
+  constructor() {
+    super();
+
+    this.name = 'queries';
+    this.runlevel = 0;
+    this.needs = ['config'];
+    // Naming `config` replaces the number, so everything that installs the
+    // instrumentation has to be named too: the model module builds the
+    // adapters and the server mounts the middleware. A module that is not
+    // there is ignored, which is why this is `before` and not `needs`
+    this.before = ['model', 'router', 'server'];
+    this.reloadable = true;
+    this.henri = null;
+
+    /** `config.queries`, normalized */
+    this.settings = { callsites: false, detect: false, enabled: false };
+    /** Whether anything is recorded at all */
+    this.enabled = false;
+    /** Whether an event carries the line it was made on */
+    this.callsites = false;
+    /** The detector, when one is wanted */
+    this.detector = null;
+    /** The handler `onQuery()` registered, if any */
+    this._handler = null;
+    /** What was seen, for `stats()` and for the header */
+    this.counters = { events: 0, findings: 0, requests: 0 };
+
+    this.init = this.init.bind(this);
+    this.reload = this.reload.bind(this);
+    this.record = this.record.bind(this);
+    this.onQuery = this.onQuery.bind(this);
+    this.middleware = this.middleware.bind(this);
+  }
+
+  /**
+   * Module initialization
+   *
+   * @returns {string} The name of the module
+   * @memberof Queries
+   */
+  init() {
+    this.build();
+
+    return this.name;
+  }
+
+  /**
+   * Reads the configuration back, and says what it decided
+   *
+   * @returns {object} The settings
+   * @memberof Queries
+   */
+  build() {
+    const { config, pen } = this.henri;
+
+    this.settings = queriesConfig(config, this.henri.isProduction);
+    this.enabled = this.settings.enabled;
+    this.callsites = this.settings.callsites;
+    this.detector = this.settings.detect
+      ? new Detector(this.settings.detect)
+      : null;
+
+    debug('enabled=%s detect=%s', this.enabled, Boolean(this.detector));
+
+    // A boot line only when there is something to say. An application that
+    // is not counting has nothing to read, and a line saying so on every
+    // production boot is noise
+    if (this.enabled && this.detector) {
+      pen.info(
+        'queries',
+        `counting model calls; the same call ${this.settings.detect.threshold} times in one request is reported`,
+        this.settings.detect.raise ? '(and raises)' : ''
+      );
+    } else if (this.enabled) {
+      pen.info('queries', 'recording model calls; nothing is detected');
+    }
+
+    return this.settings;
+  }
+
+  /**
+   * Reloads the configuration.
+   *
+   * What it cannot do is install or uninstall the adapters' hooks: those were
+   * decided when the models were built, and a model module reload is what
+   * changes them. Turning the seam on in a running process therefore needs a
+   * restart, and saying so is better than half-working.
+   *
+   * @returns {string} The name of the module
+   * @memberof Queries
+   */
+  reload() {
+    const before = this.enabled;
+
+    this.build();
+
+    if (before !== this.enabled) {
+      this.henri.pen.warn(
+        'queries',
+        'config.queries changed; the adapters keep the instrumentation they were built with until a restart'
+      );
+    }
+
+    return this.name;
+  }
+
+  /**
+   * Register the handler every query event is given to.
+   *
+   * One handler: registering another replaces it, `null` removes it. It
+   * follows `henri.reporter.onError()` and `henri.mailers.onDeliverLater()`
+   * -- one rather than a list, because two handlers means an order and an
+   * order means a contract about it.
+   *
+   * It is called synchronously, inside the call it describes, so a handler
+   * that blocks blocks a query. A handler that throws is logged once and
+   * removed: this is a development instrument and it does not get to break
+   * the application it is measuring.
+   *
+   * @param {?function} handler The handler, or null to remove it
+   * @returns {boolean} success
+   * @memberof Queries
+   */
+  onQuery(handler) {
+    if (handler !== null && typeof handler !== 'function') {
+      this.henri.pen.error('queries', 'the query handler must be a function');
+
+      return false;
+    }
+
+    this._handler = handler;
+
+    return true;
+  }
+
+  /**
+   * One model call, as the adapters report it.
+   *
+   * This is the hot path and the only method the adapters call. It is never
+   * reached on a disabled seam, because a disabled seam is not installed --
+   * there is no early return here doing the work of a flag.
+   *
+   * The adapter passes what it knows and this fills in what is henri's: the
+   * duration, the shape, the request id and the line. The filter arrives as
+   * the application wrote it and `keysOf()` takes its key names; the values
+   * never leave this call.
+   *
+   * @param {object} query What the adapter ran
+   * @param {string} query.adapter `drizzle`, `mongoose` or `sequelize`
+   * @param {string} query.operation One of `OPERATIONS`
+   * @param {string} query.method The adapter's own name for it
+   * @param {?string} query.model The model, or null for a raw query
+   * @param {*} [query.filter] The filter, for its key names only
+   * @param {?number} [query.rows] How many rows came back
+   * @param {number} query.started `performance.now()` when it began
+   * @param {?Error} [query.at] An Error captured at the call site
+   * @param {string} [query.source='application'] Who asked
+   * @param {?string} [query.store] The store name
+   * @param {?string} [query.dialect] The dialect, on SQL
+   * @returns {?object} The event, or null when nothing was recorded
+   * @memberof Queries
+   */
+  record(query) {
+    const duration = performance.now() - query.started;
+    const keys = query.filter ? keysOf(query.filter) : [];
+    const event = {
+      adapter: query.adapter,
+      at: Date.now(),
+      callsite: this.callsites ? callsiteOf(query.at, this.henri.cwd()) : null,
+      dialect: query.dialect || null,
+      duration,
+      keys,
+      method: query.method,
+      model: query.model || null,
+      operation: query.operation,
+      requestId: currentRequestId(),
+      rows: typeof query.rows === 'number' ? query.rows : null,
+      shape: shapeOf({
+        adapter: query.adapter,
+        keys,
+        model: query.model,
+        operation: query.operation,
+      }),
+      source: query.source || 'application',
+      store: query.store || null,
+    };
+
+    this.counters.events += 1;
+
+    if (this.detector) {
+      this.watch(event);
+    }
+
+    if (this._handler) {
+      this.hand(event);
+    }
+
+    return event;
+  }
+
+  /**
+   * Wraps a set of methods so that each call reports itself.
+   *
+   * This is the one API the adapters use, and it exists so that "what a model
+   * call is" is decided once, in core, rather than three times in three
+   * packages that would drift. An adapter says which methods of which object
+   * are model calls and what each one means; everything else -- the nesting
+   * rule, the timing, the row count, the filter's key names, the call site --
+   * happens here.
+   *
+   *     henri.queries.instrument(Klass, {
+   *       findById: { filter: (args) => ({ id: args[0] }), operation: 'select' },
+   *       create: { operation: 'insert' },
+   *     }, { adapter: 'drizzle', dialect: 'postgres', model: 'Proposal' });
+   *
+   * A spec entry takes `operation` (one of `OPERATIONS`), an optional
+   * `method` (the reported name, defaulting to the key), an optional `filter`
+   * reading the arguments for their **key names**, and an optional `rows`
+   * reading the answer for a count.
+   *
+   * It is never called on a disabled seam: the adapters ask `enabled` first,
+   * and an application that is not counting has its methods untouched.
+   *
+   * @param {object} target The object holding the methods (a class, a prototype)
+   * @param {object} spec What each method means
+   * @param {object} context `{ adapter, dialect, store, model }`; `model` may
+   *   be a function of the receiver, for a prototype shared by every model
+   * @returns {object} The same target
+   * @memberof Queries
+   */
+  instrument(target, spec, context) {
+    const queries = this;
+
+    for (const name of Object.keys(spec)) {
+      const original = target[name];
+
+      if (typeof original !== 'function') {
+        continue;
+      }
+
+      const entry = spec[name];
+      const method = entry.method || name;
+      const { operation } = entry;
+
+      /**
+       * The instrumented method
+       *
+       * @param {...*} args Whatever the caller passed
+       * @returns {*} Whatever the method answers
+       */
+      function measured(...args) {
+        // A layer of a call already being measured: call through, add
+        // nothing. `Model.findById()` is one event, not three
+        if (nested()) {
+          return original.apply(this, args);
+        }
+
+        const started = performance.now();
+        // Allocated, never formatted: callsiteOf() reads .stack only when a
+        // shape is actually reported
+        const at = queries.callsites ? new Error('query') : null;
+        const model =
+          typeof context.model === 'function'
+            ? context.model(this)
+            : context.model;
+        /**
+         * Reports the finished call
+         *
+         * @param {*} answer What it resolved with
+         * @returns {void}
+         */
+        const done = (answer) => {
+          queries.record({
+            adapter: context.adapter,
+            at,
+            dialect: context.dialect,
+            filter: entry.filter ? entry.filter(args) : null,
+            method,
+            model,
+            operation,
+            rows: entry.rows ? entry.rows(answer) : rowsOf(answer),
+            source: context.source,
+            started,
+            store: context.store,
+          });
+        };
+
+        return outermost(() => {
+          let answer;
+
+          try {
+            answer = original.apply(this, args);
+          } catch (error) {
+            done(null);
+
+            throw error;
+          }
+
+          if (answer && typeof answer.then === 'function') {
+            return answer.then(
+              (value) => {
+                done(value);
+
+                return value;
+              },
+              (error) => {
+                done(null);
+
+                throw error;
+              }
+            );
+          }
+
+          done(answer);
+
+          return answer;
+        });
+      }
+
+      target[name] = measured;
+    }
+
+    return target;
+  }
+
+  /**
+   * Counts an event, and raises the moment the threshold is crossed.
+   *
+   * Raising here rather than at the end of the request is the whole point of
+   * raising: the stack of this throw is the call that went one too far, which
+   * is the line the developer is looking for.
+   *
+   * @param {object} event The event
+   * @returns {void}
+   * @throws {Error} `HENRI_QUERIES_N_PLUS_ONE` when `detect.raise` is set
+   * @memberof Queries
+   */
+  watch(event) {
+    const entry = this.detector.count(event);
+
+    if (
+      !entry ||
+      !this.settings.detect.raise ||
+      entry.count !== this.detector.threshold
+    ) {
+      return;
+    }
+
+    throw fail(
+      'HENRI_QUERIES_N_PLUS_ONE',
+      `${describe(entry)} (config.queries.detect.raise)`
+    );
+  }
+
+  /**
+   * Hands an event to the application's handler, which is not trusted
+   *
+   * @param {object} event The event
+   * @returns {void}
+   * @memberof Queries
+   */
+  hand(event) {
+    try {
+      this._handler(event);
+    } catch (error) {
+      this._handler = null;
+      this.henri.pen.error(
+        'queries',
+        'the query handler threw and was removed',
+        error.message
+      );
+    }
+  }
+
+  /**
+   * What has been seen since the boot
+   *
+   * @returns {object} `{ enabled, detecting, events, findings, requests }`
+   * @memberof Queries
+   */
+  stats() {
+    return {
+      detecting: Boolean(this.detector),
+      enabled: this.enabled,
+      ...this.counters,
+    };
+  }
+
+  /**
+   * The express middleware: one report per request, or none at all.
+   *
+   * Mounted by `2.server.js` only when there is a detector, so an application
+   * that records without detecting has nothing in its stack. It does no work
+   * on the way in: the bucket is made by the first query, in
+   * `base/queries.js`, on the request-id store that already exists.
+   *
+   * @returns {?function} The middleware, or null when nothing detects
+   * @memberof Queries
+   */
+  middleware() {
+    if (!this.detector) {
+      return null;
+    }
+
+    const { header, log } = this.settings.detect;
+    // A header has to be written before the headers go out, and express
+    // gives no hook for that. Wrapping writeHead is the smallest thing that
+    // works on both an express response and a raw one, and it is undone by
+    // the response ending
+    const wantsHeader = header && this.henri.isDev;
+
+    return (req, res, next) => {
+      this.counters.requests += 1;
+
+      if (wantsHeader) {
+        const writeHead = res.writeHead.bind(res);
+
+        res.writeHead = (...args) => {
+          const line = this.summarize();
+
+          if (line && !res.headersSent) {
+            res.setHeader('X-Henri-Queries', line);
+          }
+
+          return writeHead(...args);
+        };
+      }
+
+      if (log) {
+        res.on('finish', () => this.complain(req));
+      }
+
+      next();
+    };
+  }
+
+  /**
+   * The header line: counts and names, and nothing else.
+   *
+   * Everything in it is a number henri measured or a name the application
+   * chose for one of its own models, which is the rule of `base/reporting.js`
+   * applied to a header. No filter value, no path and no identifier reaches
+   * it.
+   *
+   * @returns {?string} The line, or null when there is nothing to say
+   * @memberof Queries
+   */
+  summarize() {
+    const bucket = bucketOf(false);
+
+    if (!bucket || bucket.size === 0) {
+      return null;
+    }
+
+    let total = 0;
+
+    for (const entry of bucket.values()) {
+      total += entry.count;
+    }
+
+    const parts = [`${total}`];
+
+    for (const finding of this.detector.findings(bucket).slice(0, 3)) {
+      parts.push(
+        `n+1 ${finding.model || 'query'}.${finding.method} x${finding.count}`
+      );
+    }
+
+    return parts.join('; ');
+  }
+
+  /**
+   * One warning per request, at the end, when something repeated
+   *
+   * @param {object} req The express request
+   * @returns {number} How many findings there were
+   * @memberof Queries
+   */
+  complain(req) {
+    const findings = this.detector.findings(bucketOf(false));
+
+    if (findings.length === 0) {
+      return 0;
+    }
+
+    this.counters.findings += findings.length;
+
+    const where = req.route
+      ? `${req.method} ${req.baseUrl || ''}${req.route.path}`
+      : req.method;
+
+    for (const finding of findings) {
+      this.henri.pen.warn('queries', where, describe(finding));
+    }
+
+    return findings.length;
+  }
+}
+
+module.exports = Queries;

--- a/packages/core/src/0.queries.js
+++ b/packages/core/src/0.queries.js
@@ -299,15 +299,42 @@ class Queries extends BaseModule {
    * It is never called on a disabled seam: the adapters ask `enabled` first,
    * and an application that is not counting has its methods untouched.
    *
+   * ## Two kinds of target, and why the second one needs care
+   *
+   * A per-model class is the easy case: it belongs to one adapter, which
+   * belongs to one henri, and closing over this module is right.
+   *
+   * A **shared prototype** is not. `Relation.prototype` in the Drizzle
+   * adapter is one object for every model of every store in the process, and
+   * a test suite boots several henri instances into that process. A wrapper
+   * that closed over the first one would report a second instance's queries
+   * to the first instance's detector, which is a wrong answer rather than a
+   * missing one. So `context.queries` may be a **function of the receiver**
+   * that finds the right module at call time (`(self) =>
+   * self.Model.adapter.henri.queries`), and `context.once` is a key on the
+   * target that keeps a second instance from wrapping what the first already
+   * wrapped. A resolved module that is disabled calls straight through.
+   *
    * @param {object} target The object holding the methods (a class, a prototype)
    * @param {object} spec What each method means
-   * @param {object} context `{ adapter, dialect, store, model }`; `model` may
-   *   be a function of the receiver, for a prototype shared by every model
+   * @param {object} context `{ adapter, dialect, store, model, queries, once }`;
+   *   `model` and `queries` may be functions of the receiver, for a prototype
+   *   shared by every model
    * @returns {object} The same target
    * @memberof Queries
    */
   instrument(target, spec, context) {
-    const queries = this;
+    const owner = this;
+    const resolve =
+      typeof context.queries === 'function' ? context.queries : () => owner;
+
+    if (context.once) {
+      if (target[context.once]) {
+        return target;
+      }
+
+      Object.defineProperty(target, context.once, { value: true });
+    }
 
     for (const name of Object.keys(spec)) {
       const original = target[name];
@@ -327,9 +354,12 @@ class Queries extends BaseModule {
        * @returns {*} Whatever the method answers
        */
       function measured(...args) {
+        const queries = resolve(this);
+
         // A layer of a call already being measured: call through, add
-        // nothing. `Model.findById()` is one event, not three
-        if (nested()) {
+        // nothing. `Model.findById()` is one event, not three. A henri whose
+        // seam is off calls through for the same price
+        if (!queries || !queries.enabled || nested()) {
           return original.apply(this, args);
         }
 
@@ -337,10 +367,18 @@ class Queries extends BaseModule {
         // Allocated, never formatted: callsiteOf() reads .stack only when a
         // shape is actually reported
         const at = queries.callsites ? new Error('query') : null;
-        const model =
-          typeof context.model === 'function'
-            ? context.model(this)
-            : context.model;
+        // Everything that identifies the store may be a function of the
+        // receiver, because a shared prototype answers for several of them
+        const self = this;
+        /**
+         * One field of the context, read off the receiver when it varies
+         *
+         * @param {*} value What the adapter declared
+         * @returns {*} The value for this call
+         */
+        const of = (value) =>
+          typeof value === 'function' ? value(self) : value;
+        const model = of(context.model);
         /**
          * Reports the finished call
          *
@@ -349,9 +387,9 @@ class Queries extends BaseModule {
          */
         const done = (answer) => {
           queries.record({
-            adapter: context.adapter,
+            adapter: of(context.adapter),
             at,
-            dialect: context.dialect,
+            dialect: of(context.dialect),
             filter: entry.filter ? entry.filter(args) : null,
             method,
             model,
@@ -359,7 +397,7 @@ class Queries extends BaseModule {
             rows: entry.rows ? entry.rows(answer) : rowsOf(answer),
             source: context.source,
             started,
-            store: context.store,
+            store: of(context.store),
           });
         };
 

--- a/packages/core/src/0.queries.js
+++ b/packages/core/src/0.queries.js
@@ -489,6 +489,23 @@ class Queries extends BaseModule {
   }
 
   /**
+   * Is a model call already being measured further out?
+   *
+   * `instrument()` applies this rule itself, so a wrapper never has to ask.
+   * An adapter that cannot be wrapped does: the Mongoose one is instrumented
+   * with schema middleware rather than by wrapping its statics (a `Query` is
+   * lazy and chainable, and wrapping it away would break `find().sort()`), so
+   * it calls `record()` directly and this is how it keeps the `find` and the
+   * `countDocuments` inside `paginate()` from being counted twice.
+   *
+   * @returns {boolean} true when this call is a layer of another one
+   * @memberof Queries
+   */
+  nested() {
+    return nested();
+  }
+
+  /**
    * What has been seen since the boot
    *
    * @returns {object} `{ enabled, detecting, events, findings, requests }`

--- a/packages/core/src/2.server.js
+++ b/packages/core/src/2.server.js
@@ -387,7 +387,8 @@ class Server extends BaseModule {
     ));
     const { settings } = api;
 
-    // Middleware order: request id, telemetry, the call log, timeout,
+    // Middleware order: request id, telemetry, the call log, the N+1
+    // detector, timeout,
     // secure headers,
     // compression, cors, body parsers, cookies, boom, api version,
     // pagination, the health endpoints, static files. The user module adds
@@ -415,6 +416,19 @@ class Server extends BaseModule {
 
     if (callsConfig(config).inbound) {
       app.use(inbound(this.henri));
+    }
+
+    // The N+1 detector, and only when something detects: it needs to be
+    // outside enough to set a header before the answer goes out, and it does
+    // no work on the way in -- the bucket is made by the first model call, on
+    // the request-id store that already exists
+    const queries =
+      this.henri.queries &&
+      this.henri.queries.enabled &&
+      this.henri.queries.middleware();
+
+    if (queries) {
+      app.use(queries);
     }
 
     if (settings.requestTimeout) {

--- a/packages/core/src/3.model.js
+++ b/packages/core/src/3.model.js
@@ -316,48 +316,78 @@ class Model extends BaseModule {
   }
 
   /**
-   * Give the adapter's `query()` a span, when spans of stores are wanted
+   * Wrap the adapter's `query()`: a span for tracing, an event for the seam.
    *
    * `query()` is the one store call henri makes on its own behalf -- the
    * queue's claim, the trail's insert, a webhook lookup -- and the one
-   * boundary here that does not need anybody's driver opened up. A model
-   * call an application makes is *not* covered, deliberately: that belongs
-   * to the ORM's own instrumentation package, and `base/telemetry.js` says
-   * so.
+   * boundary here that does not need anybody's driver opened up. It is also
+   * the one call site the two instrumentations share, so what each is for is
+   * worth stating:
    *
-   * The wrapping **is** the instrumentation: an application that is not
-   * tracing gets the adapter's own method, untouched, with nothing to test
-   * per call.
+   * - **The span** is tracing, and tracing stops here. A model call an
+   *   application makes gets no span, deliberately: statements belong to the
+   *   ORM's own instrumentation package (`@opentelemetry/instrumentation-pg`
+   *   and friends), which composes with henri's because the context is
+   *   already active, and henri re-implementing it would double-count for
+   *   any application that installed one. `base/telemetry.js` says so and
+   *   still does.
+   * - **The event** is `henri.queries`, and it is not tracing. It reports
+   *   model calls so the N+1 detector can count them and so an application
+   *   can listen; the adapters install it themselves, and this is only the
+   *   raw path, which no adapter's model layer sees. Telemetry does not
+   *   consume that seam, so a call that gets both here is one span and one
+   *   event, not two of either.
    *
-   * The statement is never an attribute. It carries values.
+   * The wrapping **is** the instrumentation: an application doing neither
+   * gets the adapter's own method, untouched, with nothing to test per call.
+   *
+   * The statement is never an attribute and never a field. It carries
+   * values -- see the header of `base/queries.js` for the whole argument.
    *
    * @param {object} store the adapter henri just built
    * @returns {object} the same adapter
    * @memberof Model
    */
   instrument(store) {
-    const { telemetry } = this.henri;
+    const { queries, telemetry } = this.henri;
+    const traces = telemetry && telemetry.on('stores');
+    const events = queries && queries.enabled;
 
-    if (!telemetry || !telemetry.on('stores')) {
+    if ((!traces && !events) || typeof store.query !== 'function') {
       return store;
     }
 
-    if (typeof store.query !== 'function') {
-      return store;
+    if (traces) {
+      const query = store.query.bind(store);
+      const options = {
+        attributes: {
+          'db.system': store.dialect || store.adapterName || 'unknown',
+          'henri.store': store.name,
+        },
+        boundary: 'stores',
+        kind: 'client',
+      };
+
+      store.query = (...args) =>
+        telemetry.span('henri.store.query', options, () => query(...args));
     }
 
-    const query = store.query.bind(store);
-    const options = {
-      attributes: {
-        'db.system': store.dialect || store.adapterName || 'unknown',
-        'henri.store': store.name,
-      },
-      boundary: 'stores',
-      kind: 'client',
-    };
-
-    store.query = (...args) =>
-      telemetry.span('henri.store.query', options, () => query(...args));
+    if (events) {
+      // No model and no filter: a raw statement names its own tables and
+      // henri does not read it. What the event says is that the framework
+      // went to this store, how long it took and how much came back
+      queries.instrument(
+        store,
+        { query: { method: 'query', operation: 'raw' } },
+        {
+          adapter: store.adapterName,
+          dialect: store.dialect || null,
+          model: null,
+          source: 'henri',
+          store: store.name,
+        }
+      );
+    }
 
     return store;
   }

--- a/packages/core/src/__tests__/queries.spec.js
+++ b/packages/core/src/__tests__/queries.spec.js
@@ -1,0 +1,488 @@
+const Queries = require('../0.queries');
+const {
+  Detector,
+  OPERATIONS,
+  callsiteOf,
+  checkDetect,
+  keysOf,
+  queriesConfig,
+  rowsOf,
+  shapeOf,
+} = require('../base/queries');
+const { context } = require('../base/request-id');
+
+/**
+ * A henri stand-in with the seam built on it
+ *
+ * @param {*} [queries] What `config.queries` says
+ * @param {boolean} [production=false] Whether this is a production boot
+ * @returns {object} The module, with `henri` on it
+ */
+const build = (queries, production = false) => {
+  const lines = [];
+  const henri = {
+    config: {
+      get: () => queries,
+      has: () => typeof queries !== 'undefined',
+    },
+    cwd: () => process.cwd(),
+    isDev: !production,
+    isProduction: production,
+    lines,
+    pen: {
+      error: (...args) => lines.push(['error', ...args]),
+      info: (...args) => lines.push(['info', ...args]),
+      warn: (...args) => lines.push(['warn', ...args]),
+    },
+  };
+  const module = new Queries();
+
+  module.henri = henri;
+  module.init();
+
+  return module;
+};
+
+/** One event, as an adapter would report it */
+const record = (module, over = {}) =>
+  module.record({
+    adapter: 'drizzle',
+    method: 'findByKey',
+    model: 'Track',
+    operation: 'select',
+    rows: 1,
+    started: performance.now(),
+    ...over,
+  });
+
+/** Runs something inside a request, so the detector has a bucket */
+const inRequest = (id, fn) => context.run({ id }, fn);
+
+describe('the query seam', () => {
+  describe('the configuration', () => {
+    test('is on outside production and off inside it', () => {
+      expect(queriesConfig(null, false).enabled).toBe(true);
+      expect(queriesConfig(null, true).enabled).toBe(false);
+    });
+
+    test('false is off everywhere, and detects nothing', () => {
+      const settings = queriesConfig(
+        { get: () => false, has: () => true },
+        false
+      );
+
+      expect(settings.enabled).toBe(false);
+      expect(settings.detect).toBe(false);
+      expect(settings.callsites).toBe(false);
+    });
+
+    test('enabled: true is the production opt-in', () => {
+      const settings = queriesConfig(
+        { get: () => ({ enabled: true }), has: () => true },
+        true
+      );
+
+      expect(settings.enabled).toBe(true);
+      expect(settings.detect).toBeTruthy();
+    });
+
+    test('detect: false keeps the events and reports nothing', () => {
+      const settings = queriesConfig(
+        { get: () => ({ detect: false }), has: () => true },
+        false
+      );
+
+      expect(settings.enabled).toBe(true);
+      expect(settings.detect).toBe(false);
+      // No detector, no reason to pay for a stack per call
+      expect(settings.callsites).toBe(false);
+    });
+
+    test('refuses a threshold below two, because one call is not a repeat', () => {
+      expect(() => checkDetect({ ignore: [], threshold: 1 })).toThrow(
+        /at least 2/u
+      );
+      expect(() => checkDetect({ ignore: [], threshold: 1 })).toThrow(
+        expect.objectContaining({ code: 'HENRI_QUERIES_INVALID_DETECT' })
+      );
+    });
+
+    test('refuses an ignore entry that is not a name it understands', () => {
+      expect(() =>
+        checkDetect({ ignore: ['Track.frobnicate'], threshold: 5 })
+      ).toThrow(
+        expect.objectContaining({ code: 'HENRI_QUERIES_INVALID_DETECT' })
+      );
+      expect(
+        checkDetect({ ignore: ['Track', 'User.select', '*.raw'], threshold: 5 })
+      ).toBeTruthy();
+    });
+  });
+
+  describe('what an event carries', () => {
+    test('names and numbers, and the request id it joins on', () => {
+      const module = build();
+      const event = inRequest('req-1', () =>
+        record(module, { filter: { ownerId: 42, state: 'open' } })
+      );
+
+      expect(event).toMatchObject({
+        adapter: 'drizzle',
+        keys: ['ownerId', 'state'],
+        method: 'findByKey',
+        model: 'Track',
+        operation: 'select',
+        requestId: 'req-1',
+        rows: 1,
+        source: 'application',
+      });
+      expect(event.duration).toBeGreaterThanOrEqual(0);
+      expect(event.shape).toMatch(/^[0-9a-f]{12}$/u);
+    });
+
+    test('and never a value, a statement or a parameter', () => {
+      const module = build();
+      const event = record(module, {
+        filter: { email: 'ada@example.com', token: 'a-secret' },
+      });
+      const serialized = JSON.stringify(event);
+
+      expect(event.keys).toEqual(['email', 'token']);
+      expect(serialized).not.toContain('ada@example.com');
+      expect(serialized).not.toContain('a-secret');
+      expect(event).not.toHaveProperty('sql');
+      expect(event).not.toHaveProperty('statement');
+      expect(event).not.toHaveProperty('params');
+      // The join is the request id, and there is only one identifier
+      expect(event).not.toHaveProperty('traceId');
+    });
+
+    test('an operation is one of the vocabulary the adapters share', () => {
+      expect(OPERATIONS).toContain('select');
+      expect(OPERATIONS).toContain('raw');
+      expect([...OPERATIONS].sort()).toEqual([...OPERATIONS]);
+    });
+
+    test('a shape is the same in the next process, so it can be grepped', () => {
+      const parts = {
+        adapter: 'drizzle',
+        keys: ['id'],
+        model: 'Track',
+        operation: 'select',
+      };
+
+      expect(shapeOf(parts)).toBe(shapeOf({ ...parts }));
+      expect(shapeOf(parts)).not.toBe(shapeOf({ ...parts, model: 'Other' }));
+      expect(shapeOf(parts)).not.toBe(shapeOf({ ...parts, keys: ['slug'] }));
+    });
+  });
+
+  describe('the filter, read for its names', () => {
+    test('drops the operators and keeps the columns', () => {
+      expect(keysOf({ age: { $gt: 30 }, name: 'ada' })).toEqual([
+        'age',
+        'name',
+      ]);
+    });
+
+    test('walks the combinators the three query languages share', () => {
+      expect(
+        keysOf({ $and: [{ a: 1 }, { $or: [{ b: 2 }, { c: 3 }] }] })
+      ).toEqual(['a', 'b', 'c']);
+    });
+
+    test('walks a symbol key, which is how Sequelize spells Op.and', () => {
+      expect(keysOf({ [Symbol.for('and')]: [{ a: 1 }, { b: 2 }] })).toEqual([
+        'a',
+        'b',
+      ]);
+    });
+
+    test('answers nothing for what it cannot read', () => {
+      expect(keysOf(null)).toEqual([]);
+      expect(keysOf('a string')).toEqual([]);
+    });
+
+    test('is bounded: a filter is a shape and not a document', () => {
+      const wide = Object.fromEntries(
+        Array.from({ length: 40 }, (one, index) => [`f${index}`, index])
+      );
+
+      expect(keysOf(wide).length).toBeLessThanOrEqual(12);
+    });
+  });
+
+  describe('the row count', () => {
+    test('reads the shapes the three adapters answer with', () => {
+      expect(rowsOf([1, 2, 3])).toBe(3);
+      expect(rowsOf(null)).toBe(0);
+      expect(rowsOf(undefined)).toBe(0);
+      expect(rowsOf({ records: [1, 2] })).toBe(2);
+      expect(rowsOf({})).toBe(1);
+      expect(rowsOf(7)).toBe(7);
+      expect(rowsOf(false)).toBe(0);
+    });
+
+    test('and answers null rather than guessing', () => {
+      expect(rowsOf(Symbol('x'))).toBeNull();
+    });
+  });
+
+  describe('the call site', () => {
+    test('is the application frame and not henri or node_modules', () => {
+      const error = new Error('here');
+
+      error.stack = [
+        'Error: here',
+        '    at Model.find (/app/node_modules/drizzle-orm/index.js:1:1)',
+        '    at Queries.record (/repo/packages/core/src/0.queries.js:1:1)',
+        '    at index (/repo/app/controllers/TracksController.js:34:12)',
+      ].join('\n');
+
+      expect(callsiteOf(error, '/repo')).toEqual({
+        column: 12,
+        file: 'app/controllers/TracksController.js',
+        line: 34,
+      });
+    });
+
+    test('answers nothing when every frame belongs to somebody else', () => {
+      const error = new Error('here');
+
+      error.stack = [
+        'Error: here',
+        '    at x (/app/node_modules/pg/index.js:1:1)',
+      ].join('\n');
+
+      expect(callsiteOf(error, '/repo')).toBeNull();
+    });
+  });
+
+  describe('the detector', () => {
+    test('counts the same shape and leaves the different ones alone', () => {
+      const detector = new Detector({ threshold: 3 });
+
+      inRequest('req', () => {
+        for (let index = 0; index < 4; index += 1) {
+          detector.count({
+            duration: 1,
+            keys: ['id'],
+            method: 'findByKey',
+            model: 'Track',
+            operation: 'select',
+            shape: 'aaa',
+          });
+        }
+
+        detector.count({
+          duration: 1,
+          keys: [],
+          method: 'find',
+          model: 'Event',
+          operation: 'select',
+          shape: 'bbb',
+        });
+
+        const findings = detector.findings(context.getStore().queries);
+
+        expect(findings).toHaveLength(1);
+        expect(findings[0]).toMatchObject({ count: 4, model: 'Track' });
+      });
+    });
+
+    test('counts nothing outside a request, because that is the predicate', () => {
+      const detector = new Detector({ threshold: 2 });
+
+      expect(
+        detector.count({ duration: 1, operation: 'select', shape: 'aaa' })
+      ).toBeNull();
+    });
+
+    test('one request is not pooled with another', () => {
+      const detector = new Detector({ threshold: 2 });
+      const once = () =>
+        detector.count({
+          duration: 1,
+          keys: [],
+          method: 'find',
+          model: 'Track',
+          operation: 'select',
+          shape: 'aaa',
+        });
+
+      inRequest('one', once);
+      inRequest('two', () => {
+        once();
+
+        expect(detector.findings(context.getStore().queries)).toEqual([]);
+      });
+    });
+
+    test('ignores by model, by Model.operation and by *.operation', () => {
+      const event = {
+        duration: 1,
+        model: 'Track',
+        operation: 'select',
+        shape: 'aaa',
+      };
+
+      expect(new Detector({ ignore: ['Track'] }).ignores(event)).toBe(true);
+      expect(new Detector({ ignore: ['Track.select'] }).ignores(event)).toBe(
+        true
+      );
+      expect(new Detector({ ignore: ['*.select'] }).ignores(event)).toBe(true);
+      expect(new Detector({ ignore: ['Track.insert'] }).ignores(event)).toBe(
+        false
+      );
+    });
+  });
+
+  describe('where a finding goes', () => {
+    test('one warning per request, naming the call and what to do', () => {
+      const module = build({ detect: { threshold: 3 } });
+
+      inRequest('req', () => {
+        for (let index = 0; index < 3; index += 1) {
+          record(module);
+        }
+
+        module.complain({ method: 'GET' });
+      });
+
+      const warning = module.henri.lines.find((line) => line[0] === 'warn');
+
+      expect(warning).toBeTruthy();
+      expect(warning.join(' ')).toContain('Track.findByKey ran 3 times');
+      expect(warning.join(' ')).toContain('load them together');
+    });
+
+    test('nothing is said when nothing repeated', () => {
+      const module = build({ detect: { threshold: 3 } });
+
+      inRequest('quiet', () => {
+        record(module);
+
+        expect(module.complain({ method: 'GET' })).toBe(0);
+      });
+    });
+
+    test('the header carries counts and names, and never a value', () => {
+      const module = build({ detect: { threshold: 2 } });
+
+      inRequest('req', () => {
+        record(module, { filter: { id: 'a-secret-id' } });
+        record(module, { filter: { id: 'another-secret' } });
+
+        const line = module.summarize();
+
+        expect(line).toContain('n+1 Track.findByKey x2');
+        expect(line).not.toContain('a-secret-id');
+        expect(line).not.toContain('another-secret');
+      });
+    });
+
+    test('raise throws the moment the threshold is crossed', () => {
+      const module = build({ detect: { raise: true, threshold: 3 } });
+
+      inRequest('req', () => {
+        record(module);
+        record(module);
+
+        // The third is the one that crosses, so the stack names the call
+        // that went one too far
+        expect(() => record(module)).toThrow(
+          expect.objectContaining({ code: 'HENRI_QUERIES_N_PLUS_ONE' })
+        );
+      });
+    });
+
+    test('the reporter is deliberately not one of them', () => {
+      const module = build({ detect: { threshold: 2 } });
+      const reported = [];
+
+      module.henri.reporter = { report: (error) => reported.push(error) };
+
+      inRequest('req', () => {
+        record(module);
+        record(module);
+        module.complain({ method: 'GET' });
+      });
+
+      // An N+1 is a slow answer, not a failure: it does not belong in the
+      // stream an application wired to page somebody
+      expect(reported).toEqual([]);
+    });
+  });
+
+  describe('the handler an application registers', () => {
+    test('gets every event, and only a function is accepted', () => {
+      const module = build();
+      const seen = [];
+
+      expect(module.onQuery((event) => seen.push(event))).toBe(true);
+      record(module);
+      expect(seen).toHaveLength(1);
+
+      expect(module.onQuery(null)).toBe(true);
+      record(module);
+      expect(seen).toHaveLength(1);
+
+      expect(module.onQuery('not a function')).toBe(false);
+    });
+
+    test('one that throws is removed rather than left to break queries', () => {
+      const module = build();
+
+      module.onQuery(() => {
+        throw new Error('the handler is broken');
+      });
+
+      expect(() => record(module)).not.toThrow();
+      expect(module._handler).toBeNull();
+      expect(
+        module.henri.lines.some(
+          (line) => line[0] === 'error' && line.join(' ').includes('threw')
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe('off', () => {
+    test('installs nothing and says nothing', () => {
+      const module = build(false);
+
+      expect(module.enabled).toBe(false);
+      expect(module.detector).toBeNull();
+      expect(module.middleware()).toBeNull();
+      expect(module.henri.lines).toEqual([]);
+    });
+
+    test('a target handed to instrument() while off is untouched', () => {
+      const module = build(false);
+      const original = () => 'answer';
+      const target = { find: original };
+
+      module.instrument(
+        target,
+        { find: { operation: 'select' } },
+        { adapter: 'drizzle', model: 'Track' }
+      );
+
+      // The wrapper is installed (an adapter that asked anyway gets one) but
+      // it calls straight through, so a disabled seam costs one call
+      expect(target.find()).toBe('answer');
+    });
+
+    test('stats say what happened', () => {
+      const module = build();
+
+      record(module);
+
+      expect(module.stats()).toMatchObject({
+        detecting: true,
+        enabled: true,
+        events: 1,
+      });
+    });
+  });
+});

--- a/packages/core/src/__tests__/queries.spec.js
+++ b/packages/core/src/__tests__/queries.spec.js
@@ -447,6 +447,108 @@ describe('the query seam', () => {
     });
   });
 
+  describe('the middleware', () => {
+    /**
+     * A response double carrying the two hooks the middleware uses
+     *
+     * @returns {object} the response
+     */
+    const fakeRes = () => {
+      const listeners = [];
+
+      return {
+        finish: () => listeners.forEach((fn) => fn()),
+        headers: {},
+        headersSent: false,
+        on: (event, fn) => event === 'finish' && listeners.push(fn),
+        setHeader(name, value) {
+          this.headers[name] = value;
+        },
+        writeHead() {
+          return this;
+        },
+      };
+    };
+
+    test('writes the header before the answer goes out, in development', () => {
+      const module = build({ detect: { threshold: 2 } });
+      const middleware = module.middleware();
+      const res = fakeRes();
+
+      expect(middleware).toBeTypeOf('function');
+
+      inRequest('req', () => {
+        middleware({ method: 'GET' }, res, () => {});
+        record(module);
+        record(module);
+        // Express writes the head when the answer starts going out; the
+        // header has to be there by then, which is what the wrap is for
+        res.writeHead(200);
+      });
+
+      expect(res.headers['X-Henri-Queries']).toContain(
+        'n+1 Track.findByKey x2'
+      );
+    });
+
+    test('and outside development it writes none at all', () => {
+      const module = build({ detect: { threshold: 2 } }, true);
+
+      // Production turns the whole seam off, so there is no middleware
+      expect(module.enabled).toBe(false);
+      expect(module.middleware()).toBeNull();
+
+      // On in production by request, the header still is not: a count of an
+      // application's internals is nobody else's business
+      const counting = build({ detect: { threshold: 2 }, enabled: true }, true);
+      const res = fakeRes();
+
+      inRequest('req', () => {
+        counting.middleware()({ method: 'GET' }, res, () => {});
+        record(counting);
+        record(counting);
+        res.writeHead(200);
+      });
+
+      expect(res.headers['X-Henri-Queries']).toBeUndefined();
+    });
+
+    test('the end of the request is when the count is final', () => {
+      const module = build({ detect: { threshold: 3 } });
+      const res = fakeRes();
+
+      inRequest('req', () => {
+        module.middleware()({ method: 'GET' }, res, () => {});
+
+        for (let index = 0; index < 7; index += 1) {
+          record(module);
+        }
+
+        res.finish();
+      });
+
+      const warning = module.henri.lines.find((line) => line[0] === 'warn');
+
+      // Seven, not the three that crossed the line
+      expect(warning.join(' ')).toContain('ran 7 times');
+      expect(module.stats().findings).toBe(1);
+    });
+
+    test('a request with no query allocates no bucket', () => {
+      const module = build({ detect: { threshold: 2 } });
+      const res = fakeRes();
+
+      inRequest('quiet', () => {
+        module.middleware()({ method: 'GET' }, res, () => {});
+        res.writeHead(200);
+        res.finish();
+      });
+
+      expect(res.headers['X-Henri-Queries']).toBeUndefined();
+      expect(module.stats().findings).toBe(0);
+    });
+  });
+
   describe('off', () => {
     test('installs nothing and says nothing', () => {
       const module = build(false);

--- a/packages/core/src/base/arguments.js
+++ b/packages/core/src/base/arguments.js
@@ -1118,6 +1118,10 @@ const UNCHECKED = {
   'henri.policies.has': 'documented to answer false',
   'henri.policies.resolve': 'documented to answer null',
   'henri.policies.rule': 'documented to answer null',
+  'henri.queries.onQuery':
+    'says so and answers false, which is its documented contract, and the one it shares with henri.reporter.onError',
+  'henri.queries.stats':
+    'takes no argument: it reads counters back and there is nothing to get wrong',
   'henri.reporter.onError':
     'says so and answers false, which is its documented contract',
   'henri.reporter.report':

--- a/packages/core/src/base/config-schema.js
+++ b/packages/core/src/base/config-schema.js
@@ -1567,6 +1567,78 @@ const SCHEMA = {
     ],
   },
 
+  queries: {
+    describe:
+      'an object of query seam settings, or false to record no model call',
+    hint: 'What the adapters report running, and the repeated model calls the detector counts. On in development and in test, off in production, unless "enabled" says otherwise',
+    oneOf: [
+      { const: false },
+      {
+        keys: {
+          callsites: {
+            describe: 'true or false',
+            hint: 'Whether an event carries the line the model call was made on. It costs an Error allocation per call, so it follows the detector unless this says otherwise',
+            type: 'boolean',
+          },
+          detect: {
+            default: {},
+            describe:
+              'an object of detector settings, or false to detect nothing',
+            hint: 'false keeps the events and reports nothing; the seam is still there for onQuery()',
+            oneOf: [
+              { const: false },
+              {
+                keys: {
+                  header: {
+                    default: true,
+                    describe: 'true or false',
+                    hint: 'X-Henri-Queries on the answer, in development only: the counts and the names of the repeated calls, never a value',
+                    type: 'boolean',
+                  },
+                  ignore: {
+                    default: [],
+                    describe:
+                      'a list of Model, Model.operation or *.operation names',
+                    hint: 'Calls the detector never counts. An operation is one of count, delete, insert, other, raw, select, update',
+                    of: text(),
+                    type: 'array',
+                  },
+                  log: {
+                    default: true,
+                    describe: 'true or false',
+                    hint: 'One warning per request naming the call, the count, the line and what to do instead',
+                    type: 'boolean',
+                  },
+                  raise: {
+                    default: false,
+                    describe: 'true or false',
+                    hint: 'Throw HENRI_QUERIES_N_PLUS_ONE the moment the threshold is crossed, so the stack names the call. This is what makes a test suite fail on an N+1',
+                    type: 'boolean',
+                  },
+                  threshold: {
+                    default: 5,
+                    describe: 'a whole number, at least 2',
+                    hint: 'How many times the same model call has to run in one request before it is reported. It counts model calls, never statements',
+                    integer: true,
+                    min: 2,
+                    type: 'number',
+                  },
+                },
+                type: 'object',
+              },
+            ],
+          },
+          enabled: {
+            describe: 'true or false',
+            hint: 'Absent means on outside production. true is the production opt-in: every model call is timed and counted',
+            type: 'boolean',
+          },
+        },
+        type: 'object',
+      },
+    ],
+  },
+
   versions: {
     default: {},
     describe: 'an object of model versioning settings',

--- a/packages/core/src/base/queries.js
+++ b/packages/core/src/base/queries.js
@@ -1,0 +1,741 @@
+/**
+ * The query seam: every adapter says what it ran, and the N+1 that follows.
+ *
+ * henri has `include()` and a guide that says to use it, and nothing that
+ * *tells* you when you did not. The reason nobody outside henri could write
+ * that check either is more basic: **no adapter emitted anything when it ran
+ * a query**, so there was nothing to listen to. This file is the seam first
+ * and the detector second, because that is the order the dependency runs in.
+ *
+ * ## The seam is at the model call, and that is the whole design
+ *
+ * There were two levels to choose between and they are not close, once the
+ * adapters are measured rather than imagined:
+ *
+ * - **The statement.** What the driver ran. `sequelize.query()`, drizzle's
+ *   `session.prepareQuery()`, the MongoDB command. Precise, and the number a
+ *   `EXPLAIN` would agree with.
+ * - **The model call.** What the application asked for. `Proposal.findById`,
+ *   `Track.where(...)`, `User.paginate()`.
+ *
+ * henri emits the **model call**, for three reasons that all point the same
+ * way.
+ *
+ * First, it is the only level at which henri can give *advice*, which is the
+ * entire value of this feature. A driver instrumentation can already tell an
+ * application that forty statements ran -- `@opentelemetry/instrumentation-pg`
+ * does it better than henri would. Only henri knows that those forty
+ * statements were forty `Proposal.findById` calls in one request and that one
+ * `Proposal.find({ id: [...] })` replaces them. A count is a complaint; a
+ * count naming the call and the line is a fix.
+ *
+ * Second, the statement count is not the number the developer can act on.
+ * `paginate()` is two statements and one decision. On MySQL an insert is two
+ * statements and one decision, because the dialect has no `RETURNING`. A
+ * threshold counting statements would report those as repetition and would
+ * make the dialect visible in a warning about the application's code.
+ *
+ * Third -- and this is the measurement that settled it -- **the classic Rails
+ * N+1 does not exist on the Drizzle adapter.** `include()` compiles to a
+ * single correlated json subquery, not to a lazy association that a loop can
+ * trip over. A detector written to `bullet`'s mental model would walk a
+ * Drizzle application, find no lazy association anywhere, and report success.
+ * What is left, and what is worth detecting on all three adapters, is a loop
+ * issuing separate `find`/`findById` calls for records it could have loaded
+ * together. That is a count of model calls. There is no statement-level
+ * reading of it.
+ *
+ * So, stated once and plainly, because a person reading "40 queries" will
+ * assume the other thing: **the threshold counts model calls, never
+ * statements.** `henri.queries` is a log of what the application asked for.
+ *
+ * ## What this is not: it is not tracing, and it does not become tracing
+ *
+ * `base/telemetry.js` says a model call is not one of its boundaries and
+ * points at `@opentelemetry/instrumentation-pg` or the ORM's own package
+ * instead. That sentence stands, and this seam does not overturn it. The line
+ * is:
+ *
+ * - **Statements are the driver's instrumentation to trace.** henri
+ *   re-implementing it would double-count against an application that
+ *   installed one, and henri would be the worse of the two.
+ * - **`adapter.query()` is henri's own call**, and `3.model.js` gives it a
+ *   span. It also emits an event here, with `operation: 'raw'`, because a
+ *   seam that says what the adapter ran cannot leave out the one call henri
+ *   makes itself. Those are not a double count: one span goes to a trace
+ *   backend, one event goes to the detector, and **telemetry does not consume
+ *   this seam** -- there is no path where a model call becomes a span.
+ * - **Model calls are henri's to count**, for the detector, in development.
+ *
+ * ## What the event carries, and what it deliberately does not
+ *
+ *     { at, store, adapter, dialect, model, operation, method, keys,
+ *       shape, duration, rows, requestId, source, callsite }
+ *
+ * `operation` is one closed vocabulary across the three adapters
+ * (`OPERATIONS`), so `select` means the same thing on MongoDB and on
+ * PostgreSQL. `method` is the adapter's own word -- `findOne`, `paginate`,
+ * `BULKUPDATE` -- because that is the word the developer will search their
+ * own code for. Both are names.
+ *
+ * **The event does not carry the SQL, and at this level there is no SQL to
+ * carry.** That is the happy half of the decision: the level that gives the
+ * useful advice is also the level at which the dangerous field does not
+ * exist. A model call has a model, an operation and a filter; the statement
+ * is compiled after henri has already emitted.
+ *
+ * The unhappy half is why it would have been refused anyway, and it is worth
+ * recording because the next person will be tempted. **Sequelize's query
+ * generator interpolates values into the text it runs.**
+ * `Model.findAll({ where: { name: 'ada' } })` reaches the driver as
+ * `SELECT ... WHERE "U"."name" = 'ada'`, with the value inside the string;
+ * that is the ordinary path, not an edge case. Drizzle's statements are
+ * parameterized and Mongoose has no statement at all. So a `sql` field would
+ * have been safe on two adapters and a copy of the row on the third -- which
+ * is worse than no field, because it is the leak nobody would think to look
+ * for. henri has spent this month keeping values out of the trail, the logs,
+ * the reporter and the spans; a query event is not where that stops.
+ *
+ * `keys` is the same rule's safe half: **column names, never values.**
+ * `base/trail.js` established that a field name is schema -- it is in the
+ * model file and in the documentation -- while a field value is personal
+ * data. Every adapter hands over the keys of the filter it was given and
+ * drops what they were compared against, before an event exists. Where an
+ * adapter cannot produce them cheaply, `keys` is empty rather than guessed.
+ *
+ * Not on the event, on any adapter: the filter values, the bound parameters,
+ * the rows that came back, the attributes written, the person, the url, the
+ * path, the headers, the session.
+ *
+ * ## `callsite`, which is code and not data
+ *
+ * bullet's value was never that it counted queries. It is that it says *this*
+ * page ran the same query forty times **and names the line**.
+ *
+ * So an event carries one frame: the first frame belonging to the
+ * application's own files -- not `node_modules`, not henri, not node
+ * internals. A stack frame is source the developer wrote, the one class of
+ * context here that cannot turn out to be data.
+ *
+ * It is not free, so it is not always taken. Capturing costs an `Error`
+ * allocation per model call; V8 only formats the string when `.stack` is
+ * read, which this file defers until a shape is actually reported.
+ * `queries.callsites` follows the detector by default and can be turned off
+ * on its own.
+ *
+ * ## The join is the request id, and there is only one
+ *
+ * An event carries `requestId` from `base/request-id.js` -- the same
+ * AsyncLocalStorage the call log keys its rows by and the same id a span
+ * carries as `henri.request_id`. That is the whole join, on purpose: a query
+ * event, a call-log row, a `pen` line and a span all answer to one
+ * identifier, so "what did request X do" is one filter in four places rather
+ * than four questions.
+ *
+ * It carries **no trace id**. `base/telemetry.js` argues the direction
+ * already -- a trace usually spans several requests, so a trace id is not
+ * unique per request -- and the converse would be a second identifier to keep
+ * in step for nothing.
+ *
+ * ## What "off" costs, and why it is zero rather than cheap
+ *
+ * Off means nothing is installed, the way `base/calls.js` and
+ * `base/telemetry.js` mean it: `henri.queries.enabled` is read **once**, by
+ * each adapter, at the moment it builds its models. A disabled seam leaves
+ * Sequelize's hooks unregistered, drizzle's model class unwrapped, no
+ * Mongoose middleware added, no middleware in the express stack and no object
+ * allocated per query. There is no flag tested on the hot path, because there
+ * is no hot path to test it on.
+ *
+ * Enabled, it is on by default in development and in test and off in
+ * production, which is `bullet`'s bargain and the right one: production
+ * traffic should not pay to tell a developer something the developer is not
+ * there to read. An application that wants it in production says so.
+ *
+ * ## The detector: a shape, not a string
+ *
+ * "The same query" cannot be a string comparison, because the values differ
+ * -- forty lookups of forty different ids are the N+1, and forty *identical*
+ * lookups would be a caching bug instead. So the detector groups by `shape`:
+ * a digest of (adapter, model, operation, the filter's key names). Forty
+ * `Track.findById` are one shape with a count of forty; a page's own `find`
+ * and its `count` are two shapes with a count of one each and are never
+ * reported.
+ *
+ * The shape is deliberately **not** salted and **not** given the callsite.
+ * Unsalted, because a shape in a log line is only useful if it means the same
+ * thing in the next process and in a developer's grep, and it hashes only
+ * names so there is nothing to salt against. Without the callsite, because
+ * the same logical N+1 called from two lines is one problem, and a shape that
+ * split it would report it twice; the callsite of the *first* occurrence is
+ * carried on the finding instead, which is what names the line.
+ *
+ * A shape is counted **within one request** and nowhere else. The bucket
+ * hangs off the request-id store, so it is born and collected with the
+ * request, and a background job's queries are never pooled with a page's.
+ * Outside a request -- a job, a console, the boot -- events are emitted and
+ * nothing is counted, because "the same request" is the whole predicate and
+ * there is no honest substitute for it.
+ *
+ * @module base/queries
+ */
+
+const crypto = require('crypto');
+const path = require('path');
+const { AsyncLocalStorage } = require('async_hooks');
+
+const { fail } = require('./errors');
+const { context, currentRequestId } = require('./request-id');
+
+/**
+ * Whether a model call is already being measured.
+ *
+ * The three adapters all have layers: `Model.findById()` calls
+ * `Model.relation().first()`, `paginate()` runs a page and a count, and a
+ * Sequelize `findByPk` is a `findOne` is a `findAll`. Instrumenting every
+ * layer would count one decision three times and would report `toArray` where
+ * the developer wrote `findById`.
+ *
+ * So the **outermost call wins**: the first wrapper to run opens this
+ * context, every wrapper inside it does nothing but call through, and the
+ * event carries the name the application actually used. It is an
+ * AsyncLocalStorage rather than a counter because the inner call is often
+ * awaited rather than nested on the stack.
+ *
+ * The known cost, said out loud: a model call made from inside a model hook
+ * -- an `afterFind` that loads something -- is part of the outer call and
+ * gets no event of its own.
+ */
+const nesting = new AsyncLocalStorage();
+
+/**
+ * The one vocabulary the three adapters answer in.
+ *
+ * `raw` is `adapter.query()` and anything an application ran itself; `other`
+ * is a call henri recognises but that is none of the five verbs (a MongoDB
+ * aggregation, a `distinct`).
+ */
+const OPERATIONS = Object.freeze([
+  'count',
+  'delete',
+  'insert',
+  'other',
+  'raw',
+  'select',
+  'update',
+]);
+
+/** Who asked: henri on its own behalf, or the application */
+const SOURCES = Object.freeze(['application', 'henri']);
+
+/** How many characters of the digest an event carries */
+const SHAPE = 12;
+
+/** How deep a stack is walked looking for the application's own frame */
+const FRAMES = 12;
+
+/** What the detector treats as "the same call, again" unless told otherwise */
+const THRESHOLD = 5;
+
+/** How many filter keys reach an event; a filter is a shape, not a document */
+const KEYS = 12;
+
+/**
+ * The normalized configuration of a seam nobody configured.
+ *
+ * `enabled` is absent on purpose: only `queriesConfig()` knows the
+ * environment, and a default that reads `NODE_ENV` at require time is a
+ * default that is wrong in a test.
+ */
+const DEFAULTS = Object.freeze({
+  callsites: true,
+  detect: Object.freeze({
+    header: true,
+    ignore: Object.freeze([]),
+    log: true,
+    raise: false,
+    threshold: THRESHOLD,
+  }),
+});
+
+/**
+ * Normalizes `config.queries`.
+ *
+ * The default is on in development and in test and off in production, so an
+ * application that says nothing gets the detector where a developer is
+ * watching and pays nothing where nobody is. `false` is off everywhere and
+ * `{ "enabled": true }` is the production opt-in.
+ *
+ * @param {?object} config The henri configuration module, or null
+ * @param {boolean} [production=false] Whether this is a production boot
+ * @returns {object} `{ enabled, callsites, detect }`
+ */
+function queriesConfig(config, production = false) {
+  const given =
+    config && typeof config.get === 'function' && config.has('queries')
+      ? config.get('queries')
+      : undefined;
+
+  if (given === false) {
+    return { callsites: false, detect: false, enabled: false };
+  }
+
+  const settings = given && typeof given === 'object' ? given : {};
+  const enabled =
+    typeof settings.enabled === 'boolean' ? settings.enabled : !production;
+  const wanted =
+    settings.detect === false
+      ? false
+      : { ...DEFAULTS.detect, ...(settings.detect || {}) };
+  const detect = enabled ? checkDetect(wanted) : false;
+
+  return {
+    callsites:
+      typeof settings.callsites === 'boolean'
+        ? settings.callsites && enabled
+        : Boolean(detect),
+    detect,
+    enabled,
+  };
+}
+
+// `Model`, `Model.operation` or `*.operation`
+const IGNORE = new RegExp(
+  `^(?:\\*|[A-Za-z_][A-Za-z0-9_]*)(?:\\.(?:${OPERATIONS.join('|')}))?$`,
+  'u'
+);
+
+/**
+ * Refuses a detector the configuration asked for and henri cannot run.
+ *
+ * The schema (`base/config-schema.js`) already refuses a threshold that is
+ * not a whole number of at least two and an `ignore` that is not a list of
+ * strings. What it cannot express is the *grammar* of an entry, so that is
+ * here, and it fails the boot the way an impossible retention rule does --
+ * an `ignore` line with a typo in it would otherwise silence nothing and say
+ * nothing, which is the worst of both.
+ *
+ * @param {*} detect The normalized `queries.detect`
+ * @returns {*} The same value
+ * @throws {Error} `HENRI_QUERIES_INVALID_DETECT`
+ */
+function checkDetect(detect) {
+  if (!detect) {
+    return detect;
+  }
+
+  if (!Number.isInteger(detect.threshold) || detect.threshold < 2) {
+    throw fail(
+      'HENRI_QUERIES_INVALID_DETECT',
+      `queries.detect.threshold must be a whole number of at least 2, not ${JSON.stringify(
+        detect.threshold
+      )}: a call that ran once is not a repetition`
+    );
+  }
+
+  for (const entry of detect.ignore || []) {
+    if (typeof entry !== 'string' || !IGNORE.test(entry)) {
+      throw fail(
+        'HENRI_QUERIES_INVALID_DETECT',
+        `queries.detect.ignore takes Model, Model.operation or *.operation, not ${JSON.stringify(
+          entry
+        )} (an operation is one of ${OPERATIONS.join(', ')})`
+      );
+    }
+  }
+
+  return detect;
+}
+
+/**
+ * The key names of a filter, and never what they were compared against.
+ *
+ * Every adapter hands its filter here before an event exists, so this is the
+ * one place the values are dropped. It walks the boolean combinators the
+ * three query languages share (`$and`/`$or` on Mongoose, `Op.and`/`Op.or` on
+ * Sequelize) and keeps the leaf names; anything else contributes its own key
+ * and nothing below it.
+ *
+ * A key whose name begins with `$` is an operator, not a column, and is
+ * dropped: `{ age: { $gt: 30 } }` is `['age']`.
+ *
+ * @param {*} filter The filter as the model was given it
+ * @param {number} [limit=KEYS] How many names to keep
+ * @returns {Array<string>} The names, sorted and deduplicated
+ */
+function keysOf(filter, limit = KEYS) {
+  const found = new Set();
+
+  /**
+   * Walks one level of a filter
+   *
+   * @param {*} value What to walk
+   * @param {number} depth How deep we already are
+   * @returns {void}
+   */
+  const walk = (value, depth) => {
+    if (
+      !value ||
+      typeof value !== 'object' ||
+      depth > 4 ||
+      found.size >= limit
+    ) {
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        walk(item, depth + 1);
+      }
+
+      return;
+    }
+
+    // Symbol keys are Sequelize's operators (Op.and, Op.or): they name no
+    // column, so only what is under them counts
+    for (const key of Object.getOwnPropertySymbols(value)) {
+      walk(value[key], depth + 1);
+    }
+
+    for (const key of Object.keys(value)) {
+      if (found.size >= limit) {
+        return;
+      }
+
+      if (key.startsWith('$')) {
+        walk(value[key], depth + 1);
+
+        continue;
+      }
+
+      found.add(key);
+    }
+  };
+
+  walk(filter, 0);
+
+  return [...found].sort();
+}
+
+/**
+ * The digest that says two model calls are the same call.
+ *
+ * A plain sha256 over names, with no salt: there is nothing in it a client
+ * chose, and a shape is only useful in a log line if it means the same thing
+ * in the next process.
+ *
+ * @param {object} parts `{ adapter, model, operation, keys }`
+ * @returns {string} A short hex digest
+ */
+function shapeOf({ adapter, keys, model, operation }) {
+  return crypto
+    .createHash('sha256')
+    .update(
+      [
+        adapter || '',
+        model || '',
+        operation || '',
+        (keys || []).join(','),
+      ].join(' ')
+    )
+    .digest('hex')
+    .slice(0, SHAPE);
+}
+
+// Frames henri never blames: its own packages, the dependencies, node itself
+const FOREIGN =
+  /[\\/]node_modules[\\/]|^node:|[\\/]packages[\\/](?:core|drizzle|mongoose|sequelize|disk|jobs|webhooks|testing)[\\/]/u;
+const FRAME = /\(?([^()\s]+):(\d+):(\d+)\)?$/u;
+
+/**
+ * The first frame that belongs to the application.
+ *
+ * Called with an Error whose stack has not been read yet: reading `.stack` is
+ * where V8 formats the trace, which is the expensive half, so the adapters
+ * capture the Error and this is what decides to pay for it.
+ *
+ * @param {?Error} error An Error captured where the call was made
+ * @param {string} [cwd=''] The application directory, so the file is relative
+ * @returns {?object} `{ file, line, column }`, or null
+ */
+function callsiteOf(error, cwd = '') {
+  if (!error || typeof error.stack !== 'string') {
+    return null;
+  }
+
+  for (const line of error.stack.split('\n').slice(1, FRAMES + 1)) {
+    const match = FRAME.exec(line.trim());
+
+    if (!match || FOREIGN.test(match[1])) {
+      continue;
+    }
+
+    const file = cwd ? path.relative(cwd, match[1]) : match[1];
+
+    // A relative path that climbed out of the application is somebody else's
+    // file after all
+    if (file.startsWith('..')) {
+      continue;
+    }
+
+    return { column: Number(match[3]), file, line: Number(match[2]) };
+  }
+
+  return null;
+}
+
+/**
+ * The bucket of the request being handled, made on the first query.
+ *
+ * It hangs off the store `base/request-id.js` already put in the
+ * AsyncLocalStorage, next to the id and the actor: the reason those two
+ * travel together applies here too, and it means a query five calls deep in a
+ * service is counted against the request that caused it without anything in
+ * between carrying a handle.
+ *
+ * @param {boolean} [make=true] Whether to create the bucket when absent
+ * @returns {?Map} The shapes seen so far, or null outside a request
+ */
+function bucketOf(make = true) {
+  const store = context.getStore();
+
+  if (!store) {
+    return null;
+  }
+
+  if (!store.queries && make) {
+    store.queries = new Map();
+  }
+
+  return store.queries || null;
+}
+
+/**
+ * Counts shapes within one request and says which ones repeated.
+ *
+ * One instance per henri, with no state of its own between requests:
+ * everything it counts lives in the request's own bucket and dies with it.
+ *
+ * @class Detector
+ */
+class Detector {
+  /**
+   * Creates an instance of Detector.
+   *
+   * @param {object} [settings={}] `threshold` and `ignore`
+   * @memberof Detector
+   */
+  constructor(settings = {}) {
+    this.threshold = Number.isInteger(settings.threshold)
+      ? settings.threshold
+      : THRESHOLD;
+    this.ignore = new Set(settings.ignore || []);
+  }
+
+  /**
+   * Is this event's model and operation one the application asked to ignore?
+   *
+   * `Model`, `Model.operation` and `*.operation` all match, so an application
+   * can silence a whole model or one verb of it.
+   *
+   * @param {object} event The query event
+   * @returns {boolean} true when nothing should be counted
+   * @memberof Detector
+   */
+  ignores(event) {
+    if (this.ignore.size === 0) {
+      return false;
+    }
+
+    const model = event.model || '*';
+
+    return (
+      this.ignore.has(model) ||
+      this.ignore.has(`${model}.${event.operation}`) ||
+      this.ignore.has(`*.${event.operation}`)
+    );
+  }
+
+  /**
+   * Counts one event against the request it happened in
+   *
+   * @param {object} event The query event
+   * @returns {?object} The bucket entry, or null when nothing was counted
+   * @memberof Detector
+   */
+  count(event) {
+    const bucket = bucketOf();
+
+    if (!bucket || this.ignores(event)) {
+      return null;
+    }
+
+    const seen = bucket.get(event.shape);
+
+    if (seen) {
+      seen.count += 1;
+      seen.duration += event.duration;
+
+      return seen;
+    }
+
+    const entry = {
+      // The first occurrence's line: the same N+1 called from two places is
+      // one problem, and the first one to run is the one worth naming
+      callsite: event.callsite,
+      count: 1,
+      duration: event.duration,
+      keys: event.keys,
+      method: event.method,
+      model: event.model,
+      operation: event.operation,
+      shape: event.shape,
+    };
+
+    bucket.set(event.shape, entry);
+
+    return entry;
+  }
+
+  /**
+   * What repeated during this request, worst first
+   *
+   * @param {?Map} bucket The request's bucket
+   * @returns {Array<object>} The findings
+   * @memberof Detector
+   */
+  findings(bucket) {
+    if (!bucket || bucket.size === 0) {
+      return [];
+    }
+
+    return [...bucket.values()]
+      .filter((entry) => entry.count >= this.threshold)
+      .sort((one, two) => two.count - one.count);
+  }
+}
+
+/**
+ * What to do about a finding, in the application's own words.
+ *
+ * The advice has to match what the adapters actually do, which is why it does
+ * **not** say "add `include()`" for a repeated lookup: on the Drizzle adapter
+ * an `include()` is already one statement and there was no lazy association
+ * to eager-load. What is repeating is a lookup per record, and what replaces
+ * it is one lookup for the set.
+ *
+ * @param {object} finding One entry of `findings()`
+ * @returns {string} What to change
+ */
+function adviseOn(finding) {
+  const model = finding.model || 'the model';
+  const keys = (finding.keys || []).join(', ');
+
+  if (finding.operation === 'select' || finding.operation === 'count') {
+    return keys
+      ? `load them together: one ${model}.find({ ${keys}: [...] }) for the whole set, or include('${model.toLowerCase()}') on the query that fetched the parents`
+      : `load them together: one ${model} query for the whole set rather than one per record`;
+  }
+
+  return `write them together: one ${model} statement for the whole set rather than one per record`;
+}
+
+/**
+ * A finding, as the one line a developer reads
+ *
+ * @param {object} finding One entry of `findings()`
+ * @returns {string} The line
+ */
+function describe(finding) {
+  const what = `${finding.model || 'a query'}.${
+    finding.method || finding.operation
+  }`;
+  const where = finding.callsite
+    ? ` at ${finding.callsite.file}:${finding.callsite.line}`
+    : '';
+
+  return `${what} ran ${finding.count} times${where} (${finding.duration.toFixed(
+    1
+  )}ms) -- ${adviseOn(finding)}`;
+}
+
+/**
+ * How many rows an answer holds, for the shapes the three adapters return.
+ *
+ * A count, not the rows: nothing here looks inside a record, and the value is
+ * never kept. An answer henri does not recognise is `null` rather than a
+ * guess, because a wrong row count reads as a real measurement.
+ *
+ * @param {*} value What the model call answered
+ * @returns {?number} The count, or null when it cannot be told
+ */
+function rowsOf(value) {
+  if (value === null || typeof value === 'undefined') {
+    return 0;
+  }
+
+  if (Array.isArray(value)) {
+    return value.length;
+  }
+
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 1 : 0;
+  }
+
+  if (typeof value === 'object') {
+    // `paginate()` answers `{ records, total, ... }` on all three adapters
+    if (Array.isArray(value.records)) {
+      return value.records.length;
+    }
+
+    return 1;
+  }
+
+  return null;
+}
+
+/**
+ * Is a model call already being measured further out?
+ *
+ * @returns {boolean} true when this call is a layer of another one
+ */
+function nested() {
+  return nesting.getStore() === true;
+}
+
+/**
+ * Runs something as the outermost model call
+ *
+ * @param {function} fn What to run
+ * @returns {*} Whatever it answered
+ */
+function outermost(fn) {
+  return nesting.run(true, fn);
+}
+
+module.exports = {
+  DEFAULTS,
+  Detector,
+  FRAMES,
+  KEYS,
+  OPERATIONS,
+  SHAPE,
+  SOURCES,
+  THRESHOLD,
+  adviseOn,
+  bucketOf,
+  callsiteOf,
+  checkDetect,
+  currentRequestId,
+  describe,
+  keysOf,
+  nested,
+  outermost,
+  queriesConfig,
+  rowsOf,
+  shapeOf,
+};

--- a/packages/core/src/base/telemetry.js
+++ b/packages/core/src/base/telemetry.js
@@ -88,13 +88,26 @@
  * - `jobs` -- one span per job run, in `@usehenri/jobs`.
  * - `webhooks` -- one span per delivery attempt, in `@usehenri/webhooks`.
  *
- * **A model call an application makes is not one of them**, and that is the
- * honest gap: covering it means wrapping Drizzle, Mongoose and Sequelize
- * from the outside, which is what their own instrumentation packages exist
- * for. An application that wants it registers
- * `@opentelemetry/instrumentation-pg` (or its ORM's) in the same SDK
- * bootstrap, and those spans land under henri's request span, because the
- * context is already active when the query runs.
+ * **A model call an application makes is not one of them**, and it is worth
+ * saying where that line now sits, because henri does see those calls and
+ * still does not trace them.
+ *
+ * Tracing a statement means wrapping Drizzle, Mongoose and Sequelize from the
+ * outside, which is what their own instrumentation packages exist for. An
+ * application that wants it registers `@opentelemetry/instrumentation-pg` (or
+ * its ORM's) in the same SDK bootstrap, and those spans land under henri's
+ * request span, because the context is already active when the query runs.
+ * henri writing its own would double-count against exactly the applications
+ * that did the right thing, and would be the worse of the two.
+ *
+ * What henri does instead is **count** model calls, which is a different
+ * question with a different answer: `henri.queries` (`base/queries.js`) emits
+ * one event per model call so the N+1 detector can say that `Proposal.findById`
+ * ran forty times in one request and name the line. That is advice, not a
+ * trace, and it is deliberately not plumbed into a span -- **telemetry does
+ * not consume that seam**, and no model call becomes a span through it. The
+ * two meet at `adapter.query()` (`3.model.js`), which gets one span from here
+ * and one event from there, and nowhere else.
  *
  * ## Propagation, and which identifier wins
  *

--- a/packages/core/src/henri.js
+++ b/packages/core/src/henri.js
@@ -7,6 +7,7 @@ const { fallback } = require('./base/errors');
 const validator = require('validator');
 
 const Config = require('./0.config');
+const Queries = require('./0.queries');
 const Telemetry = require('./0.telemetry');
 const Encryption = require('./1.encryption');
 const I18n = require('./1.i18n');
@@ -89,6 +90,7 @@ class Henri extends HenriBase {
     this.modules.add(new Model());
     this.modules.add(new Policies());
     this.modules.add(new Privacy());
+    this.modules.add(new Queries());
     this.modules.add(new Retention());
     this.modules.add(new Router());
     this.modules.add(new Telemetry());

--- a/packages/drizzle/__tests__/helpers.js
+++ b/packages/drizzle/__tests__/helpers.js
@@ -3,6 +3,7 @@ const os = require('os');
 const path = require('path');
 const Drizzle = require('../index');
 const Encryption = require('@usehenri/core/src/1.encryption');
+const Queries = require('@usehenri/core/src/0.queries');
 const { generateKey } = require('@usehenri/core/src/base/encryption');
 const target = require('./targets');
 
@@ -53,6 +54,19 @@ const fakeHenri = (settings = {}) => {
 
   encryption.henri = henri;
   henri.encryption = encryption;
+
+  // The same, and for the same reason: what is being tested is that this
+  // adapter reports the calls core's seam expects, so the seam is core's
+  const queries = new Queries();
+
+  queries.henri = henri;
+  queries.init();
+  henri.queries = queries;
+
+  // The seam says at boot that it is counting. That is the module's line and
+  // not the adapter's, and `calls` is what the suites read to see what the
+  // adapter said, so the harness's own setup is not left in it
+  calls.length = 0;
 
   return henri;
 };

--- a/packages/drizzle/__tests__/queries.spec.js
+++ b/packages/drizzle/__tests__/queries.spec.js
@@ -1,0 +1,260 @@
+// What this adapter reports to `henri.queries`, on the target database:
+// sqlite in memory offline, and a database of its own on the live PostgreSQL
+// or MySQL of `pnpm test:sql:live`.
+//
+// The seam is core's and its design is argued in `base/queries.js`; what is
+// proved here is the mapping this package owns. Two things above all: that a
+// model call produces exactly one event, whatever it is built out of, and
+// that no value the caller passed is on it.
+const { context } = require('@usehenri/core/src/base/request-id');
+const { build, target, taskModel, userModel } = require('./helpers');
+
+/**
+ * Collects the events one piece of work produces
+ *
+ * @param {object} henri The fake henri of the store
+ * @param {function} fn What to run
+ * @returns {Promise<Array<object>>} The events, in order
+ */
+const recording = async (henri, fn) => {
+  const seen = [];
+
+  henri.queries.onQuery((event) => seen.push(event));
+
+  try {
+    await fn();
+  } finally {
+    henri.queries.onQuery(null);
+  }
+
+  return seen;
+};
+
+/** Runs something as if it were a request, so the detector has a bucket */
+const inRequest = (id, fn) => context.run({ id }, fn);
+
+describe(`the query seam on ${target.name}`, () => {
+  let adapter;
+  let henri;
+  let Task;
+  let User;
+
+  beforeAll(async () => {
+    ({ adapter, henri } = build());
+    User = adapter.addModel({ ...userModel }, 'user');
+    Task = adapter.addModel({
+      ...taskModel,
+      associate: (models) =>
+        models.Task.belongsTo(models.User, { as: 'owner' }),
+      schema: { ...taskModel.schema, ownerId: { type: 'integer' } },
+    });
+
+    await adapter.start();
+  });
+
+  afterAll(async () => {
+    await adapter.stop();
+  });
+
+  afterEach(async () => {
+    await Task.destroy({}, { force: true });
+    await User.destroy({}, { force: true });
+  });
+
+  test('a model call is one event, whatever it is built out of', async () => {
+    const events = await recording(henri, async () => {
+      await Task.create({ name: 'one' });
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      adapter: 'drizzle',
+      dialect: target.name,
+      method: 'create',
+      model: 'Task',
+      operation: 'insert',
+      source: 'application',
+      store: 'default',
+    });
+    expect(events[0].duration).toBeGreaterThanOrEqual(0);
+  });
+
+  test('findById is findById, and not the first() it is built out of', async () => {
+    const task = await Task.create({ name: 'two' });
+    const events = await recording(henri, async () => {
+      await Task.findById(task.externalId);
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].method).toBe('findById');
+    expect(events[0].operation).toBe('select');
+    expect(events[0].rows).toBe(1);
+  });
+
+  test('paginate is two statements and one model call', async () => {
+    await Task.create({ name: 'three' });
+
+    const events = await recording(henri, async () => {
+      await Task.paginate({ page: 1, perPage: 10 });
+    });
+
+    // The page and its count are two statements. They are one decision, and
+    // the seam counts decisions -- see the header of base/queries.js
+    expect(events).toHaveLength(1);
+    expect(events[0].method).toBe('paginate');
+    expect(events[0].rows).toBe(1);
+  });
+
+  test('the lazy path reports too: where().toArray() is a model call', async () => {
+    await Task.create({ name: 'four' });
+
+    const events = await recording(henri, async () => {
+      await Task.where({ name: 'four' }).limit(5).toArray();
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      adapter: 'drizzle',
+      method: 'toArray',
+      model: 'Task',
+      operation: 'select',
+      store: 'default',
+    });
+  });
+
+  test('the filter contributes its key names and none of its values', async () => {
+    const events = await recording(henri, async () => {
+      await Task.find({ category: 'urgent', name: 'nothing-matches-this' });
+    });
+
+    expect(events[0].keys).toEqual(['category', 'name']);
+
+    // The point of the whole design: nothing a caller passed is on the event
+    const serialized = JSON.stringify(events[0]);
+
+    expect(serialized).not.toContain('nothing-matches-this');
+    expect(serialized).not.toContain('urgent');
+    expect(events[0]).not.toHaveProperty('sql');
+    expect(events[0]).not.toHaveProperty('statement');
+    expect(events[0]).not.toHaveProperty('params');
+  });
+
+  test('the same call twice is the same shape, and two calls are not', async () => {
+    const events = await recording(henri, async () => {
+      await Task.find({ name: 'a' });
+      await Task.find({ name: 'b' });
+      await Task.find({ category: 'low' });
+      await Task.count({ name: 'a' });
+    });
+
+    expect(events).toHaveLength(4);
+    // Different values, same shape: that is what makes an N+1 findable
+    expect(events[0].shape).toBe(events[1].shape);
+    // A different column is a different question
+    expect(events[2].shape).not.toBe(events[0].shape);
+    // So is a different operation
+    expect(events[3].shape).not.toBe(events[0].shape);
+  });
+
+  test('a write per record is reported like a read per record', async () => {
+    const task = await Task.create({ name: 'five' });
+    const events = await recording(henri, async () => {
+      await task.update({ name: 'five and a half' });
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].operation).toBe('update');
+    expect(events[0].model).toBe('Task');
+  });
+
+  test('a call that throws is still reported', async () => {
+    const events = await recording(henri, async () => {
+      await expect(Task.create({})).rejects.toThrow();
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].method).toBe('create');
+    expect(events[0].rows).toBe(0);
+  });
+
+  test('outside a request there is a requestId of null, and events still flow', async () => {
+    const events = await recording(henri, () => Task.find());
+
+    expect(events[0].requestId).toBeNull();
+  });
+
+  test('inside a request the event carries the id everything else joins on', async () => {
+    const events = await recording(henri, () =>
+      inRequest('a-request-id', () => Task.find())
+    );
+
+    expect(events[0].requestId).toBe('a-request-id');
+  });
+
+  test('the N+1 a loop makes is what the detector counts', async () => {
+    const owner = await User.create({
+      email: 'ada@example.test',
+      name: 'Ada',
+      password: 'secret-enough',
+    });
+
+    for (let index = 0; index < 6; index += 1) {
+      await Task.create({ name: `task ${index}`, ownerId: owner.id });
+    }
+
+    const { detector } = henri.queries;
+    const before = detector.threshold;
+
+    detector.threshold = 5;
+
+    try {
+      const findings = await inRequest('n-plus-one', async () => {
+        const tasks = await Task.find();
+
+        // The shape this whole tranche is about: one lookup per record,
+        // where one lookup for the set would do
+        for (const task of tasks) {
+          await User.findByKey(task.ownerId);
+        }
+
+        return detector.findings(
+          context.getStore() && context.getStore().queries
+        );
+      });
+
+      expect(findings).toHaveLength(1);
+      expect(findings[0]).toMatchObject({
+        count: 6,
+        method: 'findByKey',
+        model: 'User',
+        operation: 'select',
+      });
+      // The eager load is one call and is never a finding
+      expect(findings.some((one) => one.model === 'Task')).toBe(false);
+    } finally {
+      detector.threshold = before;
+    }
+  });
+
+  test('include() is one call, which is why the detector counts calls', async () => {
+    const owner = await User.create({
+      email: 'grace@example.test',
+      name: 'Grace',
+      password: 'secret-enough',
+    });
+
+    for (let index = 0; index < 6; index += 1) {
+      await Task.create({ name: `owned ${index}`, ownerId: owner.id });
+    }
+
+    const events = await recording(henri, () =>
+      Task.find({}, { include: ['owner'] })
+    );
+
+    // Six tasks, one owner each, one model call: on this adapter an eager
+    // load compiles to a single correlated subquery, so there is no lazy
+    // association for a loop to trip over
+    expect(events).toHaveLength(1);
+    expect(events[0].rows).toBe(6);
+  });
+});

--- a/packages/drizzle/index.js
+++ b/packages/drizzle/index.js
@@ -5,6 +5,8 @@ const dialects = require('./dialects');
 const { Dump } = require('./dump');
 const { Migrations } = require('./migrations');
 const { BIND_IDENTITY, createModel } = require('./model');
+const { Relation } = require('./relation');
+const { instrument: instrumentQueries } = require('./queries');
 const { compileTable, encryptedFields, normalizeSchema } = require('./schema');
 const { decorateModel } = require('./encryption');
 const { decorateModel: decorateVersions } = require('./versions');
@@ -235,6 +237,10 @@ class Drizzle {
       this.henri._user = Model;
       this.userModelName = Model.modelName;
     }
+
+    // Last, so that what is wrapped is the model as every other decorator
+    // left it: an application that is not counting has an untouched class
+    instrumentQueries(this, Model, Relation);
 
     this.definitions[Model.modelName] = { model, user };
     this.models[Model.modelName] = Model;

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -21,6 +21,7 @@
     "external-id.js",
     "dump.js",
     "migrations.js",
+    "queries.js",
     "model.js",
     "relation.js",
     "schema.js",

--- a/packages/drizzle/queries.js
+++ b/packages/drizzle/queries.js
@@ -1,0 +1,192 @@
+/**
+ * What this adapter reports to `henri.queries`.
+ *
+ * The seam is core's (`packages/core/src/base/queries.js` has the design and
+ * the argument); this file is only the mapping: which methods of the Drizzle
+ * model layer are **model calls**, what each one means in the one vocabulary
+ * the three adapters share, and where the filter's key names come from.
+ *
+ * Nothing here runs unless `henri.queries.enabled`. `index.js` asks once, per
+ * model, while it is building it, and an application that is not counting has
+ * an untouched model class.
+ *
+ * ## Three targets, and why
+ *
+ * - **The model class**, per model. Every static that ends in a promise:
+ *   `find`, `findById`, `create`, `destroy` and the rest. These are what an
+ *   application writes, and the name it wrote is what the event reports.
+ * - **`Model.prototype`**, per model. `save`, `update`, `destroy`, `restore`,
+ *   `reload` -- a write per record in a loop is an N+1 like any other.
+ * - **`Relation.prototype`**, once per process. `Model.where({ ... }).limit(5)`
+ *   answers a relation and the statement runs at `toArray()`, so instrumenting
+ *   only the statics would miss the whole lazy path. It is one object shared by
+ *   every store in the process, which is why it is wrapped once and resolves
+ *   its henri from the receiver -- see `instrument()`'s own header.
+ *
+ * A call that goes through two of them is one event: core's nesting rule keeps
+ * the outermost, so `Model.findById()` reports `findById` rather than the
+ * `first()` it is built out of.
+ *
+ * ## What is not here
+ *
+ * `adapter.query()` is instrumented by core (`3.model.js`), because the raw
+ * path is the same on every adapter and no model layer sees it. The session
+ * store, the migrations and drizzle-kit reach the database without going
+ * through a model, and are deliberately absent: they are henri's own
+ * housekeeping, they run once, and counting them would put noise in a report
+ * about an application's code.
+ */
+
+/** Marks `Relation.prototype` as wrapped, so a second henri does not redo it */
+const INSTRUMENTED = Symbol.for('henri.queries.relation');
+
+/**
+ * The condition of a call, for its key names only.
+ *
+ * The values are never read: `keysOf()` in core takes the keys and drops
+ * everything under them. A drizzle condition that is already compiled (a `sql`
+ * chunk rather than a plain object) has no keys to take, and answers none
+ * rather than a guess.
+ *
+ * @param {number} at Which argument holds the condition
+ * @returns {function} A filter reader for a spec entry
+ */
+const where =
+  (at = 0) =>
+  (args) => {
+    const condition = args[at];
+
+    return condition && typeof condition === 'object' && !condition.queryChunks
+      ? condition
+      : null;
+  };
+
+/** The identifier of a lookup by id, as a name and not a value */
+const byId = () => ({ id: null });
+
+/** The identifier of a lookup by the public identifier */
+const byExternalId = () => ({ externalId: null });
+
+/**
+ * The statics of a model class that are model calls.
+ *
+ * Read as: `<method>: { operation, filter }`. Anything that answers a
+ * `Relation` rather than a promise -- `query`, `where`, `order`, `limit`,
+ * `include`, `relation` -- is a builder and is deliberately absent: nothing
+ * has run yet when it returns.
+ */
+const STATICS = {
+  all: { operation: 'select' },
+  count: { filter: where(), operation: 'count' },
+  countDocuments: { filter: where(), operation: 'count' },
+  create: { operation: 'insert' },
+  deleteMany: { filter: where(), operation: 'delete' },
+  destroy: { filter: where(), operation: 'delete' },
+  exists: { filter: where(), operation: 'count' },
+  find: { filter: where(), operation: 'select' },
+  findAll: { filter: where(), operation: 'select' },
+  findByExternalId: { filter: byExternalId, operation: 'select' },
+  findById: { filter: byId, operation: 'select' },
+  findByIdAndDelete: { filter: byId, operation: 'delete' },
+  findByIdAndRemove: { filter: byId, operation: 'delete' },
+  findByIdAndUpdate: { filter: byId, operation: 'update' },
+  findByKey: { filter: byId, operation: 'select' },
+  findByPk: { filter: byId, operation: 'select' },
+  findOne: { filter: where(), operation: 'select' },
+  findOneAndDelete: { filter: where(), operation: 'delete' },
+  findOneAndUpdate: { filter: where(), operation: 'update' },
+  first: { operation: 'select' },
+  internalId: { filter: byId, operation: 'select' },
+  last: { operation: 'select' },
+  paginate: { operation: 'select' },
+  pluck: { filter: where(1), operation: 'select' },
+  restore: { filter: where(), operation: 'update' },
+  update: { filter: where(), operation: 'update' },
+  updateMany: { filter: where(), operation: 'update' },
+};
+
+/** The instance methods that go to the database */
+const INSTANCE = {
+  destroy: { operation: 'delete' },
+  reload: { operation: 'select' },
+  restore: { operation: 'update' },
+  save: { operation: 'insert' },
+  update: { operation: 'update' },
+};
+
+/** The terminals of a relation: where a built query finally runs */
+const RELATION = {
+  count: { operation: 'count' },
+  exists: { operation: 'count' },
+  first: { operation: 'select' },
+  last: { operation: 'select' },
+  paginate: { operation: 'select' },
+  pluck: { operation: 'select' },
+  toArray: { operation: 'select' },
+};
+
+/**
+ * The adapter a relation belongs to, or an empty stand-in
+ *
+ * @param {object} relation A relation
+ * @returns {object} The adapter, or `{}` when the chain is incomplete
+ */
+const storeOf = (relation) =>
+  (relation && relation.Model && relation.Model.adapter) || {};
+
+/**
+ * Instruments one model class, and the shared relation the first time round
+ *
+ * @param {object} adapter The Drizzle adapter
+ * @param {function} Model The model class core just built
+ * @param {function} Relation The relation class of this package
+ * @returns {function} The same model class
+ */
+const instrument = (adapter, Model, Relation) => {
+  const { queries } = adapter.henri;
+
+  if (!queries || !queries.enabled) {
+    return Model;
+  }
+
+  const context = {
+    adapter: adapter.adapterName,
+    dialect: (adapter.dialect && adapter.dialect.name) || null,
+    store: adapter.name,
+  };
+
+  queries.instrument(Model, STATICS, { ...context, model: Model.modelName });
+  queries.instrument(Model.prototype, INSTANCE, {
+    ...context,
+    model: (self) => self.constructor.modelName,
+  });
+
+  // One object for every store in the process, so: wrapped once, and every
+  // field that names a store is read off the relation rather than closed over
+  queries.instrument(Relation.prototype, RELATION, {
+    adapter: (self) => storeOf(self).adapterName || null,
+    dialect: (self) => {
+      const { dialect } = storeOf(self);
+
+      return (dialect && dialect.name) || null;
+    },
+    model: (self) => (self.Model && self.Model.modelName) || null,
+    once: INSTRUMENTED,
+    /**
+     * The seam of whichever henri this relation's model belongs to
+     *
+     * @param {object} self The relation
+     * @returns {?object} The queries module, or null
+     */
+    queries: (self) => {
+      const { henri } = storeOf(self);
+
+      return (henri && henri.queries) || null;
+    },
+    store: (self) => storeOf(self).name || null,
+  });
+
+  return Model;
+};
+
+module.exports = { INSTANCE, INSTRUMENTED, RELATION, STATICS, instrument };

--- a/packages/mongoose/__tests__/queries.spec.js
+++ b/packages/mongoose/__tests__/queries.spec.js
@@ -1,0 +1,269 @@
+// What this adapter reports to `henri.queries`, against a real MongoDB.
+//
+// The seam is core's and its design is argued in `base/queries.js`; what is
+// proved here is the mapping this package owns, and above all the two things
+// that make Mongoose different from the other adapters: that instrumenting it
+// does not turn a chainable `Query` into a promise, and that the N+1 a loop
+// makes through a `ref` is counted.
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const Queries = require('@usehenri/core/src/0.queries');
+const { context } = require('@usehenri/core/src/base/request-id');
+const { queryOperations } = require('mongoose/lib/constants');
+const Mongoose = require('../index');
+const { QUERIES } = require('../queries');
+
+const authorModel = {
+  globalId: 'Author',
+  identity: 'author',
+  options: { timestamps: true },
+  schema: { name: { type: 'string' } },
+};
+
+const bookModel = {
+  globalId: 'Book',
+  identity: 'book',
+  options: { timestamps: true },
+  schema: {
+    authorId: { index: true, ref: 'Author', type: 'string' },
+    title: { type: 'string' },
+  },
+};
+
+/**
+ * A minimal henri stand-in carrying the real seam
+ *
+ * @param {object} [settings={}] configuration values
+ * @returns {object} fake henri
+ */
+const fakeHenri = (settings = {}) => {
+  const henri = {
+    _user: null,
+    config: {
+      get: (key) => settings[key],
+      has: (key) => typeof settings[key] !== 'undefined',
+    },
+    cwd: () => process.cwd(),
+    isProduction: false,
+    isTest: true,
+    pen: { error() {}, fatal() {}, info() {}, warn() {} },
+    user: { encrypt: async (password) => `hashed:${password}` },
+  };
+
+  // The real module, not a stand-in: what is being tested is that this
+  // adapter reports what core's seam expects
+  const queries = new Queries();
+
+  queries.henri = henri;
+  queries.init();
+  henri.queries = queries;
+
+  return henri;
+};
+
+/** Runs something as if it were a request, so the detector has a bucket */
+const inRequest = (id, fn) => context.run({ id }, fn);
+
+describe('the query seam (mongoose)', () => {
+  let mongod;
+  let adapter;
+  let henri;
+  let Author;
+  let Book;
+  let seen;
+
+  beforeAll(async () => {
+    mongod = await MongoMemoryServer.create();
+    henri = fakeHenri();
+    adapter = new Mongoose('default', { url: mongod.getUri('queries') }, henri);
+    Author = adapter.addModel(authorModel, 'nobody');
+    Book = adapter.addModel(bookModel, 'nobody');
+    await adapter.start();
+  }, 120000);
+
+  afterAll(async () => {
+    await adapter.stop();
+    await mongod.stop();
+  });
+
+  beforeEach(() => {
+    seen = [];
+    henri.queries.onQuery((event) => seen.push(event));
+  });
+
+  afterEach(async () => {
+    henri.queries.onQuery(null);
+    await Book.deleteMany({});
+    await Author.deleteMany({});
+  });
+
+  test('the operations table is the one Mongoose declares', () => {
+    // A Mongoose release that adds a query operation should fail here rather
+    // than leave a silent gap in what henri reports
+    expect(Object.keys(QUERIES).sort()).toEqual([...queryOperations].sort());
+  });
+
+  test('a query is still a chainable Query, not a promise', async () => {
+    await Author.create({ name: 'Ada' });
+    await Author.create({ name: 'Grace' });
+
+    const query = Author.find();
+
+    // The whole reason this adapter is instrumented with middleware: a
+    // wrapper would have executed the query and handed back a promise
+    expect(typeof query.sort).toBe('function');
+    expect(typeof query.limit).toBe('function');
+
+    const records = await query.sort('name').limit(1);
+
+    expect(records).toHaveLength(1);
+    expect(records[0].name).toBe('Ada');
+  });
+
+  test('a read is one event carrying the model and the operation', async () => {
+    await Author.create({ name: 'Ada' });
+    seen = [];
+
+    await Author.find({ name: 'Ada' });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({
+      adapter: 'mongoose',
+      dialect: null,
+      method: 'find',
+      model: 'Author',
+      operation: 'select',
+      rows: 1,
+      store: 'default',
+    });
+  });
+
+  test('the filter contributes its key names and none of its values', async () => {
+    await Author.find({ name: 'nothing-matches-this' });
+
+    expect(seen[0].keys).toEqual(['name']);
+
+    const serialized = JSON.stringify(seen[0]);
+
+    expect(serialized).not.toContain('nothing-matches-this');
+    expect(seen[0]).not.toHaveProperty('sql');
+    expect(seen[0]).not.toHaveProperty('statement');
+  });
+
+  test('paginate is one event, not the find and the count it is built of', async () => {
+    await Author.create({ name: 'Ada' });
+    seen = [];
+
+    const page = await Author.paginate({ page: 1, perPage: 10 });
+
+    expect(page.total).toBe(1);
+    expect(seen).toHaveLength(1);
+    expect(seen[0].method).toBe('paginate');
+    expect(seen[0].operation).toBe('select');
+  });
+
+  test('create is one event named create, not the save inside it', async () => {
+    await Author.create({ name: 'Grace' });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].method).toBe('create');
+    expect(seen[0].operation).toBe('insert');
+  });
+
+  test('a write per document is reported', async () => {
+    const author = await Author.create({ name: 'Alan' });
+
+    seen = [];
+    author.name = 'Alan Turing';
+    await author.save();
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].operation).toBe('insert');
+    expect(seen[0].model).toBe('Author');
+  });
+
+  test('an update reports how many documents it changed', async () => {
+    await Author.create({ name: 'Ada' });
+    await Author.create({ name: 'Ada' });
+    seen = [];
+
+    await Author.updateMany({ name: 'Ada' }, { name: 'Ada Lovelace' });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].operation).toBe('update');
+    expect(seen[0].rows).toBe(2);
+  });
+
+  test('the request id is the join, and it is null outside a request', async () => {
+    await Author.find();
+
+    expect(seen[0].requestId).toBeNull();
+
+    seen = [];
+    // A Mongoose query is lazy, so it has to be awaited *inside* the scope:
+    // `run(fn)` where fn answers an unexecuted Query would run it after the
+    // context closed, and the event would carry no id
+    await inRequest('a-request-id', async () => {
+      await Author.find();
+    });
+
+    expect(seen[0].requestId).toBe('a-request-id');
+  });
+
+  test('the N+1 a loop makes through a ref is what the detector counts', async () => {
+    const author = await Author.create({ name: 'Ada' });
+
+    for (let index = 0; index < 6; index += 1) {
+      await Book.create({
+        authorId: String(author._id),
+        title: `book ${index}`,
+      });
+    }
+
+    const { detector } = henri.queries;
+
+    const findings = await inRequest('n-plus-one', async () => {
+      const books = await Book.find();
+
+      // The shape this whole tranche is about: one lookup per record, where
+      // one lookup for the set would do
+      for (const book of books) {
+        await Author.findByKey(book.authorId);
+      }
+
+      return detector.findings(context.getStore().queries);
+    });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      count: 6,
+      model: 'Author',
+      operation: 'select',
+    });
+    // The one query that fetched the books is never a finding
+    expect(findings.some((one) => one.model === 'Book')).toBe(false);
+  });
+
+  test('one query for the whole set is never a finding', async () => {
+    const author = await Author.create({ name: 'Grace' });
+
+    for (let index = 0; index < 6; index += 1) {
+      await Book.create({
+        authorId: String(author._id),
+        title: `owned ${index}`,
+      });
+    }
+
+    const { detector } = henri.queries;
+
+    const findings = await inRequest('eager', async () => {
+      // What the loop above should have been: six books and one lookup
+      const books = await Book.find();
+
+      await Author.find({ _id: { $in: books.map((book) => book.authorId) } });
+
+      return detector.findings(context.getStore().queries);
+    });
+
+    expect(findings).toEqual([]);
+  });
+});

--- a/packages/mongoose/index.js
+++ b/packages/mongoose/index.js
@@ -1,6 +1,10 @@
 const mongoose = require('mongoose');
 const debug = require('debug')('henri:mongoose');
 const { externalId, lookups, owned, paginate, paranoid } = require('./plugins');
+const {
+  instrument: instrumentQueries,
+  instrumentStatics,
+} = require('./queries');
 const { normalizeModel } = require('./schema');
 const { exactPaths, exactness } = require('./exact-paths');
 const { encryption } = require('./encryption');
@@ -201,10 +205,13 @@ class Mongoose {
       versioned(schema, this.henri, model.globalId);
     }
 
-    const instance = this.mongoose.model(
-      model.globalId,
-      schema,
-      model.name || undefined
+    // Last on the schema, so what it measures is every other plugin's work
+    // as well: an application that is not counting gets no hook at all
+    instrumentQueries(schema, this, model.globalId);
+
+    const instance = instrumentStatics(
+      this.mongoose.model(model.globalId, schema, model.name || undefined),
+      this
     );
 
     if (isUser) {

--- a/packages/mongoose/package.json
+++ b/packages/mongoose/package.json
@@ -27,6 +27,7 @@
     "exact-paths.js",
     "external-id.js",
     "plugins.js",
+    "queries.js",
     "schema.js",
     "types.js",
     "utils.js",

--- a/packages/mongoose/queries.js
+++ b/packages/mongoose/queries.js
@@ -1,0 +1,292 @@
+/**
+ * What this adapter reports to `henri.queries`.
+ *
+ * The seam is core's (`packages/core/src/base/queries.js` has the design and
+ * the argument); this file is only the mapping. Nothing here runs unless
+ * `henri.queries.enabled`: `index.js` asks once, per model, while it is
+ * building the schema, and an application that is not counting gets a schema
+ * with no hook on it.
+ *
+ * ## Why this one is middleware and the others are wrappers
+ *
+ * The Drizzle adapter wraps the statics of its model class, because those
+ * return promises. **Mongoose's do not.** `Model.find()` answers a `Query`,
+ * which is lazy and chainable and only runs when it is awaited:
+ * `Model.find().sort('-createdAt').limit(5)` is three calls and one
+ * statement. A wrapper around `find` would either measure the wrong thing
+ * (the time it took to build a query object) or -- because a `Query` is
+ * thenable, so core's wrapper would happily `.then()` it -- **execute the
+ * query early and hand the caller a promise where a chainable query
+ * belonged**, breaking every `find().sort()` in every henri application.
+ *
+ * So Mongoose is instrumented where Mongoose says to: schema middleware.
+ * `pre` stamps the start on the query, the document or the aggregate, `post`
+ * reads it back with the result, and the operation names come from Mongoose's
+ * own `constants.js` rather than a list of guesses. The cost is that the
+ * reported `method` is Mongoose's word (`findOne`) rather than henri's
+ * (`findById`), which is the honest name for what ran here.
+ *
+ * ## The exception, and why it is one
+ *
+ * `paginate()` is a henri static that answers a real promise, and it is a
+ * page plus its count -- two Mongoose operations for one decision. It is
+ * wrapped, so that it reports one event named `paginate` the way it does on
+ * the other two adapters, and core's nesting rule keeps the `find` and the
+ * `countDocuments` inside it from being counted again. `create()` is wrapped
+ * for the same reason: it answers a promise and its `save` would otherwise
+ * be the name in the report.
+ *
+ * ## The one place this adapter counts operations rather than calls
+ *
+ * Core's rule is one event per model call, and the two wrapped statics keep
+ * it. Middleware cannot: `pre` and `post` are two callbacks, so there is no
+ * scope to hold open between them, and an operation that **fans out** is
+ * therefore reported once per operation. In practice that is `populate()`:
+ * `Book.find().populate('author')` is one model call and reports a `find` for
+ * the books and a `find` for the authors.
+ *
+ * It is worth being plain about, because it is the one place the vocabulary
+ * bends. It does not mislead the detector -- a `populate` in a loop shows up
+ * as two findings for one problem, with the same advice on both, which is
+ * noisier than it should be and never wrong -- and the alternative was
+ * wrapping the statics, which would have broken every `find().sort()` in
+ * every henri application. The guide says so too.
+ *
+ * ## What is not here
+ *
+ * `adapter.query()` and the collections the queue, the trail and the call log
+ * reach directly. Those go around the models on purpose (they own their
+ * tables and no model describes them), so no schema middleware can see them;
+ * core instruments the raw path itself in `3.model.js`.
+ */
+
+/** Where the start time is parked between `pre` and `post` */
+const STARTED = Symbol('henri.queries.started');
+
+/** Where the captured call site is parked between `pre` and `post` */
+const SITE = Symbol('henri.queries.at');
+
+/**
+ * Mongoose's query operations, in henri's vocabulary.
+ *
+ * The names are `queryOperations` from `mongoose/lib/constants.js`; keeping
+ * them written out rather than filtered from that file is deliberate, since
+ * it is a private module, and `__tests__/queries.spec.js` compares the two
+ * lists so a Mongoose release that adds one is a failing test rather than a
+ * silent gap.
+ */
+const QUERIES = {
+  countDocuments: 'count',
+  deleteMany: 'delete',
+  deleteOne: 'delete',
+  distinct: 'other',
+  estimatedDocumentCount: 'count',
+  find: 'select',
+  findOne: 'select',
+  findOneAndDelete: 'delete',
+  findOneAndReplace: 'update',
+  findOneAndUpdate: 'update',
+  replaceOne: 'update',
+  updateMany: 'update',
+  updateOne: 'update',
+};
+
+/** The document operations worth an event: a write per record is an N+1 too */
+const DOCUMENTS = { deleteOne: 'delete', save: 'insert', updateOne: 'update' };
+
+/** The model operations that go straight to the driver */
+const MODELS = { bulkWrite: 'other', insertMany: 'insert' };
+
+/** The statics that answer a promise, so they can be wrapped like Drizzle's */
+const STATICS = {
+  create: { operation: 'insert' },
+  paginate: { operation: 'select' },
+};
+
+/**
+ * How many documents an answer holds, for the shapes Mongoose returns.
+ *
+ * A write answers `{ acknowledged, modifiedCount, ... }`, which is a count
+ * and not a document; core's own `rowsOf()` would call that one row.
+ *
+ * @param {*} value What the operation answered
+ * @returns {?number} The count, or null when it cannot be told
+ */
+const documentsIn = (value) => {
+  if (value === null || typeof value === 'undefined') {
+    return 0;
+  }
+
+  if (Array.isArray(value)) {
+    return value.length;
+  }
+
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  if (typeof value === 'object') {
+    for (const key of ['modifiedCount', 'deletedCount', 'insertedCount']) {
+      if (typeof value[key] === 'number') {
+        return value[key];
+      }
+    }
+
+    return 1;
+  }
+
+  return null;
+};
+
+/**
+ * Adds the middleware that reports every operation of one schema
+ *
+ * @param {object} schema The Mongoose schema, before it is compiled
+ * @param {object} adapter The Mongoose adapter
+ * @param {string} model The model name
+ * @returns {object} The same schema
+ */
+const instrument = (schema, adapter, model) => {
+  const { henri } = adapter;
+  const { queries } = henri;
+
+  if (!queries || !queries.enabled) {
+    return schema;
+  }
+
+  const context = {
+    adapter: adapter.adapterName,
+    dialect: null,
+    model,
+    store: adapter.name,
+  };
+
+  /**
+   * Stamps the start of an operation on whatever is carrying it
+   *
+   * @returns {void}
+   */
+  function begin() {
+    this[STARTED] = performance.now();
+    // Allocated, never formatted: core reads `.stack` only when a shape is
+    // actually reported
+    this[SITE] = queries.callsites ? new Error('query') : null;
+  }
+
+  /**
+   * Reports a finished operation
+   *
+   * @param {string} method Mongoose's name for it
+   * @param {string} operation henri's name for it
+   * @param {*} filter The filter, for its key names only
+   * @param {*} answer What came back
+   * @param {object} carrier The query, document or aggregate
+   * @returns {void}
+   */
+  const report = (method, operation, filter, answer, carrier) => {
+    // A `pre` that never ran means the operation was started before the
+    // schema was instrumented; nothing useful can be said about its duration
+    if (typeof carrier[STARTED] !== 'number') {
+      return;
+    }
+
+    // A layer of a call already being measured: `paginate()` is a `find` and
+    // a `countDocuments`, and it is one decision. The wrappers below open
+    // that scope; this is where the middleware honours it
+    if (queries.nested()) {
+      carrier[STARTED] = null;
+      carrier[SITE] = null;
+
+      return;
+    }
+
+    queries.record({
+      ...context,
+      at: carrier[SITE],
+      filter,
+      method,
+      operation,
+      rows: documentsIn(answer),
+      started: carrier[STARTED],
+    });
+
+    carrier[STARTED] = null;
+    carrier[SITE] = null;
+  };
+
+  for (const method of Object.keys(QUERIES)) {
+    schema.pre(method, begin);
+    schema.post(method, function record(answer) {
+      // `getFilter()` answers the conditions as they were written; core's
+      // `keysOf()` takes the key names and drops every value under them
+      report(
+        method,
+        QUERIES[method],
+        typeof this.getFilter === 'function' ? this.getFilter() : null,
+        answer,
+        this
+      );
+    });
+  }
+
+  for (const method of Object.keys(DOCUMENTS)) {
+    schema.pre(method, { document: true, query: false }, begin);
+    schema.post(method, { document: true, query: false }, function record() {
+      // One document, and no filter: it is addressed by its own identity
+      report(method, DOCUMENTS[method], null, 1, this);
+    });
+  }
+
+  for (const method of Object.keys(MODELS)) {
+    schema.pre(method, begin);
+    schema.post(method, function record(answer) {
+      report(method, MODELS[method], null, answer, this);
+    });
+  }
+
+  schema.pre('aggregate', begin);
+  schema.post('aggregate', function record(answer) {
+    // A pipeline names stages and fields, and the stages carry values; only
+    // the count of stages is reported, which is a shape and not a document
+    report('aggregate', 'other', null, answer, this);
+  });
+
+  return schema;
+};
+
+/**
+ * Wraps the two henri statics that answer a promise rather than a query
+ *
+ * Called after the model is compiled, because these live on the model rather
+ * than on the schema.
+ *
+ * @param {object} instance The compiled Mongoose model
+ * @param {object} adapter The Mongoose adapter
+ * @returns {object} The same model
+ */
+const instrumentStatics = (instance, adapter) => {
+  const { queries } = adapter.henri;
+
+  if (!queries || !queries.enabled) {
+    return instance;
+  }
+
+  queries.instrument(instance, STATICS, {
+    adapter: adapter.adapterName,
+    dialect: null,
+    model: instance.modelName,
+    store: adapter.name,
+  });
+
+  return instance;
+};
+
+module.exports = {
+  DOCUMENTS,
+  MODELS,
+  QUERIES,
+  STATICS,
+  documentsIn,
+  instrument,
+  instrumentStatics,
+};

--- a/packages/sequelize/__tests__/helpers.js
+++ b/packages/sequelize/__tests__/helpers.js
@@ -1,5 +1,6 @@
 const Sql = require('../index');
 const Encryption = require('@usehenri/core/src/1.encryption');
+const Queries = require('@usehenri/core/src/0.queries');
 const { generateKey } = require('@usehenri/core/src/base/encryption');
 const target = require('./targets');
 
@@ -45,6 +46,19 @@ const fakeHenri = (settings = {}) => {
 
   encryption.henri = henri;
   henri.encryption = encryption;
+
+  // The same, and for the same reason: what is being tested is that this
+  // adapter reports the calls core's seam expects, so the seam is core's
+  const queries = new Queries();
+
+  queries.henri = henri;
+  queries.init();
+  henri.queries = queries;
+
+  // The seam says at boot that it is counting. That is the module's line and
+  // not the adapter's, and `calls` is what the suites read to see what the
+  // adapter said, so the harness's own setup is not left in it
+  calls.length = 0;
 
   return henri;
 };

--- a/packages/sequelize/__tests__/queries.spec.js
+++ b/packages/sequelize/__tests__/queries.spec.js
@@ -1,0 +1,210 @@
+// What this adapter reports to `henri.queries`, on the target database:
+// sqlite in memory offline, and a database of its own on the live PostgreSQL
+// or MySQL of `pnpm test:sql:live`.
+//
+// The seam is core's and its design is argued in `base/queries.js`. This
+// package is the reason the design says what it says about the statement, so
+// the test that matters most here is the one that proves the statement never
+// leaves: Sequelize's query generator puts values inside the SQL, and none of
+// them is on an event.
+const { context } = require('@usehenri/core/src/base/request-id');
+const { build, target, taskModel, userModel } = require('./helpers');
+
+/**
+ * Collects the events one piece of work produces
+ *
+ * @param {object} henri The fake henri of the store
+ * @param {function} fn What to run
+ * @returns {Promise<Array<object>>} The events, in order
+ */
+const recording = async (henri, fn) => {
+  const seen = [];
+
+  henri.queries.onQuery((event) => seen.push(event));
+
+  try {
+    await fn();
+  } finally {
+    henri.queries.onQuery(null);
+  }
+
+  return seen;
+};
+
+/** Runs something as if it were a request, so the detector has a bucket */
+const inRequest = (id, fn) => context.run({ id }, fn);
+
+describe(`the query seam on ${target.name} (sequelize)`, () => {
+  let adapter;
+  let henri;
+  let Task;
+  let User;
+
+  beforeAll(async () => {
+    ({ adapter, henri } = build());
+    User = adapter.addModel({ ...userModel }, 'user');
+    Task = adapter.addModel({
+      ...taskModel,
+      schema: { ...taskModel.schema, ownerId: { type: 'integer' } },
+    });
+
+    await adapter.start();
+  });
+
+  afterAll(async () => {
+    await adapter.stop();
+  });
+
+  afterEach(async () => {
+    await Task.destroy({ truncate: true });
+    await User.destroy({ truncate: true });
+  });
+
+  test('a model call is one event carrying the model and the operation', async () => {
+    const events = await recording(henri, async () => {
+      await Task.create({ name: 'one' });
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      // `adapterName` is the henri adapter, which falls back to the dialect
+      // when a store did not name one (`mssql` is what it is in an app)
+      adapter: adapter.adapterName,
+      method: 'create',
+      model: 'Task',
+      operation: 'insert',
+      source: 'application',
+      store: 'default',
+    });
+  });
+
+  test('findByPk is findByPk, not the findAll it is built out of', async () => {
+    const task = await Task.create({ name: 'two' });
+    const events = await recording(henri, async () => {
+      await Task.findByKey(task.id);
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].method).toBe('findByKey');
+    expect(events[0].operation).toBe('select');
+    expect(events[0].rows).toBe(1);
+  });
+
+  test('paginate is two statements and one model call', async () => {
+    await Task.create({ name: 'three' });
+
+    const events = await recording(henri, async () => {
+      await Task.paginate({ page: 1, perPage: 10 });
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].method).toBe('paginate');
+    expect(events[0].rows).toBe(1);
+  });
+
+  test('the statement never leaves, and this is the adapter that proves it', async () => {
+    // Sequelize compiles this to: SELECT ... WHERE `name` = 'a-secret-value'
+    // -- the value inside the statement text, which is exactly why no event
+    // on any adapter carries SQL
+    const events = await recording(henri, async () => {
+      await Task.findAll({
+        where: { category: 'urgent', name: 'a-secret-value' },
+      });
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].keys).toEqual(['category', 'name']);
+
+    const serialized = JSON.stringify(events[0]);
+
+    expect(serialized).not.toContain('a-secret-value');
+    expect(serialized).not.toContain('urgent');
+    // No statement, in any casing, and no fragment of one. (`select` on its
+    // own is henri's own word for the operation, so the check is for SQL)
+    expect(serialized).not.toMatch(/select\s|from\s|where\s/iu);
+    expect(events[0]).not.toHaveProperty('sql');
+    expect(events[0]).not.toHaveProperty('statement');
+    expect(events[0]).not.toHaveProperty('bind');
+  });
+
+  test('the same call twice is the same shape, and two calls are not', async () => {
+    const events = await recording(henri, async () => {
+      await Task.findAll({ where: { name: 'a' } });
+      await Task.findAll({ where: { name: 'b' } });
+      await Task.findAll({ where: { category: 'low' } });
+      await Task.count({ where: { name: 'a' } });
+    });
+
+    expect(events[0].shape).toBe(events[1].shape);
+    expect(events[2].shape).not.toBe(events[0].shape);
+    expect(events[3].shape).not.toBe(events[0].shape);
+  });
+
+  test('a write per record is reported', async () => {
+    const task = await Task.create({ name: 'four' });
+    const events = await recording(henri, async () => {
+      await task.update({ name: 'four and a half' });
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].operation).toBe('update');
+    expect(events[0].model).toBe('Task');
+  });
+
+  test('an update says how many rows it changed', async () => {
+    await Task.create({ name: 'same' });
+    await Task.create({ name: 'same' });
+
+    const events = await recording(henri, async () => {
+      await Task.update({ category: 'high' }, { where: { name: 'same' } });
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].operation).toBe('update');
+    expect(events[0].rows).toBe(2);
+  });
+
+  test('the request id is the join, and it is null outside a request', async () => {
+    const outside = await recording(henri, () => Task.findAll());
+
+    expect(outside[0].requestId).toBeNull();
+
+    const inside = await recording(henri, () =>
+      inRequest('a-request-id', () => Task.findAll())
+    );
+
+    expect(inside[0].requestId).toBe('a-request-id');
+  });
+
+  test('the N+1 a loop makes is what the detector counts', async () => {
+    const owner = await User.create({
+      email: 'ada@example.test',
+      name: 'Ada',
+      password: 'secret-enough',
+    });
+
+    for (let index = 0; index < 6; index += 1) {
+      await Task.create({ name: `task ${index}`, ownerId: owner.id });
+    }
+
+    const { detector } = henri.queries;
+
+    const findings = await inRequest('n-plus-one', async () => {
+      const tasks = await Task.findAll();
+
+      for (const task of tasks) {
+        await User.findByKey(task.ownerId);
+      }
+
+      return detector.findings(context.getStore().queries);
+    });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      count: 6,
+      method: 'findByKey',
+      model: 'User',
+      operation: 'select',
+    });
+  });
+});

--- a/packages/sequelize/index.js
+++ b/packages/sequelize/index.js
@@ -4,6 +4,7 @@ const { Drift, describeDifference } = require('./drift');
 const { decorateAttributes, decorateModel } = require('./encryption');
 const { decorateModel: decorateVersions } = require('./versions');
 const { lookup, paginate, publicId } = require('./plugins');
+const { instrument: instrumentQueries } = require('./queries');
 const { normalizeSchema } = require('./schema');
 const {
   EXTERNAL_ID,
@@ -293,6 +294,10 @@ class Sql {
     if (keepsVersions) {
       decorateVersions(instance, this.henri);
     }
+
+    // Last, so that what is wrapped is the model as every other decorator
+    // left it: an application that is not counting gets an untouched model
+    instrumentQueries(instance, this);
 
     this.definitions[model.globalId] = { model, user };
     this.models[model.globalId] = instance;

--- a/packages/sequelize/package.json
+++ b/packages/sequelize/package.json
@@ -27,6 +27,7 @@
     "exact.js",
     "external-id.js",
     "plugins.js",
+    "queries.js",
     "schema.js",
     "types.js",
     "utils.js",

--- a/packages/sequelize/queries.js
+++ b/packages/sequelize/queries.js
@@ -1,0 +1,185 @@
+/**
+ * What this adapter reports to `henri.queries`.
+ *
+ * The seam is core's (`packages/core/src/base/queries.js` has the design and
+ * the argument); this file is only the mapping. Nothing here runs unless
+ * `henri.queries.enabled`: `index.js` asks once, per model, and an
+ * application that is not counting gets an untouched model.
+ *
+ * ## This is the adapter whose SQL settled the design
+ *
+ * The question the whole seam turned on was whether an event carries the
+ * statement, and the answer -- no, on any adapter -- is this package's fault.
+ * **Sequelize's query generator interpolates values into the text it runs.**
+ * `Model.findAll({ where: { name: 'ada' } })` reaches the driver as
+ * `SELECT ... WHERE "U"."name" = 'ada'`: the value is inside the string, on
+ * the ordinary path, not an edge case. Drizzle parameterizes and Mongoose has
+ * no statement at all, so a `sql` field would have been safe on two adapters
+ * and a copy of the row on the third -- which is worse than no field, because
+ * it is the leak nobody would look for. The event carries the filter's key
+ * **names** instead, and the statement is never read.
+ *
+ * ## Wrapped, like Drizzle's and unlike Mongoose's
+ *
+ * Sequelize has no lazy query object: `Model.findAll(options)` answers a
+ * promise, not something chainable. So this is instrumented the way the
+ * Drizzle adapter is -- the statics and the instance methods, wrapped -- and
+ * core's nesting rule keeps a call that is built out of another one
+ * (`findByPk` is a `findOne` is a `findAll`) to a single event under the name
+ * the application wrote.
+ *
+ * ## What is not here
+ *
+ * `adapter.query()`, which core instruments itself in `3.model.js`, and
+ * `sequelize.sync()`, the session store and the drift reader, which are
+ * henri's own housekeeping rather than an application's queries.
+ */
+
+/**
+ * The condition of a call, for its key names only.
+ *
+ * Sequelize takes its condition inside an options bag (`{ where }`), and the
+ * bag also carries `attributes`, `include`, `order` and the rest -- which are
+ * names too, but not the ones that say what question was asked. Only `where`
+ * is read, and only for its keys: core's `keysOf()` walks `Op.and`/`Op.or`
+ * (symbol keys) and drops every value under them.
+ *
+ * @param {number} at Which argument holds the options bag
+ * @returns {function} A filter reader for a spec entry
+ */
+const whereIn =
+  (at = 0) =>
+  (args) => {
+    const options = args[at];
+
+    return options && typeof options === 'object'
+      ? options.where || null
+      : null;
+  };
+
+/** The identifier of a lookup by id, as a name and not a value */
+const byId = () => ({ id: null });
+
+/** The identifier of a lookup by the public identifier */
+const byExternalId = () => ({ externalId: null });
+
+/**
+ * The statics of a Sequelize model that go to the database.
+ *
+ * `findAndCountAll` is two statements and one decision, like `paginate`; both
+ * are one event, because the seam counts decisions.
+ */
+const STATICS = {
+  aggregate: { filter: whereIn(2), operation: 'other' },
+  bulkCreate: { operation: 'insert' },
+  count: { filter: whereIn(), operation: 'count' },
+  create: { operation: 'insert' },
+  destroy: { filter: whereIn(), operation: 'delete' },
+  findAll: { filter: whereIn(), operation: 'select' },
+  findAndCountAll: { filter: whereIn(), operation: 'select' },
+  findByExternalId: { filter: byExternalId, operation: 'select' },
+  findById: { filter: byId, operation: 'select' },
+  findByKey: { filter: byId, operation: 'select' },
+  findByPk: { filter: byId, operation: 'select' },
+  findOne: { filter: whereIn(), operation: 'select' },
+  findOrCreate: { filter: whereIn(), operation: 'select' },
+  increment: { filter: whereIn(1), operation: 'update' },
+  max: { filter: whereIn(1), operation: 'count' },
+  min: { filter: whereIn(1), operation: 'count' },
+  paginate: { operation: 'select' },
+  restore: { filter: whereIn(), operation: 'update' },
+  sum: { filter: whereIn(1), operation: 'count' },
+  truncate: { operation: 'delete' },
+  update: { filter: whereIn(1), operation: 'update' },
+  upsert: { operation: 'update' },
+};
+
+/** The instance methods that go to the database */
+const INSTANCE = {
+  decrement: { operation: 'update' },
+  destroy: { operation: 'delete' },
+  increment: { operation: 'update' },
+  reload: { operation: 'select' },
+  restore: { operation: 'update' },
+  save: { operation: 'insert' },
+  update: { operation: 'update' },
+};
+
+/**
+ * How many rows an answer holds, for the shapes Sequelize returns.
+ *
+ * `findAndCountAll` answers `{ count, rows }` and `update`/`destroy` answer a
+ * number (or `[affected]`), neither of which core's own `rowsOf()` would read
+ * correctly on its own.
+ *
+ * @param {*} value What the call answered
+ * @returns {?number} The count, or null when it cannot be told
+ */
+const rowsIn = (value) => {
+  if (value === null || typeof value === 'undefined') {
+    return 0;
+  }
+
+  if (Array.isArray(value)) {
+    return typeof value[0] === 'number' ? value[0] : value.length;
+  }
+
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  if (typeof value === 'object') {
+    if (Array.isArray(value.rows)) {
+      return value.rows.length;
+    }
+
+    if (Array.isArray(value.records)) {
+      return value.records.length;
+    }
+
+    return 1;
+  }
+
+  return null;
+};
+
+/**
+ * Instruments one model
+ *
+ * @param {object} instance The Sequelize model
+ * @param {object} adapter The Sequelize adapter
+ * @returns {object} The same model
+ */
+const instrument = (instance, adapter) => {
+  const { queries } = adapter.henri;
+
+  if (!queries || !queries.enabled) {
+    return instance;
+  }
+
+  const context = {
+    adapter: adapter.adapterName,
+    dialect: adapter.dialect || null,
+    store: adapter.name,
+  };
+  const rows = (spec) =>
+    Object.fromEntries(
+      Object.entries(spec).map(([name, entry]) => [
+        name,
+        { rows: rowsIn, ...entry },
+      ])
+    );
+
+  queries.instrument(instance, rows(STATICS), {
+    ...context,
+    model: instance.name,
+  });
+  queries.instrument(instance.prototype, rows(INSTANCE), {
+    ...context,
+    model: (self) => self.constructor.name,
+  });
+
+  return instance;
+};
+
+module.exports = { INSTANCE, STATICS, instrument, rowsIn };

--- a/showcase/test/references.test.js
+++ b/showcase/test/references.test.js
@@ -11,6 +11,25 @@
 //
 // These are the numbers the guide quotes. A regression to N+1 fails here.
 //
+// ## Two counters, and they count different things
+//
+// This file used to monkey-patch the connection pool and count statements.
+// It now asks `henri.queries` -- the seam the adapters report every model
+// call to -- and keeps one statement counter beside it, because the two
+// answer different questions and neither substitutes for the other:
+//
+// - `recording()` counts **model calls**: what the application asked for.
+//   `Proposal.paginate()` is one, whatever SQL it compiles to. This is what
+//   the N+1 detector counts and what `findings()` reports, and it is the
+//   honest measure of "did this page loop over its records".
+// - `counting()` counts **statements**: what the driver ran.
+//   `Proposal.paginate()` is two. This is the number that catches the
+//   adapter regressing, and it is deliberately kept for the one assertion
+//   whose subject is the SQL -- that six repeated speaker keys are one `IN`
+//   and not six lookups.
+//
+// A person reading "4 queries" would assume the second. Both are labelled.
+//
 // This file truncates nothing. Every other suite calls `reset()` in its
 // `beforeAll`, which is fine when what follows only reads its own rows;
 // here the rows are the measurement, so the edition is one of this file's
@@ -24,7 +43,64 @@ const SPEAKERS = 6;
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/u;
 
 /**
- * Counts the statements the pool runs while `fn` does its work
+ * Counts the **model calls** `fn` makes, through henri's own seam.
+ *
+ * No monkey patch: `onQuery()` is the documented way to hear about every
+ * call, and what it reports is what the detector counts.
+ *
+ * @param {function} fn What to measure
+ * @returns {Promise<{answer: *, calls: Array<object>}>} The result and the
+ *   events, in order
+ */
+const recording = async (fn) => {
+  const calls = [];
+
+  henri.queries.onQuery((event) => calls.push(event));
+
+  try {
+    return { answer: await fn(), calls };
+  } finally {
+    henri.queries.onQuery(null);
+  }
+};
+
+/**
+ * The shapes that repeated, worst first: the detector's question, asked of a
+ * list of events rather than of a request's own bucket.
+ *
+ * The detector runs server-side, inside the request, and keeps its count on
+ * the request's AsyncLocalStorage; a test holding a list of events is on the
+ * other side of the socket, so it groups them itself. The predicate is the
+ * same one `Detector` uses -- the same `shape`, at least `threshold` times.
+ *
+ * @param {Array<object>} calls What `recording()` collected
+ * @param {number} [threshold] How many repeats count as one
+ * @returns {Array<object>} `{ shape, count, what }`, worst first
+ */
+const repeated = (calls, threshold = henri.queries.detector.threshold) => {
+  const counts = new Map();
+
+  for (const call of calls) {
+    const seen = counts.get(call.shape) || {
+      count: 0,
+      shape: call.shape,
+      what: `${call.model}.${call.method}`,
+    };
+
+    seen.count += 1;
+    counts.set(call.shape, seen);
+  }
+
+  return [...counts.values()]
+    .filter((one) => one.count >= threshold)
+    .sort((one, two) => two.count - one.count);
+};
+
+/**
+ * Counts the **statements** the pool runs while `fn` does its work.
+ *
+ * The one thing the seam cannot answer: it reports model calls, and the
+ * subject of the assertion below is the SQL a model call compiles to.
  *
  * @param {function} fn What to measure
  * @returns {Promise<{answer: *, queries: number}>} The result and the count
@@ -110,7 +186,7 @@ describe('what a foreign key costs', () => {
 
   test('a page whose associations are loaded costs nothing extra', async () => {
     const url = `/proposals?event=${event.externalId}&per_page=${PAGE}`;
-    const { answer, queries } = await counting(() =>
+    const { answer, calls } = await recording(() =>
       request().get(url).set('Accept', HAL)
     );
     const records = answer.body._embedded.proposals;
@@ -126,20 +202,30 @@ describe('what a foreign key costs', () => {
       expect(record.trackId).toBe(track.externalId);
     }
 
-    // Four statements for the whole request -- the edition of the filter,
-    // the page, its count and the editions of the form -- and not one of
-    // them is a resolution: seventy five foreign keys came back for free
-    expect(queries).toBe(4);
+    // The assertion this file exists for, and the one nothing could make
+    // before the seam: whatever the request cost, no call was repeated
+    // enough times to be a loop over the records
+    expect(repeated(calls)).toEqual([]);
+
+    // Three model calls for the whole request -- the edition of the filter,
+    // the page (a `paginate`, two statements and one decision) and the
+    // editions of the form -- and not one of them is a resolution: seventy
+    // five foreign keys came back for free
+    expect(calls.map((call) => `${call.model}.${call.method}`)).toEqual([
+      'Event.findById',
+      'Proposal.paginate',
+      'Event.toArray',
+    ]);
   });
 
-  test('and one that loads nothing costs one statement per target model', async () => {
+  test('and one that loads nothing costs one call per target model', async () => {
     const records = await Proposal.where({ eventId: event.id }).limit(PAGE);
 
     expect(records).toHaveLength(PAGE);
     // No `include`: the three references have to be resolved
     expect(records[0].event).toBeUndefined();
 
-    const { answer, queries } = await counting(() =>
+    const { answer, calls } = await recording(() =>
       henri.model.publish(records)
     );
 
@@ -148,8 +234,25 @@ describe('what a foreign key costs', () => {
     expect(answer[0].trackId).toBe(track.externalId);
     expect(answer[0].speakerId).toMatch(UUID);
 
-    // Three models pointed at, three statements -- not seventy five, and
-    // not one per distinct key either: the six speakers are one `IN`
+    // Three models pointed at, three model calls -- not seventy five, and
+    // not one per distinct key either
+    expect(calls).toHaveLength(3);
+    expect(calls.map((call) => call.model).sort()).toEqual([
+      'Event',
+      'Track',
+      'User',
+    ]);
+  });
+
+  test('the six repeated speaker keys are one IN, and that is a statement count', async () => {
+    const records = await Proposal.where({ eventId: event.id }).limit(PAGE);
+
+    // The one assertion here whose subject is the SQL rather than the call:
+    // deduplicating the keys happens inside a single model call, so only a
+    // statement counter can see it. Three statements, not eight (the three
+    // models plus the five extra distinct speakers)
+    const { queries } = await counting(() => henri.model.publish(records));
+
     expect(queries).toBe(3);
   });
 

--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -68,6 +68,7 @@ Every key below is declared in `@usehenri/core`, so an editor completes them as 
 | `retention`        |               | What runs the retention sweep and what it may do, see below. How long a model keeps its records is said in the model. See [Retention](/guides/retention/).              |
 | `trail`            | off           | The append-only record of who read or changed personal data, see below. See [The access trail](/guides/trail/).                                                         |
 | `calls`            | off           | The calls the application answered and the calls it made, joined by the request id, see below. See [Call logs](/guides/calls/).                                         |
+| `queries`          | outside prod  | What the adapters report running, and the repeated model calls the detector counts, see below. `false` records nothing. See [N+1 detection](/guides/queries/).          |
 | `versions`         | `{}`          | Where the history of the models that say `versioned` is kept, and for how long. It turns nothing on: a model does. See [Model versions](/guides/versions/).             |
 | `bodyLimit`        | `1mb`         | Maximum size of a JSON or form body.                                                                                                                                    |
 | `uploads`          |               | File uploads: where they go, the limits and the accepted types, see below; needs `@usehenri/uploads`. `false` accepts no file.                                          |
@@ -487,6 +488,32 @@ turning it on.
 | `sweep`           | `5000`          | How many rows one pass of the delete path takes at a time.                                                                                                                                     |
 | `store`           | `"default"`     | Which of `stores` the table lives in.                                                                                                                                                          |
 | `table`           | `"henri_calls"` | The table henri creates at boot. Changing `partition` afterwards needs a migration of your own.                                                                                                |
+
+## The `queries` object
+
+What the adapters report running, and the N+1 detector on top of it. The seam
+emits one event per **model call** -- `Proposal.findById`, `Track.find`,
+`User.paginate` -- and the detector counts the ones that repeat inside a single
+request. It is on in development and in test and off in production, because a
+production request should not pay to tell a developer something the developer
+is not there to read.
+
+`false` records nothing anywhere: no hook is registered on any adapter, no
+middleware is mounted, and nothing is allocated per query.
+
+| Key                | Default       | Description                                                                                                                                                                 |
+| ------------------ | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enabled`          | outside prod  | Absent means on outside production. `true` is the production opt-in: every model call is timed and counted.                                                                 |
+| `callsites`        | with `detect` | Whether an event carries the line the model call was made on. It costs an `Error` allocation per call, so it follows the detector unless set.                               |
+| `detect`           | `{}`          | The detector; `false` keeps the events and reports nothing, so `henri.queries.onQuery()` still works.                                                                       |
+| `detect.threshold` | `5`           | How many times the same model call has to run in one request before it is reported. It counts **model calls, never statements**. At least `2`.                              |
+| `detect.log`       | `true`        | One warning per request naming the call, the count, the line and what to do instead.                                                                                        |
+| `detect.header`    | `true`        | `X-Henri-Queries` on the answer, in development only: counts and the names of the repeated calls, never a value.                                                            |
+| `detect.raise`     | `false`       | Throw `HENRI_QUERIES_N_PLUS_ONE` the moment the threshold is crossed, so the stack names the call. This is what makes a test suite fail on an N+1.                          |
+| `detect.ignore`    | `[]`          | Calls the detector never counts: `Model`, `Model.operation` or `*.operation`, where an operation is one of `count`, `delete`, `insert`, `other`, `raw`, `select`, `update`. |
+
+See [N+1 detection](/guides/queries/) for what an event carries, what it
+deliberately does not, and how it joins the request id.
 
 ## The `versions` object
 

--- a/website/src/content/docs/guides/queries.md
+++ b/website/src/content/docs/guides/queries.md
@@ -1,0 +1,292 @@
+---
+title: N+1 detection
+description: Every adapter says what it ran, and the detector on top of it says which model call a request made forty times -- what an event carries, what it deliberately does not, and where a finding goes.
+---
+
+henri has `include()` and a guide that tells you to use it, and until now
+nothing that _told_ you when you did not. The reason nobody outside henri
+could write that check either was more basic: **no adapter emitted anything
+when it ran a query**, so there was nothing to listen to.
+
+There are two halves here, and they arrived in that order. `henri.queries` is
+the seam: every adapter reports every model call. The N+1 detector is a
+listener on it, on in development and in test, off in production.
+
+```
+$ henri server
+  queries  counting model calls; the same call 5 times in one request is reported
+...
+    warn  queries  GET /proposals/:id  Track.findById ran 24 times at
+                   app/controllers/ProposalsController.js:41 (18.3ms) --
+                   load them together: one Track.find({ id: [...] }) for the
+                   whole set, or include('track') on the query that fetched
+                   the parents
+```
+
+## The seam is at the model call, not the statement
+
+This is the design decision everything else follows from, so it is worth the
+paragraph. There were two levels to instrument:
+
+- **The statement** -- what the driver ran. Precise, and the number `EXPLAIN`
+  would agree with.
+- **The model call** -- what the application asked for. `Proposal.findById`,
+  `Track.where(...)`, `User.paginate()`.
+
+henri reports the **model call**, for three reasons.
+
+First, it is the only level at which henri can give _advice_, which is the
+whole value. A driver instrumentation can already tell you that forty
+statements ran, and `@opentelemetry/instrumentation-pg` does it better than
+henri would. Only henri knows that those forty statements were forty
+`Proposal.findById` calls in one request and that one
+`Proposal.find({ id: [...] })` replaces them.
+
+Second, the statement count is not a number you can act on. `paginate()` is
+two statements and one decision; on MySQL an insert is two statements and one
+decision, because the dialect has no `RETURNING`. A threshold counting
+statements would report those as repetition, and would make your database
+dialect visible in a warning about your own code.
+
+Third, and this is the measurement that settled it: **the classic Rails N+1
+does not exist on the Drizzle adapter.** `include()` compiles to a single
+correlated json subquery, not to a lazy association a loop can trip over. A
+detector written to `bullet`'s mental model would walk a Drizzle application,
+find no lazy association anywhere, and report success. What is left -- and
+what is worth detecting on all three adapters -- is a loop issuing separate
+`find`/`findById` calls for records it could have loaded together.
+
+:::note[Say it once, plainly]
+**The threshold counts model calls, never statements.** A person reading "40
+queries" assumes the second one. `henri.queries` is a log of what your
+application asked for, not of what your database did.
+:::
+
+## What an event carries
+
+```js
+{
+  at: 1731000000000,        // when it finished, epoch ms
+  store: 'default',
+  adapter: 'drizzle',       // drizzle, mongoose, sequelize
+  dialect: 'postgres',      // null on MongoDB
+  model: 'Track',           // null for a raw adapter.query()
+  operation: 'select',      // count delete insert other raw select update
+  method: 'findById',       // the adapter's own word for it
+  keys: ['id'],             // the filter's column NAMES
+  shape: 'a1b2c3d4e5f6',    // what "the same call" means
+  duration: 1.83,           // milliseconds
+  rows: 1,                  // or null when it cannot be told
+  requestId: '9f2c...',     // null outside a request
+  source: 'application',    // or 'henri', for the framework's own calls
+  callsite: { file: 'app/controllers/ProposalsController.js', line: 41, column: 12 }
+}
+```
+
+`operation` is one closed vocabulary across the three adapters, so `select`
+means the same thing on MongoDB and on PostgreSQL. `method` is the adapter's
+own word, because that is the word you will search your own code for.
+
+## What it deliberately does not carry
+
+**No SQL.** At the model call there is none to carry -- the statement is
+compiled after henri has already emitted -- and that is the happy half of the
+decision. The unhappy half is why it would have been refused anyway:
+**Sequelize's query generator interpolates values into the text it runs.**
+`Model.findAll({ where: { name: 'ada' } })` reaches the driver as
+`SELECT ... WHERE "name" = 'ada'`, with the value inside the string, on the
+ordinary path. Drizzle parameterizes and Mongoose has no statement at all, so
+a `sql` field would have been safe on two adapters and a copy of your rows on
+the third -- which is worse than no field, because it is the leak nobody
+would think to look for.
+
+**No values, anywhere.** `keys` is column **names**, which is the rule
+[the access trail](/guides/trail/) already established: a field name is
+schema, in your model file and in your documentation; a field _value_ is
+personal data. Every adapter hands its filter to henri and the values are
+dropped before an event exists.
+
+Also absent, on every adapter: the bound parameters, the rows that came back,
+the attributes written, the person, the url, the path, the headers, the
+session.
+
+**One frame of stack, and that is code rather than data.** `callsite` is the
+first frame belonging to your own files -- not `node_modules`, not henri, not
+node internals. `bullet`'s value was never that it counted queries; it is
+that it names the line.
+
+## The join is the request id
+
+An event carries `requestId` from the same `AsyncLocalStorage` that
+[the call log](/guides/calls/) keys its rows by, that every `pen` line
+carries, and that a [span](/guides/telemetry/) carries as
+`henri.request_id`. One identifier: "what did request `X` do" is one filter
+in four places.
+
+It carries **no trace id**, and telemetry deliberately does **not** consume
+this seam. Statements stay the driver's own instrumentation to trace -- henri
+re-implementing that would double-count for any application that installed
+`@opentelemetry/instrumentation-pg`, and henri would be the worse of the two.
+`adapter.query()` is the one call site where both happen: it gets a span from
+telemetry and an event from here, and no model call ever becomes a span.
+
+Outside a request -- a job, `henri console`, the boot -- events are still
+emitted and `requestId` is `null`. Nothing is _counted_ there, because "the
+same request" is the whole predicate and there is no honest substitute.
+
+## The detector
+
+"The same query" cannot be a string comparison, because the values differ:
+forty lookups of forty different ids are the N+1, and forty _identical_
+lookups would be a caching bug instead. So the detector groups by `shape`, a
+digest of (adapter, model, operation, the filter's key names). Forty
+`Track.findById` are one shape with a count of forty; a page's own `find` and
+its `count` are two shapes with a count of one each and are never reported.
+
+A shape is counted **within one request** and nowhere else, on a bucket that
+is born and collected with the request, so a background job's queries are
+never pooled with a page's.
+
+### Where a finding goes
+
+Three destinations, each opting out on its own:
+
+| Setting         | Default | What it does                                                                                                              |
+| --------------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `detect.log`    | `true`  | One `pen.warn` per request, at the end, naming the call, the count, the line and what to do instead.                      |
+| `detect.header` | `true`  | `X-Henri-Queries: 47; n+1 Track.findById x24` on the answer, **development only**. Counts and names, never a value.       |
+| `detect.raise`  | `false` | Throws `HENRI_QUERIES_N_PLUS_ONE` the moment the threshold is crossed, so the stack names the call that went one too far. |
+
+The log is at the _end_ of the request because that is when the count is
+final: a warning at the moment the threshold was crossed would say "5 times"
+about something that ran forty. `raise` is the opposite on purpose -- the
+point of raising is the stack.
+
+`raise` is what turns this into a CI gate, the way `Bullet.raise = true` does
+in a Rails suite:
+
+```json
+// config/test.json
+{ "queries": { "detect": { "raise": true } } }
+```
+
+`henri audit` reports it in a production configuration
+(`queries.raise-in-production`): failing a test suite on an N+1 is the point,
+failing a real visitor's request is not.
+
+**The reporter is deliberately not one of them.**
+[`henri.reporter`](/guides/logs/) is the seam for failures henri caught, and
+an N+1 is not a failure -- it is an answer that was slower than it needed to
+be. Sending one there would put a performance note in the same stream as your
+500s, and an application that wired Sentry to page someone would be paged for
+a slow page.
+
+## Listening yourself
+
+`onQuery()` follows `henri.reporter.onError()`: one handler, replaced by
+another call, removed with `null`.
+
+```js
+// app/modules/queries.js
+const Module = require('@usehenri/core/module');
+
+module.exports = class QueryLog extends Module {
+  constructor() {
+    super();
+    this.name = 'queryLog';
+    this.needs = ['queries'];
+    this.runlevel = 6;
+  }
+
+  init() {
+    this.henri.queries.onQuery((event) => {
+      if (event.duration > 100) {
+        this.henri.pen.warn(
+          'slow',
+          `${event.model}.${event.method}`,
+          `${event.duration.toFixed(1)}ms`,
+          event.requestId
+        );
+      }
+    });
+
+    return this.name;
+  }
+};
+```
+
+It is called synchronously, inside the call it describes, so a handler that
+blocks blocks a query. A handler that throws is logged once and removed: this
+is a development instrument and it does not get to break the application it
+is measuring.
+
+## Configuration
+
+Everything is in [`config.queries`](/configuration/#the-queries-object). The
+short version: absent means on outside production, `false` means off
+everywhere, and `{ "enabled": true }` is the production opt-in.
+
+```json
+{
+  "queries": {
+    "detect": {
+      "threshold": 5,
+      "ignore": ["Setting", "User.select"]
+    }
+  }
+}
+```
+
+## What it costs
+
+Off means **nothing is installed**, the way
+[the call log](/guides/calls/) and [telemetry](/guides/telemetry/) mean it:
+no hook registered on any adapter, no middleware in the express stack, no
+object allocated per query. There is no flag tested on the hot path because
+there is no hot path to test it on.
+
+Measured on the Drizzle adapter over an in-memory sqlite, 20 000
+`Task.findAll()` calls, best of five passes each in its own process -- which
+is the harshest possible framing, because a call that costs 26µs makes the
+overhead look as large as it can:
+
+| Configuration                             | Per call | Overhead       |
+| ----------------------------------------- | -------- | -------------- |
+| `"queries": false`                        | 25.9 µs  | (baseline)     |
+| on, `detect: false`, `callsites: false`   | 29.0 µs  | +3.1 µs (+12%) |
+| on, detector, `callsites: false`          | 28.6 µs  | +2.7 µs (+11%) |
+| on, detector and call sites (the default) | 35.1 µs  | +9.2 µs (+36%) |
+
+The call site is two thirds of it: capturing one costs an `Error` allocation
+per model call. (V8 only _formats_ a stack when `.stack` is read, which henri
+defers until a shape is actually reported, so the formatting is not in these
+numbers.) Set `"callsites": false` to keep the detector and drop that cost.
+
+Read the percentages with the baseline in mind. Against a real database a
+model call is half a millisecond to five milliseconds, so the same +9 µs is
+0.2% to 2%. It is still off in production by default, because production
+traffic should not pay anything to tell a developer something the developer
+is not there to read.
+
+## What this does not do
+
+- **It is not tracing.** No spans, no propagation header, no exporter. The
+  join is the request id and nothing more. For traces, see
+  [Telemetry](/guides/telemetry/) and add your ORM's own instrumentation
+  package for statements.
+- **It does not count statements**, for the reasons at the top.
+- **It detects repetition inside one request**, never across requests. A page
+  that runs one extra query every time is not an N+1 and henri will not
+  pretend it is.
+- **It does not fix anything.** It names the call and the line and says what
+  replaces it.
+- **On Mongoose, an operation that fans out reports twice.** `pre` and `post`
+  are two callbacks with no scope between them, so `Book.find().populate('author')`
+  is one model call and reports a `find` for the books and a `find` for the
+  authors. The alternative was wrapping the statics, which would have turned
+  every chainable `find().sort()` into a promise. A `populate` in a loop
+  therefore shows up as two findings for one problem, with the same advice on
+  both.
+- **There is no history.** Findings go to the log, the header or an
+  exception; henri stores none of them. If you want them kept, `onQuery()` is
+  four lines away from your own table.

--- a/website/src/content/docs/guides/security.md
+++ b/website/src/content/docs/guides/security.md
@@ -378,6 +378,16 @@ false` (`calls.kept-forever`: a [call log](/guides/calls/) holds the bodies
 users sent, so a copy of them that nothing ever sweeps is not a setting but
 an accumulation).
 
+**A development instrument left on where it answers a visitor** --
+`queries.detect.raise: true` in a configuration a production boot reads
+(`queries.raise-in-production`). Raising on the fifth repeat of a model call
+is what makes a test suite fail on an N+1, which is what it is for; in
+production the first page that loops answers `500` to a real visitor, and a
+slow page has become a broken one. Counting in production is not reported:
+`queries.enabled: true` costs time and tells nobody's secrets, so it is a
+decision an application is allowed to make quietly. See
+[N+1 detection](/guides/queries/).
+
 **A client address the configuration cannot support** — a
 [`calls.address.from`](/guides/calls/#the-clients-address) covering every
 address (`calls.address-from-any`), which says "believe this header from

--- a/website/src/content/docs/reference/errors.md
+++ b/website/src/content/docs/reference/errors.md
@@ -1512,6 +1512,32 @@ Usually:
 
 **Fix.** Name the person by email address, by external id or by primary key. An erased person no longer answers to their address: look their receipt up by digest instead.
 
+## queries
+
+The query seam of `henri.queries`: what the adapters report running, and the repeated model calls the detector counts.
+
+### `HENRI_QUERIES_INVALID_DETECT`
+
+The N+1 detector was configured with something it cannot use.
+
+Usually:
+
+- config.queries.detect.threshold is not a whole number of at least two
+- config.queries.detect.ignore holds something that is not a model or a Model.operation name
+
+**Fix.** A threshold is a whole number of at least two, because a call that ran once is not a repetition. An `ignore` entry is `Model`, `Model.operation` or `*.operation`, where the operation is one of count, delete, insert, other, raw, select, update.
+
+### `HENRI_QUERIES_N_PLUS_ONE`
+
+The same model call ran enough times in one request for the detector to call it an N+1.
+
+Usually:
+
+- a loop made one model call per record where one call for the whole set would do
+- a view or a serializer read an association the query that fetched the parents did not include
+
+**Fix.** Load the records together: one `Model.find({ id: [...] })` for the whole set, or `include()` on the query that fetched the parents. `config.queries.detect.raise` is what turned this into an error rather than a warning; `config.queries.detect.threshold` is how many repeats it takes, and `detect.ignore` silences a model or an operation.
+
 ## retention
 
 How long the models say they keep their records, and the sweep that enforces it.


### PR DESCRIPTION
`bullet` is the most-installed Rails development tool after the linters, and henri had `include()`, a cost test in the showcase, and nothing that *tells* you. The sharper half of that finding: **no adapter emitted an event when it ran a query**, so nobody outside henri could have written this even if they wanted to.

`henri.queries` is the seam; the detector sits on it.

## The level is the design, and it moved

The brief and the first draft both assumed the statement. Two facts moved it to the **model call**:

- **Sequelize's query generator interpolates values into the SQL it runs** — probed rather than read: `findAll({ where: { name: 'ada' } })` produces `WHERE "name" = 'ada'`. An event carrying SQL would be safe on two adapters and a copy of the row on the third.
- **`include()` on Drizzle compiles to one correlated json subquery.** The Rails lazy-association N+1 *does not exist there*, so a detector written to `bullet`'s model would report success on a Drizzle application — the worst possible outcome for a tool people trust.

So the threshold **counts model calls, never statements**, and that sentence is in the header, the guide, `CLAUDE.md` and the changeset rather than left for someone to infer from a number.

## What an event carries, and what I checked

`{ at, store, adapter, dialect, model, operation, method, keys, shape, duration, rows, requestId, source, callsite }`. `operation` is one closed vocabulary across three adapters, `keys` is column **names** (the trail's rule), `shape` is a digest, and `callsite` is the first application stack frame — code, not data.

Verified on the demo application: a query whose value is a distinctive string produces an event where **that string appears nowhere**, and `shape` is a hex digest rather than a rendered condition.

No SQL, no values, no parameters, no rows, no person, no url, no headers, no trace id.

## The join, and the line against telemetry

One identifier: the request id off the existing `AsyncLocalStorage`, the same one the call log keys its rows by and a span carries as `henri.request_id`.

**This contradicted a decision that merged hours earlier** and the contradiction is resolved rather than ignored. `3.model.js` wraps `adapter.query()` for telemetry and its header said model calls belong to the ORM's own instrumentation package. That still holds *for tracing*: statements stay the driver's to trace, `adapter.query()` keeps its span, and no model call becomes a span. What is henri's is the **count**, because the advice is henri's — a driver instrumentation can say forty statements ran; only henri can say `Memo.findByKey` ran forty times and one `find({ id: { in: [...] } })` is the fix. `base/telemetry.js`'s "honest gap" paragraph now says where the line sits.

## Per adapter

Drizzle and Sequelize wrap the statics and `Relation.prototype` once per process. **Mongoose uses schema middleware instead**, and the reason is a good catch: `Model.find()` returns a lazy thenable `Query`, so wrapping it would have executed the query early and broken every `find().sort()` — a test asserts chainability. The cost is that a `populate` reports one event per operation rather than per model call, which is documented.

## Where a finding goes

The log at the end of a request, an `X-Henri-Queries` header in development, and `detect.raise` which throws **at the crossing**, so the stack names the call that went one too far — that is the CI gate. Not the reporter: an N+1 is a slow answer, not a failure.

**A limit I confirmed by watching it not fire**: repetition is counted *within one request only*. A loop of twelve `findByKey` calls in a script with `raise: true` and a threshold of five raises nothing, by design — nothing is detected in a job, in the console or across requests. The in-request path is covered end to end (`X-Henri-Queries: n+1 Track.findByKey x2`). Worth knowing before anyone reaches for this as a general profiler.

## Cost

Drizzle/sqlite, 20k calls, best of five, each configuration in its own process — the harshest framing, since the call itself is only 26 µs:

| | per call | overhead |
| --- | --- | --- |
| off | 25.9 µs | nothing installed |
| on, no detector or call sites | 29.0 µs | +3.1 µs |
| on, detector, no call sites | 28.6 µs | +2.7 µs |
| on, default | 35.1 µs | +9.2 µs |

Two thirds of the default figure is the `Error` allocation for the call site. Against a real database that is 0.2–2%, and the seam is off in production.

## The showcase's cost test

It became both counters, labelled: `recording()` counts model calls and asserts no shape repeats — the assertion that file always wanted — and one statement counter stays for the single assertion whose subject *is* the SQL (six speaker keys becoming one `IN` inside one call), which no count of model calls can see.

`pnpm test` (172 files), `pnpm test:types`, `pnpm lint --max-warnings 0`, `pnpm format:check`, `scripts/smoke.sh` and the showcase suite pass.
