### PR TITLE
feat(core): declare what a controller answers, and strip what it must not

### DIFF
--- a/.changeset/declared-answers.md
+++ b/.changeset/declared-answers.md
@@ -1,0 +1,37 @@
+---
+'@usehenri/core': minor
+'@usehenri/cli': minor
+---
+
+A declared shape for what leaves, the way `params` declares what arrives.
+
+`res.render()`, `res.resource()` and `res.collection()` have always gone through one gate on the way out: a foreign key leaves as the `externalId` of the row it names, and a field a model marked `personal: { expose: false }` is dropped. `res.json()` went through nothing, and that was not a corner: an Inertia page whose props are assembled in the controller, a JSON route answering a total next to a list, any object built by hand — none of them is a record, so nothing published its foreign keys and nothing stripped what the model said must never leave.
+
+```js
+// what the models said never leaves, leaving
+res.json({ rows: [{ email: user.email, gender: user.gender }] });
+```
+
+**The floor.** Every JSON answer of every controller action now goes through the same publish and the same strip, in the same order, whether or not the action declared anything. There is no setting that turns it off: the mark is the model's word about a person, and a controller is not where it is overruled. henri's own answers — the HAL envelope, the page options, `res.boom.*`, the 404 and 500 pages, an Inertia page object — are left exactly as they were, because they went through the gate already or are an envelope of their own.
+
+**The declaration.** Opt-in per action, in the block `before` and `params` already established, with the same selectors and the same vocabulary:
+
+```js
+module.exports = {
+  answers: {
+    all: { total: 'integer' },
+    index: {
+      rows: { model: 'Memo', type: 'array' },
+      who: { from: 'User.email', type: 'string' },
+    },
+  },
+};
+```
+
+`model` names the model whose records a field holds, and it is the only way an object that never was a record can have its foreign keys published — henri reads no field name, so a hand-built `{ ownerId }` was an opaque string until the controller said what it was. `from` is `'User.email'`, the column a value came from: the field then obeys that column's marks under whatever name the answer gives it, which is the one leak a strip matching by name cannot see, and a `from` pointing at a column marked `expose: false` fails the boot unless the rule says `expose: true` — the declared form of the `include` that `res.resource()` takes.
+
+**What is not declared does not leave.** That is `req.permit()`'s rule pointed the other way: the declaration is the list, an undeclared key is dropped and never refused. It costs an existing application nothing, because an action that declares nothing keeps every byte it sends. The other half goes the other way: a field that was declared and is missing, or holds another type, is a mistake in the declaration rather than something leaking, so it is reported once per route and only refused with `config.api.strict` — the setting that already meant that for the HAL links — as a 500 carrying `HENRI_ANSWERS_MISMATCH`. A rule henri cannot carry out fails the boot with `HENRI_ANSWERS_DECLARATION_INVALID`, naming the controller, the action and the field.
+
+`res.json()` stays synchronous whenever it can, which is nearly always: the walk is free, and only a foreign key nobody eager loaded costs a lookup.
+
+`henri openapi` reads it. An operation whose body a controller writes carried the statuses henri produces, `x-henri.known: false` and no success status at all; one that declares its answer now carries a `200` built from the declaration — a `$ref` to the model's record schema for a field naming a model, the column's own schema for a field naming one, and `additionalProperties: false`, because the document says what the gate does.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -917,12 +917,12 @@ disposition, filename, type })` is one call whatever the backend -- the
 - Controllers may export `before` (`base/hooks.js`): hooks the router runs
   between the role guard and the action, keyed by action (`all`,
   `'show,edit'`) or as `[fn, { run, only, except }]`; a hook that answers ends
-  the request, and `before` is one of the two exports that are never an
+  the request, and `before` is one of the three exports that are never an
   action. The same module wraps every action so that returning without
   answering renders `/<controller>/<action>` (`/<controller>` for `index`)
   with what it returned. `req.flash()` (`base/flash.js`) keeps one-shot messages in the
   express session and the views read them once through `flash`.
-- The other one is `params` (`base/params-schema.js`): what each action
+- The second one is `params` (`base/params-schema.js`): what each action
   accepts, in the same shape (`all`, `'index,search'`), one rule per field in
   the henri schema vocabulary (`type`, `required`, `default`, `enum`) plus the
   bounds a request needs (`min`/`max`, `minLength`/`maxLength`, `pattern`,
@@ -940,8 +940,46 @@ disposition, filename, type })` is one call whatever the backend -- the
   answers 422 with `{ field: message }` and `HENRI_PARAMS_INVALID`, negotiated
   like everything else (a browser that posted a form goes back to it with the
   messages in the flash). An action with no declaration is untouched.
-- The third boundary is every entry point an application calls
-  (`base/arguments.js`), after the configuration and the request: the
+- The third is `answers` (`base/answers.js`), the same idea pointing out:
+  what each action **answers**, in the same block shape and the same
+  vocabulary. It exists because the two directions were not equally
+  guarded -- `res.render()`, `res.resource()` and `res.collection()` all
+  went through `toPublic()` (publish the foreign keys, then strip what the
+  models marked `personal: { expose: false }`) and `res.json()` went
+  through nothing, so a hand-built object -- an Inertia page's props
+  assembled in the controller, a total next to a list -- carried both out.
+  Two things, and the difference matters: **the floor** is that publish and
+  that strip on **every JSON answer of every controller action**, declared
+  or not, with no setting that turns it off, and **the declaration** is
+  opt-in per action. A rule is `{ type, model, from, of, required, expose }`
+  or the type itself: `model` names the model whose records a field holds,
+  which is the only way an object that never was a record can have its
+  foreign keys published; `from` is `'User.gender'`, the column a value came
+  from, which binds it to that column's marks under whatever name the answer
+  gives it (the one leak a name-based strip cannot see) and fails the boot
+  when that column says `expose: false` without `expose: true` next to it;
+  and `expose: true` is the declared form of the `include` that
+  `res.resource()` takes. **What is not declared does not leave** --
+  `req.permit()`'s rule in the other direction, and the safe half -- while a
+  declared field that is missing or of another type is a mistake in the
+  declaration rather than a leak, so it is reported once per route and only
+  refused (500, `HENRI_ANSWERS_MISMATCH`) with `config.api.strict`, the knob
+  that already means that for the HAL links. `2.controllers.js` compiles the
+  block (`HENRI_ANSWERS_DECLARATION_INVALID`) and `5.router.js` checks it
+  against the models at registration, because a controller loads at runlevel
+  2 and the models at 3. The gate wraps `res.json()` per route, so henri's
+  own endpoints never see it, and it stays **synchronous** unless a foreign
+  key nobody eager loaded needs a lookup (`references.prepare()`/`settle()`
+  is that split); what henri built itself -- `res.resource`, `res.render`'s
+  JSON, `res.boom`, the 404 and 500 pages, an Inertia page object -- is
+  marked with `headers.seal()` and passes through untouched. `henri openapi`
+  reads it: an operation whose body a controller writes carried
+  `x-henri.known: false` and no success status, and one that declares its
+  answer now carries the schema. The guide is
+  `guides/controllers.md` (`#answers-what-an-action-answers`).
+- The fourth boundary is every entry point an application calls
+  (`base/arguments.js`), after the configuration, the request and the
+  answer: the
   signature of roughly fifty of them, as data, in the same node vocabulary
   `config-schema.js` uses -- `config-validate.js` exports `problems()` so
   there is one walker and no second schema language, and it

--- a/packages/cli/__tests__/openapi.spec.js
+++ b/packages/cli/__tests__/openapi.spec.js
@@ -149,6 +149,82 @@ describe('henri openapi', () => {
     });
   });
 
