### PR TITLE
Model validations that mean the same thing on all three adapters

### DIFF
--- a/.changeset/model-validations.md
+++ b/.changeset/model-validations.md
@@ -1,0 +1,46 @@
+---
+'@usehenri/core': minor
+'@usehenri/drizzle': minor
+'@usehenri/mongoose': minor
+'@usehenri/sequelize': minor
+---
+
+Model validations that mean the same thing on all three adapters.
+
+A model says what must be true of its records in a `validates` block, keyed by field, in the vocabulary a controller's `params` block already uses:
+
+```js
+// app/models/Post.js
+module.exports = {
+  schema: {
+    title: { type: 'string', required: true },
+    slug: { type: 'string', unique: true },
+    status: { type: 'string', enum: ['draft', 'live'], default: 'draft' },
+    body: { type: 'text' },
+  },
+
+  validates: {
+    title: { minLength: 3, maxLength: 120 },
+    slug: { pattern: /^[a-z0-9-]+$/ },
+    status: {
+      validate: (value, post) =>
+        value !== 'live' || Boolean(post.body) || 'needs a body first',
+    },
+  },
+};
+```
+
+`required`, `enum`, `min`, `max`, `minLength`, `maxLength`, `pattern` and `validate` — no `type`, because the schema next door already says it, and that is what decides which constraints apply. A rule henri cannot carry out fails the boot naming the model and the field (`HENRI_MODEL_VALIDATION_INVALID`) rather than being ignored.
+
+It runs where the writes are, not where each ORM happens to look. **The schema's own `required` and `enum` are the same rules**, so this changes what an application that declares no `validates` at all already does:
+
+- **Mongoose** ran its validators on `save()`, `create()` and `insertMany()` and on nothing else. `updateOne`, `updateMany` and `findOneAndUpdate` wrote a `null` over a required field and a value outside an `enum` straight into the document. They are checked now.
+- **Sequelize** skipped `bulkCreate` (its `validate` defaults to `false`), so a value outside an `enum` was written. It is checked now, and Sequelize's own validation is turned on for that call too.
+- **Sequelize on PostgreSQL and MySQL** has a native `ENUM` column and had no JavaScript check at all, so the _server_ refused the value with a `SequelizeDatabaseError` — which `henri.model.errors()` answers `null` for, so an application answered **500** where the same model file answered 422 on sqlite. henri refuses first now, and the answer is the same 422 on every dialect.
+- The message is henri's on all three: `must be one of draft, live`, `is required`, `must be at most 120 characters`. A `required` field holding nothing but spaces is missing, which is what Mongoose and Drizzle already said and Sequelize did not.
+
+The failure is the shape applications already read: `henri.model.errors(error)` answers `{ field: message }`, and nothing about the 422 changes.
+
+Two things are refused rather than quietly skipped. A `validate` that declares a second parameter is asking for the record, the way a policy rule does — a mass write has none, so a mass write naming that field is refused with the loop to write instead (`HENRI_MODEL_VALIDATION_MASS_WRITE`). And a write no hook of the ORM reaches — Mongoose's `bulkWrite`, Sequelize's `increment`/`decrement`, an update operator like `$inc` — is refused on a validated field (`HENRI_MODEL_VALIDATION_UNCHECKED_WRITE`) instead of letting the declaration stop being true. `unique` stays what it is: an index the database enforces, because a check before an insert is a race, and `henri.model.errors()` already turns the duplicate into `{ field: 'must be unique' }`.
+
+A `validate` function in the schema of a Sequelize store now fails the boot pointing at `validates`: Sequelize reads its own `validate` as an object of named validators, so a function there did nothing, while the same line on the other two adapters ran.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -515,6 +515,42 @@ model }` or Mongoose's `ref` -- which `res.render()`, `res.resource()`,
   `henri.model.errors(error)` (`base/model-errors.js`) normalizes the three
   ORMs' validation failures to `{ field: message }`, `null` for anything else.
   `henri db:seed` runs `db/seeds.js` on any adapter.
+- **What must be true of a record is `validates`** (`base/validations.js`,
+  a copy per adapter the way `exact.js` is, kept byte identical by
+  `src/__tests__/validations.spec.js`): a block keyed by field, in the
+  vocabulary `params-schema.js` already owns (`required`, `enum`, `min`,
+  `max`, `minLength`, `maxLength`, `pattern`) plus `validate`, a function.
+  No `type` -- the schema says it, and it is what decides which constraints
+  apply; a rule henri cannot carry out fails the boot naming the model and
+  the field (`HENRI_MODEL_VALIDATION_INVALID`). **The schema's own
+  `required` and `enum` are the same rules**, which is what makes those two
+  mean one thing: they used to mean three. Measured before this existed:
+  Mongoose ran its validators on `save`/`create`/`insertMany` and on
+  nothing else, so `updateMany` wrote a null over a required field;
+  Sequelize's `bulkCreate` defaults to `validate: false`, so it wrote a
+  value outside an `enum`; and on postgres and mysql the `enum` column is a
+  native `ENUM` with no JavaScript check, so the server refused the value
+  with a `SequelizeDatabaseError` -- which `model-errors.js` answers null
+  for, so the same model file answered **500** there and 422 on sqlite. The
+  rules run in `Model.prepare()` (drizzle), a `beforeValidate` plus
+  `beforeBulkCreate` (sequelize, ahead of Sequelize's own validators so the
+  sentence is henri's) and `pre('validate')` plus the query middleware
+  (mongoose, where `required` and `enum` are stripped from the path
+  definition for a field whose type henri knows, so henri owns the message
+  -- a type Mongoose brought keeps Mongoose's meaning). Two refusals rather
+  than a silence: a `validate` declaring a second parameter is asking for
+  the record, the predicate `base/policies.js` uses, so a mass write naming
+  that field is `HENRI_MODEL_VALIDATION_MASS_WRITE` (the versions
+  precedent), measured against the fields the write names so a soft delete
+  is not caught; and a write no hook reaches -- Mongoose's `bulkWrite`,
+  Sequelize's `increment`/`decrement`, a `$inc` -- is
+  `HENRI_MODEL_VALIDATION_UNCHECKED_WRITE`. **henri does not claim
+  `unique`**: a check before an insert is a race, so the index stays what
+  holds and `model-errors.js` turns the duplicate into
+  `{ field: 'must be unique' }`. The guide is `guides/models.md`
+  (`#validations`), which is also where the boundary with `params` is
+  argued: `params` checks what arrives, `validates` what is written, and a
+  job, a seed or a console has no request.
 - The user module (`4.user.js`) mounts express-session (`henri.sid`),
   passport (`local` and `jwt` strategies), `POST /login`, `POST /logout`
   (`GET` answers 405), the double-submit CSRF middleware (`base/csrf.js`,
@@ -1468,5 +1504,31 @@ filters.spec.js`), on MongoDB through the demo application core's suite
   the rest of that adapter. There is no `or` between filters, no free-text
   search across columns, no cursor paging, no filtering across an
   association and no operator an application can add.
+- Model validations (`validates`) are new, and this is the tranche that
+  landed the declaration plus the validators that work identically on all
+  three. What was **deliberately left**: no `unique` (argued above and in
+  the guide), no cross-record rule, no model-level rule filed under `base`,
+  no `if`/`unless` condition, no message of one's own per constraint (only
+  a `validate` returning a string), no `on: 'create'` / `on: 'update'`
+  selector, and no `Model.valid?`/`errors` on an unsaved instance -- a
+  refused write throws, as it always did. The **schema keys the adapters
+  brought and henri did not** are untouched and are still not portable:
+  drizzle's `min`, `max`, `minLength`, `maxLength`, `match`, `validate`,
+  `trim`, `lowercase` and `select` are drizzle's, mongoose passes its own
+  through, and sequelize refuses every one of them at boot except its own
+  `validate` object -- which is why a `validate` function there now fails
+  the boot pointing at `validates` rather than doing nothing. Coverage:
+  sqlite and MongoDB offline, PostgreSQL and MySQL through
+  `pnpm test:sql:live`; MSSQL rides the Sequelize wiring with no coverage
+  of its own, like the rest of that adapter. Two known holes henri refuses
+  rather than checks are in the error catalogue
+  (`HENRI_MODEL_VALIDATION_UNCHECKED_WRITE`), and `Model.upsert()` on
+  Sequelize is treated as a partial write, so a required column it does
+  not name is left to the database's `NOT NULL`.
+- Separate from the above and **not fixed**: on the drizzle adapter
+  `instance.update(attrs)` is `set()` then `save()`, so a write refused by
+  a validation leaves the refused value on the in-memory instance and the
+  next `update()` on that same instance is measured against it. A record
+  read again is fine; only the object in hand is stale.
 - The scaffolded app pins ESLint 9 because `eslint-plugin-react` does not
   support ESLint 10 yet.

--- a/packages/cli/scripts/agents.js
+++ b/packages/cli/scripts/agents.js
@@ -689,7 +689,9 @@ const modelSection = (facts) => {
 
 ${MODEL_API[facts.api]} ${MIGRATIONS[facts.api]}
 
-A field is \`{ type, required, default, enum, unique, index }\` and anything else is handed to the adapter as is. Every model gets \`createdAt\`/\`updatedAt\`, \`paginate({ page, perPage })\` answering \`{ records, page, perPage, total, pages }\`, and \`externalId\` -- a uuid, and the only identifier that leaves the server: routes, links and payloads carry it and \`findById()\` takes it, while the numeric key stays inside. \`henri.model.errors(error)\` turns a validation failure into \`{ field: message }\`.${carried}`;
+A field is \`{ type, required, default, enum, unique, index }\` and anything else is handed to the adapter as is. Every model gets \`createdAt\`/\`updatedAt\`, \`paginate({ page, perPage })\` answering \`{ records, page, perPage, total, pages }\`, and \`externalId\` -- a uuid, and the only identifier that leaves the server: routes, links and payloads carry it and \`findById()\` takes it, while the numeric key stays inside. \`henri.model.errors(error)\` turns a validation failure into \`{ field: message }\`.
+
+A \`validates\` block next to the schema says what must be true of a record, keyed by field: \`validates: { title: { minLength: 3, maxLength: 120 }, slug: { pattern: /^[a-z-]+$/ } }\`. The keys are \`required\`, \`enum\`, \`min\`, \`max\`, \`minLength\`, \`maxLength\`, \`pattern\` and \`validate\` (a function of the value, and of the record when it declares a second parameter) -- the same words a controller's \`params\` block uses, with no \`type\` because the schema says it. They run on **every** write: a create, a save, an update, a mass update, a bulk insert. That is where a rule about the record belongs; \`params\` and \`req.permit()\` are about the request, and a job, a seed or a console has none. Anything else in the schema -- an adapter's own \`min\`, \`match\` or \`validate\` -- is that ORM's and does not travel.${carried}`;
 };
 
 /**

--- a/packages/core/error-codes.json
+++ b/packages/core/error-codes.json
@@ -1522,6 +1522,39 @@
       "what": "A model field asks for a type henri does not have."
     },
     {
+      "area": "model",
+      "causes": [
+        "a `validates` entry naming a field the schema does not have",
+        "a constraint the field's type does not take (`min` on a string, `maxLength` on an integer)",
+        "an unknown key, usually a misspelling of `required`, `maxLength` or `pattern`",
+        "a `pattern` that is not a regular expression, or a `validate` that is not a function"
+      ],
+      "code": "HENRI_MODEL_VALIDATION_INVALID",
+      "fix": "The message names the model, the field and what is wrong with the rule. A `validates` entry takes `required`, `enum`, `min`, `max`, `minLength`, `maxLength`, `pattern` and `validate`, and the field's type in the schema is what says which of them apply. See the Models guide.",
+      "what": "A model's `validates` block holds a rule henri cannot carry out."
+    },
+    {
+      "area": "model",
+      "causes": [
+        "`Model.update(where, attrs)` or the fluent `Model.where(...).update()` on a model whose `validates` block holds a rule taking `(value, record)`",
+        "`updateMany` on such a model, on any adapter"
+      ],
+      "code": "HENRI_MODEL_VALIDATION_MASS_WRITE",
+      "fix": "A rule that declares a record parameter is never asked without one, the way a policy rule is not. A mass write has no records to give it, so henri refuses rather than recording a pass it never made. Loop over the records instead -- `for (const record of await Model.find(where)) await record.update(attrs)` -- and each one is checked. A rule that only reads the value takes one parameter and mass writes keep working.",
+      "what": "A mass update was run on a model whose validator asks for the record."
+    },
+    {
+      "area": "model",
+      "causes": [
+        "`Model.bulkWrite()` on a model that declares validations (Mongoose runs no middleware for the operations inside one)",
+        "`Model.increment()` or `Model.decrement()` on a validated field (Sequelize runs no hook for either)",
+        "an update operator that describes a change rather than a value (`$inc`, `$push`, `$mul`) on a validated field"
+      ],
+      "code": "HENRI_MODEL_VALIDATION_UNCHECKED_WRITE",
+      "fix": "The message names the call and the fields. These write paths reach the database without any hook henri could run a rule in, and none of them exists on all three adapters, so henri refuses instead of letting the declaration quietly stop being true. Read the record, change it and save it, which is checked -- or take the rules off the fields that call writes.",
+      "what": "A write the ORM runs no hook for was made on a validated field."
+    },
+    {
       "area": "params",
       "causes": [
         "a rule with no `type`, or a type henri does not have",

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -2652,6 +2652,16 @@ declare namespace start {
     name?: string;
     options?: ModelOptions;
     /**
+     * What must be true of a record, keyed by field.
+     *
+     * The same words a controller's `params` block uses, checked on every
+     * write path of every adapter -- a create, a save, an update, a mass
+     * update, a bulk insert -- rather than on the ones that ORM happens to
+     * cover. The field's `type` in the schema says which constraints
+     * apply, and a rule henri cannot carry out fails the boot.
+     */
+    validates?: Record<string, ModelValidation>;
+    /**
      * GraphQL, when the application has `@usehenri/graphql`.
      *
      * `true` derives the type, the queries and the resolvers from the
@@ -2662,6 +2672,27 @@ declare namespace start {
     graphql?: true | GraphqlModelDefinition;
     /** Called once every model exists, with the models by global id. */
     associate?(models: Record<string, unknown>): void;
+  }
+
+  /**
+   * One field's rule in a model's `validates` block.
+   *
+   * `required` is presence: absent, null and a string of nothing but
+   * spaces are all missing. The bounds need a type henri knows -- `min`
+   * and `max` a number, the two lengths and `pattern` a string -- and a
+   * `validate` that declares a second parameter is asking for the record,
+   * which makes a mass write on that model a refusal rather than a rule
+   * henri quietly skips.
+   */
+  interface ModelValidation {
+    required?: boolean;
+    enum?: unknown[];
+    min?: number | string;
+    max?: number | string;
+    minLength?: number;
+    maxLength?: number;
+    pattern?: RegExp;
+    validate?(value: any, record?: any): boolean | string | void;
   }
 
   /** The `graphql` key of a model, in its object form. */

--- a/packages/core/src/__tests__/validations.spec.js
+++ b/packages/core/src/__tests__/validations.spec.js
@@ -1,0 +1,397 @@
+const fs = require('fs');
+const path = require('path');
+
+const {
+  KEYS,
+  MASS_WRITE,
+  UNCHECKED,
+  massWrite,
+  problemsOf,
+  uncheckedWrite,
+  validationsOf,
+  wantsRecord,
+} = require('../base/validations');
+
+/** A model file, in the shape core hands the adapters */
+const model = (schema, validates) => ({
+  globalId: 'Thing',
+  identity: 'thing',
+  schema,
+  validates,
+});
+
+/** The rules of a model file, compiled */
+const rulesOf = (schema, validates) => validationsOf(model(schema, validates));
+
+describe('model validations', () => {
+  describe('the copies in the adapters', () => {
+    // Each adapter holds its own, the way `exact.js` and `external-id.js`
+    // are held: an adapter depends on no part of core at runtime. Nothing
+    // but this test keeps them the same file.
+    const root = path.join(__dirname, '..', '..', '..');
+    const source = fs.readFileSync(
+      path.join(root, 'core', 'src', 'base', 'validations.js'),
+      'utf8'
+    );
+
+    for (const adapter of ['drizzle', 'mongoose', 'sequelize']) {
+      test(`@usehenri/${adapter} carries the same file, byte for byte`, () => {
+        const copy = fs.readFileSync(
+          path.join(root, adapter, 'validations.js'),
+          'utf8'
+        );
+
+        expect(copy).toBe(source);
+      });
+
+      test(`@usehenri/${adapter} publishes it`, () => {
+        const manifest = JSON.parse(
+          fs.readFileSync(path.join(root, adapter, 'package.json'), 'utf8')
+        );
+
+        expect(manifest.files).toContain('validations.js');
+      });
+    }
+
+    test('it reaches for nothing but its neighbour', () => {
+      // A copy sits at the root of an adapter, next to that adapter's own
+      // `exact.js`, so the one require it makes has to resolve there too
+      expect(source.match(/require\('[^']+'\)/gu)).toEqual([
+        "require('./exact')",
+      ]);
+    });
+  });
+
+  describe('the vocabulary', () => {
+    test('is the one a params block already uses', () => {
+      expect(KEYS).toEqual([
+        'enum',
+        'max',
+        'maxLength',
+        'min',
+        'minLength',
+        'pattern',
+        'required',
+        'validate',
+      ]);
+    });
+
+    test('a model that declares nothing has no rules', () => {
+      expect(rulesOf({ name: 'string' })).toBeNull();
+      expect(validationsOf({})).toBeNull();
+    });
+
+    test("the schema's own required and enum are rules", () => {
+      const rules = rulesOf({
+        name: { required: true, type: 'string' },
+        note: 'text',
+        status: { enum: ['draft', 'live'], type: 'string' },
+      });
+
+      expect(Object.keys(rules)).toEqual(['name', 'status']);
+      expect(rules.name).toEqual({ required: true, type: 'string' });
+      expect(rules.status).toEqual({
+        enum: ['draft', 'live'],
+        type: 'string',
+      });
+    });
+
+    test('and so is the Sequelize spelling both adapters accept', () => {
+      const rules = rulesOf({ name: { allowNull: false, type: 'string' } });
+
+      expect(rules.name).toEqual({ required: true, type: 'string' });
+    });
+
+    test('a validates entry is merged over them', () => {
+      const rules = rulesOf(
+        { name: { required: true, type: 'string' } },
+        { name: { maxLength: 10, required: false } }
+      );
+
+      expect(rules.name).toEqual({
+        maxLength: 10,
+        required: false,
+        type: 'string',
+      });
+    });
+  });
+
+  describe('what fails the boot', () => {
+    const refused = (schema, validates) => {
+      try {
+        rulesOf(schema, validates);
+      } catch (error) {
+        return error;
+      }
+
+      return null;
+    };
+
+    test('a rule for a field the schema has no column for', () => {
+      const error = refused({ name: 'string' }, { nmae: { maxLength: 2 } });
+
+      expect(error.code).toBe('HENRI_MODEL_VALIDATION_INVALID');
+      expect(error.message).toMatch(/which its schema has no field for: name/u);
+    });
+
+    test('an unknown key', () => {
+      const error = refused({ name: 'string' }, { name: { lenght: 2 } });
+
+      expect(error.code).toBe('HENRI_MODEL_VALIDATION_INVALID');
+      expect(error.message).toMatch(/the unknown key "lenght"/u);
+    });
+
+    test('a constraint the type does not take', () => {
+      expect(refused({ name: 'string' }, { name: { min: 2 } }).message).toMatch(
+        /"min", which a string does not take: min is for bigint, decimal/u
+      );
+      expect(
+        refused({ age: 'integer' }, { age: { maxLength: 2 } }).message
+      ).toMatch(/"maxLength", which an integer does not take/u);
+    });
+
+    test('a bound on a type henri did not bring', () => {
+      const error = refused(
+        { author: { ref: 'User', type: 'ObjectId' } },
+        { author: { maxLength: 2 } }
+      );
+
+      expect(error.message).toMatch(/which needs a type henri knows/u);
+    });
+
+    test('but presence and inclusion need no type at all', () => {
+      const rules = rulesOf(
+        { author: { ref: 'User', type: 'ObjectId' } },
+        { author: { required: true } }
+      );
+
+      expect(rules.author).toEqual({ required: true, type: null });
+    });
+
+    test('a bound, a pattern or a validate of the wrong shape', () => {
+      expect(
+        refused({ age: 'integer' }, { age: { min: '2' } }).message
+      ).toMatch(/a "min" that is not a number/u);
+      expect(
+        refused({ name: 'string' }, { name: { pattern: 'a' } }).message
+      ).toMatch(/a "pattern" that is not a regular expression/u);
+      expect(
+        refused({ name: 'string' }, { name: { validate: 'yes' } }).message
+      ).toMatch(/a "validate" that is not a function/u);
+      expect(
+        refused({ name: 'string' }, { name: { required: 'yes' } }).message
+      ).toMatch(/a "required" that is not true or false/u);
+      expect(
+        refused({ name: 'string' }, { name: { enum: [] } }).message
+      ).toMatch(/an "enum" that is not a list of values/u);
+      expect(refused({ name: 'string' }, { name: 'string' }).message).toMatch(
+        /a rule is an object of enum, max/u
+      );
+    });
+
+    test('a validates block that is not an object', () => {
+      expect(() =>
+        validationsOf({ globalId: 'Thing', schema: {}, validates: 4 })
+      ).toThrow(/declares `validates` as number/u);
+    });
+
+    test('an exact bound may be written out, the way its values are', () => {
+      const rules = rulesOf(
+        { price: { precision: 12, scale: 2, type: 'decimal' } },
+        { price: { max: '99999999.99', min: '0.01' } }
+      );
+
+      expect(rules.price.min).toBe('0.01');
+    });
+  });
+
+  describe('running the rules', () => {
+    const rules = rulesOf(
+      {
+        age: 'integer',
+        name: { required: true, type: 'string' },
+        price: { precision: 12, scale: 2, type: 'decimal' },
+        slug: 'string',
+        status: { enum: ['draft', 'live'], type: 'string' },
+      },
+      {
+        age: { max: 120, min: 18 },
+        price: { max: '100.00' },
+        slug: { maxLength: 5, minLength: 2, pattern: /^[a-z-]+$/u },
+      }
+    );
+
+    test('nothing wrong is null', () => {
+      expect(problemsOf(rules, { age: 20, name: 'a', slug: 'ok' })).toBeNull();
+      expect(problemsOf(null, { name: null })).toBeNull();
+    });
+
+    test('presence is Rails’ presence', () => {
+      expect(problemsOf(rules, {})).toEqual({ name: 'is required' });
+      expect(problemsOf(rules, { name: null })).toEqual({
+        name: 'is required',
+      });
+      expect(problemsOf(rules, { name: '   ' })).toEqual({
+        name: 'is required',
+      });
+      expect(problemsOf(rules, { name: '' })).toEqual({ name: 'is required' });
+    });
+
+    test('an update leaves a field it does not name alone', () => {
+      expect(problemsOf(rules, { age: 20 }, { partial: true })).toBeNull();
+      expect(problemsOf(rules, { name: null }, { partial: true })).toEqual({
+        name: 'is required',
+      });
+    });
+
+    test('the bounds, the length, the shape and the list', () => {
+      expect(problemsOf(rules, { age: 2, name: 'a' })).toEqual({
+        age: 'must be at least 18',
+      });
+      expect(problemsOf(rules, { age: 900, name: 'a' })).toEqual({
+        age: 'must be at most 120',
+      });
+      expect(problemsOf(rules, { name: 'a', slug: 'a' })).toEqual({
+        slug: 'must be at least 2 characters',
+      });
+      expect(problemsOf(rules, { name: 'a', slug: 'abcdefg' })).toEqual({
+        slug: 'must be at most 5 characters',
+      });
+      expect(problemsOf(rules, { name: 'a', slug: 'AB' })).toEqual({
+        slug: 'is not in the expected format',
+      });
+      expect(problemsOf(rules, { name: 'a', status: 'nope' })).toEqual({
+        status: 'must be one of draft, live',
+      });
+    });
+
+    test('an exact bound is compared digit by digit, not through a double', () => {
+      expect(problemsOf(rules, { name: 'a', price: '99.99' })).toBeNull();
+      expect(problemsOf(rules, { name: 'a', price: '100.01' })).toEqual({
+        price: 'must be at most 100.00',
+      });
+      // The comparison a string would get letter by letter, and does not
+      expect(problemsOf(rules, { name: 'a', price: '9.99' })).toBeNull();
+    });
+
+    test('a null value is checked by required and by nothing else', () => {
+      expect(problemsOf(rules, { age: null, name: 'a' })).toBeNull();
+      expect(problemsOf(rules, { name: 'a', status: null })).toBeNull();
+    });
+
+    test('every field is reported, not the first', () => {
+      expect(problemsOf(rules, { age: 1, slug: 'AB', status: 'x' })).toEqual({
+        age: 'must be at least 18',
+        name: 'is required',
+        slug: 'is not in the expected format',
+        status: 'must be one of draft, live',
+      });
+    });
+  });
+
+  describe('a validator of one’s own', () => {
+    test('false is a failure, a string is the message, true is a pass', () => {
+      const rules = rulesOf(
+        { name: 'string' },
+        { name: { validate: (value) => value !== 'no' } }
+      );
+
+      expect(problemsOf(rules, { name: 'yes' })).toBeNull();
+      expect(problemsOf(rules, { name: 'no' })).toEqual({ name: 'is invalid' });
+
+      const said = rulesOf(
+        { name: 'string' },
+        { name: { validate: (value) => value === 'ok' || 'must say ok' } }
+      );
+
+      expect(problemsOf(said, { name: 'no' })).toEqual({
+        name: 'must say ok',
+      });
+    });
+
+    test('a throw is the message, so a validator never becomes a 500', () => {
+      const rules = rulesOf(
+        { name: 'string' },
+        {
+          name: {
+            validate: () => {
+              throw new Error('exploded');
+            },
+          },
+        }
+      );
+
+      expect(problemsOf(rules, { name: 'x' })).toEqual({ name: 'exploded' });
+    });
+
+    test('it is never asked about a value that is not there', () => {
+      const asked = [];
+      const rules = rulesOf(
+        { name: 'string' },
+        {
+          name: {
+            validate: (value) => {
+              asked.push(value);
+
+              return true;
+            },
+          },
+        }
+      );
+
+      problemsOf(rules, { name: null });
+      problemsOf(rules, {});
+      expect(asked).toEqual([]);
+    });
+
+    test('a second parameter is a request for the record', () => {
+      const rules = rulesOf(
+        { body: 'text', status: { enum: ['draft', 'live'], type: 'string' } },
+        {
+          status: {
+            validate: (value, record) =>
+              value !== 'live' || Boolean(record.body) || 'needs a body first',
+          },
+        }
+      );
+
+      expect(wantsRecord(rules)).toEqual(['status']);
+      expect(wantsRecord(rules, { body: 'x' })).toEqual([]);
+      expect(
+        problemsOf(rules, { status: 'live' }, { record: { body: '' } })
+      ).toEqual({ status: 'needs a body first' });
+      expect(
+        problemsOf(rules, { status: 'live' }, { record: { body: 'here' } })
+      ).toBeNull();
+    });
+
+    test('a validator that only reads the value never refuses a mass write', () => {
+      const rules = rulesOf(
+        { name: 'string' },
+        { name: { validate: (value) => value !== 'no' } }
+      );
+
+      expect(wantsRecord(rules)).toEqual([]);
+    });
+  });
+
+  describe('the refusals', () => {
+    test('a mass write names the model, the fields and the loop', () => {
+      const error = massWrite('Post', 'update', 'update(attrs)', ['status']);
+
+      expect(error.code).toBe(MASS_WRITE);
+      expect(error.message).toMatch(/status of Post is validated by a rule/u);
+      expect(error.message).toMatch(
+        /for \(const record of await Post\.find\(where\)\) await record\.update\(attrs\)/u
+      );
+    });
+
+    test('an unreachable write names the call and what to do instead', () => {
+      const error = uncheckedWrite('Post', 'bulkWrite', 'Use create().');
+
+      expect(error.code).toBe(UNCHECKED);
+      expect(error.message).toMatch(/Post\.bulkWrite\(\) writes without/u);
+      expect(error.message).toMatch(/Use create\(\)\./u);
+    });
+  });
+});

--- a/packages/core/src/base/validations.js
+++ b/packages/core/src/base/validations.js
@@ -1,0 +1,598 @@
+/**
+ * What must be true of a record, declared once and meant once.
+ *
+ * A model file says it in a `validates` block, keyed by field, in the
+ * vocabulary the request boundaries already use (`base/params-schema.js`):
+ *
+ * ```js
+ * module.exports = {
+ *   schema: {
+ *     email: { type: 'string', required: true, unique: true },
+ *     age: { type: 'integer' },
+ *     status: { type: 'string', enum: ['draft', 'live'] },
+ *   },
+ *   validates: {
+ *     age: { max: 120, min: 18 },
+ *     email: { maxLength: 120, pattern: /^[^@\s]+@[^@\s]+$/u },
+ *     status: { validate: (value, record) => value !== 'live' || record.body },
+ *   },
+ * };
+ * ```
+ *
+ * ## Why this file exists at all
+ *
+ * The three ORMs each have validations and no two of them mean the same
+ * thing. Measured, not assumed:
+ *
+ * - **Mongoose** runs its path validators on `save()`, `create()` and
+ *   `insertMany()` and on **nothing else**. `updateOne`, `updateMany`,
+ *   `findOneAndUpdate` and `findByIdAndUpdate` write straight past
+ *   `required` and `enum` -- a `null` lands in a required column and a
+ *   value outside the enum lands in the document -- unless the *caller*
+ *   remembers `runValidators: true` on that one call.
+ * - **Sequelize** validates `create`, `save`, `update` and the mass
+ *   `Model.update`, skips `bulkCreate` (its `validate` defaults to
+ *   `false`, so a value outside an `enum` is written), and on the dialects
+ *   with a native `ENUM` column has no JavaScript check at all -- the
+ *   server refuses it, as a `SequelizeDatabaseError` that
+ *   `henri.model.errors()` does not recognize, so the same model file
+ *   answers 422 on sqlite and 500 on PostgreSQL.
+ * - **Drizzle** validates every write it exposes, including the mass ones.
+ *
+ * So `required` and `enum` -- two keys the models guide says mean the same
+ * thing on every adapter -- did not. This module is what makes them, and
+ * it is the only implementation of the rules an application declares.
+ *
+ * ## One vocabulary
+ *
+ * The keys are the ones a controller's `params` block already takes, and
+ * they mean the same thing here: `required`, `enum`, `min`, `max`,
+ * `minLength`, `maxLength`, `pattern`, plus `validate`, a function of the
+ * value (and, when it asks for one, the record). There is no `type`: the
+ * schema next door already says it, and a constraint that means nothing
+ * for that type (`min` on a `string`, `maxLength` on an `integer`) fails
+ * the boot rather than being ignored.
+ *
+ * The schema's own `required` and `enum` are read into the same rules, so
+ * an application that never writes a `validates` block still gets one
+ * meaning for those two on every adapter and every write path.
+ *
+ * ## Where this belongs, and where it does not
+ *
+ * `req.permit()` and a controller's `params` block check what **arrives**:
+ * they are about a request, they coerce a query string, and they answer
+ * 422 before an action runs. This checks what is **written**, and a record
+ * is written by a job, a seed, a console and a webhook delivery as often
+ * as by a request. The two compose -- neither replaces the other -- and
+ * the guide says so where a person is deciding.
+ *
+ * ## What is refused rather than pretended
+ *
+ * A `validate` function that declares a second parameter is asking for the
+ * record, and a mass write has none: the same predicate `base/policies.js`
+ * uses for a rule that wants a record. Rather than calling it with
+ * `undefined` and recording a pass, a mass write on such a model is
+ * refused (`HENRI_MODEL_VALIDATION_MASS_WRITE`), which is the answer
+ * `HENRI_VERSION_MASS_WRITE` already gives to the same shape of problem.
+ * Every other rule reads only the value being written, so a mass write
+ * checks them exactly as a single write does.
+ *
+ * ## Uniqueness is not here, deliberately
+ *
+ * `unique` stays what it is: an index, and a race. A `SELECT` before an
+ * `INSERT` answers a question about a moment that has passed by the time
+ * the row is written, so a check would turn a guarantee the database
+ * keeps into a message henri sometimes produces. The database refuses the
+ * duplicate, and `henri.model.errors()` turns that refusal into
+ * `{ field: 'must be unique' }` on all three adapters, which is the same
+ * shape as everything here.
+ *
+ * ## A copy per adapter
+ *
+ * This file is held four times -- here and in `@usehenri/drizzle`,
+ * `@usehenri/mongoose` and `@usehenri/sequelize` -- byte for byte, the way
+ * `exact.js` and `external-id.js` are, because an adapter depends on no
+ * part of core at runtime. `src/__tests__/validations.spec.js` is what
+ * keeps them the same file. It requires nothing but `./exact`, which is
+ * held the same way, and raises its codes through a `coded()` of its own
+ * for the same reason.
+ */
+
+const { compare, isExact } = require('./exact');
+
+/** The failure a model declaration henri cannot carry out gets */
+const INVALID = 'HENRI_MODEL_VALIDATION_INVALID';
+
+/** The failure a mass write on a record-aware validator gets */
+const MASS_WRITE = 'HENRI_MODEL_VALIDATION_MASS_WRITE';
+
+/** The failure a write no hook of the ORM reaches gets */
+const UNCHECKED = 'HENRI_MODEL_VALIDATION_UNCHECKED_WRITE';
+
+/** The henri schema types, so a constraint can be bound to one */
+const TYPES = [
+  'bigint',
+  'boolean',
+  'date',
+  'decimal',
+  'float',
+  'integer',
+  'json',
+  'number',
+  'string',
+  'text',
+  'uuid',
+];
+
+/**
+ * The types each constraint applies to. `required`, `enum` and `validate`
+ * apply to every type, so they are not in here (see KEYS).
+ */
+const APPLIES = {
+  max: ['bigint', 'decimal', 'float', 'integer', 'number'],
+  maxLength: ['string', 'text'],
+  min: ['bigint', 'decimal', 'float', 'integer', 'number'],
+  minLength: ['string', 'text'],
+  pattern: ['string', 'text'],
+};
+
+/** The keys every field takes, whatever its type */
+const ANY = ['enum', 'required', 'validate'];
+
+/** Every key a `validates` entry may hold */
+const KEYS = [...ANY, ...Object.keys(APPLIES)].sort();
+
+/**
+ * An error carrying a henri code, without depending on core
+ *
+ * @param {string} code the henri error code
+ * @param {string} message what is wrong
+ * @returns {Error} the error to throw
+ */
+const coded = (code, message) => Object.assign(new Error(message), { code });
+
+/**
+ * Is the value a plain object?
+ *
+ * @param {*} value any value
+ * @returns {boolean} true for a plain object
+ */
+const isPlainObject = (value) =>
+  value !== null &&
+  typeof value === 'object' &&
+  (Object.getPrototypeOf(value) === Object.prototype ||
+    Object.getPrototypeOf(value) === null);
+
+/**
+ * Is the value missing, for `required`?
+ *
+ * Rails' `presence`, and what Mongoose and Drizzle already answer: a
+ * string of nothing but spaces is a field a person left empty, not a
+ * value. Sequelize's `allowNull` alone would have written it.
+ *
+ * @param {*} value the value
+ * @returns {boolean} true when there is nothing there
+ */
+const isBlank = (value) =>
+  typeof value === 'undefined' ||
+  value === null ||
+  (typeof value === 'string' && value.trim() === '');
+
+/**
+ * `a string`, `an integer`: the article a message needs
+ *
+ * @param {string} type the type
+ * @returns {string} the type with its article
+ */
+const article = (type) => (/^[aeiou]/u.test(type) ? `an ${type}` : `a ${type}`);
+
+/**
+ * The henri type a field declares, when it declares one henri knows
+ *
+ * A model file may write a type this file has no opinion about -- a
+ * Mongoose `ObjectId`, a Sequelize `DataTypes.STRING(50)`, a nested
+ * document -- and a constraint that measures a number or a length has
+ * nothing to measure there. Those fields still take `required`, `enum`
+ * and `validate`, which need no type at all.
+ *
+ * @param {*} definition the field definition from the model file
+ * @returns {?string} the henri type name, or null
+ */
+const typeOf = (definition) => {
+  const type = isPlainObject(definition) ? definition.type : definition;
+
+  if (typeof type !== 'string') {
+    return null;
+  }
+
+  const name = type.toLowerCase();
+
+  return TYPES.includes(name) ? name : null;
+};
+
+/**
+ * Refuses a declaration, naming the model and the field
+ *
+ * @param {string} model the model's global id
+ * @param {string} field the field name
+ * @param {string} what what is wrong with it
+ * @returns {void} never returns
+ * @throws {Error} always, HENRI_MODEL_VALIDATION_INVALID
+ */
+const refuse = (model, field, what) => {
+  throw coded(INVALID, `${model} declares \`validates.${field}\` with ${what}`);
+};
+
+/**
+ * Checks and freezes one field's rule
+ *
+ * @param {string} model the model's global id
+ * @param {string} field the field name
+ * @param {object} written what the model file wrote
+ * @param {?string} type the henri type of the field, when it has one
+ * @returns {object} the compiled rule
+ * @throws {Error} HENRI_MODEL_VALIDATION_INVALID on anything unusable
+ */
+const ruleOf = (model, field, written, type) => {
+  if (!isPlainObject(written)) {
+    refuse(
+      model,
+      field,
+      `${written === null ? 'null' : typeof written}: a rule is an object of ${KEYS.join(', ')}`
+    );
+  }
+
+  const compiled = { type };
+
+  for (const [key, value] of Object.entries(written)) {
+    if (!KEYS.includes(key)) {
+      refuse(
+        model,
+        field,
+        `the unknown key "${key}": a rule takes ${KEYS.join(', ')}`
+      );
+    }
+
+    if (APPLIES[key] && !APPLIES[key].includes(type)) {
+      refuse(
+        model,
+        field,
+        type === null
+          ? `"${key}", which needs a type henri knows: the field declares one henri has no bounds for, so it takes ${ANY.join(', ')} only`
+          : `"${key}", which ${article(type)} does not take: ${key} is for ${APPLIES[key].join(', ')}`
+      );
+    }
+
+    compiled[key] = value;
+  }
+
+  for (const key of ['max', 'maxLength', 'min', 'minLength']) {
+    if (!(key in compiled)) {
+      continue;
+    }
+
+    // The bound of an exact field may be written out, the way its values
+    // are, so a limit past what a double carries can be declared at all
+    const exact =
+      isExact(type) && (key === 'max' || key === 'min')
+        ? typeof compiled[key] === 'string'
+        : false;
+
+    if (!exact && typeof compiled[key] !== 'number') {
+      refuse(model, field, `a "${key}" that is not a number`);
+    }
+  }
+
+  if ('pattern' in compiled && !(compiled.pattern instanceof RegExp)) {
+    refuse(model, field, 'a "pattern" that is not a regular expression');
+  }
+
+  if ('required' in compiled && typeof compiled.required !== 'boolean') {
+    refuse(model, field, 'a "required" that is not true or false');
+  }
+
+  if ('enum' in compiled) {
+    if (!Array.isArray(compiled.enum) || compiled.enum.length === 0) {
+      refuse(model, field, 'an "enum" that is not a list of values');
+    }
+  }
+
+  if ('validate' in compiled && typeof compiled.validate !== 'function') {
+    refuse(
+      model,
+      field,
+      'a "validate" that is not a function: write `(value, record) => true` or a message'
+    );
+  }
+
+  return Object.freeze(compiled);
+};
+
+/**
+ * Everything a model says must be true of its records.
+ *
+ * The `validates` block, plus the `required` and `enum` the schema
+ * already declares -- those two are checked here on every adapter and
+ * every write path, which is the whole point of the file.
+ *
+ * @param {object} model the model file (`globalId`, `schema`, `validates`)
+ * @returns {?object} the rules by field, or null when there are none
+ * @throws {Error} HENRI_MODEL_VALIDATION_INVALID on a declaration henri
+ *   cannot carry out
+ */
+const validationsOf = (model = {}) => {
+  const name = model.globalId || model.identity || 'the model';
+  const schema = isPlainObject(model.schema) ? model.schema : {};
+  const written = model.validates;
+
+  if (typeof written !== 'undefined' && !isPlainObject(written)) {
+    throw coded(
+      INVALID,
+      `${name} declares \`validates\` as ${
+        written === null ? 'null' : typeof written
+      }: it is an object keyed by field`
+    );
+  }
+
+  const rules = {};
+
+  for (const field of Object.keys(schema)) {
+    const definition = schema[field];
+    const type = typeOf(definition);
+    const lifted = {};
+
+    if (isPlainObject(definition)) {
+      // `allowNull: false` is the Sequelize spelling of `required`, and
+      // the mongoose adapter accepts it too, so it is the same rule here
+      if (definition.required === true || definition.allowNull === false) {
+        lifted.required = true;
+      }
+
+      if (Array.isArray(definition.enum)) {
+        lifted.enum = definition.enum;
+      }
+    }
+
+    const declared = (written && written[field]) || null;
+
+    if (!declared && Object.keys(lifted).length === 0) {
+      continue;
+    }
+
+    rules[field] = ruleOf(
+      name,
+      field,
+      // A rule that is not an object at all is handed over as it is, so
+      // the refusal says what it was rather than spreading it into one
+      isPlainObject(declared) ? { ...lifted, ...declared } : declared || lifted,
+      type
+    );
+  }
+
+  for (const field of Object.keys(written || {})) {
+    if (!rules[field]) {
+      throw coded(
+        INVALID,
+        `${name} declares \`validates.${field}\`, which its schema has no field for: ${
+          Object.keys(schema).join(', ') || 'the schema is empty'
+        }`
+      );
+    }
+  }
+
+  return Object.keys(rules).length > 0 ? Object.freeze(rules) : null;
+};
+
+/**
+ * Does any rule want the record, rather than only the value?
+ *
+ * The predicate is the arity of the function, the way `base/policies.js`
+ * reads a rule that declares a record parameter. It is what a mass write
+ * is measured against -- and it is measured against the fields that write
+ * actually names, so a soft delete stamping `deletedAt` on a thousand rows
+ * is not refused by a rule about somebody's email address.
+ *
+ * @param {?object} rules the compiled rules
+ * @param {object} [values] the values being written, when there are some
+ * @returns {Array<string>} the fields whose rule asks for the record
+ */
+const wantsRecord = (rules, values) => {
+  if (!rules) {
+    return [];
+  }
+
+  const named = isPlainObject(values)
+    ? Object.keys(values)
+    : Object.keys(rules);
+
+  return named.filter(
+    (field) =>
+      rules[field] &&
+      typeof rules[field].validate === 'function' &&
+      rules[field].validate.length >= 2
+  );
+};
+
+/**
+ * The bounds of a rule, once there is a value to measure
+ *
+ * @param {object} rule the compiled rule
+ * @param {*} value the value being written
+ * @returns {?string} what is wrong with it, or null
+ */
+const bounds = (rule, value) => {
+  const { max, maxLength, min, minLength, pattern } = rule;
+
+  // An exact value is a string of digits, so `<` would compare it letter
+  // by letter and answer that 9.99 is more than 10 (see ./exact.js)
+  if (isExact(rule.type) && typeof value === 'string') {
+    if (typeof min !== 'undefined' && compare(value, min) < 0) {
+      return `must be at least ${min}`;
+    }
+
+    if (typeof max !== 'undefined' && compare(value, max) > 0) {
+      return `must be at most ${max}`;
+    }
+
+    return null;
+  }
+
+  if (typeof value === 'number') {
+    if (typeof min === 'number' && value < min) {
+      return `must be at least ${min}`;
+    }
+
+    if (typeof max === 'number' && value > max) {
+      return `must be at most ${max}`;
+    }
+  }
+
+  if (typeof value === 'string') {
+    if (typeof minLength === 'number' && value.length < minLength) {
+      return `must be at least ${minLength} characters`;
+    }
+
+    if (typeof maxLength === 'number' && value.length > maxLength) {
+      return `must be at most ${maxLength} characters`;
+    }
+
+    if (pattern && !pattern.test(value)) {
+      return 'is not in the expected format';
+    }
+  }
+
+  return null;
+};
+
+/**
+ * One value through one rule
+ *
+ * @param {object} rule the compiled rule
+ * @param {*} value the value being written
+ * @param {*} record the record, for a validator that asked for one
+ * @returns {?string} the message, or null when the value is fine
+ */
+const problem = (rule, value, record) => {
+  if (isBlank(value)) {
+    return rule.required ? 'is required' : null;
+  }
+
+  const wrong = bounds(rule, value);
+
+  if (wrong) {
+    return wrong;
+  }
+
+  if (rule.enum && !rule.enum.includes(value)) {
+    return `must be one of ${rule.enum.join(', ')}`;
+  }
+
+  if (typeof rule.validate !== 'function') {
+    return null;
+  }
+
+  let answer;
+
+  try {
+    answer = rule.validate(value, record);
+  } catch (error) {
+    return (error && error.message) || 'is invalid';
+  }
+
+  if (typeof answer === 'string') {
+    return answer;
+  }
+
+  return answer === false ? 'is invalid' : null;
+};
+
+/**
+ * Everything wrong with the values being written
+ *
+ * @param {?object} rules the compiled rules
+ * @param {object} values the attributes being written
+ * @param {object} [options={}] options
+ * @param {boolean} [options.partial=false] an update: a field the write
+ *   does not name is left alone rather than treated as absent
+ * @param {*} [options.record] the record, for a validator that asked
+ * @returns {?object} `{ field: message }`, or null when nothing is wrong
+ */
+const problemsOf = (rules, values, { partial = false, record } = {}) => {
+  if (!rules) {
+    return null;
+  }
+
+  const given = isPlainObject(values) ? values : {};
+  const errors = {};
+
+  for (const field of Object.keys(rules)) {
+    const has = Object.prototype.hasOwnProperty.call(given, field);
+
+    if (!has && partial) {
+      continue;
+    }
+
+    const wrong = problem(rules[field], given[field], record);
+
+    if (wrong) {
+      errors[field] = wrong;
+    }
+  }
+
+  return Object.keys(errors).length > 0 ? errors : null;
+};
+
+/**
+ * The refusal a mass write gets on a model whose validator wants a record
+ *
+ * @param {string} model the model's global id
+ * @param {string} what the call that was made (`update`, `updateMany`)
+ * @param {string} instead the single-record call to loop over
+ * @returns {Error} the error to throw
+ */
+const massWrite = (model, what, instead, fields = []) =>
+  coded(
+    MASS_WRITE,
+    `${model}.${what}() writes many rows at once, and ${
+      fields.length > 0 ? fields.join(', ') : 'a field'
+    } of ${model} is validated by a rule that asks for the record. ` +
+      `A mass write has no records to give it, so henri refuses rather than recording a pass it never made. ` +
+      `Loop instead: for (const record of await ${model}.find(where)) await record.${instead}`
+  );
+
+/**
+ * The refusal a write the ORM runs no hook for gets
+ *
+ * Sequelize's `increment`/`decrement` and Mongoose's `bulkWrite` reach the
+ * database without any middleware at all, so a rule declared on a field
+ * they write would be a promise henri does not keep. Neither call exists
+ * on all three adapters, so neither is part of what a `validates` block
+ * means; a model that declares one and calls the other is told so.
+ *
+ * @param {string} model the model's global id
+ * @param {string} what the call that was made
+ * @param {string} instead what to do instead
+ * @returns {Error} the error to throw
+ */
+const uncheckedWrite = (model, what, instead) =>
+  coded(
+    UNCHECKED,
+    `${model}.${what}() writes without running any of the ORM's hooks, so henri cannot check what it writes, and ${model} declares validations for it. ${instead}`
+  );
+
+module.exports = {
+  ANY,
+  APPLIES,
+  INVALID,
+  KEYS,
+  MASS_WRITE,
+  TYPES,
+  UNCHECKED,
+  coded,
+  isBlank,
+  massWrite,
+  problemsOf,
+  uncheckedWrite,
+  validationsOf,
+  wantsRecord,
+};