+  describe('what a controller declared it answers', () => {
+    const controller = () => path.join(app, 'app', 'controllers', 'main.js');
+    let original;
+
+    beforeEach(() => {
+      original = fs.readFileSync(controller(), 'utf8');
+    });
+
+    afterEach(() => {
+      fs.writeFileSync(controller(), original);
+    });
+
+    /**
+     * Adds an `answers` export to the scaffolded controller
+     *
+     * @param {string} block The block, as source
+     * @returns {object} The document `henri openapi` writes for it
+     */
+    const withAnswers = (block) => {
+      fs.writeFileSync(
+        controller(),
+        original.replace('module.exports = {', `module.exports = {\n${block}\n`)
+      );
+
+      return JSON.parse(henri(['openapi'], { cwd: app }).stdout);
+    };
+
+    test('gives an operation henri could not describe a success status', async () => {
+      const document = withAnswers(
+        `  answers: {
+    home: { tasks: { model: 'Task', type: 'array' }, total: { type: 'integer', required: true } },
+  },`
+      );
+      const home = document.paths['/'].get;
+
+      expect(home['x-henri'].answers).toEqual(['tasks', 'total']);
+      expect(home['x-henri'].known).toBe(true);
+      expect(home['x-henri'].enforced).toContain('answers');
+      expect(home.responses['200'].content['application/json'].schema).toEqual({
+        additionalProperties: false,
+        properties: {
+          tasks: {
+            items: { $ref: '#/components/schemas/Task' },
+            type: 'array',
+          },
+          total: { type: 'integer' },
+        },
+        required: ['total'],
+        type: 'object',
+      });
+      expect(home.description).toContain('declared');
+      expect(await validate(document)).toEqual({ valid: true });
+    });
+
+    test('a declaration that would fail the boot describes nothing', () => {
+      const document = withAnswers(
+        "  answers: { home: { tasks: { model: 'Ghost', type: 'lasagna' } } },"
+      );
+      const home = document.paths['/'].get;
+
+      expect(home['x-henri'].answers).toBeUndefined();
+      expect(home['x-henri'].known).toBe(false);
+      expect(home.responses['200']).toBeUndefined();
+      expect(home.responses.default.description).toContain('Not described');
+    });
+
+    test('a scaffolded application declares none, and nothing is invented', () => {
+      const document = JSON.parse(henri(['openapi'], { cwd: app }).stdout);
+      const home = document.paths['/'].get;
+
+      expect(home['x-henri'].answers).toBeUndefined();
+      expect(home.responses['200']).toBeUndefined();
+      expect(home.responses.default.description).toContain('Not described');
+    });
+  });
+
   test('writes the document with --out and reports what it covers', () => {
     const { status, stdout } = henri(['openapi', '--out', 'openapi.json'], {
       cwd: app,

--- a/packages/cli/scripts/openapi.js
+++ b/packages/cli/scripts/openapi.js
@@ -164,7 +164,10 @@ const controllersOf = (cwd) => {
     for (const action of names) {
       actions[`${name}#${action}`] = true;
       accepts[`${name}#${action}`] = rules ? rules[action] || {} : null;
-      answers[`${name}#${action}`] = answered ? answered[action] || {} : {};
+      // `null`, not `{}`: a file that would not load outside a booted
+      // application declares nothing henri could read, which is not the
+      // same fact as an action that declares nothing
+      answers[`${name}#${action}`] = answered ? answered[action] || {} : null;
     }
   }
 

--- a/packages/cli/scripts/openapi.js
+++ b/packages/cli/scripts/openapi.js
@@ -105,25 +105,33 @@ const scanActions = (source) => {
  * than describing an action as accepting nothing.
  *
  * @param {string} cwd The application directory
- * @returns {{accepts: ?object, actions: ?object}} `{ 'tasks#index': ... }`
+ * @returns {{accepts: ?object, actions: ?object, answers: ?object}} the
+ *   declarations, by `controller#action`
  */
 const controllersOf = (cwd) => {
   const dir = path.join(cwd, 'app', 'controllers');
 
   if (!fs.existsSync(dir)) {
-    return { accepts: null, actions: null };
+    return { accepts: null, actions: null, answers: null };
   }
 
   const params = fromCore('src/base/params-schema', cwd);
   const hooks = fromCore('src/base/hooks', cwd);
-  const reserved = new Set([...hooks.RESERVED, ...params.RESERVED]);
+  const declared = fromCore('src/base/answers', cwd);
+  const reserved = new Set([
+    ...hooks.RESERVED,
+    ...params.RESERVED,
+    ...declared.RESERVED,
+  ]);
   const accepts = {};
+  const answers = {};
   const actions = {};
 
   for (const name of listing(dir)) {
     const file = path.join(dir, `${name}.js`);
     let names;
     let rules = null;
+    let answered = null;
 
     try {
       delete require.cache[require.resolve(file)];
@@ -141,6 +149,12 @@ const controllersOf = (cwd) => {
         // is one more thing this command could not read
         rules = null;
       }
+
+      try {
+        answered = declared.declarations(loaded, name, names);
+      } catch {
+        answered = null;
+      }
     } catch {
       // A controller that cannot be loaded outside a booted application:
       // read the actions off the source instead of pretending there are none
@@ -150,10 +164,11 @@ const controllersOf = (cwd) => {
     for (const action of names) {
       actions[`${name}#${action}`] = true;
       accepts[`${name}#${action}`] = rules ? rules[action] || {} : null;
+      answers[`${name}#${action}`] = answered ? answered[action] || {} : {};
     }
   }
 
-  return { accepts, actions };
+  return { accepts, actions, answers };
 };
 
 /**
@@ -195,11 +210,12 @@ const identity = (cwd) => {
 const describe = (cwd = process.cwd()) => {
   const { build } = fromCore('src/base/openapi', cwd);
   const { loadModules } = fromCore('src/utils', cwd);
-  const { accepts, actions } = controllersOf(cwd);
+  const { accepts, actions, answers } = controllersOf(cwd);
 
   return build({
     accepts,
     actions,
+    answers,
     config: readConfig(cwd, undefined),
     info: identity(cwd),
     models: Object.values(loadModules(path.join(cwd, 'app', 'models'))),

--- a/packages/core/error-codes.json
+++ b/packages/core/error-codes.json
@@ -6,6 +6,10 @@
       "what": "the MCP server of `henri mcp` and the running application it reads"
     },
     {
+      "area": "answers",
+      "what": "what a controller declared its actions answer (`answers`), and the gate every JSON answer leaves through"
+    },
+    {
       "area": "api",
       "what": "the JSON API layer: HAL answers, the health endpoints, the OpenAPI description of what an application exposes and the optional GraphQL engine"
     },
@@ -197,6 +201,32 @@
       "code": "HENRI_AGENT_UNREACHABLE",
       "fix": "Check that the development server is still running, and read its output: a boot that failed halfway leaves the port closed.",
       "what": "The running application did not answer."
+    },
+    {
+      "area": "answers",
+      "causes": [
+        "a rule with no `type` and no `model`, or a type henri does not have",
+        "a `model` that is not a model of this application, or a `from` that is not `Model.field`",
+        "`model` next to a type that is not `array`, or a list with neither `of` nor `model`",
+        "an unknown key, usually a misspelling of `required` or `expose`",
+        "a `from` naming a column the model marked `personal: { expose: false }`, without `expose: true`",
+        "a selector naming an action the controller does not export"
+      ],
+      "code": "HENRI_ANSWERS_DECLARATION_INVALID",
+      "fix": "The message names the controller, the action and the field. A rule is `{ type, model, from, of, required, expose }`, or the type itself (`total: 'integer'`); `model` names one of this application's models and `from` is `Model.field`. See the Controllers guide.",
+      "what": "A controller declares an answer henri cannot carry out."
+    },
+    {
+      "area": "answers",
+      "causes": [
+        "a field the action declared `required` is not in what it sent",
+        "a declared field holds something other than the type it declared",
+        "the action sent fields it never declared, which were dropped",
+        "the action declared fields and answered with a list or a scalar"
+      ],
+      "code": "HENRI_ANSWERS_MISMATCH",
+      "fix": "The answer is reported once per route (`pen.warn`) and only refused like this with `config.api.strict`. Either send what the action declared, or change the `answers` block to describe what it sends.",
+      "what": "An action answered something other than what it declared, and `config.api.strict` refused it."
     },
     {
       "area": "api",
@@ -991,8 +1021,8 @@
       "area": "job",
       "causes": ["a job whose `perform()` never returned in time"],
       "code": "HENRI_JOB_TIMEOUT",
-      "fix": "Raise the job\u2019s `timeout`, or split the work: the attempt is failed and retried like any other failure.",
-      "what": "An attempt ran past the job\u2019s timeout."
+      "fix": "Raise the job’s `timeout`, or split the work: the attempt is failed and retried like any other failure.",
+      "what": "An attempt ran past the job’s timeout."
     },
     {
       "area": "job",
@@ -1915,7 +1945,7 @@
         "a receiver answering 410 Gone, which also disables the endpoint"
       ],
       "code": "HENRI_WEBHOOK_DELIVERY_FAILED",
-      "fix": "The delivery is a job: it is retried with the queue\u2019s backoff and lands in the dead letter queue when it runs out of attempts. `henri jobs:dead --queue webhooks` shows them, `henri jobs:retry <id>` sends one again.",
+      "fix": "The delivery is a job: it is retried with the queue’s backoff and lands in the dead letter queue when it runs out of attempts. `henri jobs:dead --queue webhooks` shows them, `henri jobs:retry <id>` sends one again.",
       "what": "A receiver refused a delivery."
     },
     {

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -1940,21 +1940,66 @@ declare namespace start {
    */
   type ParamsBlock = Record<string, Record<string, ParamRule | ParamType>>;
 
+  /** The types an answer rule may declare: the model types, plus lists and
+   * a record of a model. */
+  type AnswerType = ParamType | 'record';
+
+  /**
+   * One field an action answers. Every JSON answer of a controller is
+   * published and stripped whether or not it was declared; what a
+   * declaration adds is the shape, the model of a hand-built object and the
+   * column a value came from.
+   */
+  interface AnswerRule {
+    /** The shape. Implied by `model` (a record) and by `from` (`json`). */
+    type?: AnswerType;
+    /**
+     * The model whose records this field holds: one record on its own, a
+     * list of them with `type: 'array'`. It is what lets an object that
+     * never was a record have its foreign keys published.
+     */
+    model?: string;
+    /**
+     * `'User.gender'`: the column this value came from. It makes the field
+     * obey that column's marks under whatever name the answer gives it, and
+     * `henri openapi` types the field from it.
+     */
+    from?: string;
+    /** The rule every item of a list of scalars follows. */
+    of?: AnswerRule | AnswerType;
+    /** The field has to be in the answer. */
+    required?: boolean;
+    /**
+     * This action may carry a field marked `personal: { expose: false }`:
+     * the declared form of the `include` `res.resource()` takes.
+     */
+    expose?: boolean;
+  }
+
+  /**
+   * The `answers` block: what each action answers, keyed by action the way
+   * `params` is. A rule may be the type itself (`total: 'integer'`).
+   */
+  type AnswersBlock = Record<string, Record<string, AnswerRule | AnswerType>>;
+
   /**
    * A controller file. Every exported function is an action (`tasks#index`);
-   * `before` and `params` are the reserved keys.
+   * `before`, `params` and `answers` are the reserved keys.
    *
    *     /** @type {import('@usehenri/core').Controller} *\/
    *     module.exports = {
    *       before: { 'show,edit': loadTask },
    *       params: { create: { title: { type: 'string', required: true } } },
+   *       answers: { index: { tasks: { model: 'Task', type: 'array' } } },
    *       index: async (req, res) => ({ tasks: await Task.find() }),
    *     };
    */
   interface Controller {
     before?: BeforeBlock;
     params?: ParamsBlock;
-    [action: string]: Action | BeforeBlock | ParamsBlock | undefined;
+    answers?: AnswersBlock;
+    [action: string]:
+      Action | BeforeBlock | ParamsBlock | AnswersBlock | undefined;
   }
 
   // ---------------------------------------------------------------------------
@@ -2583,6 +2628,8 @@ declare namespace start {
     hooks(key: string): Array<(...args: any[]) => unknown>;
     /** What an action declared it accepts, compiled; null when nothing is. */
     accepts(key: string): Record<string, ParamRule> | null;
+    /** What an action declared it answers, compiled; null when nothing is. */
+    answers(key: string): Record<string, AnswerRule> | null;
     /** The parameter check of an action, as middlewares (none, or one). */
     checks(key: string): Array<(...args: any[]) => unknown>;
     all(): Record<string, unknown>;

--- a/packages/core/src/2.controllers.js
+++ b/packages/core/src/2.controllers.js
@@ -7,9 +7,13 @@ const {
   declarations,
   guard,
 } = require('./base/params-schema');
+const {
+  RESERVED: ANSWER_KEYS,
+  declarations: answered,
+} = require('./base/answers');
 
 /** The exports of a controller that describe it instead of answering */
-const RESERVED = new Set([...HOOK_KEYS, ...PARAM_KEYS]);
+const RESERVED = new Set([...HOOK_KEYS, ...PARAM_KEYS, ...ANSWER_KEYS]);
 
 /**
  * Controllers module
@@ -33,8 +37,11 @@ class Controllers extends BaseModule {
     this._modules = new Map();
     /** The compiled `params` declarations, by `controller#action` */
     this._params = new Map();
+    /** The compiled `answers` declarations, by `controller#action` */
+    this._answers = new Map();
 
     this.accepts = this.accepts.bind(this);
+    this.answers = this.answers.bind(this);
     this.checks = this.checks.bind(this);
     this.configure = this.configure.bind(this);
     this.init = this.init.bind(this);
@@ -63,14 +70,15 @@ class Controllers extends BaseModule {
    * Configure the models and adapters
    *
    * Every exported function becomes an action (`tasks#index`), except the
-   * reserved keys (`before`, `params`), which describe the controller
-   * instead. The `params` declarations are compiled here, so a rule henri
-   * cannot carry out fails the boot naming the controller, the action and
-   * the key rather than accepting everything (see base/params-schema.js).
+   * reserved keys (`before`, `params`, `answers`), which describe the
+   * controller instead. The `params` and `answers` declarations are compiled
+   * here, so a rule henri cannot carry out fails the boot naming the
+   * controller, the action and the key rather than accepting or sending
+   * everything (see base/params-schema.js and base/answers.js).
    *
    * @param {object} controllers Controllers loaded from disk
    * @returns {boolean} success
-   * @throws {Error} when a `params` declaration cannot be carried out
+   * @throws {Error} when a declaration cannot be carried out
    * @memberof Controllers
    */
   async configure(controllers) {
@@ -96,6 +104,12 @@ class Controllers extends BaseModule {
           declarations(controller, id, actions)
         )) {
           this._params.set(`${id}#${action}`, rules);
+        }
+
+        for (const [action, rules] of Object.entries(
+          answered(controller, id, actions)
+        )) {
+          this._answers.set(`${id}#${action}`, rules);
         }
       }
     }
@@ -131,6 +145,7 @@ class Controllers extends BaseModule {
     this._controllers.clear();
     this._modules.clear();
     this._params.clear();
+    this._answers.clear();
     await this.init();
 
     return this.name;
@@ -171,6 +186,20 @@ class Controllers extends BaseModule {
    */
   accepts(key) {
     return this._params.get(key) || null;
+  }
+
+  /**
+   * What an action declared it answers, compiled
+   *
+   * A controller exports it as `answers`: an object keyed by action the way
+   * `params` is, one rule per field. See base/answers.js.
+   *
+   * @param {string} key The controller name (ex: memos#index)
+   * @returns {?object} The rules by field, or null when nothing is declared
+   * @memberof Controllers
+   */
+  answers(key) {
+    return this._answers.get(key) || null;
   }
 
   /**

--- a/packages/core/src/5.router.js
+++ b/packages/core/src/5.router.js
@@ -16,8 +16,9 @@ const {
   resourceLinks,
 } = require('./base/hateoas');
 const { publish } = require('./base/references');
+const { guard: answerGuard, verify: verifyAnswers } = require('./base/answers');
 const { engine: graphqlEngine } = require('./base/graphql');
-const { jsonTypes, noStore, versionGuard } = require('./base/headers');
+const { jsonTypes, noStore, seal, versionGuard } = require('./base/headers');
 const { idempotency } = require('./base/idempotency');
 const { limiter, shutdown } = require('./base/rate-limit');
 const openapi = require('./base/openapi');
@@ -259,6 +260,7 @@ class Router extends BaseModule {
   describe() {
     const { config, controllers, model, policies } = this.henri;
     const accepts = {};
+    const answers = {};
     const actions = {};
     let info = {};
 
@@ -269,6 +271,7 @@ class Router extends BaseModule {
       // process read the controller, so an action declaring nothing is a
       // fact here rather than something henri could not find out
       accepts[route.controller] = controllers.accepts(route.controller) || {};
+      answers[route.controller] = controllers.answers(route.controller) || {};
     }
 
     try {
@@ -288,6 +291,7 @@ class Router extends BaseModule {
     return openapi.build({
       accepts,
       actions,
+      answers,
       config,
       info,
       models: (model && model.models) || [],
@@ -384,6 +388,7 @@ class Router extends BaseModule {
     // the `before` hooks of the controller, then the action wrapped so that
     // returning without answering renders its page (see base/hooks.js)
     const checks = this.checks(controller);
+    const gates = this.gates(controller, name);
     const hooks = this.hooks(controller);
     const handler = implicit(action, controllerName, controllerAction);
 
@@ -439,6 +444,7 @@ class Router extends BaseModule {
       ...before,
       ...guards,
       ...after,
+      ...gates,
       ...checks,
       ...hooks,
       handler
@@ -610,6 +616,50 @@ class Router extends BaseModule {
     }
 
     return found;
+  }
+
+  /**
+   * The exit gate of a controller action, as a middleware.
+   *
+   * There is always one, and that is the point: the floor -- publish, then
+   * strip what the models marked `personal: { expose: false }` -- runs on
+   * every JSON answer a controller sends, whether or not the action declared
+   * anything. What a declaration adds is the shape: the model of a
+   * hand-built object, the fields that may leave and the report when the
+   * answer is not the one that was promised (see base/answers.js).
+   *
+   * The declaration is checked against the models here rather than where it
+   * was compiled, because a controller loads at runlevel 2 and the models at
+   * 3: this runs at 5, and a declaration henri cannot carry out still fails
+   * the boot.
+   *
+   * @param {string} controller the controller (`memos#index`)
+   * @param {string} name the route name (`get /memos`)
+   * @returns {Array<function>} express middlewares (always one)
+   * @memberof Router
+   */
+  gates(controller, name) {
+    const { controllers, model, privacy } = this.henri;
+    const rules =
+      controllers && typeof controllers.answers === 'function'
+        ? controllers.answers(controller)
+        : null;
+
+    if (rules) {
+      const files = (model && model.models) || [];
+
+      verifyAnswers(rules, {
+        mark: (globalId, field) =>
+          privacy ? privacy.fields(globalId)[field] || null : null,
+        model: (globalId) =>
+          files.find((file) => file.globalId === globalId) || null,
+        where: controller,
+      });
+
+      debug('%s declares what it answers', controller);
+    }
+
+    return [answerGuard(this.henri, rules, name)];
   }
 
   /**
@@ -980,6 +1030,9 @@ class Router extends BaseModule {
     }
 
     noStore(req, res);
+    // `data` was published and stripped by viewOptions(): the answer gate
+    // leaves this shape alone (see base/answers.js)
+    seal(res);
 
     return res.json(Object.assign({}, opts, { _links: links }));
   }
@@ -1255,7 +1308,7 @@ class Router extends BaseModule {
             this.henri.view.hbs.instance.render(req, res, route, opts),
           html: () =>
             this.henri.view.hbs.instance.render(req, res, route, opts),
-          json: () => res.json(opts),
+          json: () => seal(res).json(opts),
         });
       };
 

--- a/packages/core/src/__tests__/__snapshots__/controllers.spec.js.snap
+++ b/packages/core/src/__tests__/__snapshots__/controllers.spec.js.snap
@@ -2,11 +2,13 @@
 
 exports[`controllers > should match snapshot 1`] = `
 Controllers {
+  "_answers": Map {},
   "_controllers": Map {},
   "_modules": Map {},
   "_params": Map {},
   "accepts": [Function],
   "after": [],
+  "answers": [Function],
   "before": [],
   "checks": [Function],
   "configure": [Function],

--- a/packages/core/src/__tests__/answers.spec.js
+++ b/packages/core/src/__tests__/answers.spec.js
@@ -1,0 +1,408 @@
+/* global Memo, User */
+const supertest = require('supertest');
+const Henri = require('../henri');
+
+const {
+  columnOf,
+  declarations,
+  gate,
+  includeOf,
+  mismatch,
+  pick,
+  rule,
+  verify,
+} = require('../base/answers');
+const { seal, sealed } = require('../base/headers');
+
+const password = 'difference-engine';
+
+/** A model file the way core hands one to an adapter */
+const model = (globalId) => ({
+  globalId,
+  identity: globalId.toLowerCase(),
+  options: {},
+  schema: {},
+});
+
+describe('the declaration (no application)', () => {
+  test('a rule is an object, or the type itself', () => {
+    expect(
+      declarations({ answers: { index: { total: 'integer' } } }, 'memos', [
+        'index',
+      ])
+    ).toEqual({ index: { total: { type: 'integer' } } });
+
+    expect(rule({ model: 'Memo' }, 'memos#show', 'memo')).toEqual({
+      model: 'Memo',
+      type: 'record',
+    });
+
+    expect(
+      rule({ model: 'Memo', type: 'array' }, 'memos#index', 'rows')
+    ).toEqual({ model: 'Memo', type: 'array' });
+  });
+
+  test('the selectors are the ones `before` and `params` use', () => {
+    const compiled = declarations(
+      {
+        answers: {
+          all: { total: 'integer' },
+          'index,search': { rows: { model: 'Memo', type: 'array' } },
+        },
+      },
+      'memos',
+      ['index', 'search', 'show']
+    );
+
+    expect(Object.keys(compiled).sort()).toEqual(['index', 'search', 'show']);
+    expect(Object.keys(compiled.index).sort()).toEqual(['rows', 'total']);
+    expect(Object.keys(compiled.show)).toEqual(['total']);
+  });
+
+  test('`from` names a column, and says nothing about the shape on its own', () => {
+    expect(columnOf('User.gender')).toEqual({ field: 'gender', model: 'User' });
+    expect(columnOf('User')).toBeNull();
+    expect(columnOf('a.b.c')).toBeNull();
+    expect(rule({ from: 'User.email' }, 'r#profile', 'who')).toEqual({
+      from: { field: 'email', model: 'User' },
+      type: 'json',
+    });
+  });
+
+  test('a rule henri cannot carry out fails, naming where it is', () => {
+    const bad =
+      (answers, actions = ['index']) =>
+      () =>
+        declarations({ answers }, 'memos', actions);
+
+    expect(bad({ index: { rows: {} } })).toThrow(/names no type/u);
+    expect(bad({ index: { rows: 'lasagna' } })).toThrow(
+      /which henri does not have/u
+    );
+    expect(bad({ index: { rows: { type: 'array' } } })).toThrow(
+      /no "of" and no "model"/u
+    );
+    expect(bad({ index: { rows: { model: 'Memo', type: 'string' } } })).toThrow(
+      /a record, or an array of them/u
+    );
+    expect(
+      bad({ index: { rows: { model: 'Memo', of: 'string', type: 'array' } } })
+    ).toThrow(/both "model" and "of"/u);
+    expect(bad({ index: { total: { maxLength: 2, type: 'string' } } })).toThrow(
+      /unknown key "maxLength"/u
+    );
+    expect(
+      bad({ index: { total: { required: 'yes', type: 'integer' } } })
+    ).toThrow(/"required" that is not true or false/u);
+    expect(bad({ index: { memo: { type: 'record' } } })).toThrow(
+      /a record of something/u
+    );
+    expect(bad({ index: { who: { from: 'User', type: 'string' } } })).toThrow(
+      /"from" that is not `Model.field`/u
+    );
+    expect(bad({ nope: { total: 'integer' } })).toThrow(
+      /which is not one of its actions/u
+    );
+    expect(bad({ index: 'everything' })).toThrow(
+      /something other than a list of fields/u
+    );
+    expect(() => declarations({ answers: 'all' }, 'memos', [])).toThrow(
+      /something other than an object/u
+    );
+  });
+
+  test('the second pass refuses a model or a column that is not there', () => {
+    const context = {
+      mark: (name, field) =>
+        name === 'User' && field === 'gender' ? { expose: false } : null,
+      model: (name) =>
+        name === 'Memo' || name === 'User' ? model(name) : null,
+      where: 'reports#index',
+    };
+
+    expect(() =>
+      verify({ rows: { model: 'Ghost', type: 'array' } }, context)
+    ).toThrow(/not a model of this application/u);
+    expect(() =>
+      verify(
+        { who: { from: { field: 'x', model: 'Ghost' }, type: 'string' } },
+        context
+      )
+    ).toThrow(/Ghost is not a model/u);
+    expect(() =>
+      verify(
+        { g: { from: { field: 'gender', model: 'User' }, type: 'string' } },
+        context
+      )
+    ).toThrow(/never leaves the server/u);
+    // ... and lets it through when the controller said so on purpose
+    expect(() =>
+      verify(
+        {
+          g: {
+            expose: true,
+            from: { field: 'gender', model: 'User' },
+            type: 'string',
+          },
+        },
+        context
+      )
+    ).not.toThrow();
+  });
+
+  test('`expose: true` is the declared form of `include`', () => {
+    expect(
+      includeOf({
+        g: { expose: true, from: { field: 'gender', model: 'User' } },
+        total: { type: 'integer' },
+      })
+    ).toEqual(['g', 'gender']);
+  });
+
+  test('what does not match is said in words', () => {
+    expect(mismatch({ type: 'integer' }, 'two')).toMatch(/whole number/u);
+    expect(mismatch({ type: 'integer' }, 2)).toBeNull();
+    expect(
+      mismatch({ of: { type: 'string' }, type: 'array' }, ['a', 2])
+    ).toMatch(/item 2/u);
+    expect(mismatch({ model: 'Memo', type: 'record' }, [])).toMatch(/a list/u);
+    // Absent and null say nothing: `required` is about the key
+    expect(mismatch({ type: 'integer' }, null)).toBeNull();
+  });
+
+  test('what is not declared is dropped, and reported', () => {
+    const chosen = pick(
+      { total: { type: 'integer' } },
+      { secret: 'x', total: 2 }
+    );
+
+    expect(chosen.picked).toEqual({ total: 2 });
+    expect(chosen.problems).toEqual(['secret left the answer undeclared']);
+  });
+
+  test('a declared field that is missing is reported, not invented', () => {
+    const chosen = pick({ total: { required: true, type: 'integer' } }, {});
+
+    expect(chosen.picked).toEqual({});
+    expect(chosen.problems).toEqual(['total is missing']);
+  });
+
+  test('`__proto__` is defined and never assigned', () => {
+    const body = JSON.parse('{"__proto__": {"polluted": true}}');
+    const chosen = pick({ __proto__: { type: 'json' } }, body);
+
+    expect(Object.getPrototypeOf(chosen.picked)).toBe(Object.prototype);
+    expect({}.polluted).toBeUndefined();
+  });
+
+  test('the seal is one answer long', () => {
+    const res = {};
+
+    expect(sealed(res)).toBe(false);
+    seal(res);
+    expect(sealed(res)).toBe(true);
+    expect(sealed(res)).toBe(false);
+  });
+
+  test('the gate strips without an application, and stays synchronous', () => {
+    const henri = { privacy: { strip: (value) => value } };
+    const answered = gate(henri, null, { ok: true });
+
+    expect(answered.settle).toBeNull();
+    expect(answered.answer).toEqual({ ok: true });
+  });
+});
+
+describe('the exit gate (demo app, disk store)', () => {
+  const skipWorkers = process.env.SKIP_WORKERS;
+  let henri;
+  let app;
+  let agent;
+  let user;
+
+  beforeAll(async () => {
+    process.env.SKIP_WORKERS = '1';
+    henri = new Henri();
+    await henri.init();
+    global.henri = henri;
+    app = henri.server.app;
+    agent = supertest.agent(app);
+
+    await agent.post('/register').send({
+      age: 41,
+      email: 'ada@usehenri.io',
+      gender: 'she/her',
+      name: 'Ada',
+      password,
+    });
+
+    user = await henri.user.findByEmail('ada@usehenri.io');
+    user.set({ nationalId: 'AB-123-456', phone: '+1-555-0100' });
+    await user.save();
+    await agent.post('/login').send({ email: 'ada@usehenri.io', password });
+  }, 60000);
+
+  afterAll(async () => {
+    await henri.stop();
+    delete global.henri;
+    if (typeof skipWorkers === 'undefined') {
+      delete process.env.SKIP_WORKERS;
+    } else {
+      process.env.SKIP_WORKERS = skipWorkers;
+    }
+  }, 60000);
+
+  test('the models mark three fields as never leaving', () => {
+    expect([...henri.privacy.private].sort()).toEqual([
+      'gender',
+      'nationalId',
+      'password',
+      'phone',
+    ]);
+  });
+
+  // The property this whole thing exists for. It fails without the floor:
+  // the object below is not a record, so nothing published it and nothing
+  // stripped it, and the three marked fields went out on the wire
+  test('a hand-built object cannot carry a field marked expose: false', async () => {
+    const answer = await agent.get('/reports/hand');
+    const [row] = answer.body.rows;
+
+    expect(answer.status).toBe(200);
+    expect(row.email).toBe('ada@usehenri.io');
+    expect(answer.text).not.toContain('she/her');
+    expect(answer.text).not.toContain('+1-555-0100');
+    expect(answer.text).not.toContain('AB-123-456');
+    expect(row).not.toHaveProperty('gender');
+    expect(row).not.toHaveProperty('phone');
+    expect(row).not.toHaveProperty('nationalId');
+  });
+
+  // The floor publishes; what it can publish is what carries a model. A
+  // primary key a controller copied under `id` is an opaque string, which is
+  // the limit base/references.js states -- handing over the records instead
+  // is what makes it go away, and it needs no declaration
+  test('the records themselves leave without their primary key', async () => {
+    await Memo.create({
+      body: 'the minutes',
+      ownerId: String(user.id || user._id),
+      title: 'Minutes',
+    });
+
+    const copied = await agent.get('/reports/hand');
+    const records = await agent.get('/reports/records');
+    const owner = await User.findByKey(user.id || user._id);
+
+    expect(copied.body.rows[0].id).toBe(String(user.id || user._id));
+    expect(records.body.rows[0]).not.toHaveProperty('_id');
+    expect(records.body.rows[0]).not.toHaveProperty('id');
+    expect(records.body.rows[0].externalId).toEqual(expect.any(String));
+    expect(records.body.rows[0].ownerId).toBe(owner.externalId);
+  });
+
+  test('a declared field naming a model publishes a hand-built row', async () => {
+    const answer = await agent.get('/reports/digest');
+    const [row] = answer.body.rows;
+    const owner = await User.findByKey(user.id || user._id);
+
+    expect(answer.status).toBe(200);
+    expect(row.title).toBe('Minutes');
+    // The declaration is what made this possible: a plain object carries no
+    // model, so nothing else could know that `ownerId` names a row
+    expect(row.ownerId).toBe(owner.externalId);
+    expect(answer.text).not.toContain(String(user.id || user._id));
+  });
+
+  test('what is not declared does not leave', async () => {
+    const answer = await agent.get('/reports/digest');
+
+    expect(answer.body).not.toHaveProperty('secret');
+    expect(answer.text).not.toContain('undeclared');
+    expect(answer.body.total).toBe(1);
+  });
+
+  test('a column named by `from` obeys its marks under another name', async () => {
+    const answer = await agent.get('/reports/profile');
+
+    expect(answer.status).toBe(200);
+    expect(answer.body).toEqual({ age: 41, who: 'ada@usehenri.io' });
+  });
+
+  test('`expose: true` is how a private column leaves on purpose', async () => {
+    const answer = await agent.get('/reports/sensitive');
+
+    expect(answer.status).toBe(200);
+    expect(answer.body).toEqual({ gender: 'she/her' });
+  });
+
+  test('henri s own answers go through untouched', async () => {
+    const version = await agent.get('/version');
+    const missing = await agent.get('/nope').set('Accept', 'application/json');
+
+    expect(version.body).toMatchObject({ version: null });
+    expect(missing.status).toBe(404);
+    expect(missing.body).toMatchObject({ statusCode: 404 });
+  });
+
+  test('a resource answer keeps its links and its shape', async () => {
+    const listed = await agent.get('/memos').set('Accept', 'application/json');
+
+    expect(listed.status).toBe(200);
+    expect(listed.body._links.self.href).toBe('/memos');
+    expect(listed.body._embedded.memos[0].title).toBe('Minutes');
+    expect(listed.body._embedded.memos[0]._links.self.href).toMatch(
+      /^\/memos\//u
+    );
+  });
+
+  // The other half of the decision: a field that was declared and is not
+  // there is a mistake in this application, not a leak, so it is reported
+  // and only refused where the application asked to be strict
+  test('a mismatch is reported, and refused with config.api.strict', async () => {
+    const lines = [];
+    const warn = henri.pen.warn;
+    const strict = henri.api.settings.strict;
+
+    henri.pen.warn = (...args) => lines.push(args.join(' '));
+
+    try {
+      const reported = await agent.get('/reports/digest?empty=1');
+
+      expect(reported.status).toBe(200);
+
+      henri.api.settings.strict = true;
+      henri.api.warned.clear();
+
+      const refused = await agent.get('/reports/digest?empty=1');
+
+      expect(refused.status).toBe(500);
+      expect(refused.body.code).toBe('HENRI_ANSWERS_MISMATCH');
+    } finally {
+      henri.api.settings.strict = strict;
+      henri.pen.warn = warn;
+      henri.api.warned.clear();
+    }
+
+    expect(lines.join('\n')).toMatch(/left the answer undeclared/u);
+  });
+
+  test('what an action answers is in the openapi document', () => {
+    const document = henri.router.describe();
+    const operation = document.paths['/reports/digest'].get;
+
+    expect(operation['x-henri'].answers).toEqual(['rows', 'total']);
+    expect(operation['x-henri'].known).toBe(true);
+    expect(operation['x-henri'].enforced).toContain('answers');
+    expect(
+      operation.responses['200'].content['application/json'].schema
+    ).toEqual({
+      additionalProperties: false,
+      properties: {
+        rows: { items: { $ref: '#/components/schemas/Memo' }, type: 'array' },
+        total: { type: 'integer' },
+      },
+      required: ['total'],
+      type: 'object',
+    });
+  });
+});

--- a/packages/core/src/__tests__/answers.spec.js
+++ b/packages/core/src/__tests__/answers.spec.js
@@ -321,6 +321,15 @@ describe('the exit gate (demo app, disk store)', () => {
     expect(answer.body.total).toBe(1);
   });
 
+  // Express serializes a jsonp answer itself rather than through res.json,
+  // so it is the second writer the gate wraps
+  test('res.jsonp() leaves through the same gate', async () => {
+    const answer = await agent.get('/reports/padded?callback=read');
+
+    expect(answer.status).toBe(200);
+    expect(answer.text).not.toContain('she/her');
+  });
+
   test('a column named by `from` obeys its marks under another name', async () => {
     const answer = await agent.get('/reports/profile');
 

--- a/packages/core/src/__tests__/utils.spec.js
+++ b/packages/core/src/__tests__/utils.spec.js
@@ -139,6 +139,7 @@ describe('utils', () => {
         'main',
         'memos',
         'notes',
+        'reports',
         'uploads',
         'user',
       ]);

--- a/packages/core/src/base/answers.js
+++ b/packages/core/src/base/answers.js
@@ -779,10 +779,10 @@ function gate(henri, rules, body) {
 /**
  * The middleware gating what one action answers.
  *
- * It wraps `res.json()` for this route only, so the gate covers what a
- * controller sends by hand and nothing henri serves itself: `/livez`,
- * `/_routes`, the catalogues and the mail previews are not controller
- * actions and never see it.
+ * It wraps the writers of `WRITERS` for this route only, so the gate covers
+ * what a controller sends by hand and nothing henri serves itself:
+ * `/livez`, `/_routes`, the catalogues and the mail previews are not
+ * controller actions and never see it.
  *
  * `res.json()` stays synchronous whenever it can, which is nearly always:
  * the walk is free and only a foreign key nobody eager loaded needs a

--- a/packages/core/src/base/answers.js
+++ b/packages/core/src/base/answers.js
@@ -113,6 +113,11 @@
  * way to infer it -- the same limit `base/references.js` states for an
  * undeclared foreign key, and for the same reason.
  *
+ * The other one is bytes. `res.send(JSON.stringify(value))` and anything
+ * written to the socket by hand hand over a string, and a string is not an
+ * answer this can walk. `res.json()` is where the gate is because
+ * `res.json()` is where the value still is.
+ *
  * ## What reads them besides the gate
  *
  * `henri openapi` (base/openapi.js): a declaration is a description of what
@@ -140,6 +145,18 @@ const TYPES = [...PARAM_TYPES, 'record'].sort();
 
 /** Every key a rule may hold */
 const KEYS = ['expose', 'from', 'model', 'of', 'required', 'type'];
+
+/**
+ * The methods that write a value the gate can read.
+ *
+ * `res.send(object)` is `res.json()` in express, so wrapping `json` covers
+ * it; `res.jsonp()` serializes on its own and is wrapped for that reason
+ * alone. What is deliberately not here is anything that writes bytes --
+ * `res.send(string)`, `res.write()`, a stream -- because a controller that
+ * serialized its own JSON handed henri a string, and a string is not an
+ * answer this can read.
+ */
+const WRITERS = ['json', 'jsonp'];
 
 /**
  * Is this a plain object (a declaration, a rule, an answer)?
@@ -786,80 +803,104 @@ function gate(henri, rules, body) {
  */
 function guard(henri, rules, name) {
   return (req, res, next) => {
-    const json = res.json.bind(res);
-
-    res.json = (body) => {
-      if (sealed(res)) {
-        return json(body);
-      }
-
-      // An Inertia page object is a rendered page rather than an answer of
-      // this shape, and its props went through the gate as `data` already
-      if (isInertiaPage(req, res)) {
-        return json(body);
-      }
-
-      // The implicit render reads this to tell an action that answered from
-      // one that returned without answering, and it reads it before the
-      // promise below resolves (see base/hooks.js)
-      res._answered = true;
-
-      let gated;
-
-      try {
-        gated = gate(henri, rules, body);
-      } catch (error) {
-        return next(error);
-      }
-
-      if (gated.problems.length > 0 && !report(henri, name, gated.problems)) {
-        res.statusCode = 500;
-
-        return seal(res).json({
-          code: CODE,
-          error: 'Internal Server Error',
-          message: `${name} does not answer what it declared (config.api.strict)`,
-          statusCode: 500,
+    for (const method of WRITERS) {
+      if (typeof res[method] === 'function') {
+        res[method] = wrap(henri, rules, name, {
+          next,
+          req,
+          res,
+          write: res[method].bind(res),
         });
       }
-
-      if (!gated.settle) {
-        seal(res);
-
-        return json(gated.answer);
-      }
-
-      return gated.settle().then(
-        (answer) => {
-          seal(res);
-
-          return json(answer);
-        },
-        (error) => {
-          // A controller that did not `return` its `res.json()` would turn a
-          // throw here into an unhandled rejection, so this answers instead
-          // (the same reasoning as `enforce()` in base/hateoas.js)
-          henri.pen &&
-            henri.pen.error &&
-            henri.pen.error('api', name, error.message);
-
-          if (res.headersSent) {
-            return res;
-          }
-
-          res.statusCode = 500;
-
-          return seal(res).json({
-            code: CODE,
-            error: 'Internal Server Error',
-            message: `${name} could not publish its answer`,
-            statusCode: 500,
-          });
-        }
-      );
-    };
+    }
 
     next();
+  };
+}
+
+/**
+ * One answering method, gated
+ *
+ * @param {Henri} henri the henri instance
+ * @param {?object} rules the compiled rules of the action, or null
+ * @param {string} name the route name
+ * @param {object} context `{ next, req, res, write }`
+ * @returns {function} the replacement
+ */
+function wrap(henri, rules, name, { next, req, res, write }) {
+  /**
+   * The refusal, in the envelope henri answers every failure with
+   *
+   * @param {string} message what happened
+   * @returns {*} the answer
+   */
+  const refuse = (message) => {
+    res.statusCode = 500;
+    seal(res);
+
+    return write({
+      code: CODE,
+      error: 'Internal Server Error',
+      message,
+      statusCode: 500,
+    });
+  };
+
+  return (body) => {
+    if (sealed(res)) {
+      return write(body);
+    }
+
+    // An Inertia page object is a rendered page rather than an answer of
+    // this shape, and its props went through the gate as `data` already
+    if (isInertiaPage(req, res)) {
+      return write(body);
+    }
+
+    // The implicit render reads this to tell an action that answered from
+    // one that returned without answering, and it reads it before the
+    // promise below resolves (see base/hooks.js)
+    res._answered = true;
+
+    let gated;
+
+    try {
+      gated = gate(henri, rules, body);
+    } catch (error) {
+      return next(error);
+    }
+
+    if (gated.problems.length > 0 && !report(henri, name, gated.problems)) {
+      return refuse(
+        `${name} does not answer what it declared (config.api.strict)`
+      );
+    }
+
+    if (!gated.settle) {
+      seal(res);
+
+      return write(gated.answer);
+    }
+
+    return gated.settle().then(
+      (answer) => {
+        seal(res);
+
+        return write(answer);
+      },
+      (error) => {
+        // A controller that did not `return` its `res.json()` would turn a
+        // throw here into an unhandled rejection, so this answers instead
+        // (the same reasoning as `enforce()` in base/hateoas.js)
+        henri.pen &&
+          henri.pen.error &&
+          henri.pen.error('api', name, error.message);
+
+        return res.headersSent
+          ? res
+          : refuse(`${name} could not publish its answer`);
+      }
+    );
   };
 }
 

--- a/packages/core/src/base/answers.js
+++ b/packages/core/src/base/answers.js
@@ -1,0 +1,868 @@
+/**
+ * The shape of an answer, declared by the controller.
+ *
+ * `base/params-schema.js` closed one direction: what arrives is declared per
+ * action and refused before the action runs. This is the same idea pointing
+ * the other way, and it exists because the two directions were not equally
+ * guarded.
+ *
+ * `res.render()`, `res.resource()` and `res.collection()` all go through one
+ * gate on the way out (`toPublic()`, base/hateoas.js): the foreign keys are
+ * published as the `externalId` of the row they name, and a field the model
+ * marked `personal: { expose: false }` is dropped. `res.json()` went through
+ * nothing at all:
+ *
+ * ```js
+ * // gated
+ * res.render('Users/Index', { data: records });
+ * // not gated, and the same records
+ * res.json({ rows: records.map((r) => ({ id: r.id, gender: r.gender })) });
+ * ```
+ *
+ * A hand-built object is not a record, so nothing published its foreign keys
+ * and nothing stripped what the model said must never leave. That is not an
+ * exotic controller: it is what an Inertia page whose props are assembled by
+ * hand looks like, and what every JSON route that answers a total next to a
+ * list looks like.
+ *
+ * ## Two things, and the difference between them matters
+ *
+ * **The floor** applies to every JSON answer of every controller action,
+ * declared or not: the value is published and then stripped, the same two
+ * passes and in the same order as everywhere else. Nothing an application
+ * writes turns it off, because the mark on the field is the model's word
+ * about a person and a controller is not the place to overrule it.
+ *
+ * **The declaration** is opt-in, per action, in the block `before` and
+ * `params` already established -- an export the router reads, keyed by
+ * action, never an action itself:
+ *
+ * ```js
+ * module.exports = {
+ *   answers: {
+ *     index: {
+ *       rows: { model: 'Memo', type: 'array' },
+ *       total: 'integer',
+ *     },
+ *     peek: { title: 'string' },
+ *   },
+ *
+ *   index: async (req, res) =>
+ *     res.json({ rows: await Memo.find(), total: await Memo.count() }),
+ * };
+ * ```
+ *
+ * ## The vocabulary
+ *
+ * The one `params` uses, plus the two things an answer knows and a request
+ * does not. A rule is an object, or the type itself (`total: 'integer'`):
+ *
+ * - `type`: the henri schema types, plus `array` and `record`.
+ * - `model`: the model whose records this field holds. On its own it is one
+ *   record; with `type: 'array'` it is a list of them. **This is what lets a
+ *   hand-built object be published**: an object that never was a record
+ *   carries no model, so henri cannot know that its `ownerId` names a row --
+ *   the declaration is where it is told.
+ * - `from`: `'User.gender'`, the column this value came from. It makes the
+ *   field obey that column's marks under whatever name the answer gives it,
+ *   which is the one leak a name-based strip cannot see, and it is what
+ *   `henri openapi` types the field from. On its own it says nothing about
+ *   the shape (`json`, the type that says nothing): a controller may present
+ *   a column as anything, so a rule that wants a shape checked names one.
+ * - `of`: the rule every item of a list of scalars follows.
+ * - `required`: the field has to be in the answer.
+ * - `expose`: `true` says this action may carry a field marked
+ *   `personal: { expose: false }`, and it is the declared form of the
+ *   `include` that `res.resource()` and `res.render()` already take.
+ *
+ * A rule henri cannot carry out fails the boot naming the controller, the
+ * action and the field (`HENRI_ANSWERS_DECLARATION_INVALID`), the way a
+ * `params` rule does: a declaration that is quietly ignored is worse than no
+ * declaration, because it reads like a guarantee.
+ *
+ * ### What a declaration is deliberately not
+ *
+ * It does not validate the application's own values on the way out. There is
+ * no `enum`, no `min`, no `pattern`, no `default`: the model checked those
+ * when the value was written, and a response that fails after the work is
+ * done turns a cosmetic mistake into an outage. What is checked is the
+ * shape, because the shape is what `henri openapi` publishes as a contract.
+ *
+ * ## What is not declared does not leave
+ *
+ * An action that declared answers sends the fields it declared and nothing
+ * else. That is the same rule `req.permit()` follows in the other direction
+ * -- the declaration is the list, an undeclared key is dropped and never
+ * refused -- and it is the safe direction: the field nobody declared is the
+ * field nobody thought about, and that is where a value rides out. It costs
+ * an application nothing to adopt, because an action with no declaration is
+ * untouched.
+ *
+ * The other half is the opposite: a field that was **declared and is
+ * missing**, or that holds something other than what was declared, is a
+ * mistake in the declaration rather than a leak, so it is reported once per
+ * route (`pen.warn`) and only refused with `config.api.strict` -- the knob
+ * that already means "refuse what would otherwise be a warning about this
+ * application's API" for the HAL links.
+ *
+ * ## What henri still cannot see
+ *
+ * A value taken off a record and put under another name is an opaque value:
+ * `res.json({ g: user.gender })` is a string as far as henri is concerned.
+ * `from: 'User.gender'` is how a controller says otherwise, and there is no
+ * way to infer it -- the same limit `base/references.js` states for an
+ * undeclared foreign key, and for the same reason.
+ *
+ * ## What reads them besides the gate
+ *
+ * `henri openapi` (base/openapi.js): a declaration is a description of what
+ * an operation answers, which is exactly what the document could not know
+ * for an action whose body a controller writes. Such an operation used to
+ * carry `x-henri.known: false` and no success status at all; one that
+ * declares its answer carries the schema instead.
+ *
+ * @module base/answers
+ */
+
+const { fail } = require('./errors');
+const { isInertiaPage, sealed } = require('./headers');
+const { prepare, settle } = require('./references');
+const { TYPES: PARAM_TYPES, typed } = require('./params-schema');
+
+/** The controller exports that are never actions (see base/hooks.js) */
+const RESERVED = new Set(['answers']);
+
+/** The failure an answer gets when `config.api.strict` refuses it */
+const CODE = 'HENRI_ANSWERS_MISMATCH';
+
+/** The types a rule may declare: the request vocabulary, plus a record */
+const TYPES = [...PARAM_TYPES, 'record'].sort();
+
+/** Every key a rule may hold */
+const KEYS = ['expose', 'from', 'model', 'of', 'required', 'type'];
+
+/**
+ * Is this a plain object (a declaration, a rule, an answer)?
+ *
+ * @param {*} value anything
+ * @returns {boolean} true for a plain object
+ */
+function isObject(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const proto = Object.getPrototypeOf(value);
+
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * The failure a wrong declaration raises, naming where it is
+ *
+ * @param {string} where the controller, or the controller and action
+ * @param {string} what what is wrong
+ * @returns {Error} the error to throw
+ */
+const invalid = (where, what) =>
+  fail('HENRI_ANSWERS_DECLARATION_INVALID', `${where} ${what}`);
+
+/**
+ * The action names a selector key stands for: the selectors `before` and
+ * `params` already use
+ *
+ * @param {string} key the key of the `answers` block
+ * @returns {?Array<string>} the actions, or null for every action
+ */
+function selects(key) {
+  const names = String(key)
+    .split(',')
+    .map((name) => name.trim())
+    .filter(Boolean);
+
+  if (names.length === 1 && (names[0] === 'all' || names[0] === '*')) {
+    return null;
+  }
+
+  return names;
+}
+
+/**
+ * The raw declaration of one action: every selector that names it, merged in
+ * declaration order, so `all` is the floor and the action's own key wins
+ *
+ * @param {object} block the `answers` export
+ * @param {string} action the action name
+ * @returns {?object} the fields, or null when nothing declares any
+ */
+function fieldsFor(block, action) {
+  if (!isObject(block)) {
+    return null;
+  }
+
+  let found = null;
+
+  for (const [key, fields] of Object.entries(block)) {
+    const only = selects(key);
+
+    if (only !== null && !only.includes(action)) {
+      continue;
+    }
+
+    found = Object.assign({}, found, fields);
+  }
+
+  return found;
+}
+
+/**
+ * The `Model.field` a rule's `from` names
+ *
+ * Split, never matched: a declaration is written by hand and read at boot,
+ * and there is no pattern here worth the risk of one (see base/exact.js).
+ *
+ * @param {*} written what `from` holds
+ * @returns {?{field: string, model: string}} the column, or null
+ */
+function columnOf(written) {
+  if (typeof written !== 'string') {
+    return null;
+  }
+
+  const parts = written.split('.');
+
+  if (parts.length !== 2 || !parts[0].trim() || !parts[1].trim()) {
+    return null;
+  }
+
+  return { field: parts[1].trim(), model: parts[0].trim() };
+}
+
+/**
+ * Normalizes and checks one rule
+ *
+ * @param {*} written what the controller wrote
+ * @param {string} where the controller and action (`memos#index`)
+ * @param {string} field the field name
+ * @param {boolean} [nested=false] is this the `of` of a list?
+ * @returns {object} the compiled rule
+ * @throws {Error} when the rule holds something henri cannot carry out
+ */
+function rule(written, where, field, nested = false) {
+  if (typeof written !== 'string' && !isObject(written)) {
+    throw invalid(
+      where,
+      `answers "${field}" as ${
+        written === null ? 'null' : typeof written
+      }: a rule is an object, or the type itself`
+    );
+  }
+
+  const source = typeof written === 'string' ? { type: written } : written;
+  const compiled = {};
+
+  for (const [key, value] of Object.entries(source)) {
+    if (!KEYS.includes(key)) {
+      throw invalid(
+        where,
+        `answers "${field}" with the unknown key "${key}": ` +
+          `a rule takes ${KEYS.join(', ')}`
+      );
+    }
+
+    compiled[key] = value;
+  }
+
+  return finish(compiled, where, field, nested);
+}
+
+/**
+ * The type a rule ends up with, from what it wrote down
+ *
+ * @param {object} compiled the rule
+ * @param {string} where the controller and action
+ * @param {string} field the field name
+ * @returns {string} the type
+ * @throws {Error} when there is none, or it is not one of them
+ */
+function typeOf(compiled, where, field) {
+  const { from, model, type } = compiled;
+
+  if (typeof type === 'undefined') {
+    if (typeof model === 'string') {
+      return 'record';
+    }
+
+    // A column named and nothing else: the marks are what was asked for,
+    // and the shape is whatever the column holds. `json` is the type that
+    // says nothing, here as in a request
+    if (typeof from === 'string') {
+      return 'json';
+    }
+
+    throw invalid(
+      where,
+      `answers "${field}", which names no type: the types are ` +
+        `${TYPES.join(', ')} (\`${field}: 'string'\` is the short form), ` +
+        "and `model` names one of the application's"
+    );
+  }
+
+  if (typeof type !== 'string' || !TYPES.includes(type)) {
+    throw invalid(
+      where,
+      `answers "${field}" as the type ${JSON.stringify(type)}, ` +
+        `which henri does not have: the types are ${TYPES.join(', ')}`
+    );
+  }
+
+  return type;
+}
+
+/**
+ * The checks a compiled rule goes through before it is kept
+ *
+ * @param {object} compiled the rule
+ * @param {string} where the controller and action
+ * @param {string} field the field name
+ * @param {boolean} nested is this the `of` of a list?
+ * @returns {object} the same rule, frozen
+ * @throws {Error} when a rule cannot be carried out
+ */
+function finish(compiled, where, field, nested) {
+  /**
+   * Refuses the rule
+   *
+   * @param {string} what what is wrong with it
+   * @returns {void} never returns
+   * @throws {Error} always
+   */
+  const bad = (what) => {
+    throw invalid(where, `answers "${field}" with ${what}`);
+  };
+
+  compiled.type = typeOf(compiled, where, field);
+
+  if ('model' in compiled && typeof compiled.model !== 'string') {
+    bad('a "model" that is not the name of a model');
+  }
+
+  if ('from' in compiled) {
+    const column = columnOf(compiled.from);
+
+    if (!column) {
+      bad('a "from" that is not `Model.field`');
+    }
+
+    compiled.from = column;
+  }
+
+  for (const key of ['expose', 'required']) {
+    if (key in compiled && typeof compiled[key] !== 'boolean') {
+      bad(`a "${key}" that is not true or false`);
+    }
+  }
+
+  if (compiled.model && compiled.type !== 'record') {
+    if (compiled.type !== 'array') {
+      bad(
+        `"model" and the type ${JSON.stringify(compiled.type)}: a field ` +
+          'holding records is a record, or an array of them'
+      );
+    }
+
+    if ('of' in compiled) {
+      bad('both "model" and "of": a list of records says which model, once');
+    }
+  }
+
+  if (compiled.type === 'record' && !compiled.model) {
+    bad('the type "record" and no "model": a record is a record of something');
+  }
+
+  if ('of' in compiled) {
+    if (compiled.type !== 'array') {
+      bad(`an "of", which only an array takes`);
+    }
+
+    if (nested) {
+      bad('a list of lists, which an answer does not describe');
+    }
+
+    compiled.of = rule(compiled.of, where, `${field}[]`, true);
+  }
+
+  if (compiled.type === 'array' && !compiled.model && !('of' in compiled)) {
+    bad('no "of" and no "model": a list says what it holds');
+  }
+
+  return Object.freeze(compiled);
+}
+
+/**
+ * The declarations of a controller, action by action
+ *
+ * A selector naming something that is not an action of the controller is a
+ * typo that would silently describe nothing: it fails here instead.
+ *
+ * @param {object} controller the controller module
+ * @param {string} name the controller name (`memos`, `admin/notes`)
+ * @param {Array<string>} actions the action names of the controller
+ * @returns {object} the compiled rules, keyed by action
+ * @throws {Error} when a declaration cannot be carried out
+ */
+function declarations(controller, name, actions) {
+  const block = controller && controller.answers;
+
+  if (typeof block === 'undefined' || block === null) {
+    return {};
+  }
+
+  if (!isObject(block)) {
+    throw invalid(name, 'declares `answers` as something other than an object');
+  }
+
+  for (const [key, fields] of Object.entries(block)) {
+    if (!isObject(fields)) {
+      throw invalid(
+        name,
+        `answers "${key}" with something other than a list of fields`
+      );
+    }
+
+    for (const action of selects(key) || []) {
+      if (!actions.includes(action)) {
+        throw invalid(
+          name,
+          `declares an answer for "${action}", which is not one of its ` +
+            `actions (${actions.join(', ') || 'it has none'})`
+        );
+      }
+    }
+  }
+
+  const compiled = {};
+
+  for (const action of actions) {
+    const fields = fieldsFor(block, action);
+
+    if (!fields || Object.keys(fields).length === 0) {
+      continue;
+    }
+
+    compiled[action] = Object.freeze(
+      Object.fromEntries(
+        Object.entries(fields).map(([field, written]) => [
+          field,
+          rule(written, `${name}#${action}`, field),
+        ])
+      )
+    );
+  }
+
+  return compiled;
+}
+
+/**
+ * Checks a compiled declaration against the models of the application.
+ *
+ * This runs later than the compile does -- the models are loaded at runlevel
+ * 3 and a controller at 2 -- so it is a second pass rather than part of
+ * `rule()`, and it still fails the boot.
+ *
+ * @param {object} rules the compiled rules of one action
+ * @param {object} context the context
+ * @param {string} context.where the controller and action
+ * @param {function} context.model `(globalId) => the model file, or null`
+ * @param {function} context.mark `(globalId, field) => the personal mark`
+ * @returns {void}
+ * @throws {Error} when a rule names a model or a column that is not there,
+ *   or a column that must never leave
+ */
+function verify(rules, { mark, model, where }) {
+  for (const [field, compiled] of Object.entries(rules || {})) {
+    const named = [compiled, compiled.of].filter(Boolean);
+
+    for (const entry of named) {
+      if (entry.model && !model(entry.model)) {
+        throw invalid(
+          where,
+          `answers "${field}" with records of ${entry.model}, which is not ` +
+            'a model of this application'
+        );
+      }
+
+      if (!entry.from) {
+        continue;
+      }
+
+      if (!model(entry.from.model)) {
+        throw invalid(
+          where,
+          `answers "${field}" from ${entry.from.model}.${entry.from.field}, ` +
+            `and ${entry.from.model} is not a model of this application`
+        );
+      }
+
+      const found = mark(entry.from.model, entry.from.field);
+
+      if (found && found.expose === false && compiled.expose !== true) {
+        throw invalid(
+          where,
+          `answers "${field}" from ${entry.from.model}.${entry.from.field}, ` +
+            'which the model marked `personal: { expose: false }`: that ' +
+            'field never leaves the server. Drop it from the answer, or say ' +
+            `it on purpose with \`expose: true\` on "${field}"`
+        );
+      }
+    }
+  }
+}
+
+/**
+ * The personal field names one action is allowed to carry: the `include` of
+ * `res.resource()`, written down instead of passed
+ *
+ * @param {object} rules the compiled rules
+ * @returns {Array<string>} the names
+ */
+function includeOf(rules) {
+  const names = [];
+
+  for (const [field, compiled] of Object.entries(rules || {})) {
+    if (compiled.expose !== true) {
+      continue;
+    }
+
+    names.push(field);
+
+    if (compiled.from) {
+      names.push(compiled.from.field);
+    }
+  }
+
+  return names;
+}
+
+/**
+ * What a value is, in words, for the report a person reads
+ *
+ * @param {*} value anything
+ * @returns {string} `a list`, `a string`, `null`
+ */
+function what(value) {
+  if (value === null) {
+    return 'null';
+  }
+
+  return Array.isArray(value) ? 'a list' : `a ${typeof value}`;
+}
+
+/**
+ * What one declared field says about the value that arrived, or null
+ *
+ * A value that is absent or null is nothing to say: an answer that holds no
+ * comment is not the same as one that holds the wrong kind of comment, and
+ * `required` is about the key rather than what is under it.
+ *
+ * @param {object} compiled the rule
+ * @param {*} value the value
+ * @returns {?string} what is wrong, or null
+ */
+function mismatch(compiled, value) {
+  if (value === null || typeof value === 'undefined') {
+    return null;
+  }
+
+  if (compiled.type === 'record') {
+    // Not `isObject`: a record may be a model instance, which is an object
+    // with a prototype of its own
+    return typeof value === 'object' && !Array.isArray(value)
+      ? null
+      : `must be a record, and it is ${what(value)}`;
+  }
+
+  if (compiled.type === 'array') {
+    if (!Array.isArray(value)) {
+      return `must be a list, and it is ${what(value)}`;
+    }
+
+    if (!compiled.of) {
+      return null;
+    }
+
+    for (const [index, item] of value.entries()) {
+      const wrong = mismatch(compiled.of, item);
+
+      if (wrong) {
+        return `item ${index + 1} ${wrong}`;
+      }
+    }
+
+    return null;
+  }
+
+  const wrong = typed(compiled, value);
+
+  return wrong ? `${wrong}, and it is ${what(value)}` : null;
+}
+
+/**
+ * The answer an action declared, taken out of what it sent.
+ *
+ * Only the declared fields, in declaration order, plus the map telling
+ * `publish()` which model a hand-built object holds.
+ *
+ * @param {object} rules the compiled rules
+ * @param {object} body what the action sent
+ * @returns {{picked: object, problems: Array<string>, types: WeakMap}} the
+ *   answer, what does not match and the models of its nodes
+ */
+function pick(rules, body) {
+  const picked = {};
+  const problems = [];
+  const types = new WeakMap();
+  const declared = new Set(Object.keys(rules));
+
+  for (const [field, compiled] of Object.entries(rules)) {
+    if (!Object.prototype.hasOwnProperty.call(body, field)) {
+      if (compiled.required) {
+        problems.push(`${field} is missing`);
+      }
+
+      continue;
+    }
+
+    const value = body[field];
+    const wrong = mismatch(compiled, value);
+
+    if (wrong) {
+      problems.push(`${field} ${wrong}`);
+    }
+
+    if (compiled.model && value && typeof value === 'object') {
+      // The list is not the record: the model goes on every item, which is
+      // the node `walk()` reaches
+      for (const node of Array.isArray(value) ? value : [value]) {
+        if (node && typeof node === 'object') {
+          types.set(node, compiled.model);
+        }
+      }
+    }
+
+    if (field === '__proto__') {
+      // Never assigned: the setter of Object.prototype would replace the
+      // answer's prototype instead of adding a field (see base/privacy.js)
+      Object.defineProperty(picked, field, {
+        configurable: true,
+        enumerable: true,
+        value,
+        writable: true,
+      });
+      continue;
+    }
+
+    picked[field] = value;
+  }
+
+  const dropped = Object.keys(body).filter((key) => !declared.has(key));
+
+  if (dropped.length > 0) {
+    problems.push(`${dropped.sort().join(', ')} left the answer undeclared`);
+  }
+
+  return { picked, problems, types };
+}
+
+/**
+ * Says what a declared answer did not do, once per route.
+ *
+ * A warning rather than a failure by default, and a failure with
+ * `config.api.strict`: what is reported here is a declaration that does not
+ * describe the answer, which is a mistake in this application rather than
+ * something a client did or a value that leaked.
+ *
+ * @param {Henri} henri the henri instance
+ * @param {string} name the route name (`get /memos`)
+ * @param {Array<string>} problems what does not match
+ * @returns {boolean} true when the answer may still be sent
+ */
+function report(henri, name, problems) {
+  const { api, pen } = henri;
+  const message = `${name} does not answer what it declared: ${problems.join('; ')}`;
+  const settings = (api && api.settings) || {};
+  const warned = (api && api.warned) || new Set();
+
+  if (!warned.has(message)) {
+    warned.add(message);
+    pen && pen.warn && pen.warn('api', message);
+  }
+
+  if (settings.strict !== true) {
+    return true;
+  }
+
+  pen && pen.error && pen.error('api', name, 'refused by config.api.strict');
+
+  return false;
+}
+
+/**
+ * The floor and the declaration, as one function of a body.
+ *
+ * The order is the one `toPublic()` established and it is not an accident:
+ * publishing resolves a foreign key into the public identifier of the row it
+ * names, and a field marked `personal: { expose: false }` must not leave
+ * carrying whatever it resolved to (see base/privacy.js).
+ *
+ * @param {Henri} henri the henri instance
+ * @param {?object} rules the compiled rules, or null
+ * @param {*} body what the action sent
+ * @returns {{answer: *, settle: ?function, problems: Array<string>}} the
+ *   answer as it stands, the lookups it still wants and what did not match
+ */
+function gate(henri, rules, body) {
+  const strip = (value, include) =>
+    henri.privacy ? henri.privacy.strip(value, include) : value;
+  let value = body;
+  let include = [];
+  let problems = [];
+  let types = null;
+
+  if (rules && isObject(body)) {
+    const chosen = pick(rules, body);
+
+    include = includeOf(rules);
+    problems = chosen.problems;
+    types = chosen.types;
+    value = chosen.picked;
+  } else if (rules) {
+    // A declaration names fields, and this answer has none to name. The
+    // floor still runs: the point of the floor is that it always does
+    problems = [`the declaration names fields and the answer is ${what(body)}`];
+  }
+
+  const { context, copy, pending } = prepare(henri, value, { types });
+
+  if (pending.length === 0) {
+    return { answer: strip(copy, include), problems, settle: null };
+  }
+
+  return {
+    answer: null,
+    problems,
+    settle: async () => {
+      await settle(henri, context);
+
+      return strip(copy, include);
+    },
+  };
+}
+
+/**
+ * The middleware gating what one action answers.
+ *
+ * It wraps `res.json()` for this route only, so the gate covers what a
+ * controller sends by hand and nothing henri serves itself: `/livez`,
+ * `/_routes`, the catalogues and the mail previews are not controller
+ * actions and never see it.
+ *
+ * `res.json()` stays synchronous whenever it can, which is nearly always:
+ * the walk is free and only a foreign key nobody eager loaded needs a
+ * lookup. When one does, the wrapper answers a promise -- an action that
+ * `return`s it is awaited by the implicit render (base/hooks.js), and one
+ * that does not still has its answer written, because the failure path
+ * answers rather than throwing into nobody's catch.
+ *
+ * @param {Henri} henri the henri instance
+ * @param {?object} rules the compiled rules of the action, or null
+ * @param {string} name the route name (`get /memos`)
+ * @returns {function} express middleware
+ */
+function guard(henri, rules, name) {
+  return (req, res, next) => {
+    const json = res.json.bind(res);
+
+    res.json = (body) => {
+      if (sealed(res)) {
+        return json(body);
+      }
+
+      // An Inertia page object is a rendered page rather than an answer of
+      // this shape, and its props went through the gate as `data` already
+      if (isInertiaPage(req, res)) {
+        return json(body);
+      }
+
+      // The implicit render reads this to tell an action that answered from
+      // one that returned without answering, and it reads it before the
+      // promise below resolves (see base/hooks.js)
+      res._answered = true;
+
+      let gated;
+
+      try {
+        gated = gate(henri, rules, body);
+      } catch (error) {
+        return next(error);
+      }
+
+      if (gated.problems.length > 0 && !report(henri, name, gated.problems)) {
+        return json({
+          code: CODE,
+          error: 'Internal Server Error',
+          message: `${name} does not answer what it declared (config.api.strict)`,
+          statusCode: (res.statusCode = 500),
+        });
+      }
+
+      if (!gated.settle) {
+        return json(gated.answer);
+      }
+
+      return gated.settle().then(
+        (answer) => json(answer),
+        (error) => {
+          // A controller that did not `return` its `res.json()` would turn a
+          // throw here into an unhandled rejection, so this answers instead
+          // (the same reasoning as `enforce()` in base/hateoas.js)
+          henri.pen &&
+            henri.pen.error &&
+            henri.pen.error('api', name, error.message);
+
+          if (res.headersSent) {
+            return res;
+          }
+
+          res.statusCode = 500;
+
+          return json({
+            code: CODE,
+            error: 'Internal Server Error',
+            message: `${name} could not publish its answer`,
+            statusCode: 500,
+          });
+        }
+      );
+    };
+
+    next();
+  };
+}
+
+module.exports = {
+  CODE,
+  KEYS,
+  RESERVED,
+  TYPES,
+  columnOf,
+  declarations,
+  fieldsFor,
+  gate,
+  guard,
+  includeOf,
+  mismatch,
+  pick,
+  rule,
+  verify,
+};

--- a/packages/core/src/base/answers.js
+++ b/packages/core/src/base/answers.js
@@ -125,7 +125,7 @@
  */
 
 const { fail } = require('./errors');
-const { isInertiaPage, sealed } = require('./headers');
+const { isInertiaPage, seal, sealed } = require('./headers');
 const { prepare, settle } = require('./references');
 const { TYPES: PARAM_TYPES, typed } = require('./params-schema');
 
@@ -774,6 +774,11 @@ function gate(henri, rules, body) {
  * that does not still has its answer written, because the failure path
  * answers rather than throwing into nobody's catch.
  *
+ * What it hands on is sealed, so a request that reached two matching routes
+ * -- an action that called `next()` -- is gated by the one that answered and
+ * not again by the one before it, whose declaration describes another
+ * action.
+ *
  * @param {Henri} henri the henri instance
  * @param {?object} rules the compiled rules of the action, or null
  * @param {string} name the route name (`get /memos`)
@@ -808,20 +813,28 @@ function guard(henri, rules, name) {
       }
 
       if (gated.problems.length > 0 && !report(henri, name, gated.problems)) {
-        return json({
+        res.statusCode = 500;
+
+        return seal(res).json({
           code: CODE,
           error: 'Internal Server Error',
           message: `${name} does not answer what it declared (config.api.strict)`,
-          statusCode: (res.statusCode = 500),
+          statusCode: 500,
         });
       }
 
       if (!gated.settle) {
+        seal(res);
+
         return json(gated.answer);
       }
 
       return gated.settle().then(
-        (answer) => json(answer),
+        (answer) => {
+          seal(res);
+
+          return json(answer);
+        },
         (error) => {
           // A controller that did not `return` its `res.json()` would turn a
           // throw here into an unhandled rejection, so this answers instead
@@ -836,7 +849,7 @@ function guard(henri, rules, name) {
 
           res.statusCode = 500;
 
-          return json({
+          return seal(res).json({
             code: CODE,
             error: 'Internal Server Error',
             message: `${name} could not publish its answer`,

--- a/packages/core/src/base/boom.js
+++ b/packages/core/src/base/boom.js
@@ -13,6 +13,7 @@ const { check } = require('./arguments');
  * henri.
  */
 const { isCode } = require('./errors');
+const { seal } = require('./headers');
 
 const STATUSES = {
   badData: [422, 'Unprocessable Entity'],
@@ -53,6 +54,11 @@ function boom() {
         if (typeof data !== 'undefined') {
           body.data = data;
         }
+
+        // The envelope henri writes itself: the answer gate leaves it
+        // alone rather than dropping a field name that is a message here
+        // (see base/answers.js)
+        seal(res);
 
         return res.status(statusCode).json(body);
       };

--- a/packages/core/src/base/config-schema.js
+++ b/packages/core/src/base/config-schema.js
@@ -898,7 +898,7 @@ const SCHEMA = {
       strict: {
         default: false,
         describe: 'true or false',
-        hint: 'true refuses (500) a JSON answer without _links',
+        hint: 'true refuses (500) a JSON answer without _links, and one that does not match what the action declared it answers',
         type: 'boolean',
       },
     },

--- a/packages/core/src/base/hateoas.js
+++ b/packages/core/src/base/hateoas.js
@@ -2,7 +2,7 @@ const { EXTERNAL_ID, hasExternalId } = require('./external-id');
 const { publish } = require('./references');
 const { check } = require('./arguments');
 const { stamp } = require('./errors');
-const { jsonType, noStore } = require('./headers');
+const { isInertiaPage, jsonType, noStore, seal } = require('./headers');
 const { linkHeader, pageLinks, paginate } = require('./pagination');
 
 /**
@@ -289,6 +289,11 @@ function routeType(res) {
 function send(req, res, body, status) {
   res.type(jsonType(req));
   noStore(req, res);
+
+  // Published and stripped already, by `toPublic()` above: the answer gate
+  // of a declared action must not describe this shape and must not walk it
+  // a second time (see base/answers.js)
+  seal(res);
 
   return res.status(status).json(body);
 }
@@ -646,25 +651,6 @@ function collection(henri, req, res, records, options = {}) {
 
     return send(req, res, body, status);
   })();
-}
-
-/**
- * Is this answer an Inertia page object rather than an API answer?
- *
- * The Inertia view engine answers a visit with `{ component, props, url,
- * version }`, a protocol of its own with no room for `_links`, and marks it
- * with the `X-Inertia` header. Such an answer is a rendered page, not JSON
- * the API guard below has anything to say about.
- *
- * @param {Express.Request} req the request
- * @param {Express.Response} res the response
- * @returns {boolean} true for an Inertia page object
- */
-function isInertiaPage(req, res) {
-  return Boolean(
-    (typeof res.getHeader === 'function' && res.getHeader('X-Inertia')) ||
-    (typeof req.get === 'function' && req.get('x-inertia'))
-  );
 }
 
 /**

--- a/packages/core/src/base/headers.js
+++ b/packages/core/src/base/headers.js
@@ -547,6 +547,65 @@ function noStore(req, res) {
   return false;
 }
 
+/**
+ * Is this answer an Inertia page object rather than an API answer?
+ *
+ * The Inertia view engine answers a visit with `{ component, props, url,
+ * version }`, a protocol of its own with no room for `_links`, and marks it
+ * with the `X-Inertia` header. Such an answer is a rendered page, not JSON
+ * the HAL guard or the answer gate has anything to say about -- its props
+ * went through the gate as `data` when the router built them.
+ *
+ * @param {Express.Request} req the request
+ * @param {Express.Response} res the response
+ * @returns {boolean} true for an Inertia page object
+ */
+function isInertiaPage(req, res) {
+  return Boolean(
+    (typeof res.getHeader === 'function' && res.getHeader('X-Inertia')) ||
+    (typeof req.get === 'function' && req.get('x-inertia'))
+  );
+}
+
+/**
+ * Marks a body henri built itself, so the answer gate lets it through.
+ *
+ * `res.resource()`, `res.collection()`, `res.render()`'s JSON and the boom
+ * envelope are henri's own answers: the ones carrying records went through
+ * the publish and the strip already, and the ones that do not are an
+ * envelope with a shape of its own. Doing it twice would cost a copy per
+ * answer and, on an error body, would drop a field *name* that is a message
+ * rather than a value. The mark lives here, with no dependency of its own,
+ * because everything that writes an answer can reach it and nothing that
+ * writes an answer may import the gate (see base/answers.js).
+ *
+ * @param {Express.Response} res the response
+ * @returns {Express.Response} the response
+ */
+function seal(res) {
+  if (res) {
+    res._sealed = true;
+  }
+
+  return res;
+}
+
+/**
+ * Was this body sealed? Reading it clears the mark: it describes one answer
+ *
+ * @param {Express.Response} res the response
+ * @returns {boolean} sealed or not
+ */
+function sealed(res) {
+  if (!res || res._sealed !== true) {
+    return false;
+  }
+
+  res._sealed = false;
+
+  return true;
+}
+
 module.exports = {
   HAL,
   JSON_TYPE,
@@ -557,12 +616,15 @@ module.exports = {
   cachedCsp,
   createNonce,
   cspDirectives,
+  isInertiaPage,
   jsonType,
   jsonTypes,
   merge,
   noStore,
   nonceEnabled,
   normalizeVersion,
+  seal,
+  sealed,
   secureHeaders,
   versionGuard,
 };

--- a/packages/core/src/base/http.js
+++ b/packages/core/src/base/http.js
@@ -4,6 +4,7 @@ const { isLoopback } = require('../utils');
 const { recorder } = require('./runtime');
 const { STATUSES } = require('./boom');
 const { coded } = require('./errors');
+const { seal } = require('./headers');
 
 /**
  * Escape a string for html
@@ -88,7 +89,8 @@ function negotiate(
       redirect
         ? res.redirect(redirect)
         : res.type('html').send(page(status, title, details, code)),
-    json: () => res.json(body),
+    // The envelope henri writes itself, like base/boom.js (base/answers.js)
+    json: () => seal(res).json(body),
     // Escaped as well: static analyzers treat every send() as an html sink
     // eslint-disable-next-line sort-keys
     default: () =>

--- a/packages/core/src/base/openapi.js
+++ b/packages/core/src/base/openapi.js
@@ -1574,7 +1574,7 @@ function operationDescription(
 
   if (params.read === false) {
     lines.push(
-      `Parameters: henri could not read the \`params\` export of \`app/controllers/${controller}.js\` -- the file did not load outside a booted application, or its declaration would fail the boot. If the action declares any, they are checked at runtime and are **not** in this operation; nothing was guessed in their place.`
+      `Parameters: henri could not read the \`params\` export of \`app/controllers/${controller}.js\` -- the file did not load outside a booted application, or its declaration would fail the boot. If the action declares any, they are checked at runtime and are **not** in this operation; nothing was guessed in their place, and the same is true of its \`answers\` block.`
     );
   }
 

--- a/packages/core/src/base/openapi.js
+++ b/packages/core/src/base/openapi.js
@@ -682,6 +682,92 @@ function ruleSchema(compiled) {
 }
 
 /**
+ * One rule of an `answers` declaration as a JSON Schema.
+ *
+ * The three shapes a rule has, in the order they are read: a field naming a
+ * model is that model's record schema, a field naming a column is typed from
+ * the model file, and anything else is its own type. `henri openapi` reads
+ * the model files, so both references resolve here even though the check
+ * that runs at boot lives in `base/answers.js`.
+ *
+ * @param {object} compiled a compiled rule (base/answers.js)
+ * @param {object} context the builder context
+ * @returns {object} the schema
+ */
+function answerSchema(compiled, context) {
+  const written = objectOf(compiled);
+  const { models, settings } = context;
+  const fileOf = (name) =>
+    models.find((file) => String(file.globalId) === String(name)) || null;
+
+  if (written.model) {
+    const known = fileOf(written.model);
+    const record = known
+      ? { $ref: `#/components/schemas/${known.globalId}` }
+      : { type: 'object' };
+
+    return written.type === 'array' ? { type: 'array', items: record } : record;
+  }
+
+  if (written.type === 'array') {
+    return { type: 'array', items: answerSchema(written.of, context) };
+  }
+
+  if (written.from) {
+    const source = fileOf(written.from.model);
+    const columns = source ? columnsOf(source, settings) : {};
+
+    if (columns[written.from.field]) {
+      return fieldSchema(
+        written.from.field,
+        columns[written.from.field],
+        context
+      );
+    }
+  }
+
+  return ruleSchema(written);
+}
+
+/**
+ * The 200 of an action that said what it answers.
+ *
+ * This is the one thing the document could not know: an operation whose body
+ * a controller writes carried no success status at all. Additional
+ * properties are refused, and that is not a style choice -- what is not
+ * declared does not leave (see base/answers.js), so the document says what
+ * the gate does.
+ *
+ * @param {object} rules the compiled rules of the action
+ * @param {object} context the builder context
+ * @param {object} where `{ action, controller }`
+ * @returns {object} the response object
+ */
+function declaredAnswer(rules, context, { action, controller }) {
+  const properties = {};
+  const required = [];
+
+  for (const name of Object.keys(rules).sort()) {
+    properties[name] = answerSchema(rules[name], context);
+
+    if (rules[name].required) {
+      required.push(name);
+    }
+  }
+
+  const schema = { type: 'object', properties, additionalProperties: false };
+
+  if (required.length > 0) {
+    schema.required = required;
+  }
+
+  return {
+    description: `What \`${controller}#${action}\` declared it answers (\`answers\`). henri sends the declared fields and nothing else, publishes the ones naming a model and drops every field the models marked \`personal: { expose: false }\`.`,
+    content: { [JSON_MEDIA]: { schema } },
+  };
+}
+
+/**
  * Where every declared field of an action is described.
  *
  * henri reads a field from the query string, the body and the path
@@ -1429,12 +1515,13 @@ function guardResponses(route, settings, rules) {
  * not
  *
  * @param {object} route the route
- * @param {object} context `{ answer, known, model, params, policy, settings }`
+ * @param {object} context `{ answer, answers, known, model, params, policy,
+ *   settings }`
  * @returns {string} the description
  */
 function operationDescription(
   route,
-  { answer, known, model, params, policy, settings }
+  { answer, answers, known, model, params, policy, settings }
 ) {
   const [controller, action] = String(route.controller).split('#');
   const lines = [
@@ -1525,7 +1612,18 @@ function operationDescription(
 
   if (answer === 'unknown') {
     lines.push(
-      'henri does not know what this action answers: it is not one of the seven actions expanded from `resources`, so nothing wraps it and the controller writes the body. The statuses below are the ones henri produces before the action runs, or in place of it.'
+      answers
+        ? `Answers ${Object.keys(answers)
+            .sort()
+            .map((field) => `\`${field}\``)
+            .join(
+              ', '
+            )}, which \`${controller}#${action}\` declared (\`answers\`). henri sends those fields and nothing else, publishes the ones naming a model, and drops every field the models marked \`personal: { expose: false }\`; a field that is missing or of another type is ${
+            settings.strict
+              ? 'refused with a 500 (config.api.strict)'
+              : 'reported in the log'
+          }.`
+        : 'henri does not know what this action answers: it is not one of the seven actions expanded from `resources`, so nothing wraps it and the controller writes the body. The statuses below are the ones henri produces before the action runs, or in place of it. An action says what it answers with an `answers` block (base/answers.js), and this operation then describes it.'
     );
   }
 
@@ -1676,6 +1774,24 @@ function resourceResponses(action, { embed, model }) {
 }
 
 /**
+ * What the catch-all response of an operation henri does not write says
+ *
+ * @param {object} context `{ declaredAnswers, known }`
+ * @returns {string} the description
+ */
+function defaultDescription({ declaredAnswers, known }) {
+  if (known === false) {
+    return 'The controller has no such action: 501 in development, 404 in production.';
+  }
+
+  if (declaredAnswers) {
+    return 'The statuses this action chooses for itself. Its successful answer is the one above, which the action declared; a failure henri answers itself uses the error envelope.';
+  }
+
+  return "Not described: what this action answers is the controller's own. A failure henri answers itself uses the error envelope; anything else is this application's.";
+}
+
+/**
  * One operation of the description
  *
  * @param {object} route the route
@@ -1693,6 +1809,8 @@ function operationFor(route, context) {
   const answer = isResource ? ANSWERS[action] || 'unknown' : 'unknown';
   const known = context.actionKnown(route.controller);
   const params = context.declared(route.controller);
+  const declaredAnswers =
+    known === false ? null : context.answered(route.controller);
   const { names } = template(route.route);
   const declared = params.rules
     ? splitDeclaration(params.rules, { names, verb: route.verb })
@@ -1743,14 +1861,20 @@ function operationFor(route, context) {
     );
   }
 
+  // The one thing this document could not know, until an action said it:
+  // a body a controller writes has a shape henri now enforces
+  if (answer === 'unknown' && declaredAnswers) {
+    responses['200'] = declaredAnswer(declaredAnswers, context, {
+      action,
+      controller,
+    });
+  }
+
   Object.assign(responses, guardResponses(route, settings, params.rules));
 
   if (answer === 'unknown' || known === false) {
     responses.default = {
-      description:
-        known === false
-          ? 'The controller has no such action: 501 in development, 404 in production.'
-          : "Not described: what this action answers is the controller's own. A failure henri answers itself uses the error envelope; anything else is this application's.",
+      description: defaultDescription({ declaredAnswers, known }),
       content: { [JSON_MEDIA]: { schema: {} } },
     };
   } else {
@@ -1763,7 +1887,8 @@ function operationFor(route, context) {
   // What henri itself checks on this route, and nothing an application does
   const enforced = []
     .concat(described || answer === 'page' ? ['_links'] : [])
-    .concat(params.rules ? ['params'] : []);
+    .concat(params.rules ? ['params'] : [])
+    .concat(declaredAnswers ? ['answers'] : []);
   const marks = prune({
     fields: params.rules ? Object.keys(params.rules).sort() : undefined,
     read: params.read === false ? false : undefined,
@@ -1773,6 +1898,7 @@ function operationFor(route, context) {
     summary: `${controller}#${action}`,
     description: operationDescription(route, {
       answer,
+      answers: declaredAnswers,
       known,
       model,
       params,
@@ -1785,9 +1911,12 @@ function operationFor(route, context) {
     'x-henri': prune({
       action,
       answer: known === false ? 'unknown' : answer,
+      answers: declaredAnswers
+        ? Object.keys(declaredAnswers).sort()
+        : undefined,
       controller,
       enforced: enforced.length > 0 ? enforced : undefined,
-      known: known !== false && described,
+      known: known !== false && (described || Boolean(declaredAnswers)),
       model: answer !== 'unknown' && model ? model.globalId : undefined,
       params: Object.keys(marks).length > 0 ? marks : undefined,
       pathHelper: route.path,
@@ -2322,6 +2451,10 @@ function overview(settings) {
  *   otherwise. An entry that is `null` is a controller whose declaration
  *   could not be read; a missing entry is one that declares nothing; `null`
  *   for the whole map is a caller that could not find out at all
+ * @param {?object} [input.answers=null] what each action declared it answers,
+ *   compiled, as `{ 'reports#digest': rules }` -- `henri.controllers.answers()`
+ *   on a booted application, `declarations()` of base/answers.js over the
+ *   controller files otherwise. A missing entry declares nothing
  * @param {*} [input.config={}] henri's config module, or the plain object a
  *   command read from `config/<env>.json`
  * @param {Array<object>} [input.models=[]] the model files, with `globalId`
@@ -2340,6 +2473,7 @@ function overview(settings) {
 function build({
   accepts = null,
   actions = null,
+  answers = null,
   config = {},
   info = {},
   models = [],
@@ -2365,6 +2499,23 @@ function build({
   const context = {
     actionKnown: (controller) =>
       actions === null ? null : Boolean(actions[controller]),
+    /**
+     * What an action declared it answers (see base/answers.js)
+     *
+     * @param {string} controller the `controller#action` key
+     * @returns {?object} the rules, or null when nothing is declared
+     */
+    answered: (controller) => {
+      if (!answers || typeof answers !== 'object') {
+        return null;
+      }
+
+      const written = answers[controller];
+      const rules =
+        written && typeof written === 'object' ? objectOf(written) : {};
+
+      return Object.keys(rules).length > 0 ? rules : null;
+    },
     /**
      * What an action declared it accepts, and whether henri got to read it
      *

--- a/packages/core/src/base/params-schema.js
+++ b/packages/core/src/base/params-schema.js
@@ -1155,5 +1155,8 @@ module.exports = {
   guard,
   inspect,
   rule,
+  // `base/answers.js` asks the same question in the other direction, so
+  // there is one table of what each type is and one answer per type
+  typed,
   write,
 };

--- a/packages/core/src/base/references.js
+++ b/packages/core/src/base/references.js
@@ -422,7 +422,14 @@ function walk(context, value, name = null) {
     return copy;
   }
 
-  const model = name || modelOf(context.classes, value);
+  // The caller's word first, then the map of registered constructors: a
+  // controller that says which model a plain object holds (`base/answers.js`)
+  // is the only way an object that never was a record can have its foreign
+  // keys published, and it is the reason `types` exists
+  const model =
+    name ||
+    (context.types ? context.types.get(value) : null) ||
+    modelOf(context.classes, value);
   const plain = typeof value.toJSON === 'function' ? value.toJSON() : value;
 
   // A registered model is a record whatever its prototype is; anything else
@@ -552,17 +559,24 @@ async function settle(henri, context) {
 }
 
 /**
- * The last gate on the way out: a copy of the value with no internal id and
- * no foreign key that names a row by its primary key.
+ * The walk, without the lookups: the copy, and what is still missing.
  *
- * Everything an application hands `res.render()`, `res.resource()` or
- * `res.collection()` goes through here, once per answer.
+ * The two halves are separate because one of them is free and the other is
+ * a query. An answer whose foreign keys were all eager loaded -- or that
+ * holds no record at all, which is most of what a controller hands
+ * `res.json()` -- comes back complete from here, and the caller answers
+ * without an asynchronous hop it does not need (see base/answers.js).
  *
  * @param {Henri} henri the henri instance
  * @param {*} value a record, a list of records, or anything else
- * @returns {Promise<*>} the value, published
+ * @param {object} [options={}] options
+ * @param {?WeakMap} [options.types=null] the model of a node the caller
+ *   knows and henri cannot see: a plain object carries no model, so this is
+ *   what lets a declared answer publish one
+ * @returns {{context: object, copy: *, pending: Array}} the copy, the
+ *   context to hand `settle()` and the keys it would resolve
  */
-async function publish(henri, value) {
+function prepare(henri, value, { types = null } = {}) {
   const table = (henri && henri.model && henri.model.referenceTable) || {
     classes: new Map(),
     models: {},
@@ -573,14 +587,41 @@ async function publish(henri, value) {
     pending: [],
     references: settings(henri).references,
     seen: new WeakMap(),
+    types,
   };
   const copy = walk(context, value);
 
-  if (context.pending.length > 0) {
+  return { context, copy, pending: context.pending };
+}
+
+/**
+ * The last gate on the way out: a copy of the value with no internal id and
+ * no foreign key that names a row by its primary key.
+ *
+ * Everything an application hands `res.render()`, `res.resource()` or
+ * `res.collection()` goes through here, once per answer.
+ *
+ * @param {Henri} henri the henri instance
+ * @param {*} value a record, a list of records, or anything else
+ * @param {object} [options={}] options (see `prepare`)
+ * @returns {Promise<*>} the value, published
+ */
+async function publish(henri, value, options = {}) {
+  const { context, copy, pending } = prepare(henri, value, options);
+
+  if (pending.length > 0) {
     await settle(henri, context);
   }
 
   return copy;
 }
 
-module.exports = { DEFAULTS, build, keyOf, publish, settings };
+module.exports = {
+  DEFAULTS,
+  build,
+  keyOf,
+  prepare,
+  publish,
+  settings,
+  settle,
+};

--- a/packages/demo/app/controllers/reports.js
+++ b/packages/demo/app/controllers/reports.js
@@ -60,6 +60,10 @@ module.exports = {
     });
   },
 
+  // The other method that writes a value: express serializes this one
+  // itself instead of going through res.json(), so the gate wraps it too
+  padded: async (req, res) => res.jsonp({ gender: req.user.gender }),
+
   profile: async (req, res) =>
     res.json({ age: req.user.age, who: req.user.email }),
 

--- a/packages/demo/app/controllers/reports.js
+++ b/packages/demo/app/controllers/reports.js
@@ -1,0 +1,72 @@
+// Everything in here answers through `res.json()`, the one call that used to
+// leave the server without the two passes `res.render()` and `res.resource()`
+// have always run (see base/answers.js).
+//
+// `hand` declares nothing: it is the controller the survey was about, and the
+// floor is what stops it -- `gender`, `phone` and `nationalId` are marked
+// `personal: { expose: false }` on the user model and never reach the wire,
+// whatever this action puts in the object.
+//
+// `digest` declares what it answers, which buys three things a floor cannot:
+// the rows are Memo records, so `ownerId` leaves as the owner's `externalId`
+// even though these are objects a controller built; `secret` is not declared,
+// so it does not leave; and `henri openapi` describes the 200.
+module.exports = {
+  answers: {
+    digest: {
+      rows: { model: 'Memo', type: 'array' },
+      total: { required: true, type: 'integer' },
+    },
+    // A column of the user model under a name of its own: henri cannot see
+    // that `who` holds an address, so the declaration says it
+    profile: {
+      age: { from: 'User.age', type: 'integer' },
+      who: { from: 'User.email', type: 'string' },
+    },
+    // The declared way to carry a field the model marked `expose: false`,
+    // and the mirror of `res.resource(record, { include })`
+    sensitive: {
+      gender: { expose: true, from: 'User.gender', type: 'string' },
+    },
+  },
+
+  digest: async (req, res) => {
+    const memos = await Memo.find();
+
+    return res.json({
+      rows: memos.map((memo) => ({
+        ownerId: memo.ownerId,
+        title: memo.title,
+      })),
+      secret: 'undeclared',
+      total: memos.length,
+    });
+  },
+
+  hand: async (req, res) => {
+    const user = await User.findByKey(req.user.id || req.user._id);
+
+    return res.json({
+      rows: [
+        {
+          email: user.email,
+          gender: user.gender,
+          id: user.id || user._id,
+          nationalId: user.nationalId,
+          phone: user.phone,
+        },
+      ],
+      total: 1,
+    });
+  },
+
+  profile: async (req, res) =>
+    res.json({ age: req.user.age, who: req.user.email }),
+
+  // The records themselves rather than a copy of their fields: those carry
+  // their model, so the floor alone drops the primary key and publishes the
+  // foreign keys, declaration or not
+  records: async (req, res) => res.json({ rows: await Memo.find() }),
+
+  sensitive: async (req, res) => res.json({ gender: req.user.gender }),
+};

--- a/packages/demo/app/routes.js
+++ b/packages/demo/app/routes.js
@@ -22,6 +22,7 @@ module.exports = {
   // What an action answers, declared and not (see base/answers.js)
   'get /reports/digest': 'reports#digest',
   'get /reports/hand': { controller: 'reports#hand', roles: ['member'] },
+  'get /reports/padded': { controller: 'reports#padded', roles: ['member'] },
   'get /reports/profile': { controller: 'reports#profile', roles: ['member'] },
   'get /reports/records': 'reports#records',
   'get /reports/sensitive': {

--- a/packages/demo/app/routes.js
+++ b/packages/demo/app/routes.js
@@ -19,6 +19,15 @@ module.exports = {
     rateLimit: { max: 2, windowMs: 60000 },
   },
   'get /profile': { controller: 'user#profile', roles: ['member'] },
+  // What an action answers, declared and not (see base/answers.js)
+  'get /reports/digest': 'reports#digest',
+  'get /reports/hand': { controller: 'reports#hand', roles: ['member'] },
+  'get /reports/profile': { controller: 'reports#profile', roles: ['member'] },
+  'get /reports/records': 'reports#records',
+  'get /reports/sensitive': {
+    controller: 'reports#sensitive',
+    roles: ['member'],
+  },
   'get /uploads/:id': 'uploads#show',
   'get /version': 'main#version',
   // A namespace: the controllers live in app/controllers/admin

--- a/types/core.test-d.ts
+++ b/types/core.test-d.ts
@@ -7,6 +7,7 @@
 import type {
   AccountResult,
   AccountSettings,
+  AnswerRule,
   BootAnalysis,
   Boom,
   Cache,
@@ -556,9 +557,51 @@ expectType<Controller>(badParams);
 expectType<Controller>(badRule);
 expectType<Controller>(badKey);
 
+const answering: Controller = {
+  answers: {
+    all: { total: 'integer' },
+    index: {
+      // a list of records: the model is what publishes a hand-built row
+      rows: { model: 'Task', type: 'array' },
+      // a column of a model, under a name of its own
+      who: { from: 'User.email', type: 'string' },
+    },
+    show: {
+      task: { model: 'Task' },
+      tags: { type: 'array', of: 'string' },
+      // the declared form of `res.resource(record, { include })`
+      gender: { from: 'User.gender', type: 'string', expose: true },
+    },
+  },
+  index: async (req, res) => res.json({ rows: [], total: 0 }),
+  show: async (req, res) => res.json({ tags: [], task: {}, total: 1 }),
+};
+
+expectType<Controller>(answering);
+
+const badAnswer: Controller = {
+  answers: {
+    // @ts-expect-error a rule names a type henri has
+    index: { total: { type: 'intger' } },
+  },
+};
+
+const badAnswerKey: Controller = {
+  answers: {
+    // @ts-expect-error an answer rule takes no `default`
+    index: { total: { type: 'integer', default: 0 } },
+  },
+};
+
+expectType<Controller>(badAnswer);
+expectType<Controller>(badAnswerKey);
+
 // `henri.controllers` answers what an action declared
 expectType<Record<string, ParamRule> | null>(
   henri.controllers.accepts('tasks#create')
+);
+expectType<Record<string, AnswerRule> | null>(
+  henri.controllers.answers('tasks#index')
 );
 
 // --- routes -----------------------------------------------------------------

--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -205,11 +205,11 @@ See [Models](/guides/models/#adapters) for each adapter.
 
 The keys of the [JSON API](/guides/api/), all optional:
 
-| Key                             | Default                              | Description                                                                                                                                           |
-| ------------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `api.perPage`, `api.maxPerPage` | `25`, `100`                          | Page size read by `req.pagination()` and its upper bound.                                                                                             |
-| `api.strict`                    | `false`                              | Refuse (500) a JSON answer without `_links` on a `resources`/`crud` route instead of logging it.                                                      |
-| `api.idempotency`               | `{ "ttl": 86400000, "store": null }` | How long answers are kept for `Idempotency-Key` replays and the module exporting a shared `{ get, set, delete }` store; `false` disables the feature. |
+| Key                             | Default                              | Description                                                                                                                                                                                                               |
+| ------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `api.perPage`, `api.maxPerPage` | `25`, `100`                          | Page size read by `req.pagination()` and its upper bound.                                                                                                                                                                 |
+| `api.strict`                    | `false`                              | Refuse (500) a JSON answer without `_links` on a `resources`/`crud` route, and one that does not match what the action [declared it answers](/guides/controllers/#answers-what-an-action-answers), instead of logging it. |
+| `api.idempotency`               | `{ "ttl": 86400000, "store": null }` | How long answers are kept for `Idempotency-Key` replays and the module exporting a shared `{ get, set, delete }` store; `false` disables the feature.                                                                     |
 
 ## Rate limits
 

--- a/website/src/content/docs/guides/api.md
+++ b/website/src/content/docs/guides/api.md
@@ -89,7 +89,7 @@ Options: `type` names the controller when it is not the route's (`res.resource(u
 
 `res.negotiate({ html, json })` runs `html` for browsers (and clients accepting `*/*`) and `json` for `application/json`, `application/hal+json` and the versioned media type below. `res.render()` keeps answering `{ data, user, paths, ... }` to JSON clients and now adds `_links` too.
 
-Routes expanded from `resources` and `crud` are expected to answer HAL: a JSON answer without `_links` on one of them is reported once per route in the log, and refused with a `500` when `config.api.strict` is `true`. The page object the [Inertia](/guides/views/#inertia) engine answers a client-side visit with (`X-Inertia`) is a rendered page, not an API answer, and is never checked. `henri generate scaffold` and `henri generate crud` write controllers in the shape above, and `henri generate test <name>` asserts the links when the name has a `resources` or `crud` route.
+Routes expanded from `resources` and `crud` are expected to answer HAL: a JSON answer without `_links` on one of them is reported once per route in the log, and refused with a `500` when `config.api.strict` is `true` — which is also what refuses an answer that does not match what the action [declared it answers](/guides/controllers/#answers-what-an-action-answers). The page object the [Inertia](/guides/views/#inertia) engine answers a client-side visit with (`X-Inertia`) is a rendered page, not an API answer, and is never checked. `henri generate scaffold` and `henri generate crud` write controllers in the shape above, and `henri generate test <name>` asserts the links when the name has a `resources` or `crud` route.
 
 ## Pagination
 

--- a/website/src/content/docs/guides/controllers.md
+++ b/website/src/content/docs/guides/controllers.md
@@ -194,6 +194,8 @@ henri's own answers are untouched by it — the HAL envelope, the page options, 
 
 What the floor cannot do is see through a name. `res.json({ g: user.gender })` is a string as far as henri is concerned, and so is `{ ownerId: memo.ownerId }` — a plain object carries no model, so nothing knows that key names a row. Both are what a declaration is for.
 
+The other thing it cannot do is read bytes. `res.json()` and `res.jsonp()` are gated because that is where the value still is; `res.send(JSON.stringify(value))`, `res.write()` and a stream hand over a string, and a string is not an answer henri can walk.
+
 ### The declaration
 
 ```js

--- a/website/src/content/docs/guides/controllers.md
+++ b/website/src/content/docs/guides/controllers.md
@@ -1,13 +1,13 @@
 ---
 title: Controllers
-description: Express handlers under app/controllers, autoloaded and reloaded on save, with before hooks, declared parameters, implicit rendering and flash messages.
+description: Express handlers under app/controllers, autoloaded and reloaded on save, with before hooks, declared parameters, declared answers, implicit rendering and flash messages.
 sidebar:
   order: 2
 ---
 
 Controllers live in `app/controllers`. Every `.js` file there is loaded on boot, reloaded on save and referenced from `config/routes.js` as `file#action`; a file in a subdirectory is prefixed with it (`app/controllers/admin/users.js` is `admin/users#index`).
 
-A controller is a plain object of Express handlers, `(req, res)` or `(req, res, next)`, sync or async, plus an optional `before` block and an optional `params` block saying what each action accepts. Models are globals, `henri` is a global, and `res.render()` hands data to the view.
+A controller is a plain object of Express handlers, `(req, res)` or `(req, res, next)`, sync or async, plus an optional `before` block, an optional `params` block saying what each action accepts and an optional `answers` block saying what each action answers. Models are globals, `henri` is a global, and `res.render()` hands data to the view.
 
 A `/** @type {import('@usehenri/core').Controller} */` line above `module.exports` is what gives `req` and `res` completion in an editor; the generators write it for you. See [Types](/reference/types/).
 
@@ -98,7 +98,7 @@ module.exports = {
 };
 ```
 
-A hook may also be given by name (`before: { show: 'loadTask' }`), which resolves to another export of the same controller. `before` and [`params`](#params-what-an-action-accepts) are never routable: they are the keys of a controller that are not actions.
+A hook may also be given by name (`before: { show: 'loadTask' }`), which resolves to another export of the same controller. `before`, [`params`](#params-what-an-action-accepts) and [`answers`](#answers-what-an-action-answers) are never routable: they are the keys of a controller that are not actions.
 
 ## `params`: what an action accepts
 
@@ -173,6 +173,86 @@ The check runs once the route is allowed — behind the [role guard](/guides/rou
 ### It is also the description of the request
 
 [`henri openapi`](/guides/openapi/) reads this block: the fields become the query, path and body parameters of the operation, with the types, the bounds and the enums declared here, and the `422` becomes a response the document names. Declaring `params` is how an action gets a request body in the description that is the one it actually accepts, rather than the writable columns of its model.
+
+## `answers`: what an action answers
+
+`params` declares what arrives. `answers` declares what leaves, in the same block shape and with the same vocabulary — and it sits next to a rule that needs no declaration at all, so read the floor first.
+
+### The floor: every JSON answer is published and stripped
+
+`res.render()`, `res.resource()` and `res.collection()` have always gone through one gate on the way out: a foreign key leaves as the [`externalId`](/guides/models/#two-identifiers) of the row it names, and a field a model marked [`personal: { expose: false }`](/guides/privacy/) is dropped. **`res.json()` now goes through the same gate**, on every action of every controller, declared or not:
+
+```js
+// the models say `gender` never leaves; this does not change that
+res.json({ rows: [{ email: user.email, gender: user.gender }] });
+// => {"rows":[{"email":"ada@usehenri.io"}]}
+```
+
+That is the hole this closes. An object a controller builds by hand is not a record — the props of an Inertia page assembled in the action, a total next to a list — so nothing published it and nothing stripped it, and a field marked as never leaving left. There is no setting that turns the floor off: the mark is the model's word about a person, and a controller is not where it is overruled. `res.resource(record, { include })` and `res.render(view, { data, include })` are still how a private field is sent on purpose, and `expose: true` below is the third way.
+
+henri's own answers are untouched by it — the HAL envelope, the page options, the `res.boom.*` body, the 404 and 500 pages, an Inertia page object — because those were built through the gate already or are an envelope with a shape of their own.
+
+What the floor cannot do is see through a name. `res.json({ g: user.gender })` is a string as far as henri is concerned, and so is `{ ownerId: memo.ownerId }` — a plain object carries no model, so nothing knows that key names a row. Both are what a declaration is for.
+
+### The declaration
+
+```js
+module.exports = {
+  answers: {
+    all: { total: 'integer' },
+    index: {
+      rows: { model: 'Memo', type: 'array' },
+      who: { from: 'User.email', type: 'string' },
+    },
+    show: { memo: { model: 'Memo' } },
+  },
+
+  index: async (req, res) =>
+    res.json({
+      rows: (await Memo.find()).map((memo) => ({
+        ownerId: memo.ownerId,
+        title: memo.title,
+      })),
+      total: await Memo.count(),
+      who: req.user.email,
+    }),
+};
+```
+
+`all` (or `*`) is every action, any other key is one action or a comma-separated list, and the action's own key wins over the lists before it — the selectors `before` and `params` already use. A rule may be the type itself: `total: 'integer'` is `total: { type: 'integer' }`.
+
+| Key        | What it does                                                                                                                                                                                             |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `type`     | the [model types](/guides/models/), plus `array` and `record`. Implied by `model` (a record) and by `from` (`json`, the type that says nothing)                                                          |
+| `model`    | the model whose records this field holds: one record on its own, a list of them with `type: 'array'`. **This is what publishes a hand-built object**: `ownerId` above leaves as the owner's `externalId` |
+| `from`     | `'User.email'`, the column this value came from. The field then obeys that column's marks under whatever name the answer gives it, and `henri openapi` types it from the model file                      |
+| `of`       | the rule every item of a list of scalars follows                                                                                                                                                         |
+| `required` | the field has to be in the answer                                                                                                                                                                        |
+| `expose`   | `true` says this action may carry a field marked `personal: { expose: false }` — the declared form of the `include` `res.resource()` takes                                                               |
+
+A rule henri cannot carry out fails the boot with `HENRI_ANSWERS_DECLARATION_INVALID`, naming the controller, the action and the field: an unknown type or key, a `model` that is not one of this application's, a `from` that is not `Model.field`, a list with neither `of` nor `model`, a selector naming an action the controller does not export, and a `from` pointing at a column marked `expose: false` without `expose: true` next to it. A declaration that reads like a guarantee and is quietly ignored is the mistake this exists to remove.
+
+There is no `enum`, no `min`, no `pattern` and no `default`: a declaration describes the shape of an answer, and henri does not validate an application's own values on the way out — the model did that on the way in, and a response that fails after the work is done turns a cosmetic mistake into an outage.
+
+### What is not declared does not leave
+
+An action that declared answers sends the fields it declared, and nothing else:
+
+```js
+answers: { peek: { title: 'string' } },
+peek: async (req, res) => res.json({ secret: req.memo.body, title: req.memo.title }),
+// => {"title":"Minutes"}
+```
+
+That is the same rule `req.permit()` follows in the other direction — the declaration is the list, an undeclared key is dropped and never refused — and it is the safe direction: the field nobody declared is the field nobody thought about. It costs nothing to adopt, because it only applies to an action that declared: one that declares nothing keeps every byte it sends today.
+
+The other half goes the other way. A field that was **declared and is missing**, or that holds something other than what was declared, is a mistake in the declaration rather than something leaking, so it is reported once per route in the log and only refused with [`config.api.strict`](/configuration/) — the setting that already means "refuse what would otherwise be a warning about this application's API", where it answers a 500 carrying `HENRI_ANSWERS_MISMATCH`.
+
+The declaration is one level deep, like `params`: it describes the fields of the answer, not the inside of a record it names. What leaves inside a declared record is what the record holds, published and stripped by the floor.
+
+### It is also the description of the answer
+
+[`henri openapi`](/guides/openapi/) refused to describe what a controller writes: such an operation carried the statuses henri produces, `x-henri.known: false` and no success status at all. A declared answer is exactly what it could not know, so an operation that has one carries a `200` with the schema — `$ref`ing the model's record schema for a field naming a model, the column's own schema for a field naming one, and `additionalProperties: false`, because the document says what the gate does.
 
 ## Implicit rendering
 

--- a/website/src/content/docs/guides/openapi.md
+++ b/website/src/content/docs/guides/openapi.md
@@ -35,7 +35,7 @@ Everything below comes from the application, never from a convention henri hopes
 | `POST /login`, the account flows  | `config.user`: they are in the document only when henri actually mounts them                                                                                              |
 | `/livez`, `/readyz`, `/healthz`   | Always: every henri application answers them                                                                                                                              |
 
-Every operation also carries `x-henri.enforced`, a list naming what henri actually checks on that route — `_links` on the ones expanded from `resources` and `crud`, `params` on the ones whose action declared any — as opposed to what it expects.
+Every operation also carries `x-henri.enforced`, a list naming what henri actually checks on that route — `_links` on the ones expanded from `resources` and `crud`, `params` on the ones whose action declared any, `answers` on the ones whose action declared what it sends — as opposed to what it expects.
 
 A field marked `personal: { expose: false }` is in **no** schema, because [privacy](/guides/privacy/) strips that name from every answer henri builds, at every depth. Neither is `password`. A declared foreign key is typed as the `externalId` of the row it names, because that is what [`base/references.js`](/guides/models/#identifiers) publishes — and `null`, because a key that names no row resolves to nothing.
 
@@ -90,6 +90,10 @@ A hand-written route (`get /about`), a `member` or `collection` route of a resou
 
 `{}` is the JSON Schema for "any value". It is the only correct answer, and the operation's `x-henri.known` is `false` so a reader — a person or an agent — never has to work that out from prose.
 
+### An operation that said what it answers
+
+There is one way to move an operation out of that column without changing what it answers: the action declares it. An [`answers`](/guides/controllers/#answers-what-an-action-answers) block is a description of what leaves, which is exactly what this document could not know, so an operation that has one carries a `200` built from it — a field naming a model `$ref`s that model's record schema, a field naming a column carries that column's schema, and `additionalProperties` is `false` because henri drops what the action did not declare. `x-henri.known` is then `true`, `x-henri.answers` lists the fields and `x-henri.enforced` names `answers`. The `default` response stays, for the statuses the action chooses itself.
+
 ### Which of two shapes a guarded route answers
 
 The routes expanded from `resources` and `crud` are the ones henri does guard — but what it guards is `_links`, and nothing else. Two of henri's own answers carry them: the HAL envelope of `res.resource()` and `res.collection()`, and the page options of `res.render()` and of the implicit render (an action that returns an object without answering). A `resources` route that renders a page answers the second one, and it is a perfectly ordinary thing to do — the showcase's `events#index` does it.
@@ -135,7 +139,7 @@ OpenAPI 3.1.0 for @usehenri/showcase 0.0.0
     ...
 ```
 
-Twenty of forty-seven is not a failure of the tool: it is what an application with pages, member routes and form actions actually looks like. Moving an operation from one column to the other is a matter of answering it with `res.resource()` or `res.collection()` from a `resources` route, which is what henri asks for anyway.
+Twenty of forty-seven is not a failure of the tool: it is what an application with pages, member routes and form actions actually looks like. Moving an operation from one column to the other is a matter of answering it with `res.resource()` or `res.collection()` from a `resources` route, which is what henri asks for anyway — or of declaring its answer, for the ones that legitimately send something else.
 
 ## Where the document lives
 

--- a/website/src/content/docs/guides/privacy.md
+++ b/website/src/content/docs/guides/privacy.md
@@ -22,12 +22,12 @@ module.exports = {
 
 That is the whole mark. Four things follow from it:
 
-| What        | Where                                                                    |
-| ----------- | ------------------------------------------------------------------------ |
-| Redaction   | Every log line and every recorded error masks the field, by name         |
-| What leaves | `expose: false` drops it from every answer henri builds                  |
-| Export      | `henri privacy:export <who>` hands the person everything held about them |
-| Erasure     | `henri privacy:erase <who>` removes them, and leaves a receipt           |
+| What        | Where                                                                          |
+| ----------- | ------------------------------------------------------------------------------ |
+| Redaction   | Every log line and every recorded error masks the field, by name               |
+| What leaves | `expose: false` drops it from every answer henri builds, `res.json()` included |
+| Export      | `henri privacy:export <who>` hands the person everything held about them       |
+| Erasure     | `henri privacy:erase <who>` removes them, and leaves a receipt                 |
 
 `henri privacy` prints the map, the way `henri routes` prints the routes:
 
@@ -109,9 +109,10 @@ default would break every application there is. The rule is one sentence:
 > `expose: false`, and then it never leaves at all.
 
 `expose: false` is absolute and it applies by name, everywhere: `res.render()`,
-`res.resource()`, `res.collection()`, the public user of every page, at every
-depth of the payload, whether the value came from a model instance, a `.lean()`
-query or an object a presenter built. The one way back is to ask for it:
+`res.resource()`, `res.collection()`, **`res.json()` on any controller
+action**, the public user of every page, at every depth of the payload,
+whether the value came from a model instance, a `.lean()` query or an object a
+presenter built. The one way back is to ask for it:
 
 ```js
 // app/controllers/accounts.js -- the person's own page, and only this one
@@ -122,7 +123,17 @@ return res.render('/account', {
 ```
 
 `res.resource(record, { include: ['phone'] })` and
-`res.collection(records, { include: ['phone'] })` take the same option.
+`res.collection(records, { include: ['phone'] })` take the same option, and an
+action answering with `res.json()` says it in its
+[`answers`](/guides/controllers/#answers-what-an-action-answers) block
+(`phone: { from: 'User.phone', type: 'string', expose: true }`), which is the
+same permission written down instead of passed.
+
+What a name-based rule cannot see is the same value under another name:
+`res.json({ p: user.phone })` is a string as far as henri is concerned. That is
+the other half of what `answers` is for — `from: 'User.phone'` is how a
+controller says which column a value came from, and a `from` naming a column
+marked `expose: false` fails the boot unless the rule says `expose: true`.
 
 `config.privacy.expose: false` flips the default the other way: every personal
 field is then private unless it says `personal: { expose: true }`. It is one

--- a/website/src/content/docs/reference/errors.md
+++ b/website/src/content/docs/reference/errors.md
@@ -157,6 +157,38 @@ Usually:
 
 **Fix.** Check that the development server is still running, and read its output: a boot that failed halfway leaves the port closed.
 
+## answers
+
+What a controller declared its actions answer (`answers`), and the gate every JSON answer leaves through.
+
+### `HENRI_ANSWERS_DECLARATION_INVALID`
+
+A controller declares an answer henri cannot carry out.
+
+Usually:
+
+- a rule with no `type` and no `model`, or a type henri does not have
+- a `model` that is not a model of this application, or a `from` that is not `Model.field`
+- `model` next to a type that is not `array`, or a list with neither `of` nor `model`
+- an unknown key, usually a misspelling of `required` or `expose`
+- a `from` naming a column the model marked `personal: { expose: false }`, without `expose: true`
+- a selector naming an action the controller does not export
+
+**Fix.** The message names the controller, the action and the field. A rule is `{ type, model, from, of, required, expose }`, or the type itself (`total: 'integer'`); `model` names one of this application's models and `from` is `Model.field`. See the Controllers guide.
+
+### `HENRI_ANSWERS_MISMATCH`
+
+An action answered something other than what it declared, and `config.api.strict` refused it.
+
+Usually:
+
+- a field the action declared `required` is not in what it sent
+- a declared field holds something other than the type it declared
+- the action sent fields it never declared, which were dropped
+- the action declared fields and answered with a list or a scalar
+
+**Fix.** The answer is reported once per route (`pen.warn`) and only refused like this with `config.api.strict`. Either send what the action declared, or change the `answers` block to describe what it sends.
+
 ## api
 
 The JSON API layer: HAL answers, the health endpoints, the OpenAPI description of what an application exposes and the optional GraphQL engine.


### PR DESCRIPTION
## What

Two things, and the difference between them is the point.

**The floor.** Every JSON answer of every controller action is published and
then stripped -- the same two passes, in the same order, that `res.render()`,
`res.resource()` and `res.collection()` have always run on the way out. No
setting turns it off, because the mark on the field is the model's word about
a person and a controller is not the place to overrule it.

**The declaration.** Opt-in, per action, in the block `before` and `params`
already established -- an export the router reads, keyed by action, never an
action itself:

```js
module.exports = {
  answers: {
    index: {
      rows: { model: 'Memo', type: 'array' },
      total: 'integer',
    },
  },

  index: async (req, res) =>
    res.json({ rows: await Memo.find(), total: await Memo.count() }),
};
```

`model` is what lets a hand-built object be published: an object that never
was a record carries no model, so henri cannot know that its `ownerId` names
a row -- the declaration is where it is told. `from: 'User.email'` makes a
value obey its column's marks under whatever name the answer gives it, which
is the one leak a name-based strip cannot see. `expose: true` is the declared
form of the `include` that `res.resource()` already takes. An undeclared
field is dropped; a declared field that is missing or mistyped warns once and
only fails the request under `config.api.strict`. A rule henri cannot carry
out fails the boot naming the controller, the action and the field
(`HENRI_ANSWERS_DECLARATION_INVALID`), the way a `params` rule does.

`henri openapi` now emits a `200` for a declared answer, where before an
operation a controller wrote carried no success status at all.

## Why

`base/params-schema.js` closed one direction: what arrives is declared per
action and refused before the action runs. The other direction was not
equally guarded. `res.render()` and `res.resource()` went through
`toPublic()`; `res.json()` went through nothing:

```js
// gated
res.render('Users/Index', { data: records });
// not gated, and the same records
res.json({ rows: records.map((r) => ({ id: r.id, gender: r.gender })) });
```

That is not an exotic controller. It is what an Inertia page whose props are
assembled by hand looks like, and what every JSON route answering a total
next to a list looks like.

## Verified on the wire, not on report

`packages/demo/app/controllers/reports.js` is the fixture: `hand` declares
nothing and hands `res.json()` a user's `gender`, `nationalId` and `phone`,
all three marked `personal: { expose: false }`.

Against the booted demo application, signed in as a member, asserting on the
response bytes:

| route | answer |
| --- | --- |
| `/reports/hand` | `{"rows":[{"email":"…","id":"…"}],"total":1}` -- the three marked fields gone |
| `/reports/padded` | `{}` -- `res.jsonp()` serializes on its own, and is wrapped too |
| `/reports/digest` | `ownerId` published as the owner's `externalId` from a hand-built object, `secret: 'undeclared'` dropped |
| `/reports/records` | real records: no primary key on the wire, `externalId` and the published foreign key |
| `/reports/sensitive` | `{"gender":"she/her"}` -- declared `expose: true`, so it carries |

Replacing the strip with the identity function fails
`packages/core/src/__tests__/answers.spec.js` in two places, including the
jsonp padding, so the assertions are load-bearing rather than incidental.

The limit is stated where it applies: `hand`'s `id` is a plain key on an
object that carries no model, and henri reads no field name. A controller
that wants that published declares a `model`, or answers with the records.

## Gates

`pnpm test` (173 files), `pnpm test:types`, `pnpm lint --max-warnings 0`,
`pnpm format:check`, `scripts/smoke.sh` end to end, and the showcase suite
against a live PostgreSQL (166 tests) -- a real application's JSON answers
pass through the floor unchanged.