--- a/packages/drizzle/__tests__/validations.spec.js
+++ b/packages/drizzle/__tests__/validations.spec.js
@@ -1,0 +1,286 @@
+const { build, target } = require('./helpers');
+
+/**
+ * A model file declaring what must be true of its records
+ *
+ * @param {object} [validates] The `validates` block
+ * @returns {object} The model file
+ */
+const postModel = (validates) => ({
+  globalId: 'Post',
+  identity: 'post',
+  options: { timestamps: true },
+  schema: {
+    body: { type: 'text' },
+    slug: { type: 'string' },
+    status: { enum: ['draft', 'live'], type: 'string' },
+    title: { required: true, type: 'string' },
+    views: { type: 'integer' },
+  },
+  store: 'default',
+  validates,
+});
+
+/**
+ * The `{ field: message }` of a rejected write
+ *
+ * @param {Promise} promise The write
+ * @returns {Promise<object>} The messages by field
+ */
+const errorsOf = async (promise) => {
+  try {
+    await promise;
+  } catch (error) {
+    return error.toJSON ? error.toJSON() : { code: error.code };
+  }
+
+  return null;
+};
+
+describe('validations on a drizzle store', () => {
+  describe('what a validates block checks', () => {
+    let Post;
+    let adapter;
+
+    beforeAll(async () => {
+      ({ adapter } = build());
+      Post = adapter.addModel(
+        postModel({
+          slug: { maxLength: 8, minLength: 3, pattern: /^[a-z-]+$/u },
+          views: { max: 1000, min: 0 },
+        }),
+        'user'
+      );
+      await adapter.start();
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('on a create', async () => {
+      expect(await errorsOf(Post.create({ slug: 'A', title: 'a' }))).toEqual({
+        slug: 'must be at least 3 characters',
+      });
+      expect(
+        await errorsOf(Post.create({ slug: 'shouting', title: 'a' }))
+      ).toBeNull();
+      expect(
+        await errorsOf(Post.create({ slug: 'Shouting', title: 'b' }))
+      ).toEqual({ slug: 'is not in the expected format' });
+      expect(await errorsOf(Post.create({ title: 'c', views: -1 }))).toEqual({
+        views: 'must be at least 0',
+      });
+    });
+
+    test('on an instance update', async () => {
+      // One record per write: `instance.update()` is `set()` then
+      // `save()`, so a refused value is still on the instance afterwards
+      expect(
+        await errorsOf(
+          (await Post.create({ title: 'one' })).update({ slug: 'no' })
+        )
+      ).toEqual({ slug: 'must be at least 3 characters' });
+      expect(
+        await errorsOf(
+          (await Post.create({ title: 'two' })).update({ views: 9000 })
+        )
+      ).toEqual({ views: 'must be at most 1000' });
+    });
+
+    test('on a mass update, which is the one a save() hook would miss', async () => {
+      await Post.create({ title: 'two' });
+      expect(
+        await errorsOf(Post.update({ title: 'two' }, { slug: 'no' }))
+      ).toEqual({ slug: 'must be at least 3 characters' });
+      expect(
+        await errorsOf(Post.where({ title: 'two' }).update({ views: 9000 }))
+      ).toEqual({ views: 'must be at most 1000' });
+      expect(
+        await errorsOf(Post.updateMany({ title: 'two' }, { slug: 'no' }))
+      ).toEqual({ slug: 'must be at least 3 characters' });
+    });
+
+    test('a field the update does not name is left alone', async () => {
+      const post = await Post.create({ slug: 'fine', title: 'three' });
+
+      await post.update({ title: 'four' });
+      expect((await Post.findById(post.externalId)).slug).toBe('fine');
+    });
+  });
+
+  describe('a validator of one’s own', () => {
+    test('reads the value, and says what is wrong with it', async () => {
+      const { adapter } = build();
+      const Post = adapter.addModel(
+        postModel({
+          slug: {
+            validate: (value) => value !== 'taken' || 'that one is spoken for',
+          },
+        }),
+        'user'
+      );
+
+      await adapter.start();
+      expect(
+        await errorsOf(Post.create({ slug: 'taken', title: 'a' }))
+      ).toEqual({ slug: 'that one is spoken for' });
+      // And on the mass path too, because it only reads the value
+      await Post.create({ slug: 'free', title: 'b' });
+      expect(
+        await errorsOf(Post.update({ title: 'b' }, { slug: 'taken' }))
+      ).toEqual({ slug: 'that one is spoken for' });
+      await adapter.stop();
+    });
+
+    test('a rule asking for the record gets it, on every single write', async () => {
+      const { adapter } = build();
+      const Post = adapter.addModel(
+        postModel({
+          status: {
+            validate: (value, record) =>
+              value !== 'live' ||
+              Boolean(record.body) ||
+              'cannot go live without a body',
+          },
+        }),
+        'user'
+      );
+
+      await adapter.start();
+      expect(
+        await errorsOf(Post.create({ status: 'live', title: 'a' }))
+      ).toEqual({ status: 'cannot go live without a body' });
+      expect(
+        await errorsOf(
+          Post.create({ body: 'here', status: 'live', title: 'b' })
+        )
+      ).toBeNull();
+
+      const empty = await Post.create({ title: 'c' });
+
+      // The record it is given is the record as it will be, so a body
+      // written in the same call counts
+      expect(await errorsOf(empty.update({ status: 'live' }))).toEqual({
+        status: 'cannot go live without a body',
+      });
+      expect(
+        await errorsOf(empty.update({ body: 'now', status: 'live' }))
+      ).toBeNull();
+      await adapter.stop();
+    });
+
+    test('and a mass write on that model is refused, naming the loop', async () => {
+      const { adapter } = build();
+      const Post = adapter.addModel(
+        postModel({
+          status: { validate: (value, record) => Boolean(record) },
+        }),
+        'user'
+      );
+
+      await adapter.start();
+      await Post.create({ title: 'a' });
+
+      for (const write of [
+        () => Post.update({ title: 'a' }, { status: 'live' }),
+        () => Post.updateMany({ title: 'a' }, { status: 'live' }),
+        () => Post.where({ title: 'a' }).update({ status: 'live' }),
+      ]) {
+        const error = await write().catch((thrown) => thrown);
+
+        expect(error.code).toBe('HENRI_MODEL_VALIDATION_MASS_WRITE');
+        expect(error.message).toMatch(/status of Post is validated by a rule/u);
+        expect(error.message).toMatch(
+          /for \(const record of await Post\.find\(where\)\) await record\.update\(attrs\)/u
+        );
+      }
+
+      // A mass write that does not name the validated field still works:
+      // the refusal is about the rule, not about the model
+      await expect(Post.update({ title: 'a' }, { views: 3 })).resolves.toBe(1);
+      await adapter.stop();
+    });
+
+    test('findByIdAndUpdate reads the record rather than refusing', async () => {
+      const { adapter } = build();
+      const Post = adapter.addModel(
+        postModel({
+          status: {
+            validate: (value, record) =>
+              value !== 'live' || Boolean(record.body) || 'no body',
+          },
+        }),
+        'user'
+      );
+
+      await adapter.start();
+
+      const post = await Post.create({ body: 'here', title: 'a' });
+      const bare = await Post.create({ title: 'b' });
+
+      await expect(
+        Post.findByIdAndUpdate(post.externalId, { status: 'live' })
+      ).resolves.toMatchObject({ status: 'live' });
+      expect(
+        await errorsOf(
+          Post.findByIdAndUpdate(bare.externalId, { status: 'live' })
+        )
+      ).toEqual({ status: 'no body' });
+      await adapter.stop();
+    });
+  });
+
+  describe('the schema’s own required and enum', () => {
+    let Post;
+    let adapter;
+
+    beforeAll(async () => {
+      ({ adapter } = build());
+      Post = adapter.addModel(postModel(), 'user');
+      await adapter.start();
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('are the same sentence on every write path', async () => {
+      expect(await errorsOf(Post.create({}))).toEqual({
+        title: 'is required',
+      });
+      expect(await errorsOf(Post.create({ status: 'x', title: 'a' }))).toEqual({
+        status: 'must be one of draft, live',
+      });
+
+      await Post.create({ title: 'here' });
+      expect(
+        await errorsOf(Post.update({ title: 'here' }, { status: 'x' }))
+      ).toEqual({ status: 'must be one of draft, live' });
+    });
+  });
+
+  describe('a declaration henri cannot carry out', () => {
+    test('fails the boot, naming the model and the field', () => {
+      const { adapter } = build();
+
+      expect(() =>
+        adapter.addModel(postModel({ title: { min: 3 } }), 'user')
+      ).toThrow(/Post declares `validates.title` with "min"/u);
+      expect(() =>
+        adapter.addModel(postModel({ ttile: { maxLength: 3 } }), 'user')
+      ).toThrow(/which its schema has no field for/u);
+
+      const thrown = (() => {
+        try {
+          return adapter.addModel(
+            postModel({ title: { maxLenght: 3 } }),
+            'user'
+          );
+        } catch (error) {
+          return error;
+        }
+      })();
+
+      expect(thrown.code).toBe('HENRI_MODEL_VALIDATION_INVALID');
+    });
+  });
+
+  afterAll(() => target.cleanup());
+});

--- a/packages/drizzle/model.js
+++ b/packages/drizzle/model.js
@@ -12,6 +12,12 @@ const { normalizeField } = require('./schema');
 const { checkMassWrite, plainOf, write } = require('./versions');
 const { ValidationError, failure, validate } = require('./validation');
 const {
+  massWrite: massValidation,
+  problemsOf,
+  validationsOf,
+  wantsRecord,
+} = require('./validations');
+const {
   coded,
   isPlainObject,
   lowerFirst,
@@ -750,8 +756,13 @@ class Model {
   static async findByIdAndUpdate(id, attrs, options = {}) {
     // A versioned model has to know what the row said before the write,
     // and this path has no instance to ask: it reads the record first, and
-    // then every single-row update of this adapter runs through save()
-    if (this.versioned && options.versions !== false) {
+    // then every single-row update of this adapter runs through save().
+    // A validator that asked for the record wants the same thing, and this
+    // names one row, so it is a read rather than a refusal
+    if (
+      (this.versioned && options.versions !== false) ||
+      wantsRecord(this.validations, attrs).length > 0
+    ) {
       const found = await this.findById(id);
 
       return found ? found.update(attrs, options) : null;
@@ -1167,6 +1178,15 @@ class Model {
       skip: kind === 'update' ? [...PROTECTED, ...IMMUTABLE] : PROTECTED,
     });
 
+    // What the model declared, in the vocabulary every adapter shares
+    // (./validations.js). It runs on the coerced values and before the
+    // `beforeCreate`/`beforeUpdate` hooks, so a `maxLength` measures the
+    // plaintext of an encrypted field rather than its envelope
+    this.checkValidations(values, {
+      partial: kind === 'update',
+      record: instance,
+    });
+
     if (kind === 'create' && data.id !== undefined && this.isValidId(data.id)) {
       values.id = this.castId(data.id);
     }
@@ -1185,6 +1205,65 @@ class Model {
     }
 
     return values;
+  }
+
+  /**
+   * Runs what the model's `validates` block declared, plus the `required`
+   * and `enum` its schema declared, over the values being written
+   *
+   * @param {object} values The coerced values
+   * @param {object} [options={}] Options
+   * @param {boolean} [options.partial=false] An update
+   * @param {?Model} [options.record] The instance being written, if any
+   * @returns {void}
+   * @throws {ValidationError} When a rule refuses a value
+   * @memberof Model
+   */
+  static checkValidations(values, { partial = false, record } = {}) {
+    if (!this.validations) {
+      return;
+    }
+
+    // What a rule that asked for the record is given: the record as it
+    // will be once this write lands, so a rule reads the new value of the
+    // field next to it rather than the old one
+    const after = record ? { ...record, ...values } : values;
+    const problems = problemsOf(this.validations, values, {
+      partial,
+      record: after,
+    });
+
+    if (!problems) {
+      return;
+    }
+
+    throw new ValidationError(
+      this.modelName,
+      Object.fromEntries(
+        Object.entries(problems).map(([field, message]) => [
+          field,
+          failure('validates', message, field, values[field]),
+        ])
+      )
+    );
+  }
+
+  /**
+   * Refuses a mass write on a model whose validator asked for the record
+   *
+   * @param {string} what The call that was made
+   * @param {string} instead The single-record call to loop over
+   * @param {object} attrs The attributes the write names
+   * @returns {void}
+   * @throws {Error} HENRI_MODEL_VALIDATION_MASS_WRITE
+   * @memberof Model
+   */
+  static checkValidationsMassWrite(what, instead, attrs) {
+    const fields = wantsRecord(this.validations, attrs);
+
+    if (fields.length > 0) {
+      throw massValidation(this.modelName, what, instead, fields);
+    }
   }
 
   /**
@@ -1331,6 +1410,7 @@ class Model {
     // place an unknown option is still dropped in silence
     checkOptions(this, 'update', options);
     checkMassWrite(this, 'update', options);
+    this.checkValidationsMassWrite('update', 'update(attrs)', attrs);
 
     const values = await this.prepare(
       'update',
@@ -1865,6 +1945,10 @@ const createModel = (adapter, definition, fields) => {
     paranoid,
     tableName: tableNameOf(definition),
     timestamps,
+    // What the model's `validates` block and its schema's `required` and
+    // `enum` declared, compiled once (./validations.js). Null when the
+    // model declared none, so nothing runs on the write path
+    validations: validationsOf(definition),
     // What `options.versioned` said, or null. The wiring reads it, and so
     // does every path that has to behave differently because a history is
     // being kept (see ./versions.js)

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -29,6 +29,7 @@
     "types.js",
     "utils.js",
     "validation.js",
+    "validations.js",
     "encrypted.js",
     "encryption.js",
     "versions.js"

--- a/packages/drizzle/validations.js
+++ b/packages/drizzle/validations.js
@@ -1,0 +1,598 @@
+/**
+ * What must be true of a record, declared once and meant once.
+ *
+ * A model file says it in a `validates` block, keyed by field, in the
+ * vocabulary the request boundaries already use (`base/params-schema.js`):
+ *
+ * ```js
+ * module.exports = {
+ *   schema: {
+ *     email: { type: 'string', required: true, unique: true },
+ *     age: { type: 'integer' },
+ *     status: { type: 'string', enum: ['draft', 'live'] },
+ *   },
+ *   validates: {
+ *     age: { max: 120, min: 18 },
+ *     email: { maxLength: 120, pattern: /^[^@\s]+@[^@\s]+$/u },
+ *     status: { validate: (value, record) => value !== 'live' || record.body },
+ *   },
+ * };
+ * ```
+ *
+ * ## Why this file exists at all
+ *
+ * The three ORMs each have validations and no two of them mean the same
+ * thing. Measured, not assumed:
+ *
+ * - **Mongoose** runs its path validators on `save()`, `create()` and
+ *   `insertMany()` and on **nothing else**. `updateOne`, `updateMany`,
+ *   `findOneAndUpdate` and `findByIdAndUpdate` write straight past
+ *   `required` and `enum` -- a `null` lands in a required column and a
+ *   value outside the enum lands in the document -- unless the *caller*
+ *   remembers `runValidators: true` on that one call.
+ * - **Sequelize** validates `create`, `save`, `update` and the mass
+ *   `Model.update`, skips `bulkCreate` (its `validate` defaults to
+ *   `false`, so a value outside an `enum` is written), and on the dialects
+ *   with a native `ENUM` column has no JavaScript check at all -- the
+ *   server refuses it, as a `SequelizeDatabaseError` that
+ *   `henri.model.errors()` does not recognize, so the same model file
+ *   answers 422 on sqlite and 500 on PostgreSQL.
+ * - **Drizzle** validates every write it exposes, including the mass ones.
+ *
+ * So `required` and `enum` -- two keys the models guide says mean the same
+ * thing on every adapter -- did not. This module is what makes them, and
+ * it is the only implementation of the rules an application declares.
+ *
+ * ## One vocabulary
+ *
+ * The keys are the ones a controller's `params` block already takes, and
+ * they mean the same thing here: `required`, `enum`, `min`, `max`,
+ * `minLength`, `maxLength`, `pattern`, plus `validate`, a function of the
+ * value (and, when it asks for one, the record). There is no `type`: the
+ * schema next door already says it, and a constraint that means nothing
+ * for that type (`min` on a `string`, `maxLength` on an `integer`) fails
+ * the boot rather than being ignored.
+ *
+ * The schema's own `required` and `enum` are read into the same rules, so
+ * an application that never writes a `validates` block still gets one
+ * meaning for those two on every adapter and every write path.
+ *
+ * ## Where this belongs, and where it does not
+ *
+ * `req.permit()` and a controller's `params` block check what **arrives**:
+ * they are about a request, they coerce a query string, and they answer
+ * 422 before an action runs. This checks what is **written**, and a record
+ * is written by a job, a seed, a console and a webhook delivery as often
+ * as by a request. The two compose -- neither replaces the other -- and
+ * the guide says so where a person is deciding.
+ *
+ * ## What is refused rather than pretended
+ *
+ * A `validate` function that declares a second parameter is asking for the
+ * record, and a mass write has none: the same predicate `base/policies.js`
+ * uses for a rule that wants a record. Rather than calling it with
+ * `undefined` and recording a pass, a mass write on such a model is
+ * refused (`HENRI_MODEL_VALIDATION_MASS_WRITE`), which is the answer
+ * `HENRI_VERSION_MASS_WRITE` already gives to the same shape of problem.
+ * Every other rule reads only the value being written, so a mass write
+ * checks them exactly as a single write does.
+ *
+ * ## Uniqueness is not here, deliberately
+ *
+ * `unique` stays what it is: an index, and a race. A `SELECT` before an
+ * `INSERT` answers a question about a moment that has passed by the time
+ * the row is written, so a check would turn a guarantee the database
+ * keeps into a message henri sometimes produces. The database refuses the
+ * duplicate, and `henri.model.errors()` turns that refusal into
+ * `{ field: 'must be unique' }` on all three adapters, which is the same
+ * shape as everything here.
+ *
+ * ## A copy per adapter
+ *
+ * This file is held four times -- here and in `@usehenri/drizzle`,
+ * `@usehenri/mongoose` and `@usehenri/sequelize` -- byte for byte, the way
+ * `exact.js` and `external-id.js` are, because an adapter depends on no
+ * part of core at runtime. `src/__tests__/validations.spec.js` is what
+ * keeps them the same file. It requires nothing but `./exact`, which is
+ * held the same way, and raises its codes through a `coded()` of its own
+ * for the same reason.
+ */
+
+const { compare, isExact } = require('./exact');
+
+/** The failure a model declaration henri cannot carry out gets */
+const INVALID = 'HENRI_MODEL_VALIDATION_INVALID';
+
+/** The failure a mass write on a record-aware validator gets */
+const MASS_WRITE = 'HENRI_MODEL_VALIDATION_MASS_WRITE';
+
+/** The failure a write no hook of the ORM reaches gets */
+const UNCHECKED = 'HENRI_MODEL_VALIDATION_UNCHECKED_WRITE';
+
+/** The henri schema types, so a constraint can be bound to one */
+const TYPES = [
+  'bigint',
+  'boolean',
+  'date',
+  'decimal',
+  'float',
+  'integer',
+  'json',
+  'number',
+  'string',
+  'text',
+  'uuid',
+];
+
+/**
+ * The types each constraint applies to. `required`, `enum` and `validate`
+ * apply to every type, so they are not in here (see KEYS).
+ */
+const APPLIES = {
+  max: ['bigint', 'decimal', 'float', 'integer', 'number'],
+  maxLength: ['string', 'text'],
+  min: ['bigint', 'decimal', 'float', 'integer', 'number'],
+  minLength: ['string', 'text'],
+  pattern: ['string', 'text'],
+};
+
+/** The keys every field takes, whatever its type */
+const ANY = ['enum', 'required', 'validate'];
+
+/** Every key a `validates` entry may hold */
+const KEYS = [...ANY, ...Object.keys(APPLIES)].sort();
+
+/**
+ * An error carrying a henri code, without depending on core
+ *
+ * @param {string} code the henri error code
+ * @param {string} message what is wrong
+ * @returns {Error} the error to throw
+ */
+const coded = (code, message) => Object.assign(new Error(message), { code });
+
+/**
+ * Is the value a plain object?
+ *
+ * @param {*} value any value
+ * @returns {boolean} true for a plain object
+ */
+const isPlainObject = (value) =>
+  value !== null &&
+  typeof value === 'object' &&
+  (Object.getPrototypeOf(value) === Object.prototype ||
+    Object.getPrototypeOf(value) === null);
+
+/**
+ * Is the value missing, for `required`?
+ *
+ * Rails' `presence`, and what Mongoose and Drizzle already answer: a
+ * string of nothing but spaces is a field a person left empty, not a
+ * value. Sequelize's `allowNull` alone would have written it.
+ *
+ * @param {*} value the value
+ * @returns {boolean} true when there is nothing there
+ */
+const isBlank = (value) =>
+  typeof value === 'undefined' ||
+  value === null ||
+  (typeof value === 'string' && value.trim() === '');
+
+/**
+ * `a string`, `an integer`: the article a message needs
+ *
+ * @param {string} type the type
+ * @returns {string} the type with its article
+ */
+const article = (type) => (/^[aeiou]/u.test(type) ? `an ${type}` : `a ${type}`);
+
+/**
+ * The henri type a field declares, when it declares one henri knows
+ *
+ * A model file may write a type this file has no opinion about -- a
+ * Mongoose `ObjectId`, a Sequelize `DataTypes.STRING(50)`, a nested
+ * document -- and a constraint that measures a number or a length has
+ * nothing to measure there. Those fields still take `required`, `enum`
+ * and `validate`, which need no type at all.
+ *
+ * @param {*} definition the field definition from the model file
+ * @returns {?string} the henri type name, or null
+ */
+const typeOf = (definition) => {
+  const type = isPlainObject(definition) ? definition.type : definition;
+
+  if (typeof type !== 'string') {
+    return null;
+  }
+
+  const name = type.toLowerCase();
+
+  return TYPES.includes(name) ? name : null;
+};
+
+/**
+ * Refuses a declaration, naming the model and the field
+ *
+ * @param {string} model the model's global id
+ * @param {string} field the field name
+ * @param {string} what what is wrong with it
+ * @returns {void} never returns
+ * @throws {Error} always, HENRI_MODEL_VALIDATION_INVALID
+ */
+const refuse = (model, field, what) => {
+  throw coded(INVALID, `${model} declares \`validates.${field}\` with ${what}`);
+};
+
+/**
+ * Checks and freezes one field's rule
+ *
+ * @param {string} model the model's global id
+ * @param {string} field the field name
+ * @param {object} written what the model file wrote
+ * @param {?string} type the henri type of the field, when it has one
+ * @returns {object} the compiled rule
+ * @throws {Error} HENRI_MODEL_VALIDATION_INVALID on anything unusable
+ */
+const ruleOf = (model, field, written, type) => {
+  if (!isPlainObject(written)) {
+    refuse(
+      model,
+      field,
+      `${written === null ? 'null' : typeof written}: a rule is an object of ${KEYS.join(', ')}`
+    );
+  }
+
+  const compiled = { type };
+
+  for (const [key, value] of Object.entries(written)) {
+    if (!KEYS.includes(key)) {
+      refuse(
+        model,
+        field,
+        `the unknown key "${key}": a rule takes ${KEYS.join(', ')}`
+      );
+    }
+
+    if (APPLIES[key] && !APPLIES[key].includes(type)) {
+      refuse(
+        model,
+        field,
+        type === null
+          ? `"${key}", which needs a type henri knows: the field declares one henri has no bounds for, so it takes ${ANY.join(', ')} only`
+          : `"${key}", which ${article(type)} does not take: ${key} is for ${APPLIES[key].join(', ')}`
+      );
+    }
+
+    compiled[key] = value;
+  }
+
+  for (const key of ['max', 'maxLength', 'min', 'minLength']) {
+    if (!(key in compiled)) {
+      continue;
+    }
+
+    // The bound of an exact field may be written out, the way its values
+    // are, so a limit past what a double carries can be declared at all
+    const exact =
+      isExact(type) && (key === 'max' || key === 'min')
+        ? typeof compiled[key] === 'string'
+        : false;
+
+    if (!exact && typeof compiled[key] !== 'number') {
+      refuse(model, field, `a "${key}" that is not a number`);
+    }
+  }
+
+  if ('pattern' in compiled && !(compiled.pattern instanceof RegExp)) {
+    refuse(model, field, 'a "pattern" that is not a regular expression');
+  }
+
+  if ('required' in compiled && typeof compiled.required !== 'boolean') {
+    refuse(model, field, 'a "required" that is not true or false');
+  }
+
+  if ('enum' in compiled) {
+    if (!Array.isArray(compiled.enum) || compiled.enum.length === 0) {
+      refuse(model, field, 'an "enum" that is not a list of values');
+    }
+  }
+
+  if ('validate' in compiled && typeof compiled.validate !== 'function') {
+    refuse(
+      model,
+      field,
+      'a "validate" that is not a function: write `(value, record) => true` or a message'
+    );
+  }
+
+  return Object.freeze(compiled);
+};
+
+/**
+ * Everything a model says must be true of its records.
+ *
+ * The `validates` block, plus the `required` and `enum` the schema
+ * already declares -- those two are checked here on every adapter and
+ * every write path, which is the whole point of the file.
+ *
+ * @param {object} model the model file (`globalId`, `schema`, `validates`)
+ * @returns {?object} the rules by field, or null when there are none
+ * @throws {Error} HENRI_MODEL_VALIDATION_INVALID on a declaration henri
+ *   cannot carry out
+ */
+const validationsOf = (model = {}) => {
+  const name = model.globalId || model.identity || 'the model';
+  const schema = isPlainObject(model.schema) ? model.schema : {};
+  const written = model.validates;
+
+  if (typeof written !== 'undefined' && !isPlainObject(written)) {
+    throw coded(
+      INVALID,
+      `${name} declares \`validates\` as ${
+        written === null ? 'null' : typeof written
+      }: it is an object keyed by field`
+    );
+  }
+
+  const rules = {};
+
+  for (const field of Object.keys(schema)) {
+    const definition = schema[field];
+    const type = typeOf(definition);
+    const lifted = {};
+
+    if (isPlainObject(definition)) {
+      // `allowNull: false` is the Sequelize spelling of `required`, and
+      // the mongoose adapter accepts it too, so it is the same rule here
+      if (definition.required === true || definition.allowNull === false) {
+        lifted.required = true;
+      }
+
+      if (Array.isArray(definition.enum)) {
+        lifted.enum = definition.enum;
+      }
+    }
+
+    const declared = (written && written[field]) || null;
+
+    if (!declared && Object.keys(lifted).length === 0) {
+      continue;
+    }
+
+    rules[field] = ruleOf(
+      name,
+      field,
+      // A rule that is not an object at all is handed over as it is, so
+      // the refusal says what it was rather than spreading it into one
+      isPlainObject(declared) ? { ...lifted, ...declared } : declared || lifted,
+      type
+    );
+  }
+
+  for (const field of Object.keys(written || {})) {
+    if (!rules[field]) {
+      throw coded(
+        INVALID,
+        `${name} declares \`validates.${field}\`, which its schema has no field for: ${
+          Object.keys(schema).join(', ') || 'the schema is empty'
+        }`
+      );
+    }
+  }
+
+  return Object.keys(rules).length > 0 ? Object.freeze(rules) : null;
+};
+
+/**
+ * Does any rule want the record, rather than only the value?
+ *
+ * The predicate is the arity of the function, the way `base/policies.js`
+ * reads a rule that declares a record parameter. It is what a mass write
+ * is measured against -- and it is measured against the fields that write
+ * actually names, so a soft delete stamping `deletedAt` on a thousand rows
+ * is not refused by a rule about somebody's email address.
+ *
+ * @param {?object} rules the compiled rules
+ * @param {object} [values] the values being written, when there are some
+ * @returns {Array<string>} the fields whose rule asks for the record
+ */
+const wantsRecord = (rules, values) => {
+  if (!rules) {
+    return [];
+  }
+
+  const named = isPlainObject(values)
+    ? Object.keys(values)
+    : Object.keys(rules);
+
+  return named.filter(
+    (field) =>
+      rules[field] &&
+      typeof rules[field].validate === 'function' &&
+      rules[field].validate.length >= 2
+  );
+};
+
+/**
+ * The bounds of a rule, once there is a value to measure
+ *
+ * @param {object} rule the compiled rule
+ * @param {*} value the value being written
+ * @returns {?string} what is wrong with it, or null
+ */
+const bounds = (rule, value) => {
+  const { max, maxLength, min, minLength, pattern } = rule;
+
+  // An exact value is a string of digits, so `<` would compare it letter
+  // by letter and answer that 9.99 is more than 10 (see ./exact.js)
+  if (isExact(rule.type) && typeof value === 'string') {
+    if (typeof min !== 'undefined' && compare(value, min) < 0) {
+      return `must be at least ${min}`;
+    }
+
+    if (typeof max !== 'undefined' && compare(value, max) > 0) {
+      return `must be at most ${max}`;
+    }
+
+    return null;
+  }
+
+  if (typeof value === 'number') {
+    if (typeof min === 'number' && value < min) {
+      return `must be at least ${min}`;
+    }
+
+    if (typeof max === 'number' && value > max) {
+      return `must be at most ${max}`;
+    }
+  }
+
+  if (typeof value === 'string') {
+    if (typeof minLength === 'number' && value.length < minLength) {
+      return `must be at least ${minLength} characters`;
+    }
+
+    if (typeof maxLength === 'number' && value.length > maxLength) {
+      return `must be at most ${maxLength} characters`;
+    }
+
+    if (pattern && !pattern.test(value)) {
+      return 'is not in the expected format';
+    }
+  }
+
+  return null;
+};
+
+/**
+ * One value through one rule
+ *
+ * @param {object} rule the compiled rule
+ * @param {*} value the value being written
+ * @param {*} record the record, for a validator that asked for one
+ * @returns {?string} the message, or null when the value is fine
+ */
+const problem = (rule, value, record) => {
+  if (isBlank(value)) {
+    return rule.required ? 'is required' : null;
+  }
+
+  const wrong = bounds(rule, value);
+
+  if (wrong) {
+    return wrong;
+  }
+
+  if (rule.enum && !rule.enum.includes(value)) {
+    return `must be one of ${rule.enum.join(', ')}`;
+  }
+
+  if (typeof rule.validate !== 'function') {
+    return null;
+  }
+
+  let answer;
+
+  try {
+    answer = rule.validate(value, record);
+  } catch (error) {
+    return (error && error.message) || 'is invalid';
+  }
+
+  if (typeof answer === 'string') {
+    return answer;
+  }
+
+  return answer === false ? 'is invalid' : null;
+};
+
+/**
+ * Everything wrong with the values being written
+ *
+ * @param {?object} rules the compiled rules
+ * @param {object} values the attributes being written
+ * @param {object} [options={}] options
+ * @param {boolean} [options.partial=false] an update: a field the write
+ *   does not name is left alone rather than treated as absent
+ * @param {*} [options.record] the record, for a validator that asked
+ * @returns {?object} `{ field: message }`, or null when nothing is wrong
+ */
+const problemsOf = (rules, values, { partial = false, record } = {}) => {
+  if (!rules) {
+    return null;
+  }
+
+  const given = isPlainObject(values) ? values : {};
+  const errors = {};
+
+  for (const field of Object.keys(rules)) {
+    const has = Object.prototype.hasOwnProperty.call(given, field);
+
+    if (!has && partial) {
+      continue;
+    }
+
+    const wrong = problem(rules[field], given[field], record);
+
+    if (wrong) {
+      errors[field] = wrong;
+    }
+  }
+
+  return Object.keys(errors).length > 0 ? errors : null;
+};
+
+/**
+ * The refusal a mass write gets on a model whose validator wants a record
+ *
+ * @param {string} model the model's global id
+ * @param {string} what the call that was made (`update`, `updateMany`)
+ * @param {string} instead the single-record call to loop over
+ * @returns {Error} the error to throw
+ */
+const massWrite = (model, what, instead, fields = []) =>
+  coded(
+    MASS_WRITE,
+    `${model}.${what}() writes many rows at once, and ${
+      fields.length > 0 ? fields.join(', ') : 'a field'
+    } of ${model} is validated by a rule that asks for the record. ` +
+      `A mass write has no records to give it, so henri refuses rather than recording a pass it never made. ` +
+      `Loop instead: for (const record of await ${model}.find(where)) await record.${instead}`
+  );
+
+/**
+ * The refusal a write the ORM runs no hook for gets
+ *
+ * Sequelize's `increment`/`decrement` and Mongoose's `bulkWrite` reach the
+ * database without any middleware at all, so a rule declared on a field
+ * they write would be a promise henri does not keep. Neither call exists
+ * on all three adapters, so neither is part of what a `validates` block
+ * means; a model that declares one and calls the other is told so.
+ *
+ * @param {string} model the model's global id
+ * @param {string} what the call that was made
+ * @param {string} instead what to do instead
+ * @returns {Error} the error to throw
+ */
+const uncheckedWrite = (model, what, instead) =>
+  coded(
+    UNCHECKED,
+    `${model}.${what}() writes without running any of the ORM's hooks, so henri cannot check what it writes, and ${model} declares validations for it. ${instead}`
+  );
+
+module.exports = {
+  ANY,
+  APPLIES,
+  INVALID,
+  KEYS,
+  MASS_WRITE,
+  TYPES,
+  UNCHECKED,
+  coded,
+  isBlank,
+  massWrite,
+  problemsOf,
+  uncheckedWrite,
+  validationsOf,
+  wantsRecord,
+};

--- a/packages/mongoose/__tests__/mongoose.spec.js
+++ b/packages/mongoose/__tests__/mongoose.spec.js
@@ -235,7 +235,10 @@ describe('mongoose adapter', () => {
       });
 
       expect(definition.active).toBe(Boolean);
-      expect(definition.age).toEqual({ required: true, type: Number });
+      // `required` on a field whose type henri knows is henri's, checked
+      // by ./validations.js on every write path rather than by Mongoose on
+      // the three it covers, so it is not a path option any more
+      expect(definition.age).toEqual({ type: Number });
       expect(definition.birthday).toBe(Date);
       expect(definition.id).toBe(String);
       expect(definition.name).toEqual({ type: String });
@@ -358,10 +361,12 @@ describe('mongoose adapter', () => {
       expect(task.category).toBe('low');
       expect(task.done).toBe(false);
       expect(task.createdAt).toBeInstanceOf(Date);
-      await expect(Task.create({})).rejects.toThrow(/`name` is required/);
+      // Henri's sentence, not Mongoose's: `required` and `enum` mean the
+      // same thing and say the same thing on all three adapters now
+      await expect(Task.create({})).rejects.toThrow(/name: is required/);
       await expect(
         Task.create({ category: 'nope', name: 'x' })
-      ).rejects.toThrow(/not a valid enum value/);
+      ).rejects.toThrow(/category: must be one of urgent, high, medium, low/);
     });
 
     test('pings the server', async () => {

--- a/packages/mongoose/__tests__/validations.spec.js
+++ b/packages/mongoose/__tests__/validations.spec.js
@@ -1,0 +1,308 @@
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const Mongoose = require('../index');
+const { modelErrors } = require('@usehenri/core/src/base/model-errors');
+
+let mongod;
+let sequence = 0;
+
+/**
+ * Builds a minimal henri stand-in for the adapter
+ *
+ * @returns {object} fake henri
+ */
+const fakeHenri = () => {
+  const pen = {};
+
+  ['error', 'fatal', 'info', 'warn'].forEach((level) => {
+    pen[level] = () => undefined;
+  });
+
+  return {
+    _user: null,
+    config: { get: () => undefined, has: () => false },
+    isTest: true,
+    pen,
+    user: { encrypt: async (password) => `hashed:${password}` },
+  };
+};
+
+/**
+ * A model file declaring what must be true of its records
+ *
+ * @param {object} [validates] The `validates` block
+ * @returns {object} The model file
+ */
+const postModel = (validates) => ({
+  globalId: 'Post',
+  identity: 'post',
+  options: { timestamps: true },
+  schema: {
+    body: { type: 'text' },
+    slug: { type: 'string' },
+    status: { enum: ['draft', 'live'], type: 'string' },
+    title: { required: true, type: 'string' },
+    views: { type: 'integer' },
+  },
+  store: 'default',
+  validates,
+});
+
+/**
+ * An adapter with the model on a database of its own
+ *
+ * @param {object} [validates] The `validates` block
+ * @returns {Promise<{adapter: object, Post: object}>} Both
+ */
+const boot = async (validates) => {
+  const adapter = new Mongoose(
+    'default',
+    { url: mongod.getUri(`validations${(sequence += 1)}`) },
+    fakeHenri()
+  );
+  const Post = adapter.addModel(postModel(validates), 'user');
+
+  await adapter.start();
+
+  return { Post, adapter };
+};
+
+/**
+ * The `{ field: message }` a controller would answer with
+ *
+ * @param {Promise} promise The write
+ * @returns {Promise<object>} The messages by field, through core's helper
+ */
+const errorsOf = async (promise) => {
+  try {
+    await promise;
+  } catch (error) {
+    return modelErrors(error) || { code: error.code };
+  }
+
+  return null;
+};
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+}, 60000);
+
+afterAll(() => mongod && mongod.stop());
+
+describe('validations on a mongoose store', () => {
+  describe('what a validates block checks', () => {
+    let Post;
+    let adapter;
+
+    beforeAll(async () => {
+      ({ Post, adapter } = await boot({
+        slug: { maxLength: 8, minLength: 3, pattern: /^[a-z-]+$/u },
+        views: { max: 1000, min: 0 },
+      }));
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('on a create', async () => {
+      expect(await errorsOf(Post.create({ slug: 'A', title: 'a' }))).toEqual({
+        slug: 'must be at least 3 characters',
+      });
+      expect(await errorsOf(Post.create({ title: 'b', views: -1 }))).toEqual({
+        views: 'must be at least 0',
+      });
+      expect(
+        await errorsOf(Post.create({ slug: 'shouting', title: 'c' }))
+      ).toBeNull();
+    });
+
+    test('on a document save', async () => {
+      const post = await Post.create({ title: 'one' });
+
+      post.slug = 'no';
+      expect(await errorsOf(post.save())).toEqual({
+        slug: 'must be at least 3 characters',
+      });
+    });
+
+    test('on insertMany', async () => {
+      expect(
+        await errorsOf(Post.insertMany([{ slug: 'no', title: 'x' }]))
+      ).toEqual({ slug: 'must be at least 3 characters' });
+    });
+
+    test('on the query updates, which Mongoose validates on none of', async () => {
+      await Post.create({ title: 'two' });
+
+      for (const write of [
+        () => Post.updateOne({ title: 'two' }, { slug: 'no' }),
+        () => Post.updateMany({ title: 'two' }, { slug: 'no' }),
+        () => Post.findOneAndUpdate({ title: 'two' }, { slug: 'no' }),
+        () => Post.updateOne({ title: 'two' }, { $set: { slug: 'no' } }),
+      ]) {
+        expect(await errorsOf(write())).toEqual({
+          slug: 'must be at least 3 characters',
+        });
+      }
+
+      expect((await Post.findOne({ title: 'two' })).slug).toBeUndefined();
+    });
+
+    test('and on the one that takes a value away', async () => {
+      await Post.create({ title: 'three' });
+      expect(
+        await errorsOf(
+          Post.updateOne({ title: 'three' }, { $unset: { title: '' } })
+        )
+      ).toEqual({ title: 'is required' });
+    });
+
+    test('a field the update does not name is left alone', async () => {
+      await Post.create({ slug: 'fine', title: 'four' });
+      await Post.updateOne({ title: 'four' }, { views: 3 });
+      expect((await Post.findOne({ title: 'four' })).slug).toBe('fine');
+    });
+  });
+
+  describe('the schema’s own required and enum', () => {
+    let Post;
+    let adapter;
+
+    beforeAll(async () => {
+      ({ Post, adapter } = await boot());
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('are checked on the query updates too, which is the hole', async () => {
+      // Measured before this existed: `updateMany` wrote a null over a
+      // required field and a value outside the enum into the document,
+      // because Mongoose runs its own validators on save(), create() and
+      // insertMany() and on nothing else
+      await Post.create({ status: 'draft', title: 'here' });
+      expect(
+        await errorsOf(Post.updateMany({ title: 'here' }, { title: null }))
+      ).toEqual({ title: 'is required' });
+      expect(
+        await errorsOf(Post.updateOne({ title: 'here' }, { status: 'x' }))
+      ).toEqual({ status: 'must be one of draft, live' });
+
+      const post = await Post.findOne({ title: 'here' });
+
+      expect(post.title).toBe('here');
+      expect(post.status).toBe('draft');
+    });
+
+    test('and answer henri’s sentence on the paths Mongoose did cover', async () => {
+      expect(await errorsOf(Post.create({}))).toEqual({
+        title: 'is required',
+      });
+      expect(await errorsOf(Post.create({ title: '   ' }))).toEqual({
+        title: 'is required',
+      });
+    });
+  });
+
+  describe('a validator asking for the record', () => {
+    let Post;
+    let adapter;
+
+    beforeAll(async () => {
+      ({ Post, adapter } = await boot({
+        status: {
+          validate: (value, record) =>
+            value !== 'live' || Boolean(record.body) || 'no body',
+        },
+      }));
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('gets it on a create and on a save', async () => {
+      expect(
+        await errorsOf(Post.create({ status: 'live', title: 'a' }))
+      ).toEqual({ status: 'no body' });
+      expect(
+        await errorsOf(
+          Post.create({ body: 'here', status: 'live', title: 'b' })
+        )
+      ).toBeNull();
+    });
+
+    test('and on a query update that names one document, which is read', async () => {
+      await Post.create({ title: 'bare' });
+      await Post.create({ body: 'has one', title: 'full' });
+      expect(
+        await errorsOf(Post.updateOne({ title: 'bare' }, { status: 'live' }))
+      ).toEqual({ status: 'no body' });
+      expect(
+        await errorsOf(Post.updateOne({ title: 'full' }, { status: 'live' }))
+      ).toBeNull();
+    });
+
+    test('while updateMany is refused, naming the loop', async () => {
+      const error = await Post.updateMany(
+        { title: 'bare' },
+        { status: 'live' }
+      ).catch((thrown) => thrown);
+
+      expect(error.code).toBe('HENRI_MODEL_VALIDATION_MASS_WRITE');
+      expect(error.message).toMatch(/status of Post is validated by a rule/u);
+      // One that does not name the validated field is untouched
+      await expect(
+        Post.updateMany({ title: 'bare' }, { views: 1 })
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe('a write no Mongoose middleware reaches', () => {
+    let Post;
+    let adapter;
+
+    beforeAll(async () => {
+      ({ Post, adapter } = await boot({ views: { max: 10 } }));
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('bulkWrite is refused', async () => {
+      const error = await Post.bulkWrite([
+        { insertOne: { document: { title: 'a', views: 99 } } },
+      ]).catch((thrown) => thrown);
+
+      expect(error.code).toBe('HENRI_MODEL_VALIDATION_UNCHECKED_WRITE');
+      expect(error.message).toMatch(/Mongoose runs no middleware/u);
+    });
+
+    test('so is an operator that describes a change rather than a value', async () => {
+      await Post.create({ title: 'a', views: 1 });
+
+      const error = await Post.updateOne(
+        { title: 'a' },
+        { $inc: { views: 100 } }
+      ).catch((thrown) => thrown);
+
+      expect(error.code).toBe('HENRI_MODEL_VALIDATION_UNCHECKED_WRITE');
+      expect(error.message).toMatch(/views is changed by an operator/u);
+      // An operator on a field nothing validates is nothing to refuse
+      await expect(
+        Post.updateOne({ title: 'a' }, { $unset: { slug: '' } })
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe('a declaration henri cannot carry out', () => {
+    test('fails the boot, naming the model and the field', () => {
+      const adapter = new Mongoose(
+        'default',
+        { url: mongod.getUri('validations-boot') },
+        fakeHenri()
+      );
+
+      expect(() =>
+        adapter.addModel(postModel({ title: { min: 3 } }), 'user')
+      ).toThrow(/Post declares `validates.title` with "min"/u);
+      expect(() =>
+        adapter.addModel(postModel({ ttile: { maxLength: 3 } }), 'user')
+      ).toThrow(/which its schema has no field for/u);
+    });
+  });
+});

--- a/packages/mongoose/index.js
+++ b/packages/mongoose/index.js
@@ -1,6 +1,14 @@
 const mongoose = require('mongoose');
 const debug = require('debug')('henri:mongoose');
-const { externalId, lookups, owned, paginate, paranoid } = require('./plugins');
+const {
+  externalId,
+  lookups,
+  owned,
+  paginate,
+  paranoid,
+  validations,
+} = require('./plugins');
+const { validationsOf } = require('./validations');
 const {
   instrument: instrumentQueries,
   instrumentStatics,
@@ -175,6 +183,15 @@ class Mongoose {
     owned(schema, this.henri);
     paginate(schema);
     lookups(schema);
+
+    // Before every other hook, so what a rule measures is the value the
+    // application wrote rather than an envelope. A declaration henri
+    // cannot carry out failed the boot in `normalizeModel` above
+    const rules = validationsOf(model);
+
+    if (rules) {
+      validations(schema, rules, model.globalId);
+    }
 
     // Before everything else that reads a document back: a `decimal` and a
     // `bigint` are strings in JavaScript, and every other hook here has to

--- a/packages/mongoose/package.json
+++ b/packages/mongoose/package.json
@@ -31,6 +31,7 @@
     "schema.js",
     "types.js",
     "utils.js",
+    "validations.js",
     "CHANGELOG.md",
     "encrypted.js",
     "encryption.js",

--- a/packages/mongoose/plugins.js
+++ b/packages/mongoose/plugins.js
@@ -6,6 +6,12 @@ const {
   resolvesKeys,
   uuidv7,
 } = require('./external-id');
+const {
+  massWrite,
+  problemsOf,
+  uncheckedWrite,
+  wantsRecord,
+} = require('./validations');
 
 /**
  * The Rails behaviours henri adds to Mongoose models: `paginate()` and the
@@ -460,10 +466,186 @@ const externalId = (schema) => {
   return schema;
 };
 
+/** The query middleware a write with attributes goes through */
+const WRITE_HOOKS = [
+  'findOneAndReplace',
+  'findOneAndUpdate',
+  'replaceOne',
+  'updateMany',
+  'updateOne',
+];
+
+/** The ones of those that name a single document, so it can be read */
+const ONE_HOOKS = new Set([
+  'findOneAndReplace',
+  'findOneAndUpdate',
+  'replaceOne',
+  'updateOne',
+]);
+
+/** Mongo update operators henri can read a value out of */
+const SETTERS = ['$set', '$setOnInsert'];
+
+/**
+ * The values a query update writes, and the fields it changes some other
+ * way
+ *
+ * A `$set` and a plain document are values henri can check. `$unset` takes
+ * the value away, which `required` is exactly about, so it arrives as
+ * `undefined`. Every other operator (`$inc`, `$push`, `$mul`, ...) changes
+ * a field by describing the change rather than the result, and there is
+ * nothing to measure until the server has done it.
+ *
+ * @param {*} update What `getUpdate()` answered
+ * @returns {{values: object, opaque: Array<string>}} The values, and the
+ *   fields changed by an operator henri cannot read
+ */
+const updateValues = (update) => {
+  const values = {};
+  const opaque = [];
+
+  if (!update || typeof update !== 'object' || Array.isArray(update)) {
+    return { opaque, values };
+  }
+
+  for (const [key, value] of Object.entries(update)) {
+    if (!key.startsWith('$')) {
+      values[key] = value;
+
+      continue;
+    }
+
+    if (SETTERS.includes(key)) {
+      Object.assign(values, value);
+
+      continue;
+    }
+
+    if (key === '$unset') {
+      for (const field of Object.keys(value || {})) {
+        values[field] = undefined;
+      }
+
+      continue;
+    }
+
+    opaque.push(...Object.keys(value || {}));
+  }
+
+  return { opaque, values };
+};
+
+/**
+ * What a model's `validates` block declared, on every Mongoose write.
+ *
+ * Mongoose runs its own validators on `save()`, `create()` and
+ * `insertMany()` and on nothing else: `updateOne`, `updateMany` and
+ * `findOneAndUpdate` write straight past `required` and `enum` unless the
+ * caller remembers `runValidators` on that one call. That is the hole this
+ * closes, and it is why the rules are registered twice -- once as document
+ * middleware and once as query middleware.
+ *
+ * On a document the failure goes through `invalidate()`, so what a
+ * controller catches is the `ValidationError` Mongoose already answers
+ * with, carrying henri's sentence (the argument is in the header of
+ * ./exact-paths.js). On a query there is no document to invalidate, so one
+ * is thrown with the same shape.
+ *
+ * @param {object} schema The Mongoose schema
+ * @param {object} rules The compiled rules (./validations.js)
+ * @param {string} model The model's global id, for the messages
+ * @returns {object} The schema
+ */
+const validations = (schema, rules, model) => {
+  /**
+   * The error a query update gets, in the shape a document would have
+   *
+   * @param {object} problems `{ field: message }`
+   * @param {object} values The values being written
+   * @returns {Error} A ValidationError
+   */
+  const failure = (problems, values) => {
+    const details = Object.entries(problems)
+      .map(([field, message]) => `${field}: ${message}`)
+      .join(', ');
+    const error = new Error(`${model} validation failed: ${details}`);
+
+    error.name = 'ValidationError';
+    error.errors = Object.fromEntries(
+      Object.entries(problems).map(([field, message]) => [
+        field,
+        { kind: 'validates', message, path: field, value: values[field] },
+      ])
+    );
+
+    return error;
+  };
+
+  schema.pre('validate', function henriValidates() {
+    const record = this.toObject({ depopulate: true, virtuals: false });
+    const problems = problemsOf(rules, record, {
+      partial: false,
+      record,
+    });
+
+    for (const [field, message] of Object.entries(problems || {})) {
+      this.invalidate(field, message, record[field]);
+    }
+  });
+
+  schema.pre(WRITE_HOOKS, async function henriValidatesUpdate() {
+    const { opaque, values } = updateValues(this.getUpdate());
+    const changed = opaque.filter((field) => rules[field]);
+
+    if (changed.length > 0) {
+      throw uncheckedWrite(
+        model,
+        this.op,
+        `${changed.join(' and ')} ${changed.length === 1 ? 'is' : 'are'} changed by an operator rather than set to a value. Read the record, change it and save it, which is checked.`
+      );
+    }
+
+    const wanted = wantsRecord(rules, values);
+    let record = null;
+
+    if (wanted.length > 0) {
+      if (!ONE_HOOKS.has(this.op)) {
+        throw massWrite(model, this.op, 'update(attrs)', wanted);
+      }
+
+      // One document is named, so the rule that asked for it gets it,
+      // the way `findByIdAndUpdate` reads one on the drizzle adapter
+      const found = await this.model.findOne(this.getFilter()).lean();
+
+      record = found ? { ...found, ...values } : values;
+    }
+
+    const problems = problemsOf(rules, values, {
+      partial: true,
+      record: record || values,
+    });
+
+    if (problems) {
+      throw failure(problems, values);
+    }
+  });
+
+  schema.pre('bulkWrite', function henriValidatesBulk() {
+    throw uncheckedWrite(
+      model,
+      'bulkWrite',
+      'Mongoose runs no middleware for the operations of a bulk write, so henri never sees what they write. Use create(), insertMany() or one update per record, all of which are checked.'
+    );
+  });
+
+  return schema;
+};
+
 module.exports = {
   DELETE_STATICS,
   NOTHING,
   READ_HOOKS,
+  WRITE_HOOKS,
   externalId,
   idFilter,
   keyFilter,
@@ -471,4 +653,6 @@ module.exports = {
   owned,
   paginate,
   paranoid,
+  updateValues,
+  validations,
 };

--- a/packages/mongoose/schema.js
+++ b/packages/mongoose/schema.js
@@ -108,6 +108,18 @@ const normalizeField = (
     shaped.required = true;
   }
 
+  // `required` and `enum` on a field whose type henri knows are henri's,
+  // not Mongoose's: they are checked by ./validations.js on every write
+  // path -- including the query updates Mongoose's own validators never
+  // see -- and they say the same sentence there that they say on the other
+  // two adapters. A type Mongoose brought (an `ObjectId`, a nested
+  // document, `[String]`) keeps Mongoose's meaning for both, because henri
+  // has no column to reason about
+  if (TYPES[name]) {
+    delete shaped.required;
+    delete shaped.enum;
+  }
+
   if (typeof defaultValue !== 'undefined' && !('default' in shaped)) {
     shaped.default = defaultValue;
   }

--- a/packages/mongoose/validations.js
+++ b/packages/mongoose/validations.js
@@ -1,0 +1,598 @@
+/**
+ * What must be true of a record, declared once and meant once.
+ *
+ * A model file says it in a `validates` block, keyed by field, in the
+ * vocabulary the request boundaries already use (`base/params-schema.js`):
+ *
+ * ```js
+ * module.exports = {
+ *   schema: {
+ *     email: { type: 'string', required: true, unique: true },
+ *     age: { type: 'integer' },
+ *     status: { type: 'string', enum: ['draft', 'live'] },
+ *   },
+ *   validates: {
+ *     age: { max: 120, min: 18 },
+ *     email: { maxLength: 120, pattern: /^[^@\s]+@[^@\s]+$/u },
+ *     status: { validate: (value, record) => value !== 'live' || record.body },
+ *   },
+ * };
+ * ```
+ *
+ * ## Why this file exists at all
+ *
+ * The three ORMs each have validations and no two of them mean the same
+ * thing. Measured, not assumed:
+ *
+ * - **Mongoose** runs its path validators on `save()`, `create()` and
+ *   `insertMany()` and on **nothing else**. `updateOne`, `updateMany`,
+ *   `findOneAndUpdate` and `findByIdAndUpdate` write straight past
+ *   `required` and `enum` -- a `null` lands in a required column and a
+ *   value outside the enum lands in the document -- unless the *caller*
+ *   remembers `runValidators: true` on that one call.
+ * - **Sequelize** validates `create`, `save`, `update` and the mass
+ *   `Model.update`, skips `bulkCreate` (its `validate` defaults to
+ *   `false`, so a value outside an `enum` is written), and on the dialects
+ *   with a native `ENUM` column has no JavaScript check at all -- the
+ *   server refuses it, as a `SequelizeDatabaseError` that
+ *   `henri.model.errors()` does not recognize, so the same model file
+ *   answers 422 on sqlite and 500 on PostgreSQL.
+ * - **Drizzle** validates every write it exposes, including the mass ones.
+ *
+ * So `required` and `enum` -- two keys the models guide says mean the same
+ * thing on every adapter -- did not. This module is what makes them, and
+ * it is the only implementation of the rules an application declares.
+ *
+ * ## One vocabulary
+ *
+ * The keys are the ones a controller's `params` block already takes, and
+ * they mean the same thing here: `required`, `enum`, `min`, `max`,
+ * `minLength`, `maxLength`, `pattern`, plus `validate`, a function of the
+ * value (and, when it asks for one, the record). There is no `type`: the
+ * schema next door already says it, and a constraint that means nothing
+ * for that type (`min` on a `string`, `maxLength` on an `integer`) fails
+ * the boot rather than being ignored.
+ *
+ * The schema's own `required` and `enum` are read into the same rules, so
+ * an application that never writes a `validates` block still gets one
+ * meaning for those two on every adapter and every write path.
+ *
+ * ## Where this belongs, and where it does not
+ *
+ * `req.permit()` and a controller's `params` block check what **arrives**:
+ * they are about a request, they coerce a query string, and they answer
+ * 422 before an action runs. This checks what is **written**, and a record
+ * is written by a job, a seed, a console and a webhook delivery as often
+ * as by a request. The two compose -- neither replaces the other -- and
+ * the guide says so where a person is deciding.
+ *
+ * ## What is refused rather than pretended
+ *
+ * A `validate` function that declares a second parameter is asking for the
+ * record, and a mass write has none: the same predicate `base/policies.js`
+ * uses for a rule that wants a record. Rather than calling it with
+ * `undefined` and recording a pass, a mass write on such a model is
+ * refused (`HENRI_MODEL_VALIDATION_MASS_WRITE`), which is the answer
+ * `HENRI_VERSION_MASS_WRITE` already gives to the same shape of problem.
+ * Every other rule reads only the value being written, so a mass write
+ * checks them exactly as a single write does.
+ *
+ * ## Uniqueness is not here, deliberately
+ *
+ * `unique` stays what it is: an index, and a race. A `SELECT` before an
+ * `INSERT` answers a question about a moment that has passed by the time
+ * the row is written, so a check would turn a guarantee the database
+ * keeps into a message henri sometimes produces. The database refuses the
+ * duplicate, and `henri.model.errors()` turns that refusal into
+ * `{ field: 'must be unique' }` on all three adapters, which is the same
+ * shape as everything here.
+ *
+ * ## A copy per adapter
+ *
+ * This file is held four times -- here and in `@usehenri/drizzle`,
+ * `@usehenri/mongoose` and `@usehenri/sequelize` -- byte for byte, the way
+ * `exact.js` and `external-id.js` are, because an adapter depends on no
+ * part of core at runtime. `src/__tests__/validations.spec.js` is what
+ * keeps them the same file. It requires nothing but `./exact`, which is
+ * held the same way, and raises its codes through a `coded()` of its own
+ * for the same reason.
+ */
+
+const { compare, isExact } = require('./exact');
+
+/** The failure a model declaration henri cannot carry out gets */
+const INVALID = 'HENRI_MODEL_VALIDATION_INVALID';
+
+/** The failure a mass write on a record-aware validator gets */
+const MASS_WRITE = 'HENRI_MODEL_VALIDATION_MASS_WRITE';
+
+/** The failure a write no hook of the ORM reaches gets */
+const UNCHECKED = 'HENRI_MODEL_VALIDATION_UNCHECKED_WRITE';
+
+/** The henri schema types, so a constraint can be bound to one */
+const TYPES = [
+  'bigint',
+  'boolean',
+  'date',
+  'decimal',
+  'float',
+  'integer',
+  'json',
+  'number',
+  'string',
+  'text',
+  'uuid',
+];
+
+/**
+ * The types each constraint applies to. `required`, `enum` and `validate`
+ * apply to every type, so they are not in here (see KEYS).
+ */
+const APPLIES = {
+  max: ['bigint', 'decimal', 'float', 'integer', 'number'],
+  maxLength: ['string', 'text'],
+  min: ['bigint', 'decimal', 'float', 'integer', 'number'],
+  minLength: ['string', 'text'],
+  pattern: ['string', 'text'],
+};
+
+/** The keys every field takes, whatever its type */
+const ANY = ['enum', 'required', 'validate'];
+
+/** Every key a `validates` entry may hold */
+const KEYS = [...ANY, ...Object.keys(APPLIES)].sort();
+
+/**
+ * An error carrying a henri code, without depending on core
+ *
+ * @param {string} code the henri error code
+ * @param {string} message what is wrong
+ * @returns {Error} the error to throw
+ */
+const coded = (code, message) => Object.assign(new Error(message), { code });
+
+/**
+ * Is the value a plain object?
+ *
+ * @param {*} value any value
+ * @returns {boolean} true for a plain object
+ */
+const isPlainObject = (value) =>
+  value !== null &&
+  typeof value === 'object' &&
+  (Object.getPrototypeOf(value) === Object.prototype ||
+    Object.getPrototypeOf(value) === null);
+
+/**
+ * Is the value missing, for `required`?
+ *
+ * Rails' `presence`, and what Mongoose and Drizzle already answer: a
+ * string of nothing but spaces is a field a person left empty, not a
+ * value. Sequelize's `allowNull` alone would have written it.
+ *
+ * @param {*} value the value
+ * @returns {boolean} true when there is nothing there
+ */
+const isBlank = (value) =>
+  typeof value === 'undefined' ||
+  value === null ||
+  (typeof value === 'string' && value.trim() === '');
+
+/**
+ * `a string`, `an integer`: the article a message needs
+ *
+ * @param {string} type the type
+ * @returns {string} the type with its article
+ */
+const article = (type) => (/^[aeiou]/u.test(type) ? `an ${type}` : `a ${type}`);
+
+/**
+ * The henri type a field declares, when it declares one henri knows
+ *
+ * A model file may write a type this file has no opinion about -- a
+ * Mongoose `ObjectId`, a Sequelize `DataTypes.STRING(50)`, a nested
+ * document -- and a constraint that measures a number or a length has
+ * nothing to measure there. Those fields still take `required`, `enum`
+ * and `validate`, which need no type at all.
+ *
+ * @param {*} definition the field definition from the model file
+ * @returns {?string} the henri type name, or null
+ */
+const typeOf = (definition) => {
+  const type = isPlainObject(definition) ? definition.type : definition;
+
+  if (typeof type !== 'string') {
+    return null;
+  }
+
+  const name = type.toLowerCase();
+
+  return TYPES.includes(name) ? name : null;
+};
+
+/**
+ * Refuses a declaration, naming the model and the field
+ *
+ * @param {string} model the model's global id
+ * @param {string} field the field name
+ * @param {string} what what is wrong with it
+ * @returns {void} never returns
+ * @throws {Error} always, HENRI_MODEL_VALIDATION_INVALID
+ */
+const refuse = (model, field, what) => {
+  throw coded(INVALID, `${model} declares \`validates.${field}\` with ${what}`);
+};
+
+/**
+ * Checks and freezes one field's rule
+ *
+ * @param {string} model the model's global id
+ * @param {string} field the field name
+ * @param {object} written what the model file wrote
+ * @param {?string} type the henri type of the field, when it has one
+ * @returns {object} the compiled rule
+ * @throws {Error} HENRI_MODEL_VALIDATION_INVALID on anything unusable
+ */
+const ruleOf = (model, field, written, type) => {
+  if (!isPlainObject(written)) {
+    refuse(
+      model,
+      field,
+      `${written === null ? 'null' : typeof written}: a rule is an object of ${KEYS.join(', ')}`
+    );
+  }
+
+  const compiled = { type };
+
+  for (const [key, value] of Object.entries(written)) {
+    if (!KEYS.includes(key)) {
+      refuse(
+        model,
+        field,
+        `the unknown key "${key}": a rule takes ${KEYS.join(', ')}`
+      );
+    }
+
+    if (APPLIES[key] && !APPLIES[key].includes(type)) {
+      refuse(
+        model,
+        field,
+        type === null
+          ? `"${key}", which needs a type henri knows: the field declares one henri has no bounds for, so it takes ${ANY.join(', ')} only`
+          : `"${key}", which ${article(type)} does not take: ${key} is for ${APPLIES[key].join(', ')}`
+      );
+    }
+
+    compiled[key] = value;
+  }
+
+  for (const key of ['max', 'maxLength', 'min', 'minLength']) {
+    if (!(key in compiled)) {
+      continue;
+    }
+
+    // The bound of an exact field may be written out, the way its values
+    // are, so a limit past what a double carries can be declared at all
+    const exact =
+      isExact(type) && (key === 'max' || key === 'min')
+        ? typeof compiled[key] === 'string'
+        : false;
+
+    if (!exact && typeof compiled[key] !== 'number') {
+      refuse(model, field, `a "${key}" that is not a number`);
+    }
+  }
+
+  if ('pattern' in compiled && !(compiled.pattern instanceof RegExp)) {
+    refuse(model, field, 'a "pattern" that is not a regular expression');
+  }
+
+  if ('required' in compiled && typeof compiled.required !== 'boolean') {
+    refuse(model, field, 'a "required" that is not true or false');
+  }
+
+  if ('enum' in compiled) {
+    if (!Array.isArray(compiled.enum) || compiled.enum.length === 0) {
+      refuse(model, field, 'an "enum" that is not a list of values');
+    }
+  }
+
+  if ('validate' in compiled && typeof compiled.validate !== 'function') {
+    refuse(
+      model,
+      field,
+      'a "validate" that is not a function: write `(value, record) => true` or a message'
+    );
+  }
+
+  return Object.freeze(compiled);
+};
+
+/**
+ * Everything a model says must be true of its records.
+ *
+ * The `validates` block, plus the `required` and `enum` the schema
+ * already declares -- those two are checked here on every adapter and
+ * every write path, which is the whole point of the file.
+ *
+ * @param {object} model the model file (`globalId`, `schema`, `validates`)
+ * @returns {?object} the rules by field, or null when there are none
+ * @throws {Error} HENRI_MODEL_VALIDATION_INVALID on a declaration henri
+ *   cannot carry out
+ */
+const validationsOf = (model = {}) => {
+  const name = model.globalId || model.identity || 'the model';
+  const schema = isPlainObject(model.schema) ? model.schema : {};
+  const written = model.validates;
+
+  if (typeof written !== 'undefined' && !isPlainObject(written)) {
+    throw coded(
+      INVALID,
+      `${name} declares \`validates\` as ${
+        written === null ? 'null' : typeof written
+      }: it is an object keyed by field`
+    );
+  }
+
+  const rules = {};
+
+  for (const field of Object.keys(schema)) {
+    const definition = schema[field];
+    const type = typeOf(definition);
+    const lifted = {};
+
+    if (isPlainObject(definition)) {
+      // `allowNull: false` is the Sequelize spelling of `required`, and
+      // the mongoose adapter accepts it too, so it is the same rule here
+      if (definition.required === true || definition.allowNull === false) {
+        lifted.required = true;
+      }
+
+      if (Array.isArray(definition.enum)) {
+        lifted.enum = definition.enum;
+      }
+    }
+
+    const declared = (written && written[field]) || null;
+
+    if (!declared && Object.keys(lifted).length === 0) {
+      continue;
+    }
+
+    rules[field] = ruleOf(
+      name,
+      field,
+      // A rule that is not an object at all is handed over as it is, so
+      // the refusal says what it was rather than spreading it into one
+      isPlainObject(declared) ? { ...lifted, ...declared } : declared || lifted,
+      type
+    );
+  }
+
+  for (const field of Object.keys(written || {})) {
+    if (!rules[field]) {
+      throw coded(
+        INVALID,
+        `${name} declares \`validates.${field}\`, which its schema has no field for: ${
+          Object.keys(schema).join(', ') || 'the schema is empty'
+        }`
+      );
+    }
+  }
+
+  return Object.keys(rules).length > 0 ? Object.freeze(rules) : null;
+};
+
+/**
+ * Does any rule want the record, rather than only the value?
+ *
+ * The predicate is the arity of the function, the way `base/policies.js`
+ * reads a rule that declares a record parameter. It is what a mass write
+ * is measured against -- and it is measured against the fields that write
+ * actually names, so a soft delete stamping `deletedAt` on a thousand rows
+ * is not refused by a rule about somebody's email address.
+ *
+ * @param {?object} rules the compiled rules
+ * @param {object} [values] the values being written, when there are some
+ * @returns {Array<string>} the fields whose rule asks for the record
+ */
+const wantsRecord = (rules, values) => {
+  if (!rules) {
+    return [];
+  }
+
+  const named = isPlainObject(values)
+    ? Object.keys(values)
+    : Object.keys(rules);
+
+  return named.filter(
+    (field) =>
+      rules[field] &&
+      typeof rules[field].validate === 'function' &&
+      rules[field].validate.length >= 2
+  );
+};
+
+/**
+ * The bounds of a rule, once there is a value to measure
+ *
+ * @param {object} rule the compiled rule
+ * @param {*} value the value being written
+ * @returns {?string} what is wrong with it, or null
+ */
+const bounds = (rule, value) => {
+  const { max, maxLength, min, minLength, pattern } = rule;
+
+  // An exact value is a string of digits, so `<` would compare it letter
+  // by letter and answer that 9.99 is more than 10 (see ./exact.js)
+  if (isExact(rule.type) && typeof value === 'string') {
+    if (typeof min !== 'undefined' && compare(value, min) < 0) {
+      return `must be at least ${min}`;
+    }
+
+    if (typeof max !== 'undefined' && compare(value, max) > 0) {
+      return `must be at most ${max}`;
+    }
+
+    return null;
+  }
+
+  if (typeof value === 'number') {
+    if (typeof min === 'number' && value < min) {
+      return `must be at least ${min}`;
+    }
+
+    if (typeof max === 'number' && value > max) {
+      return `must be at most ${max}`;
+    }
+  }
+
+  if (typeof value === 'string') {
+    if (typeof minLength === 'number' && value.length < minLength) {
+      return `must be at least ${minLength} characters`;
+    }
+
+    if (typeof maxLength === 'number' && value.length > maxLength) {
+      return `must be at most ${maxLength} characters`;
+    }
+
+    if (pattern && !pattern.test(value)) {
+      return 'is not in the expected format';
+    }
+  }
+
+  return null;
+};
+
+/**
+ * One value through one rule
+ *
+ * @param {object} rule the compiled rule
+ * @param {*} value the value being written
+ * @param {*} record the record, for a validator that asked for one
+ * @returns {?string} the message, or null when the value is fine
+ */
+const problem = (rule, value, record) => {
+  if (isBlank(value)) {
+    return rule.required ? 'is required' : null;
+  }
+
+  const wrong = bounds(rule, value);
+
+  if (wrong) {
+    return wrong;
+  }
+
+  if (rule.enum && !rule.enum.includes(value)) {
+    return `must be one of ${rule.enum.join(', ')}`;
+  }
+
+  if (typeof rule.validate !== 'function') {
+    return null;
+  }
+
+  let answer;
+
+  try {
+    answer = rule.validate(value, record);
+  } catch (error) {
+    return (error && error.message) || 'is invalid';
+  }
+
+  if (typeof answer === 'string') {
+    return answer;
+  }
+
+  return answer === false ? 'is invalid' : null;
+};
+
+/**
+ * Everything wrong with the values being written
+ *
+ * @param {?object} rules the compiled rules
+ * @param {object} values the attributes being written
+ * @param {object} [options={}] options
+ * @param {boolean} [options.partial=false] an update: a field the write
+ *   does not name is left alone rather than treated as absent
+ * @param {*} [options.record] the record, for a validator that asked
+ * @returns {?object} `{ field: message }`, or null when nothing is wrong
+ */
+const problemsOf = (rules, values, { partial = false, record } = {}) => {
+  if (!rules) {
+    return null;
+  }
+
+  const given = isPlainObject(values) ? values : {};
+  const errors = {};
+
+  for (const field of Object.keys(rules)) {
+    const has = Object.prototype.hasOwnProperty.call(given, field);
+
+    if (!has && partial) {
+      continue;
+    }
+
+    const wrong = problem(rules[field], given[field], record);
+
+    if (wrong) {
+      errors[field] = wrong;
+    }
+  }
+
+  return Object.keys(errors).length > 0 ? errors : null;
+};
+
+/**
+ * The refusal a mass write gets on a model whose validator wants a record
+ *
+ * @param {string} model the model's global id
+ * @param {string} what the call that was made (`update`, `updateMany`)
+ * @param {string} instead the single-record call to loop over
+ * @returns {Error} the error to throw
+ */
+const massWrite = (model, what, instead, fields = []) =>
+  coded(
+    MASS_WRITE,
+    `${model}.${what}() writes many rows at once, and ${
+      fields.length > 0 ? fields.join(', ') : 'a field'
+    } of ${model} is validated by a rule that asks for the record. ` +
+      `A mass write has no records to give it, so henri refuses rather than recording a pass it never made. ` +
+      `Loop instead: for (const record of await ${model}.find(where)) await record.${instead}`
+  );
+
+/**
+ * The refusal a write the ORM runs no hook for gets
+ *
+ * Sequelize's `increment`/`decrement` and Mongoose's `bulkWrite` reach the
+ * database without any middleware at all, so a rule declared on a field
+ * they write would be a promise henri does not keep. Neither call exists
+ * on all three adapters, so neither is part of what a `validates` block
+ * means; a model that declares one and calls the other is told so.
+ *
+ * @param {string} model the model's global id
+ * @param {string} what the call that was made
+ * @param {string} instead what to do instead
+ * @returns {Error} the error to throw
+ */
+const uncheckedWrite = (model, what, instead) =>
+  coded(
+    UNCHECKED,
+    `${model}.${what}() writes without running any of the ORM's hooks, so henri cannot check what it writes, and ${model} declares validations for it. ${instead}`
+  );
+
+module.exports = {
+  ANY,
+  APPLIES,
+  INVALID,
+  KEYS,
+  MASS_WRITE,
+  TYPES,
+  UNCHECKED,
+  coded,
+  isBlank,
+  massWrite,
+  problemsOf,
+  uncheckedWrite,
+  validationsOf,
+  wantsRecord,
+};

--- a/packages/sequelize/__tests__/sequelize.spec.js
+++ b/packages/sequelize/__tests__/sequelize.spec.js
@@ -16,13 +16,14 @@ const { DataTypes, QueryTypes } = Sql.Sequelize;
 const tasks = target.quote('Tasks');
 const users = target.quote('Users');
 
-// How a bad enum value is refused: sqlite validates it in the model, the
-// dialects with a native ENUM column let the server refuse the value
-const ENUM_ERROR = {
-  mysql: /Data truncated for column 'category'|CHECK constraint/,
-  postgres: /invalid input value for enum/,
-  sqlite: /isIn/,
-};
+// How a bad enum value is refused. It used to depend on the dialect: the
+// column is a native ENUM on postgres and mysql, so the *server* refused
+// the value and answered a SequelizeDatabaseError that
+// `henri.model.errors()` does not recognize -- a 500 where sqlite answered
+// a 422. henri checks the value first now (./validations.js), on every
+// dialect and every write path, so the refusal is the same sentence
+// everywhere and the column is the backstop it was always meant to be
+const ENUM_ERROR = /category: must be one of urgent, high, medium, low/;
 
 /**
  * A JSON column, read back (a string on sqlite, parsed elsewhere)
@@ -153,11 +154,10 @@ describe('sequelize adapter', () => {
       expect((await Task.findAll()).map((row) => row.name)).toEqual([
         'write docs',
       ]);
-      await expect(Task.create({})).rejects.toThrow(/notNull Violation/);
-      // The dialects with a native ENUM check the value themselves
+      await expect(Task.create({})).rejects.toThrow(/name: is required/);
       await expect(
         Task.create({ category: 'nope', name: 'x' })
-      ).rejects.toThrow(ENUM_ERROR[target.name]);
+      ).rejects.toThrow(ENUM_ERROR);
     });
 
     test('exposes ping, query and transaction', async () => {

--- a/packages/sequelize/__tests__/validations.spec.js
+++ b/packages/sequelize/__tests__/validations.spec.js
@@ -1,0 +1,253 @@
+const { build, target } = require('./helpers');
+const { modelErrors } = require('@usehenri/core/src/base/model-errors');
+
+/**
+ * A model file declaring what must be true of its records
+ *
+ * @param {object} [validates] The `validates` block
+ * @returns {object} The model file
+ */
+const postModel = (validates) => ({
+  globalId: 'Post',
+  identity: 'post',
+  options: { timestamps: true },
+  schema: {
+    body: { type: 'text' },
+    slug: { type: 'string' },
+    status: { enum: ['draft', 'live'], type: 'string' },
+    title: { required: true, type: 'string' },
+    views: { type: 'integer' },
+  },
+  store: 'default',
+  validates,
+});
+
+/**
+ * The `{ field: message }` a controller would answer with
+ *
+ * @param {Promise} promise The write
+ * @returns {Promise<object>} The messages by field, through core's helper
+ */
+const errorsOf = async (promise) => {
+  try {
+    await promise;
+  } catch (error) {
+    // The point of the shape: whatever the ORM threw, this is what a
+    // controller reads, and it is the same object on all three adapters
+    return modelErrors(error) || { code: error.code };
+  }
+
+  return null;
+};
+
+describe('validations on a sequelize store', () => {
+  describe('what a validates block checks', () => {
+    let Post;
+    let adapter;
+
+    beforeAll(async () => {
+      ({ adapter } = build());
+      Post = adapter.addModel(
+        postModel({
+          slug: { maxLength: 8, minLength: 3, pattern: /^[a-z-]+$/u },
+          views: { max: 1000, min: 0 },
+        }),
+        'user'
+      );
+      await adapter.start();
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('on a create', async () => {
+      expect(await errorsOf(Post.create({ slug: 'A', title: 'a' }))).toEqual({
+        slug: 'must be at least 3 characters',
+      });
+      expect(await errorsOf(Post.create({ title: 'b', views: -1 }))).toEqual({
+        views: 'must be at least 0',
+      });
+      expect(
+        await errorsOf(Post.create({ slug: 'shouting', title: 'c' }))
+      ).toBeNull();
+    });
+
+    test('on an instance update', async () => {
+      const post = await Post.create({ title: 'one' });
+
+      expect(await errorsOf(post.update({ slug: 'no' }))).toEqual({
+        slug: 'must be at least 3 characters',
+      });
+    });
+
+    test('on the mass Model.update', async () => {
+      await Post.create({ title: 'two' });
+      expect(
+        await errorsOf(
+          Post.update({ views: 9000 }, { where: { title: 'two' } })
+        )
+      ).toEqual({ views: 'must be at most 1000' });
+    });
+
+    test('on bulkCreate, which Sequelize does not validate on its own', async () => {
+      expect(
+        await errorsOf(
+          Post.bulkCreate([{ title: 'x' }, { slug: 'no', title: 'y' }])
+        )
+      ).toEqual({ slug: 'must be at least 3 characters' });
+      // And nothing of the batch was written
+      expect(await Post.count({ where: { title: 'x' } })).toBe(0);
+    });
+
+    test('on upsert', async () => {
+      expect(await errorsOf(Post.upsert({ slug: 'no', title: 'up' }))).toEqual({
+        slug: 'must be at least 3 characters',
+      });
+    });
+
+    test('a field the update does not name is left alone', async () => {
+      const post = await Post.create({ slug: 'fine', title: 'three' });
+
+      await post.update({ title: 'four' });
+      expect((await Post.findByPk(post.id)).slug).toBe('fine');
+    });
+  });
+
+  describe('the schema’s own required and enum', () => {
+    let Post;
+    let adapter;
+
+    beforeAll(async () => {
+      ({ adapter } = build());
+      Post = adapter.addModel(postModel(), 'user');
+      await adapter.start();
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('answer henri’s sentence, whatever the dialect makes of the column', async () => {
+      expect(await errorsOf(Post.create({}))).toEqual({
+        title: 'is required',
+      });
+      // The one this fixes: on postgres and mysql the column is a native
+      // ENUM, so the server used to refuse the value with a
+      // SequelizeDatabaseError -- which `henri.model.errors()` answers
+      // null for, so an application answered 500 where sqlite answered 422
+      expect(await errorsOf(Post.create({ status: 'x', title: 'a' }))).toEqual({
+        status: 'must be one of draft, live',
+      });
+      expect(
+        await errorsOf(Post.bulkCreate([{ status: 'x', title: 'b' }]))
+      ).toEqual({ status: 'must be one of draft, live' });
+      expect(
+        await errorsOf(
+          Post.update({ status: 'x' }, { where: { title: 'nobody' } })
+        )
+      ).toEqual({ status: 'must be one of draft, live' });
+    });
+
+    test('a blank string is a missing value, as it is on the other two', async () => {
+      expect(await errorsOf(Post.create({ title: '   ' }))).toEqual({
+        title: 'is required',
+      });
+    });
+  });
+
+  describe('a validator asking for the record', () => {
+    let Post;
+    let adapter;
+
+    beforeAll(async () => {
+      ({ adapter } = build());
+      Post = adapter.addModel(
+        postModel({
+          status: {
+            validate: (value, record) =>
+              value !== 'live' || Boolean(record.body) || 'no body',
+          },
+        }),
+        'user'
+      );
+      await adapter.start();
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('gets it on a create and on an instance update', async () => {
+      expect(
+        await errorsOf(Post.create({ status: 'live', title: 'a' }))
+      ).toEqual({ status: 'no body' });
+      expect(
+        await errorsOf(
+          Post.create({ body: 'here', status: 'live', title: 'b' })
+        )
+      ).toBeNull();
+
+      const post = await Post.create({ title: 'c' });
+
+      expect(await errorsOf(post.update({ status: 'live' }))).toEqual({
+        status: 'no body',
+      });
+    });
+
+    test('and the mass update is refused', async () => {
+      const error = await Post.update(
+        { status: 'live' },
+        { where: { title: 'a' } }
+      ).catch((thrown) => thrown);
+
+      expect(error.code).toBe('HENRI_MODEL_VALIDATION_MASS_WRITE');
+      expect(error.message).toMatch(/status of Post is validated by a rule/u);
+      // A mass write that does not name the validated field is untouched
+      await expect(
+        Post.update({ views: 2 }, { where: { title: 'a' } })
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe('a write no Sequelize hook reaches', () => {
+    test('increment on a validated field is refused', async () => {
+      const { adapter } = build();
+      const Post = adapter.addModel(postModel({ views: { max: 10 } }), 'user');
+
+      await adapter.start();
+
+      const post = await Post.create({ title: 'a', views: 1 });
+      const error = await Post.increment('views', {
+        where: { id: post.id },
+      }).catch((thrown) => thrown);
+
+      expect(error.code).toBe('HENRI_MODEL_VALIDATION_UNCHECKED_WRITE');
+      expect(error.message).toMatch(/Post\.increment\(\) writes without/u);
+      // A field nothing validates still increments
+      await expect(
+        Post.increment('id', { by: 0, where: { id: post.id } })
+      ).resolves.toBeDefined();
+      await adapter.stop();
+    });
+  });
+
+  describe('a declaration henri cannot carry out', () => {
+    test('fails the boot, naming the model and the field', () => {
+      const { adapter } = build();
+
+      expect(() =>
+        adapter.addModel(postModel({ title: { min: 3 } }), 'user')
+      ).toThrow(/Post declares `validates.title` with "min"/u);
+      expect(() =>
+        adapter.addModel(postModel({ ttile: { maxLength: 3 } }), 'user')
+      ).toThrow(/which its schema has no field for/u);
+    });
+
+    test('so does a `validate` function in the schema, which Sequelize ignores', () => {
+      const { adapter } = build();
+      const model = postModel();
+
+      model.schema.slug = { type: 'string', validate: () => true };
+      expect(() => adapter.addModel(model, 'user')).toThrow(
+        /has a `validate` function, which Sequelize reads as nothing/u
+      );
+    });
+  });
+
+  afterAll(() => target.cleanup());
+});

--- a/packages/sequelize/index.js
+++ b/packages/sequelize/index.js
@@ -3,7 +3,8 @@ const debug = require('debug')('henri:sequelize');
 const { Drift, describeDifference } = require('./drift');
 const { decorateAttributes, decorateModel } = require('./encryption');
 const { decorateModel: decorateVersions } = require('./versions');
-const { lookup, paginate, publicId } = require('./plugins');
+const { lookup, paginate, publicId, validations } = require('./plugins');
+const { validationsOf } = require('./validations');
 const { instrument: instrumentQueries } = require('./queries');
 const { normalizeSchema } = require('./schema');
 const {
@@ -235,6 +236,10 @@ class Sql {
     // Rails has timestamps on every table: `timestamps: false` opts out
     const options = { timestamps: true, ...(model.options || {}) };
     const external = wantsExternalId(model);
+    // What the model says must be true of its records, compiled once. A
+    // declaration henri cannot carry out fails the boot here, naming the
+    // model and the field (./validations.js)
+    const rules = validationsOf(model);
 
     // `externalId`, `personal`, `retention` and `versioned` are henri
     // options, not Sequelize ones
@@ -280,6 +285,13 @@ class Sql {
       external,
       this.henri
     );
+
+    // First of the hooks, so what a rule measures is the value the
+    // application wrote: the encryption hooks below turn it into an
+    // envelope and the user hooks turn a password into a hash
+    if (rules) {
+      validations(instance, rules);
+    }
 
     if (Object.keys(encrypted).length > 0) {
       decorateModel(instance, encrypted, this.henri);

--- a/packages/sequelize/package.json
+++ b/packages/sequelize/package.json
@@ -31,6 +31,7 @@
     "schema.js",
     "types.js",
     "utils.js",
+    "validations.js",
     "CHANGELOG.md",
     "encrypted.js",
     "encryption.js",

--- a/packages/sequelize/plugins.js
+++ b/packages/sequelize/plugins.js
@@ -1,4 +1,8 @@
-const { DataTypes } = require('sequelize');
+const {
+  DataTypes,
+  ValidationError,
+  ValidationErrorItem,
+} = require('sequelize');
 const {
   EXTERNAL_ID,
   isUuid,
@@ -6,6 +10,12 @@ const {
   resolvesKeys,
   withoutInternalIds,
 } = require('./external-id');
+const {
+  massWrite,
+  problemsOf,
+  uncheckedWrite,
+  wantsRecord,
+} = require('./validations');
 
 /**
  * The Rails behaviours henri adds to every Sequelize model. Soft deletes
@@ -226,4 +236,184 @@ const publicId = (Model) => {
   return Model;
 };
 
-module.exports = { lookup, paginate, publicId };
+/**
+ * The `ValidationError` shape Sequelize already answers with, built from
+ * what `./validations.js` said is wrong
+ *
+ * @param {string} model The model's global id
+ * @param {object} problems `{ field: message }`
+ * @param {object} values The values being written
+ * @returns {Error} A SequelizeValidationError
+ */
+const validationError = (model, problems, values) =>
+  new ValidationError(
+    `${model} validation failed: ${Object.entries(problems)
+      .map(([field, message]) => `${field}: ${message}`)
+      .join(', ')}`,
+    Object.entries(problems).map(
+      ([field, message]) =>
+        new ValidationErrorItem(
+          message,
+          'Validation error',
+          field,
+          values ? values[field] : undefined,
+          null,
+          'henriValidates'
+        )
+    )
+  );
+
+/**
+ * The fields an `increment`/`decrement` names, however it names them
+ *
+ * @param {*} fields A field, a list of them, or `{ field: by }`
+ * @returns {Array<string>} The field names
+ */
+const namesOf = (fields) => {
+  if (Array.isArray(fields)) {
+    return fields;
+  }
+
+  return typeof fields === 'string' ? [fields] : Object.keys(fields || {});
+};
+
+/**
+ * What a model's `validates` block declared, on every Sequelize write path
+ * that carries attributes.
+ *
+ * Sequelize's own validation is not one thing: `create`, `save`, `update`
+ * and the mass `Model.update` validate; `bulkCreate` does not unless the
+ * caller says so; `upsert` validates only the columns it was given; and
+ * `increment`/`decrement` run no hook at all. Rather than reason about
+ * which of them Sequelize covers, henri runs the shared rules itself in
+ * the two hooks that see attributes -- `beforeValidate`, which every write
+ * but a bulk insert goes through, and `beforeBulkCreate`, which is that
+ * one -- so a declaration means the same thing on every one of them and
+ * the same thing it means on the other two adapters. The three writes no
+ * hook reaches are wrapped below rather than left to be missed.
+ *
+ * Registered before the encryption and user hooks, so what a `maxLength`
+ * measures is the plaintext a person wrote rather than its envelope or its
+ * hash.
+ *
+ * @param {object} Model A Sequelize model
+ * @param {object} rules The compiled rules (./validations.js)
+ * @returns {object} The model
+ */
+const validations = (Model, rules) => {
+  const name = Model.name;
+
+  /**
+   * Runs the rules, or throws
+   *
+   * @param {object} values The values being written
+   * @param {boolean} partial Is this an update, naming only some fields?
+   * @param {*} record The record, for a rule that asked for one
+   * @returns {void}
+   * @throws {Error} A SequelizeValidationError
+   */
+  const check = (values, partial, record) => {
+    const problems = problemsOf(rules, values, { partial, record });
+
+    if (problems) {
+      throw validationError(name, problems, values);
+    }
+  };
+
+  // `beforeValidate` is the one hook that runs ahead of Sequelize's own
+  // validators, which is where henri's rules have to be for the message a
+  // person reads to be the same sentence on all three adapters. It covers
+  // `create`, `save`, `instance.update`, `upsert` and the mass
+  // `Model.update`; `bulkCreate` is the one it does not reach.
+  Model.addHook('beforeValidate', 'henriValidates', (record, options = {}) => {
+    // Sequelize validates a second time on an update, after the `before`
+    // hooks have run -- by then an encrypted field holds its envelope and
+    // a password its hash, and a `maxLength` would be measuring those.
+    // henri checks what the application wrote, once
+    if (options.henriValidates) {
+      return;
+    }
+
+    options.henriValidates = true;
+
+    const after = record.get();
+    // A create names every column (Sequelize leaves `skip` empty); every
+    // other path names some of them, and the rest are left alone
+    const partial =
+      !record.isNewRecord ||
+      (Array.isArray(options.skip) && options.skip.length > 0);
+
+    if (!partial) {
+      check(after, false, after);
+
+      return;
+    }
+
+    const written = {};
+
+    for (const field of record.changed() || []) {
+      written[field] = after[field];
+    }
+
+    check(written, true, after);
+  });
+
+  Model.addHook('beforeBulkCreate', 'henriValidates', (records, options) => {
+    // Sequelize's `bulkCreate` does not validate unless it is told to, so
+    // an `enum` was written straight past on this one path. henri's rules
+    // run here whatever it decides, and Sequelize's own run from now on
+    options.validate = true;
+
+    for (const record of records) {
+      check(record.get(), false, record.get());
+    }
+  });
+
+  const update = Model.update.bind(Model);
+
+  /**
+   * The mass update, refused when a rule asked for the record
+   *
+   * @param {object} values The values
+   * @param {object} [options] The options (`where`)
+   * @returns {Promise<*>} What Sequelize answers
+   */
+  Model.update = async (values, options) => {
+    const fields = wantsRecord(rules, values);
+
+    if (fields.length > 0) {
+      throw massWrite(name, 'update', 'update(attrs)', fields);
+    }
+
+    return update(values, options);
+  };
+
+  for (const what of ['decrement', 'increment']) {
+    const original = Model[what].bind(Model);
+
+    /**
+     * The same call, refused when henri cannot check what it writes
+     *
+     * @param {*} fields The fields to change
+     * @param {object} [options] The options
+     * @returns {Promise<*>} What Sequelize answers
+     */
+    Model[what] = async (fields, options) => {
+      const ruled = namesOf(fields).filter((field) => rules[field]);
+
+      if (ruled.length > 0) {
+        throw uncheckedWrite(
+          name,
+          what,
+          `Read the record, change ${ruled.join(' and ')} on it and save it, which is checked; or take the rules off ${ruled.join(' and ')}.`
+        );
+      }
+
+      return original(fields, options);
+    };
+  }
+
+  return Model;
+};
+
+module.exports = { lookup, paginate, publicId, validations };

--- a/packages/sequelize/schema.js
+++ b/packages/sequelize/schema.js
@@ -399,6 +399,17 @@ const normalizeField = (
       // Marks for henri, and nothing Sequelize has to know about: the
       // encryption one and the decimal column are applied below, once the
       // type has resolved
+    } else if (key === 'validate' && typeof value === 'function') {
+      // Sequelize's `validate` is an object of named validators, so a
+      // function there is read as nothing and does nothing -- while the
+      // same line on the drizzle and mongoose adapters is a validator that
+      // runs. `validates` is the spelling that means one thing everywhere
+      throw coded(
+        'HENRI_MODEL_INVALID_FIELD',
+        `Field '${field}' of ${
+          (context && context.model) || 'the model'
+        } has a \`validate\` function, which Sequelize reads as nothing: its own \`validate\` is an object of named validators. Write it in the model's \`validates\` block instead -- validates: { ${field}: { validate: (value, record) => ... } } -- which runs on every write path of every adapter`
+      );
     } else if (KNOWN_KEYS.has(key)) {
       attribute[key] = value;
     } else {

--- a/packages/sequelize/validations.js
+++ b/packages/sequelize/validations.js
@@ -1,0 +1,598 @@
+/**
+ * What must be true of a record, declared once and meant once.
+ *
+ * A model file says it in a `validates` block, keyed by field, in the
+ * vocabulary the request boundaries already use (`base/params-schema.js`):
+ *
+ * ```js
+ * module.exports = {
+ *   schema: {
+ *     email: { type: 'string', required: true, unique: true },
+ *     age: { type: 'integer' },
+ *     status: { type: 'string', enum: ['draft', 'live'] },
+ *   },
+ *   validates: {
+ *     age: { max: 120, min: 18 },
+ *     email: { maxLength: 120, pattern: /^[^@\s]+@[^@\s]+$/u },
+ *     status: { validate: (value, record) => value !== 'live' || record.body },
+ *   },
+ * };
+ * ```
+ *
+ * ## Why this file exists at all
+ *
+ * The three ORMs each have validations and no two of them mean the same
+ * thing. Measured, not assumed:
+ *
+ * - **Mongoose** runs its path validators on `save()`, `create()` and
+ *   `insertMany()` and on **nothing else**. `updateOne`, `updateMany`,
+ *   `findOneAndUpdate` and `findByIdAndUpdate` write straight past
+ *   `required` and `enum` -- a `null` lands in a required column and a
+ *   value outside the enum lands in the document -- unless the *caller*
+ *   remembers `runValidators: true` on that one call.
+ * - **Sequelize** validates `create`, `save`, `update` and the mass
+ *   `Model.update`, skips `bulkCreate` (its `validate` defaults to
+ *   `false`, so a value outside an `enum` is written), and on the dialects
+ *   with a native `ENUM` column has no JavaScript check at all -- the
+ *   server refuses it, as a `SequelizeDatabaseError` that
+ *   `henri.model.errors()` does not recognize, so the same model file
+ *   answers 422 on sqlite and 500 on PostgreSQL.
+ * - **Drizzle** validates every write it exposes, including the mass ones.
+ *
+ * So `required` and `enum` -- two keys the models guide says mean the same
+ * thing on every adapter -- did not. This module is what makes them, and
+ * it is the only implementation of the rules an application declares.
+ *
+ * ## One vocabulary
+ *
+ * The keys are the ones a controller's `params` block already takes, and
+ * they mean the same thing here: `required`, `enum`, `min`, `max`,
+ * `minLength`, `maxLength`, `pattern`, plus `validate`, a function of the
+ * value (and, when it asks for one, the record). There is no `type`: the
+ * schema next door already says it, and a constraint that means nothing
+ * for that type (`min` on a `string`, `maxLength` on an `integer`) fails
+ * the boot rather than being ignored.
+ *
+ * The schema's own `required` and `enum` are read into the same rules, so
+ * an application that never writes a `validates` block still gets one
+ * meaning for those two on every adapter and every write path.
+ *
+ * ## Where this belongs, and where it does not
+ *
+ * `req.permit()` and a controller's `params` block check what **arrives**:
+ * they are about a request, they coerce a query string, and they answer
+ * 422 before an action runs. This checks what is **written**, and a record
+ * is written by a job, a seed, a console and a webhook delivery as often
+ * as by a request. The two compose -- neither replaces the other -- and
+ * the guide says so where a person is deciding.
+ *
+ * ## What is refused rather than pretended
+ *
+ * A `validate` function that declares a second parameter is asking for the
+ * record, and a mass write has none: the same predicate `base/policies.js`
+ * uses for a rule that wants a record. Rather than calling it with
+ * `undefined` and recording a pass, a mass write on such a model is
+ * refused (`HENRI_MODEL_VALIDATION_MASS_WRITE`), which is the answer
+ * `HENRI_VERSION_MASS_WRITE` already gives to the same shape of problem.
+ * Every other rule reads only the value being written, so a mass write
+ * checks them exactly as a single write does.
+ *
+ * ## Uniqueness is not here, deliberately
+ *
+ * `unique` stays what it is: an index, and a race. A `SELECT` before an
+ * `INSERT` answers a question about a moment that has passed by the time
+ * the row is written, so a check would turn a guarantee the database
+ * keeps into a message henri sometimes produces. The database refuses the
+ * duplicate, and `henri.model.errors()` turns that refusal into
+ * `{ field: 'must be unique' }` on all three adapters, which is the same
+ * shape as everything here.
+ *
+ * ## A copy per adapter
+ *
+ * This file is held four times -- here and in `@usehenri/drizzle`,
+ * `@usehenri/mongoose` and `@usehenri/sequelize` -- byte for byte, the way
+ * `exact.js` and `external-id.js` are, because an adapter depends on no
+ * part of core at runtime. `src/__tests__/validations.spec.js` is what
+ * keeps them the same file. It requires nothing but `./exact`, which is
+ * held the same way, and raises its codes through a `coded()` of its own
+ * for the same reason.
+ */
+
+const { compare, isExact } = require('./exact');
+
+/** The failure a model declaration henri cannot carry out gets */
+const INVALID = 'HENRI_MODEL_VALIDATION_INVALID';
+
+/** The failure a mass write on a record-aware validator gets */
+const MASS_WRITE = 'HENRI_MODEL_VALIDATION_MASS_WRITE';
+
+/** The failure a write no hook of the ORM reaches gets */
+const UNCHECKED = 'HENRI_MODEL_VALIDATION_UNCHECKED_WRITE';
+
+/** The henri schema types, so a constraint can be bound to one */
+const TYPES = [
+  'bigint',
+  'boolean',
+  'date',
+  'decimal',
+  'float',
+  'integer',
+  'json',
+  'number',
+  'string',
+  'text',
+  'uuid',
+];
+
+/**
+ * The types each constraint applies to. `required`, `enum` and `validate`
+ * apply to every type, so they are not in here (see KEYS).
+ */
+const APPLIES = {
+  max: ['bigint', 'decimal', 'float', 'integer', 'number'],
+  maxLength: ['string', 'text'],
+  min: ['bigint', 'decimal', 'float', 'integer', 'number'],
+  minLength: ['string', 'text'],
+  pattern: ['string', 'text'],
+};
+
+/** The keys every field takes, whatever its type */
+const ANY = ['enum', 'required', 'validate'];
+
+/** Every key a `validates` entry may hold */
+const KEYS = [...ANY, ...Object.keys(APPLIES)].sort();
+
+/**
+ * An error carrying a henri code, without depending on core
+ *
+ * @param {string} code the henri error code
+ * @param {string} message what is wrong
+ * @returns {Error} the error to throw
+ */
+const coded = (code, message) => Object.assign(new Error(message), { code });
+
+/**
+ * Is the value a plain object?
+ *
+ * @param {*} value any value
+ * @returns {boolean} true for a plain object
+ */
+const isPlainObject = (value) =>
+  value !== null &&
+  typeof value === 'object' &&
+  (Object.getPrototypeOf(value) === Object.prototype ||
+    Object.getPrototypeOf(value) === null);
+
+/**
+ * Is the value missing, for `required`?
+ *
+ * Rails' `presence`, and what Mongoose and Drizzle already answer: a
+ * string of nothing but spaces is a field a person left empty, not a
+ * value. Sequelize's `allowNull` alone would have written it.
+ *
+ * @param {*} value the value
+ * @returns {boolean} true when there is nothing there
+ */
+const isBlank = (value) =>
+  typeof value === 'undefined' ||
+  value === null ||
+  (typeof value === 'string' && value.trim() === '');
+
+/**
+ * `a string`, `an integer`: the article a message needs
+ *
+ * @param {string} type the type
+ * @returns {string} the type with its article
+ */
+const article = (type) => (/^[aeiou]/u.test(type) ? `an ${type}` : `a ${type}`);
+
+/**
+ * The henri type a field declares, when it declares one henri knows
+ *
+ * A model file may write a type this file has no opinion about -- a
+ * Mongoose `ObjectId`, a Sequelize `DataTypes.STRING(50)`, a nested
+ * document -- and a constraint that measures a number or a length has
+ * nothing to measure there. Those fields still take `required`, `enum`
+ * and `validate`, which need no type at all.
+ *
+ * @param {*} definition the field definition from the model file
+ * @returns {?string} the henri type name, or null
+ */
+const typeOf = (definition) => {
+  const type = isPlainObject(definition) ? definition.type : definition;
+
+  if (typeof type !== 'string') {
+    return null;
+  }
+
+  const name = type.toLowerCase();
+
+  return TYPES.includes(name) ? name : null;
+};
+
+/**
+ * Refuses a declaration, naming the model and the field
+ *
+ * @param {string} model the model's global id
+ * @param {string} field the field name
+ * @param {string} what what is wrong with it
+ * @returns {void} never returns
+ * @throws {Error} always, HENRI_MODEL_VALIDATION_INVALID
+ */
+const refuse = (model, field, what) => {
+  throw coded(INVALID, `${model} declares \`validates.${field}\` with ${what}`);
+};
+
+/**
+ * Checks and freezes one field's rule
+ *
+ * @param {string} model the model's global id
+ * @param {string} field the field name
+ * @param {object} written what the model file wrote
+ * @param {?string} type the henri type of the field, when it has one
+ * @returns {object} the compiled rule
+ * @throws {Error} HENRI_MODEL_VALIDATION_INVALID on anything unusable
+ */
+const ruleOf = (model, field, written, type) => {
+  if (!isPlainObject(written)) {
+    refuse(
+      model,
+      field,
+      `${written === null ? 'null' : typeof written}: a rule is an object of ${KEYS.join(', ')}`
+    );
+  }
+
+  const compiled = { type };
+
+  for (const [key, value] of Object.entries(written)) {
+    if (!KEYS.includes(key)) {
+      refuse(
+        model,
+        field,
+        `the unknown key "${key}": a rule takes ${KEYS.join(', ')}`
+      );
+    }
+
+    if (APPLIES[key] && !APPLIES[key].includes(type)) {
+      refuse(
+        model,
+        field,
+        type === null
+          ? `"${key}", which needs a type henri knows: the field declares one henri has no bounds for, so it takes ${ANY.join(', ')} only`
+          : `"${key}", which ${article(type)} does not take: ${key} is for ${APPLIES[key].join(', ')}`
+      );
+    }
+
+    compiled[key] = value;
+  }
+
+  for (const key of ['max', 'maxLength', 'min', 'minLength']) {
+    if (!(key in compiled)) {
+      continue;
+    }
+
+    // The bound of an exact field may be written out, the way its values
+    // are, so a limit past what a double carries can be declared at all
+    const exact =
+      isExact(type) && (key === 'max' || key === 'min')
+        ? typeof compiled[key] === 'string'
+        : false;
+
+    if (!exact && typeof compiled[key] !== 'number') {
+      refuse(model, field, `a "${key}" that is not a number`);
+    }
+  }
+
+  if ('pattern' in compiled && !(compiled.pattern instanceof RegExp)) {
+    refuse(model, field, 'a "pattern" that is not a regular expression');
+  }
+
+  if ('required' in compiled && typeof compiled.required !== 'boolean') {
+    refuse(model, field, 'a "required" that is not true or false');
+  }
+
+  if ('enum' in compiled) {
+    if (!Array.isArray(compiled.enum) || compiled.enum.length === 0) {
+      refuse(model, field, 'an "enum" that is not a list of values');
+    }
+  }
+
+  if ('validate' in compiled && typeof compiled.validate !== 'function') {
+    refuse(
+      model,
+      field,
+      'a "validate" that is not a function: write `(value, record) => true` or a message'
+    );
+  }
+
+  return Object.freeze(compiled);
+};
+
+/**
+ * Everything a model says must be true of its records.
+ *
+ * The `validates` block, plus the `required` and `enum` the schema
+ * already declares -- those two are checked here on every adapter and
+ * every write path, which is the whole point of the file.
+ *
+ * @param {object} model the model file (`globalId`, `schema`, `validates`)
+ * @returns {?object} the rules by field, or null when there are none
+ * @throws {Error} HENRI_MODEL_VALIDATION_INVALID on a declaration henri
+ *   cannot carry out
+ */
+const validationsOf = (model = {}) => {
+  const name = model.globalId || model.identity || 'the model';
+  const schema = isPlainObject(model.schema) ? model.schema : {};
+  const written = model.validates;
+
+  if (typeof written !== 'undefined' && !isPlainObject(written)) {
+    throw coded(
+      INVALID,
+      `${name} declares \`validates\` as ${
+        written === null ? 'null' : typeof written
+      }: it is an object keyed by field`
+    );
+  }
+
+  const rules = {};
+
+  for (const field of Object.keys(schema)) {
+    const definition = schema[field];
+    const type = typeOf(definition);
+    const lifted = {};
+
+    if (isPlainObject(definition)) {
+      // `allowNull: false` is the Sequelize spelling of `required`, and
+      // the mongoose adapter accepts it too, so it is the same rule here
+      if (definition.required === true || definition.allowNull === false) {
+        lifted.required = true;
+      }
+
+      if (Array.isArray(definition.enum)) {
+        lifted.enum = definition.enum;
+      }
+    }
+
+    const declared = (written && written[field]) || null;
+
+    if (!declared && Object.keys(lifted).length === 0) {
+      continue;
+    }
+
+    rules[field] = ruleOf(
+      name,
+      field,
+      // A rule that is not an object at all is handed over as it is, so
+      // the refusal says what it was rather than spreading it into one
+      isPlainObject(declared) ? { ...lifted, ...declared } : declared || lifted,
+      type
+    );
+  }
+
+  for (const field of Object.keys(written || {})) {
+    if (!rules[field]) {
+      throw coded(
+        INVALID,
+        `${name} declares \`validates.${field}\`, which its schema has no field for: ${
+          Object.keys(schema).join(', ') || 'the schema is empty'
+        }`
+      );
+    }
+  }
+
+  return Object.keys(rules).length > 0 ? Object.freeze(rules) : null;
+};
+
+/**
+ * Does any rule want the record, rather than only the value?
+ *
+ * The predicate is the arity of the function, the way `base/policies.js`
+ * reads a rule that declares a record parameter. It is what a mass write
+ * is measured against -- and it is measured against the fields that write
+ * actually names, so a soft delete stamping `deletedAt` on a thousand rows
+ * is not refused by a rule about somebody's email address.
+ *
+ * @param {?object} rules the compiled rules
+ * @param {object} [values] the values being written, when there are some
+ * @returns {Array<string>} the fields whose rule asks for the record
+ */
+const wantsRecord = (rules, values) => {
+  if (!rules) {
+    return [];
+  }
+
+  const named = isPlainObject(values)
+    ? Object.keys(values)
+    : Object.keys(rules);
+
+  return named.filter(
+    (field) =>
+      rules[field] &&
+      typeof rules[field].validate === 'function' &&
+      rules[field].validate.length >= 2
+  );
+};
+
+/**
+ * The bounds of a rule, once there is a value to measure
+ *
+ * @param {object} rule the compiled rule
+ * @param {*} value the value being written
+ * @returns {?string} what is wrong with it, or null
+ */
+const bounds = (rule, value) => {
+  const { max, maxLength, min, minLength, pattern } = rule;
+
+  // An exact value is a string of digits, so `<` would compare it letter
+  // by letter and answer that 9.99 is more than 10 (see ./exact.js)
+  if (isExact(rule.type) && typeof value === 'string') {
+    if (typeof min !== 'undefined' && compare(value, min) < 0) {
+      return `must be at least ${min}`;
+    }
+
+    if (typeof max !== 'undefined' && compare(value, max) > 0) {
+      return `must be at most ${max}`;
+    }
+
+    return null;
+  }
+
+  if (typeof value === 'number') {
+    if (typeof min === 'number' && value < min) {
+      return `must be at least ${min}`;
+    }
+
+    if (typeof max === 'number' && value > max) {
+      return `must be at most ${max}`;
+    }
+  }
+
+  if (typeof value === 'string') {
+    if (typeof minLength === 'number' && value.length < minLength) {
+      return `must be at least ${minLength} characters`;
+    }
+
+    if (typeof maxLength === 'number' && value.length > maxLength) {
+      return `must be at most ${maxLength} characters`;
+    }
+
+    if (pattern && !pattern.test(value)) {
+      return 'is not in the expected format';
+    }
+  }
+
+  return null;
+};
+
+/**
+ * One value through one rule
+ *
+ * @param {object} rule the compiled rule
+ * @param {*} value the value being written
+ * @param {*} record the record, for a validator that asked for one
+ * @returns {?string} the message, or null when the value is fine
+ */
+const problem = (rule, value, record) => {
+  if (isBlank(value)) {
+    return rule.required ? 'is required' : null;
+  }
+
+  const wrong = bounds(rule, value);
+
+  if (wrong) {
+    return wrong;
+  }
+
+  if (rule.enum && !rule.enum.includes(value)) {
+    return `must be one of ${rule.enum.join(', ')}`;
+  }
+
+  if (typeof rule.validate !== 'function') {
+    return null;
+  }
+
+  let answer;
+
+  try {
+    answer = rule.validate(value, record);
+  } catch (error) {
+    return (error && error.message) || 'is invalid';
+  }
+
+  if (typeof answer === 'string') {
+    return answer;
+  }
+
+  return answer === false ? 'is invalid' : null;
+};
+
+/**
+ * Everything wrong with the values being written
+ *
+ * @param {?object} rules the compiled rules
+ * @param {object} values the attributes being written
+ * @param {object} [options={}] options
+ * @param {boolean} [options.partial=false] an update: a field the write
+ *   does not name is left alone rather than treated as absent
+ * @param {*} [options.record] the record, for a validator that asked
+ * @returns {?object} `{ field: message }`, or null when nothing is wrong
+ */
+const problemsOf = (rules, values, { partial = false, record } = {}) => {
+  if (!rules) {
+    return null;
+  }
+
+  const given = isPlainObject(values) ? values : {};
+  const errors = {};
+
+  for (const field of Object.keys(rules)) {
+    const has = Object.prototype.hasOwnProperty.call(given, field);
+
+    if (!has && partial) {
+      continue;
+    }
+
+    const wrong = problem(rules[field], given[field], record);
+
+    if (wrong) {
+      errors[field] = wrong;
+    }
+  }
+
+  return Object.keys(errors).length > 0 ? errors : null;
+};
+
+/**
+ * The refusal a mass write gets on a model whose validator wants a record
+ *
+ * @param {string} model the model's global id
+ * @param {string} what the call that was made (`update`, `updateMany`)
+ * @param {string} instead the single-record call to loop over
+ * @returns {Error} the error to throw
+ */
+const massWrite = (model, what, instead, fields = []) =>
+  coded(
+    MASS_WRITE,
+    `${model}.${what}() writes many rows at once, and ${
+      fields.length > 0 ? fields.join(', ') : 'a field'
+    } of ${model} is validated by a rule that asks for the record. ` +
+      `A mass write has no records to give it, so henri refuses rather than recording a pass it never made. ` +
+      `Loop instead: for (const record of await ${model}.find(where)) await record.${instead}`
+  );
+
+/**
+ * The refusal a write the ORM runs no hook for gets
+ *
+ * Sequelize's `increment`/`decrement` and Mongoose's `bulkWrite` reach the
+ * database without any middleware at all, so a rule declared on a field
+ * they write would be a promise henri does not keep. Neither call exists
+ * on all three adapters, so neither is part of what a `validates` block
+ * means; a model that declares one and calls the other is told so.
+ *
+ * @param {string} model the model's global id
+ * @param {string} what the call that was made
+ * @param {string} instead what to do instead
+ * @returns {Error} the error to throw
+ */
+const uncheckedWrite = (model, what, instead) =>
+  coded(
+    UNCHECKED,
+    `${model}.${what}() writes without running any of the ORM's hooks, so henri cannot check what it writes, and ${model} declares validations for it. ${instead}`
+  );
+
+module.exports = {
+  ANY,
+  APPLIES,
+  INVALID,
+  KEYS,
+  MASS_WRITE,
+  TYPES,
+  UNCHECKED,
+  coded,
+  isBlank,
+  massWrite,
+  problemsOf,
+  uncheckedWrite,
+  validationsOf,
+  wantsRecord,
+};

--- a/showcase/app/models/Proposal.js
+++ b/showcase/app/models/Proposal.js
@@ -75,8 +75,6 @@ module.exports = {
 
   schema: {
     abstract: {
-      maxLength: 4000,
-      minLength: 60,
       required: true,
       type: 'text',
     },
@@ -113,8 +111,6 @@ module.exports = {
     },
     submittedAt: { type: 'date' },
     title: {
-      maxLength: 120,
-      minLength: 8,
       required: true,
       trim: true,
       type: 'string',
@@ -125,5 +121,16 @@ module.exports = {
       references: { model: 'Track', onDelete: 'set null' },
       type: 'integer',
     },
+  },
+
+  // What must be true of a proposal, in the one vocabulary every adapter
+  // shares. The two lengths used to sit in the schema next to the types,
+  // where they were the drizzle adapter's own keys: they worked here, and
+  // the same lines would have failed the boot on an mssql store and been
+  // checked on three write paths out of five on MongoDB. Here they mean
+  // one thing, and the schema above says what the columns are.
+  validates: {
+    abstract: { maxLength: 4000, minLength: 60 },
+    title: { maxLength: 120, minLength: 8 },
   },
 };

--- a/types/core.test-d.ts
+++ b/types/core.test-d.ts
@@ -734,12 +734,40 @@ const model: ModelFile = {
     amount: { type: 'decimal', precision: 12, scale: 2, min: '0' },
     reference: { type: 'bigint', unique: true },
   },
+  validates: {
+    title: { maxLength: 120, minLength: 3, pattern: /^[A-Z]/u },
+    amount: { min: '0.00', max: '9999.99' },
+    status: { required: true, enum: ['todo', 'done'] },
+    body: {
+      validate: (value, record) => value !== 'live' || Boolean(record.title),
+    },
+  },
   associate(models) {
     expectType<Record<string, unknown>>(models);
   },
 };
 
 expectType<ModelFile>(model);
+
+const badValidation: ModelFile = {
+  schema: { title: { type: 'string' } },
+  validates: {
+    // @ts-expect-error a pattern is a regular expression, not a string
+    title: { pattern: '^[A-Z]' },
+  },
+};
+
+expectType<ModelFile>(badValidation);
+
+const badValidator: ModelFile = {
+  schema: { title: { type: 'string' } },
+  validates: {
+    // @ts-expect-error a validate is a function, not a message
+    title: { validate: 'must be shouted' },
+  },
+};
+
+expectType<ModelFile>(badValidator);
 
 const badModel: ModelFile = {
   schema: {

--- a/website/src/content/docs/guides/models.md
+++ b/website/src/content/docs/guides/models.md
@@ -26,12 +26,16 @@ module.exports = {
     },
     done: { type: 'boolean', default: false },
   },
+  validates: {
+    name: { minLength: 2, maxLength: 120 },
+  },
 };
 ```
 
 | Key                 | Description                                                                                                                                                                                                                                                                                                                                      |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `schema`            | The fields, in the format below.                                                                                                                                                                                                                                                                                                                 |
+| `validates`         | What must be true of a record, keyed by field. Checked on every write path of every adapter — see [Validations](#validations).                                                                                                                                                                                                                   |
 | `options`           | `timestamps`, `paranoid`, `personal`, `retention`, `versioned` ([Model versions](/guides/versions/)) and `externalId` (below). A drizzle store takes those and refuses any other key at boot, naming what to write instead; Mongoose and an mssql store also pass what they do not recognize to `new mongoose.Schema()` or `sequelize.define()`. |
 | `store`             | The store to use, `default` when omitted. The boot fails when the store is not configured.                                                                                                                                                                                                                                                       |
 | `name`              | Collection name (Mongoose), table name (Drizzle) or `tableName` (Sequelize).                                                                                                                                                                                                                                                                     |
@@ -75,9 +79,9 @@ A field is `{ type, ...keys }` or a bare type. The type names and the keys below
 
 | Key         | Description                                                                                                                                                                                              |
 | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `required`  | `required: true` (Mongoose) or `allowNull: false` (Drizzle, Sequelize).                                                                                                                                  |
+| `required`  | The field has to hold something, on every write path of every adapter ([Validations](#validations)); the column is `NOT NULL` as well, where the store has columns.                                      |
 | `default`   | Default value. `Date.now` becomes `NOW` on SQL.                                                                                                                                                          |
-| `enum`      | Allowed values. An `ENUM` column on MySQL, MariaDB and PostgreSQL, an `isIn` validation elsewhere.                                                                                                       |
+| `enum`      | The values accepted, refused by henri before the write ([Validations](#validations)); still an `ENUM` column on MySQL, MariaDB and PostgreSQL underneath.                                                |
 | `unique`    | Unique index or constraint.                                                                                                                                                                              |
 | `index`     | `index: true` adds an index on the field.                                                                                                                                                                |
 | `precision` | A `decimal` only: the total number of digits, 19 by default and 38 at most — the widest every dialect henri writes carries. See [Exact numbers](#exact-numbers).                                         |
@@ -90,7 +94,90 @@ What the adapters do with anything else differs:
 - **Mongoose** passes every other key and type through, so `{ type: 'ObjectId', ref: 'Post' }`, `[String]`, nested objects, `lowercase`, `trim`, `match`, `select`, `validate` and the JavaScript constructors (`String`, `Number`, `Date`) all work. It also understands the Sequelize spellings `allowNull: false` and `defaultValue`.
 - **Sequelize** (`mssql` only) accepts its own attribute options (`allowNull`, `defaultValue`, `validate`, `field`, `primaryKey`, `autoIncrement`, `references`, `onDelete`, `onUpdate`, `comment`, `get`, `set`, `values`, ...), its data types (`type: DataTypes.STRING(50)` or the uppercase name as a string, `'STRING'`), the JavaScript constructors (`Object` and `Array` become `JSON`, `Buffer` a `BLOB`), and stores nested objects and arrays as `JSON`. Any other key throws at boot with the list of supported keys, so a typo never becomes a silently ignored option. A field with a known key but no `type` is an error too.
 
+Those extra keys are the adapter's, not henri's: what they do — and which writes they run on — is that ORM's business, and a model file that leans on them stops moving between stores. [Validations](#validations) below is the portable place for the same thing.
+
 `@usehenri/drizzle/types`, `@usehenri/mongoose/types` and `@usehenri/sequelize/types` export the map above if you need the column or ORM types themselves.
+
+## Validations
+
+A model says what must be true of its records in a `validates` block, keyed by field:
+
+```js
+// app/models/Post.js
+module.exports = {
+  schema: {
+    title: { type: 'string', required: true },
+    slug: { type: 'string', unique: true },
+    views: { type: 'integer', default: 0 },
+    status: { type: 'string', enum: ['draft', 'live'], default: 'draft' },
+    body: { type: 'text' },
+  },
+
+  validates: {
+    title: { minLength: 3, maxLength: 120 },
+    slug: { pattern: /^[a-z0-9-]+$/ },
+    views: { min: 0 },
+    status: {
+      validate: (value, post) =>
+        value !== 'live' || Boolean(post.body) || 'needs a body first',
+    },
+  },
+};
+```
+
+| Key                      | Description                                                                                                                                                                              |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `required`               | The field has to hold something. Absent, `null` and a string of nothing but spaces are all missing — Rails' `presence`.                                                                  |
+| `enum`                   | The values accepted.                                                                                                                                                                     |
+| `min`, `max`             | The bounds of a number. On a `decimal` or a `bigint` they may be written out as strings, the way those values are.                                                                       |
+| `minLength`, `maxLength` | The bounds of a string's length.                                                                                                                                                         |
+| `pattern`                | A regular expression a string has to match.                                                                                                                                              |
+| `validate`               | A function of the value. `true` (or nothing) passes; `false` is `is invalid`; a string is the message. A second parameter is the record — see [below](#a-rule-that-asks-for-the-record). |
+
+It is the vocabulary a controller's [`params` block](/guides/controllers/#params-what-an-action-accepts) uses, and it means the same thing here. There is no `type` key: the schema next door already says it, and that is what decides which constraints apply — `min` on a `string`, `maxLength` on an `integer` or a rule for a field the schema has no column for all fail the boot naming the model and the field (`HENRI_MODEL_VALIDATION_INVALID`) rather than being ignored.
+
+### The schema's `required` and `enum` are the same rules
+
+They always were the schema's, and now they are checked in the same place, so those two mean one thing on every adapter and on every write path — no `validates` block needed. That is a change: they used to mean three things.
+
+|                              | Mongoose            | Sequelize (`mssql`)                                                                               | Drizzle             |
+| ---------------------------- | ------------------- | ------------------------------------------------------------------------------------------------- | ------------------- |
+| `create`, `save`             | checked             | checked                                                                                           | checked             |
+| `instance.update`            | checked             | checked                                                                                           | checked             |
+| mass `update` / `updateMany` | **wrote past both** | checked                                                                                           | checked             |
+| bulk insert                  | checked             | **wrote past both**                                                                               | checked             |
+| what a bad `enum` answered   | a `ValidationError` | a `ValidationError` on sqlite, a **database error** (so a 500, not a 422) on PostgreSQL and MySQL | a `ValidationError` |
+
+Every cell is checked now, with the same sentence in all of them. The column is still whatever the adapter writes — `NOT NULL`, a native `ENUM` on PostgreSQL and MySQL — and it stays there as the backstop for anything that reaches the database another way. henri simply refuses first, so what a person sees does not depend on the dialect.
+
+### Where this belongs, and where `params` belongs
+
+They are not the same boundary and neither replaces the other:
+
+- A controller's `params` block and `req.permit()` check **what arrives**. They are about a request: they coerce a query string into the type the action declared, they drop what was not asked for, and they answer 422 before the action runs.
+- `validates` checks **what is written**. A record is written by a job, a seed, `henri console`, a webhook delivery and a factory as often as by a request, and none of those has a `req`.
+
+Declare the shape of the request in the controller and the truth about the record in the model. A rule that needs two fields, or the record it is changing, is a model rule; a rule about a page number is not.
+
+### A rule that asks for the record
+
+A `validate` that declares a second parameter is asking for the record it is about, the way [a policy rule that declares a record parameter](/guides/policies/) is. It is given the record **as it will be once the write lands**, so a rule reads the value written next to it in the same call and not the stale one.
+
+A mass write has no records to give it. Rather than call it with nothing and record a pass it never made, henri refuses that write (`HENRI_MODEL_VALIDATION_MASS_WRITE`) and the message names the loop to write instead:
+
+```js
+for (const post of await Post.find({ status: 'draft' })) {
+  await post.update({ status: 'live' });
+}
+```
+
+The refusal is measured against the fields the write actually names, so a mass update that does not touch the validated field goes through, and so does a soft delete. A rule that only reads its value takes one parameter and never refuses anything.
+
+### What henri does not check
+
+- **`unique` is not a validation, and henri does not pretend otherwise.** A `SELECT` before an `INSERT` answers a question about a moment that has already passed: two requests both find nothing and both write. The unique index is what actually holds, so the database refuses the second one and `henri.model.errors()` turns that refusal into `{ field: 'must be unique' }` — [the same shape](#validation-errors) as everything above. What you give up is the message arriving before the round trip; what you get is a guarantee rather than a near-miss.
+- **A write no hook of the ORM reaches is refused, not skipped** (`HENRI_MODEL_VALIDATION_UNCHECKED_WRITE`). Mongoose runs no middleware for the operations inside a `bulkWrite`, Sequelize runs none for `increment` and `decrement`, and an update operator that describes a change rather than a value (`$inc`, `$push`) has nothing to measure until the server has applied it. None of the three exists on all three adapters, so none of them is part of what a `validates` block means. Read the record, change it and save it.
+- **Cross-record rules are yours.** "No two posts published the same day" is a query, and a query in a validator is a race with a nicer message.
 
 ## Exact numbers
 
@@ -431,7 +518,7 @@ await Task.where({ done: false }).order('-createdAt').paginate({ page: 2 });
 
 ### Validation errors
 
-The three ORMs reject an invalid write differently: a Mongoose `ValidationError` keyed by path, a Sequelize `SequelizeValidationError` holding an array, a Drizzle `ValidationError`, a MongoDB duplicate key or a `SequelizeUniqueConstraintError`. `henri.model.errors(error)` turns any of them into `{ field: message }`, and answers `null` for anything that is not a validation failure, so a controller can answer a 422 and let the rest bubble up:
+What [a validation](#validations) refuses, and what the ORM refuses on its own, arrive in one shape. The three reject an invalid write differently: a Mongoose `ValidationError` keyed by path, a Sequelize `SequelizeValidationError` holding an array, a Drizzle `ValidationError`, a MongoDB duplicate key or a `SequelizeUniqueConstraintError`. `henri.model.errors(error)` turns any of them into `{ field: message }`, and answers `null` for anything that is not a validation failure, so a controller can answer a 422 and let the rest bubble up:
 
 ```js
 try {

--- a/website/src/content/docs/reference/errors.md
+++ b/website/src/content/docs/reference/errors.md
@@ -1661,6 +1661,42 @@ Usually:
 
 **Fix.** henri's types are `string`, `text`, `number`, `integer`, `float`, `decimal`, `bigint`, `boolean`, `date`, `json` and `uuid`. The adapter maps them to the ORM's own.
 
+### `HENRI_MODEL_VALIDATION_INVALID`
+
+A model's `validates` block holds a rule henri cannot carry out.
+
+Usually:
+
+- a `validates` entry naming a field the schema does not have
+- a constraint the field's type does not take (`min` on a string, `maxLength` on an integer)
+- an unknown key, usually a misspelling of `required`, `maxLength` or `pattern`
+- a `pattern` that is not a regular expression, or a `validate` that is not a function
+
+**Fix.** The message names the model, the field and what is wrong with the rule. A `validates` entry takes `required`, `enum`, `min`, `max`, `minLength`, `maxLength`, `pattern` and `validate`, and the field's type in the schema is what says which of them apply. See the Models guide.
+
+### `HENRI_MODEL_VALIDATION_MASS_WRITE`
+
+A mass update was run on a model whose validator asks for the record.
+
+Usually:
+
+- `Model.update(where, attrs)` or the fluent `Model.where(...).update()` on a model whose `validates` block holds a rule taking `(value, record)`
+- `updateMany` on such a model, on any adapter
+
+**Fix.** A rule that declares a record parameter is never asked without one, the way a policy rule is not. A mass write has no records to give it, so henri refuses rather than recording a pass it never made. Loop over the records instead -- `for (const record of await Model.find(where)) await record.update(attrs)` -- and each one is checked. A rule that only reads the value takes one parameter and mass writes keep working.
+
+### `HENRI_MODEL_VALIDATION_UNCHECKED_WRITE`
+
+A write the ORM runs no hook for was made on a validated field.
+
+Usually:
+
+- `Model.bulkWrite()` on a model that declares validations (Mongoose runs no middleware for the operations inside one)
+- `Model.increment()` or `Model.decrement()` on a validated field (Sequelize runs no hook for either)
+- an update operator that describes a change rather than a value (`$inc`, `$push`, `$mul`) on a validated field
+
+**Fix.** The message names the call and the fields. These write paths reach the database without any hook henri could run a rule in, and none of them exists on all three adapters, so henri refuses instead of letting the declaration quietly stop being true. Read the record, change it and save it, which is checked -- or take the rules off the fields that call writes.
+
 ## params
 
 What a controller declares its actions accept, and the requests checked against it.


### PR DESCRIPTION
## The survey first, because it is the reason for the shape

Measured against each adapter — `create`, instance update, mass update, bulk insert, upsert, `findOneAndUpdate`, plus raw SQL to see what the *database* ended up holding — on sqlite, live PostgreSQL, live MySQL and MongoDB:

| | Mongoose | Sequelize | Drizzle |
| --- | --- | --- | --- |
| `required` — what layer | ORM validator only | JS check **and** `NOT NULL` | JS check **and** `NOT NULL` |
| `required` on **mass update** | **not checked — wrote `null` into a required field** | checked | checked |
| `required` on bulk insert | checked | **not checked — `bulkCreate` defaults to `validate: false`** | n/a |
| `'   '` counts as missing | yes | **no** | yes |
| `enum` — what layer | ORM validator | native `ENUM` on postgres/mysql with **no JS check at all**; `isIn` on sqlite/mssql | JS always; native on postgres/mysql, **nothing** on sqlite |
| `enum` on mass update | **not checked** | checked on sqlite, DB error on postgres/mysql | checked |
| `enum` on bulk insert | checked | **not checked — wrote a value outside it** | n/a |
| what a bad `enum` *returns* | `ValidationError` | `ValidationError` on sqlite, **`DatabaseError` on postgres/mysql** | `ValidationError` |

Four defects fell out of that, all measured rather than reasoned about:

1. **Mongoose query updates wrote past everything** — `runValidators` was set nowhere, so `updateMany`/`findByIdAndUpdate` left a document with `null` on a required field and a value outside its enum.
2. **Sequelize `bulkCreate` wrote outside a declared `enum`** on sqlite and mssql. The row was in the table.
3. **The same model file answered 422 on sqlite and 500 on PostgreSQL**: the native `ENUM` refusal is a `DatabaseError`, which `henri.model.errors()` returns `null` for, so a generated controller rethrows.
4. **`validate: <function>` meant three different things** — enforced on drizzle, enforced on mongoose, silently ignored on sequelize.

## What this adds

A `validates` block on the model file, keyed by field, in the `params-schema.js` vocabulary — `required`, `enum`, `min`, `max`, `minLength`, `maxLength`, `pattern`, `validate`. No `type`: the schema already says it, and it decides which constraints apply. A rule henri cannot carry out fails the boot.

**The schema's own `required` and `enum` are lifted into the same rules**, so every existing application gets one meaning for those two with no model change — that is what closes 1 through 3.

`base/validations.js` is one compiler and one runner, copied byte-identical into the three adapters (the `exact.js` pattern, with a test keeping the four files identical and published). It runs in `Model.prepare()` on drizzle, `beforeValidate` + `beforeBulkCreate` on sequelize — registered ahead of the encryption hooks so a `maxLength` measures plaintext — and `pre('validate')` plus the five query middlewares and `pre('bulkWrite')` on mongoose.

Where a rule cannot be carried out, henri **refuses** rather than silently missing: `HENRI_MODEL_VALIDATION_MASS_WRITE` when a `validate` needs the record and a mass write names that field (the `HENRI_VERSION_MASS_WRITE` precedent), and `HENRI_MODEL_VALIDATION_UNCHECKED_WRITE` for the writes no hook reaches. The failure shape is unchanged: `{ field: message }` through `henri.model.errors()`, the same 422.

## Verified, both directions

The claim that matters is defect 1, so I measured it on the demo application (mongoose) **on master and on this branch**, with `Invoice.title` (`required: true`) and a row holding `"Kept"`:

| write | on master | on this branch |
| --- | --- | --- |
| `Invoice.create({})` | refused | refused |
| `create({ title: '   ' })` | — | refused |
| `updateOne({...}, { title: null })` | **WROTE** | refused |
| `findByIdAndUpdate(id, { title: null })` | **WROTE** | refused |
| `updateMany(...)` | — | refused |
| `$unset: { title: '' }` | — | refused |
| the row afterwards | `title: null` | `title: "Kept"`, and zero rows without one |

## What it refuses to claim

**`unique`.** A `SELECT` before an `INSERT` answers about a moment that has passed. The index stays what holds, the database refuses the duplicate, and `model-errors.js` already turns that into `{ field: 'must be unique' }`. Argued in the module header, the guide and the changeset.

Also out, and listed in the known gaps: cross-record rules, model-level rules, `if`/`unless`, per-constraint messages, `on: 'create'`, and a `valid?`-style check on an unsaved instance. The adapters' own schema keys are untouched and still not portable; the guide says so and points at `validates`.

One thing found and **not** fixed, reported instead: on drizzle `instance.update()` is `set()` + `save()`, so a refused write leaves the refused value on the in-memory instance and the next `update()` on that object is measured against it. It is in `CLAUDE.md`'s known gaps.

## Gates

`pnpm test` (3939), `pnpm test:types`, `pnpm lint --max-warnings 0`, `pnpm format:check`, `scripts/smoke.sh` end to end (`henri audit`: nothing found in 52 checks), the SQL suites against the **live PostgreSQL** (673), and the showcase — a real application on live PostgreSQL, with a `validates` block on `Proposal` (170). The postgres run is what proves the native-`ENUM` fix: before, `SequelizeDatabaseError: invalid input value for enum`; after, `SequelizeValidationError: status: must be one of draft, live`.