### PR TITLE
A wrong configuration value says what to do next

### DIFF
--- a/.changeset/configuration-hints.md
+++ b/.changeset/configuration-hints.md
@@ -1,0 +1,19 @@
+---
+'@usehenri/core': patch
+'@usehenri/cli': patch
+---
+
+A wrong configuration value says what to do about it, and the instructions are checked against the source that owns them.
+
+The error catalogue was audited a tranche ago and its "how to fix it" reached the terminal. The configuration schema was the half that was left, and it is the failure people hit first — often before the application has ever run. 138 keys of `base/config-schema.js` gained a `hint`: the command that fixes it, the other key that decides the same thing, the package the value needs, or what the value that arrived actually does.
+
+```
+config ✖ "filterParameters[1]" must be a string, but it is the number 7 => from config/default.json
+config ✖ The list replaces the defaults rather than adding to them, so name password, token, secret and authorization again next to your own; they are matched as substrings, and "encryption" is masked whatever this says
+```
+
+An **item of a list now inherits the hint of the list**, the way a branch of a union already inherited the union's: what to do about `retention.approved` is what to do about the token that is wrong inside it, and a schema that had to repeat the sentence on every item would end up not saying it at all. Two keys carry no hint on purpose, and they are named in the test: where "a path to land on once the address is confirmed" leaves nothing to add, henri says nothing rather than padding.
+
+The durable half is a test. `packages/core/src/__tests__/instructions.js` holds the two readers `error-codes.spec.js` already used — the commands, from the `commands` of `packages/cli`'s package.json and the `COMMANDS` a group's script exports; the configuration keys, from the schema itself — and `instructions.spec.js` runs them over the schema's own `hint` and `describe` and over every `hint` the command line ships. A hint naming a command henri does not have (the first pass found the catalogue saying `henri credentials:init`, which has never existed), a key the schema does not declare, an `@usehenri/` package that is not in the workspace or a `base/*.js` that has moved now fails the suite, as does a hint that only restates its own `describe`. The command reader also learned to read a bare `henri db:status` in a sentence, not only a backticked one.
+
+Four failures of the command line gained a hint of their own where the catalogue's was wrong for that call site: `henri build` on a missing view engine now prints the install line its code promises, `henri console --sandbox` tells apart a store that cannot hold a transaction from one where the transaction would not open, and `henri credentials:edit` says what an editor has to do and that the file was left as it was.

--- a/packages/cli/scripts/build.js
+++ b/packages/cli/scripts/build.js
@@ -2,7 +2,12 @@ const path = require('path');
 const { spawnSync } = require('child_process');
 
 const { CliError } = require('./errors');
-const { readConfig, resolveFrom, validInstall } = require('./utils');
+const {
+  detectPackageManager,
+  readConfig,
+  resolveFrom,
+  validInstall,
+} = require('./utils');
 
 /**
  * The view engines that need a production build, by renderer. Each module
@@ -41,10 +46,19 @@ const main = async () => {
   try {
     engine = require(resolveFrom(name, cwd));
   } catch (error) {
+    // The catalogue's fix for this code is "run the install command the
+    // message prints", so this one has to print it
+    const pm = detectPackageManager(cwd);
+    const add = pm === 'npm' ? 'npm install' : `${pm} add`;
+    const useHenri = name.replace(/\/engine$/u, '');
+
     throw new CliError(
       'HENRI_CLI_NOT_INSTALLED',
-      `${name.replace(/\/engine$/, '')} is not installed in this project (${error.message})`,
-      { cause: error }
+      `${useHenri} is not installed in this project (${error.message})`,
+      {
+        cause: error,
+        hint: `The "${renderer}" renderer is what asks for it: ${add} ${useHenri}, or set config.renderer to a renderer this application has`,
+      }
     );
   }
 

--- a/packages/cli/scripts/console.js
+++ b/packages/cli/scripts/console.js
@@ -133,10 +133,15 @@ const open = async (henri) => {
       // a lock nobody can see
       await rollback(opened).catch(() => null);
 
+      // Not the refusal the catalogue's fix describes: this adapter does
+      // hold a sandbox, and the transaction is what would not open
       throw new CliError(
         'HENRI_STORE_SANDBOX_UNSUPPORTED',
         `henri console --sandbox could not open a transaction on ${name}: ${error.message}`,
-        { cause: error }
+        {
+          cause: error,
+          hint: "The message is the store's own and nothing was left open. Check the store is reachable (henri doctor), or run henri console without --sandbox",
+        }
       );
     }
   }

--- a/packages/cli/scripts/credentials.js
+++ b/packages/cli/scripts/credentials.js
@@ -169,14 +169,17 @@ const open = (file) => {
   if (result.error) {
     throw new CliError('FAILED', `The editor (${command}) could not start`, {
       cause: result.error,
-      hint: 'EDITOR is run as a command with the file as its last argument',
+      hint: 'EDITOR is run as a command with the file as its last argument, so it has to be on the PATH: EDITOR="code --wait" henri credentials:edit',
     });
   }
 
   if (result.status !== 0) {
     throw new CliError(
       'FAILED',
-      `The editor (${command}) exited with ${result.status}: nothing was written`
+      `The editor (${command}) exited with ${result.status}: nothing was written`,
+      {
+        hint: 'The editor has to stay in the foreground until the file is saved and then exit 0: EDITOR="code --wait", EDITOR=vim. Run henri credentials:edit again',
+      }
     );
   }
 };
@@ -234,13 +237,13 @@ const edit = (credentials, cwd, env) => {
       } catch {
         // The parser's message quotes the file, and the file is plaintext
         throw new CliError('FAILED', 'What you saved is not valid JSON', {
-          hint: `The ${env} credentials were left as they were`,
+          hint: `Nothing was written and the ${env} credentials were left as they were: run henri credentials:edit --env ${env} again`,
         });
       }
 
       if (parsed === null || typeof parsed !== 'object') {
         throw new CliError('FAILED', 'The credentials must be a JSON object', {
-          hint: `The ${env} credentials were left as they were`,
+          hint: `A credentials file is { "key": "value" } at the top level. Nothing was written and the ${env} credentials were left as they were: run henri credentials:edit --env ${env} again`,
         });
       }
 

--- a/packages/core/src/__tests__/error-codes.spec.js
+++ b/packages/core/src/__tests__/error-codes.spec.js
@@ -16,11 +16,16 @@ const {
   url,
 } = require('../base/errors');
 
-const { SCHEMA } = require('../base/config-schema');
+const {
+  commandLines,
+  declares,
+  keysNamed,
+  overlap,
+  wrongCommand,
+} = require('./instructions');
 
 const ROOT = path.resolve(__dirname, '..', '..', '..', '..');
 const PACKAGES = path.join(ROOT, 'packages');
-const CLI = path.join(PACKAGES, 'cli');
 const PAGE = path.join(
   ROOT,
   'website',
@@ -136,230 +141,6 @@ const texts = (code) => [
   ...code.causes.map((cause) => ['causes', cause]),
 ];
 
-/* --------------------------------------------------------------------- *
- * The commands the catalogue is allowed to name.
- *
- * `packages/cli` owns the list and this reads it: the top level from the
- * `commands` of its package.json (which is what `index.js` dispatches on),
- * the subcommands from the `COMMANDS` a group's script exports, and the
- * generators from `generate.js`. Nothing is copied here, so a command that
- * is renamed or retired makes the catalogue that still names it fail.
- * --------------------------------------------------------------------- */
-
-/** The top level commands, straight from the package that dispatches them */
-const COMMANDS = require(path.join(CLI, 'package.json')).commands;
-
-/** What a group's script exports, once per group */
-const groups = new Map();
-
-/**
- * The subcommands of a command, or null when it takes none
- *
- * @param {string} name a top level command
- * @returns {?Array<string>} the subcommands, or null
- */
-function subcommandsOf(name) {
-  if (!groups.has(name)) {
-    const script = require(path.join(CLI, 'scripts', name));
-    const named = script.generators || script.destroyers;
-    const list = Array.isArray(script.COMMANDS)
-      ? script.COMMANDS
-      : named && Object.keys(named);
-
-    groups.set(
-      name,
-      Array.isArray(list) && list.every((one) => typeof one === 'string')
-        ? list
-        : null
-    );
-  }
-
-  return groups.get(name);
-}
-
-/**
- * What is wrong with a command line the catalogue printed, if anything
- *
- * A span stops being read at the first thing that is not a name: a flag, a
- * placeholder, a redirection. `henri db:status --sql` is `db:status`, and
- * `henri versions <Model>` is `versions`.
- *
- * @param {string} line the command line, without its backticks
- * @returns {?string} what is wrong, or null when it is a real command
- */
-function wrongCommand(line) {
-  const [, first, second] = line.split(/\s+/u);
-  const [name, ...rest] = String(first || '').split(':');
-
-  if (!COMMANDS.includes(name)) {
-    return `there is no \`henri ${name}\` command`;
-  }
-
-  const subcommands = subcommandsOf(name);
-
-  if (rest.length > 0) {
-    return subcommands && subcommands.includes(rest.join(':'))
-      ? null
-      : `\`henri ${name}\` has no "${rest.join(':')}" (it has ${
-          subcommands ? subcommands.join(', ') : 'no subcommands'
-        })`;
-  }
-
-  // `henri jobs list` is `henri jobs:list` written the other way; anything
-  // that is not a bare name (a flag, `<who>`, `>`) ends the command
-  if (!subcommands || !/^[a-z][a-z0-9:-]*$/u.test(second || '')) {
-    return null;
-  }
-
-  return subcommands.includes(second)
-    ? null
-    : `\`henri ${name}\` has no "${second}" (it has ${subcommands.join(', ')})`;
-}
-
-/* --------------------------------------------------------------------- *
- * The configuration keys the catalogue is allowed to name: the ones
- * `base/config-schema.js` declares, and only those.
- * --------------------------------------------------------------------- */
-
-/** Every path of the schema, `*` standing for a key an application names */
-const PATHS = new Set();
-
-/**
- * Walk a schema node, collecting the paths under it
- *
- * @param {object} node a schema node
- * @param {string} prefix the path so far
- * @param {number} [depth=0] recursion guard
- * @returns {void}
- */
-function collect(node, prefix, depth = 0) {
-  if (!node || typeof node !== 'object' || depth > 8) {
-    return;
-  }
-
-  for (const one of node.oneOf || []) {
-    collect(one, prefix, depth + 1);
-  }
-
-  for (const [key, child] of Object.entries(node.keys || {})) {
-    const full = prefix ? `${prefix}.${key}` : key;
-
-    PATHS.add(full);
-    collect(child, full, depth + 1);
-  }
-
-  if (node.values) {
-    PATHS.add(`${prefix}.*`);
-    collect(node.values, `${prefix}.*`, depth + 1);
-  }
-}
-
-for (const [key, node] of Object.entries(SCHEMA)) {
-  PATHS.add(key);
-  collect(node, key);
-}
-
-/** The top level keys, which is what says a dotted name is a config key */
-const TOP = new Set(Object.keys(SCHEMA));
-
-/**
- * Does the schema declare this key? (`stores.default.url` is `stores.*.url`)
- *
- * @param {string} key a dotted key, without the `config.` prefix
- * @returns {boolean} true when it is declared
- */
-const declares = (key) => {
-  const wanted = key.split('.');
-
-  return [...PATHS].some((declared) => {
-    const parts = declared.split('.');
-
-    return (
-      parts.length === wanted.length &&
-      parts.every((part, index) => part === '*' || part === wanted[index])
-    );
-  });
-};
-
-/** `config.<key>`, unless it is a call (`config.get(...)`) */
-const EXPLICIT = /(?<![\w.])config\.([a-z]\w*(?:\.\w+)*)/gu;
-
-/** Anything inside backticks */
-const TICKED = /`([^`]+)`/gu;
-
-/** A dotted name, the shape a configuration key is written in */
-const DOTTED = /^[a-z][a-zA-Z0-9]*(?:\.[a-zA-Z0-9]+)+$/u;
-
-/**
- * The configuration keys a text names
- *
- * Two shapes: `config.<key>` anywhere, and a dotted name inside backticks
- * whose first segment is a key henri owns (`jobs.store`), which is how the
- * catalogue writes them when the sentence already said "configuration".
- *
- * @param {string} text the text
- * @returns {Array<string>} the keys, without the `config.` prefix
- */
-function keysNamed(text) {
-  const found = [];
-
-  for (const match of text.matchAll(EXPLICIT)) {
-    if (text[match.index + match[0].length] !== '(') {
-      found.push(match[1]);
-    }
-  }
-
-  for (const match of text.matchAll(TICKED)) {
-    const span = match[1].replace(/^config\./u, '');
-
-    if (DOTTED.test(span) && TOP.has(span.split('.')[0])) {
-      found.push(span);
-    }
-  }
-
-  return [...new Set(found)];
-}
-
-/** Words that carry no meaning when two sentences are compared */
-const STOP = new Set(
-  (
-    'a an the and or of to it is was be been are for in on at that this which ' +
-    'who with what not no nor but so as by from into its their there here ' +
-    'they them he she'
-  ).split(' ')
-);
-
-/**
- * The content words of a sentence
- *
- * @param {string} text the sentence
- * @returns {Set<string>} the words
- */
-const words = (text) =>
-  new Set(
-    text
-      .toLowerCase()
-      .replace(/[^a-z0-9 ]/gu, ' ')
-      .split(/\s+/u)
-      .filter((word) => word.length > 2 && !STOP.has(word))
-  );
-
-/**
- * How much two sentences say the same thing (0 nothing, 1 everything)
- *
- * @param {string} one the first
- * @param {string} two the second
- * @returns {number} the Jaccard similarity of their content words
- */
-function overlap(one, two) {
-  const left = words(one);
-  const right = words(two);
-  const shared = [...left].filter((word) => right.has(word)).length;
-  const union = new Set([...left, ...right]).size;
-
-  return union === 0 ? 1 : shared / union;
-}
-
 describe('the error code catalogue', () => {
   test('every entry is complete, unique and shaped like a code', () => {
     const names = catalogue.codes.map((code) => code.code);
@@ -439,7 +220,9 @@ describe('the catalogue and the source', () => {
  * it sends a person down a path that ends nowhere. So the two kinds of
  * thing a fix points at are checked against the source that owns them --
  * `packages/cli` for the commands, `base/config-schema.js` for the keys --
- * rather than against a copy kept here.
+ * rather than against a copy kept here. Both readers live in
+ * `__tests__/instructions.js`, which `config-hints.spec.js` runs over the
+ * configuration schema's own text.
  */
 describe('the catalogue reads like an instruction', () => {
   test('every command it names is a real one', () => {
@@ -447,12 +230,8 @@ describe('the catalogue reads like an instruction', () => {
 
     for (const code of catalogue.codes) {
       for (const [field, text] of texts(code)) {
-        for (const match of text.matchAll(TICKED)) {
-          if (!/^henri\s/u.test(match[1])) {
-            continue;
-          }
-
-          const problem = wrongCommand(match[1]);
+        for (const line of commandLines(text)) {
+          const problem = wrongCommand(line);
 
           problem && wrong.push(`${code.code}.${field}: ${problem}`);
         }
@@ -477,29 +256,6 @@ describe('the catalogue reads like an instruction', () => {
     }
 
     expect(wrong).toEqual([]);
-  });
-
-  test('the rules would catch a command or a key that is not there', () => {
-    expect(wrongCommand('henri nope')).toMatch(/no `henri nope` command/u);
-    expect(wrongCommand('henri db:nope')).toMatch(/has no "nope"/u);
-    expect(wrongCommand('henri jobs nope')).toMatch(/has no "nope"/u);
-    expect(wrongCommand('henri db:status --sql')).toBeNull();
-    expect(wrongCommand('henri versions <Model> <record>')).toBeNull();
-    expect(wrongCommand('henri openapi > openapi.json')).toBeNull();
-    expect(wrongCommand('henri generate policy <Model>')).toBeNull();
-    expect(wrongCommand('henri destroy model Thing')).toBeNull();
-    expect(wrongCommand('henri destroy nope Thing')).toMatch(/has no "nope"/u);
-
-    expect(keysNamed('`jobs.nope` and `config.jobs.store`')).toEqual([
-      'jobs.store',
-      'jobs.nope',
-    ]);
-    expect(keysNamed('`config.jobs.store` twice: config.jobs.store')).toEqual([
-      'jobs.store',
-    ]);
-    expect(declares('jobs.nope')).toBe(false);
-    expect(declares('stores.default.url')).toBe(true);
-    expect(keysNamed('`henri.model.errors()` and config.get(key)')).toEqual([]);
   });
 
   test('every fix says something the meaning did not', () => {

--- a/packages/core/src/__tests__/instructions.js
+++ b/packages/core/src/__tests__/instructions.js
@@ -1,0 +1,297 @@
+/**
+ * What henri is allowed to tell a person to do.
+ *
+ * Two bodies of text send people somewhere: `packages/core/error-codes.json`,
+ * where every code says how to fix it, and `base/config-schema.js`, where
+ * every key says what it accepts (`describe`) and what to do about it
+ * (`hint`). Both name commands and configuration keys, and a name that is
+ * wrong is worse than no instruction at all -- it sends a person down a path
+ * that ends nowhere. The first pass found the catalogue telling people to run
+ * `henri credentials:init`, a command henri has never had.
+ *
+ * So this holds the two checks, and the source that owns each answer is read
+ * rather than copied: `packages/cli` for the commands (the top level from the
+ * `commands` of its package.json, the subcommands from what a group's script
+ * exports) and `base/config-schema.js` for the keys. A command that is
+ * renamed or retired makes every text that still names it fail.
+ *
+ * `error-codes.spec.js` and `config-hints.spec.js` are the two callers. This
+ * file is not a suite of its own: vitest collects `*.spec.js` and `*.test.js`,
+ * so a helper next to them is a helper.
+ *
+ * The boundary of the command check, said out loud: a span is read as a
+ * command when it carries a colon (`henri db:status`), when it sits inside
+ * backticks, or when the word after `henri` is a command the CLI dispatches.
+ * Everything else is prose -- "henri owns the table", "henri ships no SDK" --
+ * because `henri` is the name of the framework as well as the name of the
+ * binary, and no rule can tell a retired one-word command from a verb.
+ */
+
+const path = require('path');
+
+const { SCHEMA } = require('../base/config-schema');
+
+const CLI = path.resolve(__dirname, '..', '..', '..', 'cli');
+
+/* --------------------------------------------------------------------- *
+ * The commands a text is allowed to name.
+ * --------------------------------------------------------------------- */
+
+/** The top level commands, straight from the package that dispatches them */
+const COMMANDS = require(path.join(CLI, 'package.json')).commands;
+
+/** What a group's script exports, once per group */
+const groups = new Map();
+
+/**
+ * The subcommands of a command, or null when it takes none
+ *
+ * @param {string} name a top level command
+ * @returns {?Array<string>} the subcommands, or null
+ */
+function subcommandsOf(name) {
+  if (!groups.has(name)) {
+    const script = require(path.join(CLI, 'scripts', name));
+    const named = script.generators || script.destroyers;
+    const list = Array.isArray(script.COMMANDS)
+      ? script.COMMANDS
+      : named && Object.keys(named);
+
+    groups.set(
+      name,
+      Array.isArray(list) && list.every((one) => typeof one === 'string')
+        ? list
+        : null
+    );
+  }
+
+  return groups.get(name);
+}
+
+/**
+ * What is wrong with a command line a text printed, if anything
+ *
+ * A span stops being read at the first thing that is not a name: a flag, a
+ * placeholder, a redirection. `henri db:status --sql` is `db:status`, and
+ * `henri versions <Model>` is `versions`.
+ *
+ * @param {string} line the command line, without its backticks
+ * @returns {?string} what is wrong, or null when it is a real command
+ */
+function wrongCommand(line) {
+  const [, first, second] = line.split(/\s+/u);
+  const [name, ...rest] = String(first || '').split(':');
+
+  if (!COMMANDS.includes(name)) {
+    return `there is no \`henri ${name}\` command`;
+  }
+
+  const subcommands = subcommandsOf(name);
+
+  if (rest.length > 0) {
+    return subcommands && subcommands.includes(rest.join(':'))
+      ? null
+      : `\`henri ${name}\` has no "${rest.join(':')}" (it has ${
+          subcommands ? subcommands.join(', ') : 'no subcommands'
+        })`;
+  }
+
+  // `henri jobs list` is `henri jobs:list` written the other way; anything
+  // that is not a bare name (a flag, `<who>`, `>`) ends the command
+  if (!subcommands || !/^[a-z][a-z0-9:-]*$/u.test(second || '')) {
+    return null;
+  }
+
+  return subcommands.includes(second)
+    ? null
+    : `\`henri ${name}\` has no "${second}" (it has ${subcommands.join(', ')})`;
+}
+
+/** Anything inside backticks */
+const TICKED = /`([^`]+)`/gu;
+
+/**
+ * `henri` followed by a name, wherever it appears.
+ *
+ * A colon only belongs to the name when a name follows it, so the sentence
+ * "The document henri fills: ..." is prose and `henri db:status` is not.
+ */
+const INVOKED = /(?<![\w`.])henri\s+([a-z][a-z0-9_-]*(?::[a-z][a-z0-9_-]*)*)/gu;
+
+/**
+ * The command lines a text names
+ *
+ * A backticked span that starts with `henri ` is one whatever it holds, and
+ * everything in it is read: `henri jobs list` is `henri jobs:list` written
+ * the other way. A bare one is only ever the name -- it is read as a command
+ * when it carries a colon or when the word is one the CLI dispatches, and
+ * what follows it in the sentence is prose ("Let henri generate the secret").
+ *
+ * @param {string} text the text
+ * @returns {Array<string>} the command lines, backticks stripped
+ */
+function commandLines(text) {
+  const found = [];
+
+  for (const match of text.matchAll(TICKED)) {
+    /^henri\s/u.test(match[1]) && found.push(match[1]);
+  }
+
+  for (const match of text.matchAll(INVOKED)) {
+    const [name] = match[1].split(':');
+
+    if (match[1].includes(':') || COMMANDS.includes(name)) {
+      found.push(`henri ${match[1]}`);
+    }
+  }
+
+  return [...new Set(found)];
+}
+
+/* --------------------------------------------------------------------- *
+ * The configuration keys a text is allowed to name: the ones
+ * `base/config-schema.js` declares, and only those.
+ * --------------------------------------------------------------------- */
+
+/** The top level keys, which is what says a dotted name is a config key */
+const TOP = new Set(Object.keys(SCHEMA));
+
+/**
+ * Does the schema declare this key?
+ *
+ * A record's key is whatever an application named it (`stores.default.url`),
+ * and everything under a node that forwards what it does not know
+ * (`unknown: 'allow'`: helmet's options, cors', a nodemailer transport) is
+ * that library's to declare rather than henri's -- so the walk stops there
+ * and says yes.
+ *
+ * @param {string} key a dotted key, without the `config.` prefix
+ * @param {object} [schema=SCHEMA] the schema
+ * @returns {boolean} true when it is declared
+ */
+function declares(key, schema = SCHEMA) {
+  const walk = (nodes, parts, depth) => {
+    if (parts.length === 0) {
+      return true;
+    }
+
+    if (depth > 12) {
+      return false;
+    }
+
+    const [head, ...tail] = parts;
+    const branches = nodes.flatMap((node) => node.oneOf || [node]);
+
+    return branches.some((node) => {
+      if (node.keys && node.keys[head]) {
+        return walk([node.keys[head]], tail, depth + 1);
+      }
+
+      if (node.values) {
+        return walk([node.values], tail, depth + 1);
+      }
+
+      // A node that forwards what it does not know owns nothing below it
+      return node.type === 'any' || (node.type === 'object' && !node.keys);
+    });
+  };
+
+  const parts = key.split('.');
+
+  return (
+    TOP.has(parts[0]) && walk([{ keys: schema, type: 'object' }], parts, 0)
+  );
+}
+
+/** `config.<key>`, unless it is a call (`config.get(...)`) */
+const EXPLICIT = /(?<![\w.])config\.([a-z]\w*(?:\.\w+)*)/gu;
+
+/** A dotted name, the shape a configuration key is written in */
+const DOTTED = /^[a-z][a-zA-Z0-9]*(?:\.[a-zA-Z0-9]+)+$/u;
+
+/**
+ * The configuration keys a text names
+ *
+ * Two shapes: `config.<key>` anywhere, and a dotted name inside backticks
+ * whose first segment is a key henri owns (`jobs.store`), which is how the
+ * text writes them when the sentence already said "configuration".
+ *
+ * @param {string} text the text
+ * @returns {Array<string>} the keys, without the `config.` prefix
+ */
+function keysNamed(text) {
+  const found = [];
+
+  for (const match of text.matchAll(EXPLICIT)) {
+    if (text[match.index + match[0].length] !== '(') {
+      found.push(match[1]);
+    }
+  }
+
+  for (const match of text.matchAll(TICKED)) {
+    const span = match[1].replace(/^config\./u, '');
+
+    if (DOTTED.test(span) && TOP.has(span.split('.')[0])) {
+      found.push(span);
+    }
+  }
+
+  return [...new Set(found)];
+}
+
+/* --------------------------------------------------------------------- *
+ * Whether one sentence says something the other did not.
+ * --------------------------------------------------------------------- */
+
+/** Words that carry no meaning when two sentences are compared */
+const STOP = new Set(
+  (
+    'a an the and or of to it is was be been are for in on at that this which ' +
+    'who with what not no nor but so as by from into its their there here ' +
+    'they them he she'
+  ).split(' ')
+);
+
+/**
+ * The content words of a sentence
+ *
+ * @param {string} text the sentence
+ * @returns {Set<string>} the words
+ */
+const words = (text) =>
+  new Set(
+    text
+      .toLowerCase()
+      .replace(/[^a-z0-9 ]/gu, ' ')
+      .split(/\s+/u)
+      .filter((word) => word.length > 2 && !STOP.has(word))
+  );
+
+/**
+ * How much two sentences say the same thing (0 nothing, 1 everything)
+ *
+ * @param {string} one the first
+ * @param {string} two the second
+ * @returns {number} the Jaccard similarity of their content words
+ */
+function overlap(one, two) {
+  const left = words(one);
+  const right = words(two);
+  const shared = [...left].filter((word) => right.has(word)).length;
+  const union = new Set([...left, ...right]).size;
+
+  return union === 0 ? 1 : shared / union;
+}
+
+module.exports = {
+  COMMANDS,
+  TICKED,
+  TOP,
+  commandLines,
+  declares,
+  keysNamed,
+  overlap,
+  subcommandsOf,
+  words,
+  wrongCommand,
+};

--- a/packages/core/src/__tests__/instructions.spec.js
+++ b/packages/core/src/__tests__/instructions.spec.js
@@ -1,0 +1,340 @@
+/**
+ * Everything henri tells a person to do next reads like an instruction.
+ *
+ * `error-codes.spec.js` holds the catalogue to this bar; these are the other
+ * two bodies of text, checked by the same readers
+ * (`__tests__/instructions.js`):
+ *
+ * - `base/config-schema.js`, where a wrong value in `config/<env>.json` --
+ *   the failure people hit first, often before the application has ever run
+ *   -- reaches the terminal as a `describe` saying what the value must be
+ *   and a `hint` saying what to do about it;
+ * - the `hint` of every failure `packages/cli` raises, read out of the
+ *   source the way this repository already reads the codes.
+ *
+ * What it enforces, and why each rule is here:
+ *
+ * - every `henri <command>` a hint or a `describe` names is a command the
+ *   CLI dispatches, read out of `packages/cli` rather than copied;
+ * - every `config.<key>` one names is a key the schema declares, read out of
+ *   the schema itself;
+ * - every `@usehenri/<package>` one names is a package of this workspace and
+ *   every `base/<file>.js` one names is a file of this package, because a
+ *   pointer at something that moved is the same failure as a retired
+ *   command;
+ * - a hint that only restates its `describe` is not a hint.
+ *
+ * The nodes that deliberately have no hint are named in `SILENT`, with the
+ * reason: a `describe` that leaves nothing to say is better left alone than
+ * padded with "set this to a valid value".
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const {
+  commandLines,
+  declares,
+  keysNamed,
+  overlap,
+  wrongCommand,
+} = require('./instructions');
+
+const { SCHEMA } = require('../base/config-schema');
+const { describe: expectationOf } = require('../base/config-validate');
+
+const ROOT = path.resolve(__dirname, '..', '..', '..', '..');
+const PACKAGES = path.join(ROOT, 'packages');
+const BASE = path.resolve(__dirname, '..', 'base');
+const SCRIPTS = path.join(PACKAGES, 'cli', 'scripts');
+
+/**
+ * Every node of the schema, with the path it sits at.
+ *
+ * A branch of a union is `key|0`, an item of a list `key[]` and the value of
+ * a record `key.*`, so a node that is only reachable through one of the
+ * three still has a name a failure can be traced back to.
+ *
+ * @param {object} node a schema node
+ * @param {string} at the path so far
+ * @param {Array<object>} [found=[]] what has been found so far
+ * @returns {Array<object>} `{ at, node }` entries
+ */
+function nodes(node, at, found = []) {
+  if (!node || typeof node !== 'object') {
+    return found;
+  }
+
+  found.push({ at, node });
+
+  (node.oneOf || []).forEach((branch, index) =>
+    nodes(branch, `${at}|${index}`, found)
+  );
+
+  for (const [key, child] of Object.entries(node.keys || {})) {
+    nodes(child, at ? `${at}.${key}` : key, found);
+  }
+
+  node.values && nodes(node.values, `${at}.*`, found);
+  node.of && nodes(node.of, `${at}[]`, found);
+
+  return found;
+}
+
+/** Every node of the schema */
+const ALL = Object.entries(SCHEMA).flatMap(([key, node]) => nodes(node, key));
+
+/**
+ * The nodes a person can be sent to directly: a declared key, or the value
+ * of a record. A branch of a union inherits the union's hint and an item of
+ * a list its list's (`config-validate.js`), so neither needs one of its own
+ * -- which is what the last segment of the path says.
+ */
+const NAMED = ALL.filter(({ at }) => {
+  const last = at.split('.').pop();
+
+  return !/\|\d+$/u.test(last) && !last.endsWith('[]');
+});
+
+/**
+ * Every text of the schema, with the node it belongs to: an instruction is
+ * an instruction wherever it was written down.
+ */
+const TEXTS = ALL.flatMap(({ at, node }) =>
+  [
+    ['hint', node.hint],
+    ['describe', node.describe],
+  ]
+    .filter(([, text]) => typeof text === 'string')
+    .map(([field, text]) => [`${at}.${field}`, text])
+);
+
+/**
+ * The keys whose `describe` says everything there is to say, so a hint would
+ * only be a longer way of reading it again. Adding one is a decision: the
+ * reason goes next to it.
+ */
+const SILENT = new Map([
+  [
+    'user|1.confirmation|1.after',
+    'a path to land on is a path to land on; the flow has no other setting to point at',
+  ],
+  [
+    'user|1.identities|1.after',
+    'the same, and the sign-in half of the flow lands on user.afterLogin, which is its own key',
+  ],
+]);
+
+/** A package of the workspace, as `@usehenri/<name>` */
+const workspace = new Set(
+  fs
+    .readdirSync(PACKAGES, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => `@usehenri/${entry.name}`)
+);
+
+describe('the configuration schema reads like an instruction', () => {
+  test('every command it names is a real one', () => {
+    const wrong = [];
+
+    for (const [where, text] of TEXTS) {
+      for (const line of commandLines(text)) {
+        const problem = wrongCommand(line);
+
+        problem && wrong.push(`${where}: ${problem}`);
+      }
+    }
+
+    expect(wrong).toEqual([]);
+  });
+
+  test('every configuration key it names is one henri declares', () => {
+    const wrong = [];
+
+    for (const [where, text] of TEXTS) {
+      for (const key of keysNamed(text)) {
+        declares(key) || wrong.push(`${where}: config.${key} is not a key`);
+      }
+    }
+
+    expect(wrong).toEqual([]);
+  });
+
+  test('every package and source file it names is there', () => {
+    const wrong = [];
+
+    for (const [where, text] of TEXTS) {
+      for (const match of text.matchAll(/@usehenri\/[a-z0-9-]+/gu)) {
+        workspace.has(match[0]) ||
+          wrong.push(`${where}: there is no ${match[0]} package`);
+      }
+
+      for (const match of text.matchAll(/base\/[a-z-]+\.js/gu)) {
+        fs.existsSync(path.join(BASE, path.basename(match[0]))) ||
+          wrong.push(`${where}: there is no ${match[0]}`);
+      }
+    }
+
+    expect(wrong).toEqual([]);
+  });
+
+  test('a hint says something the expectation did not', () => {
+    const restated = [];
+
+    for (const { at, node } of ALL) {
+      if (!node.hint) {
+        continue;
+      }
+
+      expect(typeof node.hint).toBe('string');
+      expect(node.hint.trim().length).toBeGreaterThan(15);
+
+      const said = expectationOf(node);
+      const one = node.hint.toLowerCase().replace(/[^a-z0-9]/gu, '');
+      const two = said.toLowerCase().replace(/[^a-z0-9]/gu, '');
+
+      // Quoting the expectation only means restating it when there is
+      // something to restate: "a string" is inside half the sentences in
+      // English, and a hint that says "a value is a string, appended to the
+      // url as it is" is doing its job
+      if (
+        one === two ||
+        (two.length > 24 && one.includes(two)) ||
+        overlap(node.hint, said) > 0.5
+      ) {
+        restated.push(at);
+      }
+    }
+
+    expect(restated).toEqual([]);
+  });
+
+  test('every key a person can be sent to says what to do about it', () => {
+    const silent = NAMED.filter(({ node }) => !node.hint).map(({ at }) => at);
+
+    expect(silent).toEqual([...SILENT.keys()]);
+
+    for (const reason of SILENT.values()) {
+      expect(reason.length).toBeGreaterThan(20);
+    }
+  });
+
+  test('SILENT names nodes the schema still has', () => {
+    const known = new Set(ALL.map(({ at }) => at));
+
+    for (const at of SILENT.keys()) {
+      expect(known.has(at)).toBe(true);
+    }
+  });
+});
+
+/**
+ * Every `hint` the command line ships, read out of the source.
+ *
+ * A `CliError` builds its hint at the call site, often out of a template, so
+ * there is nothing to import: the literal is what can be checked, the way
+ * `error-codes.spec.js` reads the codes out of the source rather than out of
+ * a running process. An interpolation ends the span it sits in, so
+ * `henri flags:${command}` is read as `henri flags` and passes -- the rule
+ * is only ever stricter about what is written down whole.
+ */
+const CLI_HINTS = fs
+  .readdirSync(SCRIPTS)
+  .filter((name) => name.endsWith('.js'))
+  .flatMap((name) => {
+    const src = fs.readFileSync(path.join(SCRIPTS, name), 'utf8');
+
+    return [
+      ...src.matchAll(
+        /\bhint:\s*(?:'((?:[^'\\]|\\.)*)'|"((?:[^"\\]|\\.)*)"|`((?:[^`\\]|\\.)*)`)/gu
+      ),
+    ].map((match) => [
+      `${name}:${src.slice(0, match.index).split('\n').length}`,
+      match[1] || match[2] || match[3] || '',
+    ]);
+  });
+
+describe('the hints of the command line', () => {
+  test('there are hints to read', () => {
+    expect(CLI_HINTS.length).toBeGreaterThan(100);
+  });
+
+  test('every command they name is a real one', () => {
+    const wrong = [];
+
+    for (const [where, text] of CLI_HINTS) {
+      for (const line of commandLines(text)) {
+        const problem = wrongCommand(line);
+
+        problem && wrong.push(`${where}: ${problem}`);
+      }
+    }
+
+    expect(wrong).toEqual([]);
+  });
+
+  test('every configuration key they name is one henri declares', () => {
+    const wrong = [];
+
+    for (const [where, text] of CLI_HINTS) {
+      for (const key of keysNamed(text)) {
+        declares(key) || wrong.push(`${where}: config.${key} is not a key`);
+      }
+    }
+
+    expect(wrong).toEqual([]);
+  });
+});
+
+describe('the readers of instructions.js', () => {
+  test('they would catch a command or a key that is not there', () => {
+    expect(wrongCommand('henri nope')).toMatch(/no `henri nope` command/u);
+    expect(wrongCommand('henri db:nope')).toMatch(/has no "nope"/u);
+    expect(wrongCommand('henri jobs nope')).toMatch(/has no "nope"/u);
+    expect(wrongCommand('henri db:status --sql')).toBeNull();
+    expect(wrongCommand('henri versions <Model> <record>')).toBeNull();
+    expect(wrongCommand('henri openapi > openapi.json')).toBeNull();
+    expect(wrongCommand('henri generate policy <Model>')).toBeNull();
+    expect(wrongCommand('henri destroy model Thing')).toBeNull();
+    expect(wrongCommand('henri destroy nope Thing')).toMatch(/has no "nope"/u);
+
+    expect(keysNamed('`jobs.nope` and `config.jobs.store`')).toEqual([
+      'jobs.store',
+      'jobs.nope',
+    ]);
+    expect(keysNamed('`config.jobs.store` twice: config.jobs.store')).toEqual([
+      'jobs.store',
+    ]);
+    expect(declares('jobs.nope')).toBe(false);
+    expect(declares('stores.default.url')).toBe(true);
+    expect(keysNamed('`henri.model.errors()` and config.get(key)')).toEqual([]);
+  });
+
+  test('a command is read out of a bare sentence, and prose is not', () => {
+    // The retired command of the first pass, written the way a hint writes it
+    expect(commandLines('Run henri credentials:init first')).toEqual([
+      'henri credentials:init',
+    ]);
+    expect(wrongCommand('henri credentials:init')).toMatch(/has no "init"/u);
+
+    expect(
+      commandLines('`henri jobs list` and henri audit reports it')
+    ).toEqual(['henri jobs list', 'henri audit']);
+
+    // `henri` is the name of the framework as well as the binary
+    expect(commandLines('henri owns the table and ships no SDK')).toEqual([]);
+    expect(commandLines('Let henri generate the secret')).toEqual([
+      'henri generate',
+    ]);
+  });
+
+  test('a key under a node that forwards what it does not know is declared', () => {
+    // Helmet's own options, cors', a nodemailer transport: henri validates
+    // the block and declares nothing inside it
+    expect(declares('helmet.contentSecurityPolicy')).toBe(true);
+    expect(declares('stores.default.opts.autoIndex')).toBe(true);
+    // ... but a store still refuses a misspelling of a key henri owns
+    expect(declares('stores.default.adaptor')).toBe(false);
+    expect(declares('nope.at.all')).toBe(false);
+  });
+});

--- a/packages/core/src/base/config-schema.js
+++ b/packages/core/src/base/config-schema.js
@@ -126,11 +126,12 @@ const BOUNDARIES = [
 /** A string that is not empty */
 const text = (extra = {}) => ({ pattern: /\S/u, type: 'string', ...extra });
 
-/** One bound of the graphql endpoint: a whole number, or false to lift it */
-const limit = (value) => ({
+/** A counted bound: a whole number, or false to lift it */
+const limit = (value, extra = {}) => ({
   default: value,
   describe: 'a whole number above zero, or false',
   oneOf: [{ const: false }, { above: 0, integer: true, type: 'number' }],
+  ...extra,
 });
 
 /** A number strictly above zero */
@@ -196,6 +197,7 @@ const sizeLimit = (extra = {}) => ({
  * `henri audit` reports.
  */
 const IDENTITY_PROVIDER = {
+  hint: 'A provider needs authorizationUrl, tokenUrl, userinfoUrl, clientId and clientSecret; everything else has a default',
   keys: {
     allows: text({
       default: 'signin',
@@ -215,11 +217,17 @@ const IDENTITY_PROVIDER = {
     }),
     claims: {
       describe: 'which fields of the userinfo answer henri reads',
+      hint: 'Only for a provider that does not use the OpenID Connect names: henri reads sub, email and email_verified without this',
       keys: {
-        email: text({ default: 'email', describe: 'the address claim' }),
+        email: text({
+          default: 'email',
+          describe: 'the address claim',
+          hint: 'A field of what userinfoUrl answers; henri never reads an address out of an id_token',
+        }),
         subject: text({
           default: 'sub',
           describe: "the claim holding the provider's identifier for a person",
+          hint: 'It has to be stable and never reused: the row it keys is a credential, and a provider that hands the same one to a second person hands over the account',
         }),
         verified: {
           default: 'email_verified',
@@ -230,17 +238,25 @@ const IDENTITY_PROVIDER = {
       },
       type: 'object',
     },
-    clientId: text({ describe: 'the client identifier the provider issued' }),
+    clientId: text({
+      describe: 'the client identifier the provider issued',
+      hint: 'It reaches a browser in the authorization url, so it is not a secret; clientSecret is',
+    }),
     clientSecret: text({
       describe: 'the client secret the provider issued',
       hint: 'Put it in the encrypted credentials (henri credentials:edit) or in the environment; henri audit reports one written here',
     }),
-    label: text({ describe: 'what a button calls this provider' }),
+    label: text({
+      describe: 'what a button calls this provider',
+      hint: 'What the button says ("Sign in with Acme"); the name under providers is what the url carries',
+    }),
     params: {
       describe: 'extra authorization parameters, by name',
       hint: 'What a provider asks for beyond the standard ones',
       type: 'record',
-      values: text(),
+      values: text({
+        hint: 'A value is a string, appended to the authorization url as it is; henri sends the standard parameters itself',
+      }),
     },
     pkce: {
       default: true,
@@ -250,9 +266,13 @@ const IDENTITY_PROVIDER = {
     },
     scope: {
       describe: "a list of scopes, or one string ('openid email')",
+      hint: 'What the provider is asked for; the list and the space-separated string are the same thing',
       oneOf: [text(), { of: text(), type: 'array' }],
     },
-    tokenUrl: text({ describe: 'where an authorization code is redeemed' }),
+    tokenUrl: text({
+      describe: 'where an authorization code is redeemed',
+      hint: 'Called by henri from the server with the code and the client secret, so it never reaches a browser',
+    }),
     trusted: {
       default: false,
       describe: 'true or false',
@@ -261,6 +281,7 @@ const IDENTITY_PROVIDER = {
     },
     userinfoUrl: text({
       describe: "where the person's claims are read with the access token",
+      hint: 'What it answers is the profile henri reads: no id_token is ever parsed, so a provider that only signs its claims into one cannot be used',
     }),
   },
   required: [
@@ -283,15 +304,25 @@ const STORE = {
       required: true,
       type: 'string',
     },
-    database: text({ describe: 'a database name' }),
-    dbName: text({ default: 'henri', describe: 'a database name (disk)' }),
+    database: text({
+      describe: 'a database name',
+      hint: 'One of `host`, `port`, `database`, `username` and `password`, the long form of a connection; a `url` replaces all five',
+    }),
+    dbName: text({
+      default: 'henri',
+      describe: 'a database name (disk)',
+      hint: 'The disk adapter is the one that calls it that; every other adapter names it `database`',
+    }),
     dialect: {
       describe: `one of ${DIALECTS.join(', ')} (drizzle)`,
       enum: DIALECTS,
       hint: 'The application installs the driver: better-sqlite3, pg or mysql2',
       type: 'string',
     },
-    host: text({ describe: 'a host name (or a url, on mongoose)' }),
+    host: text({
+      describe: 'a host name (or a url, on mongoose)',
+      hint: 'With `port`, `database`, `username` and `password` it is the whole connection; a `url` replaces all five',
+    }),
     migrate: {
       describe: 'true or false',
       hint: 'drizzle: true applies db/migrations on a production boot',
@@ -299,16 +330,22 @@ const STORE = {
     },
     opts: {
       describe: 'an object of mongoose.connect() options',
+      hint: 'Handed to mongoose.connect() untouched; henri only sets connectTimeoutMS and serverSelectionTimeoutMS itself',
       type: 'object',
       unknown: 'allow',
     },
-    password: { type: 'string' },
+    password: {
+      hint: 'Never in a config/*.json, which is committed: put the connection in DATABASE_URL, in the credentials (`henri credentials:edit`) or in the environment',
+      type: 'string',
+    },
     path: text({
       default: '.henri/data',
       describe: 'a data directory, relative to the application (disk)',
+      hint: 'Where the local mongod keeps its files. The default is under .henri, which the scaffold already keeps out of git',
     }),
     port: {
       describe: 'a port number between 1 and 65535',
+      hint: "The database server's port; the one the application listens on is config.port",
       integer: true,
       max: 65535,
       min: 1,
@@ -316,6 +353,7 @@ const STORE = {
     },
     session: {
       describe: 'an object of session store options',
+      hint: 'Handed to the session store the adapter builds: connect-mongo on mongoose, the henri_sessions table on drizzle, connect-session-sequelize on mssql',
       type: 'object',
       unknown: 'allow',
     },
@@ -329,8 +367,14 @@ const STORE = {
       hint: 'SQL: false stops a development boot from bringing the schema up; on a Sequelize store true also lets a production boot create the tables that are missing, which it otherwise refuses to do',
       type: 'boolean',
     },
-    url: text({ describe: 'a connection string' }),
-    username: { type: 'string' },
+    url: text({
+      describe: 'a connection string',
+      hint: 'It replaces `host`, `port`, `database`, `username` and `password`; DATABASE_URL sets it for the default store',
+    }),
+    username: {
+      hint: 'With `password`, the long form of a connection; a `url` carries both',
+      type: 'string',
+    },
   },
   // Everything else reaches the driver (Sequelize takes `logging`, `pool`,
   // `dialectOptions`, ...), so only a misspelling is worth a word
@@ -360,6 +404,7 @@ const SCHEMA = {
 
   cors: {
     describe: 'true for the cors defaults, or an object of cors options',
+    hint: 'Absent means no cross-origin header at all, which is what a same-origin application wants; an object reaches the cors package unread, and whatever its origin allows csrf.trustedOrigins trusts',
     oneOf: [{ type: 'boolean' }, { type: 'object', unknown: 'allow' }],
   },
 
@@ -374,20 +419,33 @@ const SCHEMA = {
 
   inertia: {
     describe: 'an object of Inertia renderer options',
+    hint: 'Read by the inertia renderer alone: the keys rename the files it boots from, which henri new wrote into app/views, and turn server-side rendering off',
     keys: {
       entry: text({
         default: 'main.jsx',
         describe: 'a client entry, relative to app/views',
+        hint: 'The file Vite bundles for the browser, the one that calls createInertiaApp',
       }),
-      id: text({ default: 'app', describe: 'the id of the root element' }),
-      ssr: { default: true, type: 'boolean' },
+      id: text({
+        default: 'app',
+        describe: 'the id of the root element',
+        hint: 'It has to be the id of an element of inertia.template, which is what a page mounts into',
+      }),
+      ssr: {
+        default: true,
+        describe: 'true or false',
+        hint: 'false renders every page in the browser, so the first answer is an empty shell carrying the page object',
+        type: 'boolean',
+      },
       ssrEntry: text({
         default: 'ssr.jsx',
         describe: 'a server entry, relative to app/views',
+        hint: 'Built only while inertia.ssr is on: it renders the same pages without a browser and answers { head, body }',
       }),
       template: text({
         default: 'index.html',
         describe: 'an html shell, relative to app/views',
+        hint: 'The document henri fills: <!--head--> and <!--body--> receive the rendered page',
       }),
     },
     type: 'object',
@@ -395,7 +453,14 @@ const SCHEMA = {
 
   experimental: {
     describe: 'an object of renderer opt-ins',
-    keys: { vue: { type: 'boolean' } },
+    hint: 'The only opt-in henri has is { "vue": true }; a supported renderer needs nothing here',
+    keys: {
+      vue: {
+        describe: 'true or false',
+        hint: 'true loads the Vue/Nuxt renderer, which has not been exercised since 2020 and is not supported',
+        type: 'boolean',
+      },
+    },
     type: 'object',
   },
 
@@ -420,6 +485,7 @@ const SCHEMA = {
   user: {
     describe:
       'the name of the user model, or an object ({ model, public, loginPath, afterLogin, sessionMaxAge, password, lockout, signup, passwordReset, confirmation })',
+    hint: '"user" is the short form of { "model": "user" }; the object is where the sign-in paths, the password policy and the account flows go',
     oneOf: [
       text(),
       {
@@ -427,6 +493,7 @@ const SCHEMA = {
           afterLogin: text({
             default: '/',
             describe: 'a path to land on after a form login',
+            hint: 'Where a browser is redirected; a client asking for JSON is answered the user and never redirected',
           }),
           confirmation: {
             default: false,
@@ -444,6 +511,7 @@ const SCHEMA = {
                   emailPath: text({
                     default: '/account/email',
                     describe: 'where an account asks to change its address',
+                    hint: 'A POST from a signed-in account; the link goes to the new address and nothing changes until it is followed',
                   }),
                   enabled: {
                     default: true,
@@ -454,10 +522,12 @@ const SCHEMA = {
                   expiresIn: duration({
                     default: '3d',
                     describe: 'how long a confirmation link stays valid',
+                    hint: 'The token is signed rather than stored, so rotating config.secret invalidates every link already sent, whatever this says',
                   }),
                   path: text({
                     default: '/confirm',
                     describe: 'the prefix of the confirmation endpoints',
+                    hint: 'GET <path>/:token confirms an address, POST <path> mails the link again',
                   }),
                   required: {
                     default: false,
@@ -510,6 +580,7 @@ const SCHEMA = {
                   path: text({
                     default: '/auth',
                     describe: 'the prefix of the identity endpoints',
+                    hint: 'POST <path>/:provider, GET <path>/:provider/callback and POST <path>/:provider/unlink; the callback url registered with each provider has to match',
                   }),
                   providers: {
                     describe:
@@ -527,14 +598,17 @@ const SCHEMA = {
                   stateExpiresIn: duration({
                     default: '10m',
                     describe: 'how long one sign-in attempt stays valid',
+                    hint: 'How long a person has between the button and the callback; the state is minted per attempt, kept in the session and single use',
                   }),
                   table: text({
                     default: 'henri_identities',
                     describe: 'the table the identities live in',
+                    hint: 'henri creates it and owns it: a row is a credential, never a model',
                   }),
                   timeout: duration({
                     default: '10s',
                     describe: 'how long a provider has to answer',
+                    hint: 'One bound for the token request and for the userinfo request; a provider slower than this fails the sign-in',
                   }),
                 },
                 type: 'object',
@@ -552,6 +626,7 @@ const SCHEMA = {
                   max: {
                     default: 10,
                     describe: 'a number of failed attempts, above zero',
+                    hint: 'Failed attempts one account may receive per window, whoever sends them; rateLimit.auth is what bounds one client',
                     integer: true,
                     min: 1,
                     type: 'number',
@@ -565,6 +640,7 @@ const SCHEMA = {
                   windowMs: positive({
                     default: 900000,
                     describe: 'a window in milliseconds',
+                    hint: 'The window user.lockout.max is counted in; nothing else unlocks an account',
                   }),
                 },
                 type: 'object',
@@ -574,10 +650,16 @@ const SCHEMA = {
           loginPath: text({
             default: '/login',
             describe: 'a path to send denied browsers to',
+            hint: 'Where a browser goes when a route or a policy denies an anonymous visitor; a JSON client gets a 401 instead',
           }),
-          model: text({ default: 'user', describe: 'the user model name' }),
+          model: text({
+            default: 'user',
+            describe: 'the user model name',
+            hint: 'A model of app/models; henri adds email, password and roles to whichever one it names',
+          }),
           password: {
             describe: 'the password policy and the hashing parameters',
+            hint: 'The defaults are the safe ones (argon2id where @node-rs/argon2 resolves, bcrypt otherwise); lower nothing here without a reason',
             keys: {
               algorithm: text({
                 default: 'auto',
@@ -588,6 +670,7 @@ const SCHEMA = {
               bcryptRounds: {
                 default: 12,
                 describe: 'a bcrypt work factor, at least 10',
+                hint: 'Only read when bcrypt is what hashes; every step up doubles the work of a sign-in as well as an attacker',
                 integer: true,
                 min: 10,
                 type: 'number',
@@ -609,6 +692,7 @@ const SCHEMA = {
                       enabled: {
                         default: true,
                         describe: 'true or false',
+                        hint: 'false writes new hashes unbound; the bound ones keep verifying, because the marker in the column is what decides',
                         type: 'boolean',
                       },
                     },
@@ -627,6 +711,7 @@ const SCHEMA = {
               memoryCost: {
                 default: 19456,
                 describe: 'argon2id memory in kibibytes, at least 8',
+                hint: 'argon2id only, and the parameter that costs an attacker most; 19456 next to timeCost 2 and parallelism 1 is what OWASP recommends',
                 integer: true,
                 min: 8,
                 type: 'number',
@@ -634,6 +719,7 @@ const SCHEMA = {
               minLength: {
                 default: 12,
                 describe: 'a password length, at least 8',
+                hint: 'Checked when a password is set and never when one is verified, so raising it locks nobody out',
                 integer: true,
                 min: 8,
                 type: 'number',
@@ -641,6 +727,7 @@ const SCHEMA = {
               parallelism: {
                 default: 1,
                 describe: 'a number of argon2id lanes, at least 1',
+                hint: 'argon2id only; one lane is what OWASP recommends next to the default memoryCost',
                 integer: true,
                 min: 1,
                 type: 'number',
@@ -659,9 +746,13 @@ const SCHEMA = {
                         hint: 'false refuses hashes written before the pepper',
                         type: 'boolean',
                       },
-                      current: text({ describe: 'the key in force' }),
+                      current: text({
+                        describe: 'the key in force',
+                        hint: 'What every new hash is written under; a rotation moves the old key into `previous` rather than dropping it',
+                      }),
                       previous: {
                         describe: 'a list of keys it replaced',
+                        hint: 'Still accepted on the way in: a password that verified under one is written again under `current` at that sign-in, so a rotation ends when nothing verifies under them any more',
                         of: text(),
                         type: 'array',
                       },
@@ -674,6 +765,7 @@ const SCHEMA = {
               timeCost: {
                 default: 2,
                 describe: 'a number of argon2id iterations, at least 1',
+                hint: 'argon2id only; two iterations is what OWASP recommends next to the default memoryCost, and memory is the parameter to raise first',
                 integer: true,
                 min: 1,
                 type: 'number',
@@ -693,6 +785,7 @@ const SCHEMA = {
                   after: text({
                     default: '/',
                     describe: 'a path to land on once the password changed',
+                    hint: 'user.passwordReset.login is what decides whether the browser arrives there signed in',
                   }),
                   enabled: {
                     default: true,
@@ -703,6 +796,7 @@ const SCHEMA = {
                   expiresIn: duration({
                     default: '1h',
                     describe: 'how long a reset link stays valid',
+                    hint: 'A reset also stamps passwordChangedAt, which closes every session opened before it',
                   }),
                   login: {
                     default: true,
@@ -713,6 +807,7 @@ const SCHEMA = {
                   path: text({
                     default: '/password',
                     describe: 'the prefix of the reset endpoints',
+                    hint: 'POST <path>/forgot asks for the mail, GET <path>/reset/:token opens the form and POST <path>/reset writes the password',
                   }),
                 },
                 type: 'object',
@@ -728,6 +823,7 @@ const SCHEMA = {
           sessionMaxAge: positive({
             default: 2592000000,
             describe: 'a session lifetime in milliseconds',
+            hint: 'The lifetime of the session cookie, thirty days by default; rotating config.secret ends every session at once whatever this says',
           }),
           signup: {
             default: false,
@@ -741,6 +837,7 @@ const SCHEMA = {
                   after: text({
                     default: '/',
                     describe: 'a path to land on after a signup',
+                    hint: 'user.signup.login is what decides whether the browser arrives there signed in',
                   }),
                   enabled: {
                     default: true,
@@ -763,6 +860,7 @@ const SCHEMA = {
                   path: text({
                     default: '/signup',
                     describe: 'where the endpoint is mounted',
+                    hint: 'A POST here opens an account with email, password and the fields of user.signup.fields, and nothing else',
                   }),
                 },
                 type: 'object',
@@ -777,6 +875,7 @@ const SCHEMA = {
 
   baseRole: {
     describe: 'a role name, or a list of them',
+    hint: 'What the roles column of a new account is set to; without this key an account starts with none, and setRoles() is what changes them afterwards',
     oneOf: [text(), { of: text(), type: 'array' }],
   },
 
@@ -826,6 +925,7 @@ const SCHEMA = {
     default: true,
     describe:
       "express' trust proxy setting: a boolean, a hop count or a list of addresses",
+    hint: 'What express believes of X-Forwarded-For, which is what the rate limit counts by. Set false with no proxy in front; a blanket true behind one is also what makes the call log record no client address at all',
     oneOf: [
       { type: 'boolean' },
       { integer: true, min: 0, type: 'number' },
@@ -868,6 +968,7 @@ const SCHEMA = {
   graphql: {
     default: '/_henri/gql',
     describe: 'a path starting with /, or an object ({ endpoint, ... })',
+    hint: 'The path is the short form of { "endpoint": ... }; the object is where the guards and the query limits go. Serving any of it needs @usehenri/graphql in the application',
     oneOf: [
       text({ pattern: /^\//u }),
       {
@@ -881,6 +982,7 @@ const SCHEMA = {
           endpoint: text({
             default: '/_henri/gql',
             describe: 'a path starting with /',
+            hint: 'One path is the whole surface: graphql.authenticated, graphql.roles and graphql.loopbackOnly are what guard it, and moving it guards nothing',
             pattern: /^\//u,
           }),
           introspection: {
@@ -894,10 +996,18 @@ const SCHEMA = {
             hint: 'true answers 404 to anything but the loopback interface',
             type: 'boolean',
           },
-          maxAliases: limit(15),
-          maxComplexity: limit(1000),
-          maxDepth: limit(10),
-          maxTokens: limit(5000),
+          maxAliases: limit(15, {
+            hint: 'The most aliases one query may use. It needs no cycle and no deep schema to be worth refusing, which is why it is the strict one; false lifts it',
+          }),
+          maxComplexity: limit(1000, {
+            hint: 'The most fields one query may select, fragments expanded, which is what a fragment bomb inflates; false lifts it',
+          }),
+          maxDepth: limit(10, {
+            hint: 'The deepest query accepted. It only bites on a schema with somewhere deep to go, so it is the loosest of the three; false lifts it',
+          }),
+          maxTokens: limit(5000, {
+            hint: "The most tokens one document may hold. It is graphql's own parser bound, so it refuses a document before parsing it; false lifts it",
+          }),
           roles: {
             describe: 'a role name, or a list of them',
             hint: 'asking for a role implies authenticated',
@@ -911,17 +1021,23 @@ const SCHEMA = {
 
   mail: {
     describe: 'a nodemailer transport object, or "test"',
+    hint: 'Absent, henri warns at boot and sends nothing; "test" opens an Ethereal account, and anything else reaches nodemailer.createTransport() and is verified before the boot finishes',
     oneOf: [{ const: 'test' }, { type: 'object', unknown: 'allow' }],
   },
 
   mailers: {
     describe: 'an object of mailer defaults',
+    hint: "Defaults for every mailer of app/mailers; a mailer's own `defaults` wins over them, and config.mail is the transport that sends them",
     keys: {
-      from: text({ describe: 'a sender address' }),
+      from: text({
+        describe: 'a sender address',
+        hint: 'Used by every message that sets none of its own',
+      }),
       layout: {
         default: 'mailer',
         describe:
           'the name of a layout in app/views/mailers/layouts, or false for none',
+        hint: 'The file is app/views/mailers/layouts/<name>.hbs and it wraps every view around {{{body}}}',
         oneOf: [{ const: false }, text()],
       },
       previews: {
@@ -978,6 +1094,7 @@ const SCHEMA = {
               query: {
                 default: 'locale',
                 describe: 'a query parameter name, or false',
+                hint: 'The parameter of ?locale=fr; false takes that one step out of the order and turns nothing else off',
                 oneOf: [{ const: false }, text()],
               },
               user: {
@@ -1005,6 +1122,7 @@ const SCHEMA = {
           path: text({
             default: 'config/locales',
             describe: 'the directory the catalogues live in',
+            hint: 'A catalogue is <locale>.json, or <locale>/<namespace>.json for one file per area; a directory that is not there means no catalogue is read at all',
           }),
           serverOnly: {
             default: ['mailers'],
@@ -1021,10 +1139,12 @@ const SCHEMA = {
 
   api: {
     describe: 'an object of JSON API settings',
+    hint: 'A block of settings and not a switch: the JSON layer is always on, and these only change the paging, the Idempotency-Key window and how strict an answer has to be',
     keys: {
       idempotency: {
         describe:
           'false, or an object ({ ttl, store }) of Idempotency-Key settings',
+        hint: 'false stops honouring Idempotency-Key on every mutating route; one route opts out on its own with `idempotent: false`',
         oneOf: [
           { const: false },
           {
@@ -1056,6 +1176,7 @@ const SCHEMA = {
       maxPerPage: {
         default: 100,
         describe: 'a whole number of records, above zero',
+        hint: 'The ceiling on ?perPage=, which is what stops a client asking for the whole table in one answer',
         integer: true,
         min: 1,
         type: 'number',
@@ -1071,6 +1192,7 @@ const SCHEMA = {
       perPage: {
         default: 25,
         describe: 'a whole number of records, above zero',
+        hint: 'The page size req.pagination() takes when a request names none; api.maxPerPage is the ceiling on the one it does',
         integer: true,
         min: 1,
         type: 'number',
@@ -1091,23 +1213,36 @@ const SCHEMA = {
     keys: {
       backoff: {
         describe: 'an object ({ base, factor, jitter, max })',
+        hint: 'The wait before the next attempt is base x factor^(attempt - 1), capped at max and spread by jitter',
         keys: {
-          base: duration({ default: '5s' }),
-          factor: positive({ default: 4, describe: 'a number above zero' }),
+          base: duration({
+            default: '5s',
+            hint: 'The wait before the second attempt; every one after it is multiplied by jobs.backoff.factor',
+          }),
+          factor: positive({
+            default: 4,
+            describe: 'a number above zero',
+            hint: 'What each attempt multiplies the wait by, until jobs.backoff.max caps it',
+          }),
           jitter: {
             default: 0.15,
             describe: 'a number between 0 and 1',
+            hint: 'The share of the wait that is randomised, so a hundred jobs that failed together do not retry together',
             max: 1,
             min: 0,
             type: 'number',
           },
-          max: duration({ default: '1h' }),
+          max: duration({
+            default: '1h',
+            hint: 'The cap on the wait, however many attempts a job has had',
+          }),
         },
         type: 'object',
       },
       concurrency: {
         default: 5,
         describe: 'a whole number of jobs, above zero',
+        hint: 'How many jobs one runner performs at once; `henri jobs --concurrency` says it for one runner',
         integer: true,
         min: 1,
         type: 'number',
@@ -1118,11 +1253,19 @@ const SCHEMA = {
         hint: 'false stops the boot from creating the tables (henri jobs:install does)',
         type: 'boolean',
       },
-      keepCompleted: duration({ default: '1d' }),
-      mailQueue: text({ default: 'mailers', describe: 'a queue name' }),
+      keepCompleted: duration({
+        default: '1d',
+        hint: 'How long a finished job stays in the table before a runner prunes it; 0 keeps them forever',
+      }),
+      mailQueue: text({
+        default: 'mailers',
+        describe: 'a queue name',
+        hint: 'Where deliverLater() puts a rendered message; a runner has to be taking from it or nothing is sent',
+      }),
       maxArgsBytes: {
         default: 524288,
         describe: 'a whole number of bytes, above zero',
+        hint: 'The serialized arguments of one job; past it the enqueue fails rather than storing a truncated payload',
         integer: true,
         min: 1,
         type: 'number',
@@ -1130,36 +1273,67 @@ const SCHEMA = {
       maxAttempts: {
         default: 5,
         describe: 'a whole number of attempts, above zero',
+        hint: 'Attempts before a job goes to the dead letter queue, where `henri jobs:dead` finds it',
         integer: true,
         min: 1,
         type: 'number',
       },
-      pollInterval: duration({ default: '1s' }),
+      pollInterval: duration({
+        default: '1s',
+        hint: 'How often a runner looks for work while the queue is empty; never under 50ms',
+      }),
       priority: {
         default: 0,
         describe: 'a number (the higher, the sooner)',
+        hint: 'What a job file declaring no `priority` of its own gets',
         type: 'number',
       },
-      queue: text({ default: 'default', describe: 'a queue name' }),
+      queue: text({
+        default: 'default',
+        describe: 'a queue name',
+        hint: 'What a job file declaring no `queue` of its own gets; jobs.queues is what a runner takes from',
+      }),
       queues: {
         describe: "a list of queue names, or one string ('a,b')",
+        hint: 'What a runner takes from when `henri jobs` is given no --queue; the string form is comma separated',
         oneOf: [text(), { of: text(), type: 'array' }],
       },
       recurring: {
         describe: 'an object of schedules, by name',
+        hint: 'A runner is what puts them on the queue, so nothing recurs unless `henri jobs` is running somewhere',
         type: 'record',
         values: {
           hint: 'A schedule needs a "cron" or an "every", never both',
           keys: {
-            args: { describe: 'the arguments of the job', type: 'any' },
-            cron: text({ describe: 'a cron expression, read in UTC' }),
-            every: duration(),
+            args: {
+              describe: 'the arguments of the job',
+              hint: 'What perform(args) receives, the same value a henri.jobs.perform() call would pass',
+              type: 'any',
+            },
+            cron: text({
+              describe: 'a cron expression, read in UTC',
+              hint: "UTC whatever the server's zone is, and it has a minute of resolution; `every` is the other way to say when",
+            }),
+            every: duration({
+              hint: 'An interval counted from the last run; `cron` is the other way to say when, and a schedule takes one of the two',
+            }),
             job: text({
               describe: 'the job name (the schedule name by default)',
+              hint: 'The file of app/jobs to perform, so a schedule may be named for what it is for rather than for the job it runs',
             }),
-            name: text({ describe: 'an alias of `job`' }),
-            priority: { describe: 'a number', type: 'number' },
-            queue: text({ describe: 'a queue name' }),
+            name: text({
+              describe: 'an alias of `job`',
+              hint: 'Write one or the other; `job` is the spelling the guide uses',
+            }),
+            priority: {
+              describe: 'a number',
+              hint: 'The priority of what this schedule enqueues; jobs.priority is what it falls back to',
+              type: 'number',
+            },
+            queue: text({
+              describe: 'a queue name',
+              hint: 'The queue this schedule enqueues into; jobs.queue is what it falls back to',
+            }),
           },
           type: 'object',
         },
@@ -1167,15 +1341,21 @@ const SCHEMA = {
       store: text({
         default: 'default',
         describe: 'the name of a store of `stores`',
+        hint: 'Which of config.stores holds the queue; it is reached with raw SQL and never through a model',
       }),
-      stuckAfter: duration({ default: '5m' }),
+      stuckAfter: duration({
+        default: '5m',
+        hint: 'Without a heartbeat for that long a running job is taken to belong to a dead runner and put back, so keep it above the longest jobs.timeout',
+      }),
       table: text({
         default: 'henri_jobs',
         describe: 'a table name: letters, digits and underscores only',
+        hint: 'henri creates it, and the schedules live next to it in <table>_schedules',
         pattern: /^[A-Za-z_][A-Za-z0-9_]*$/u,
       }),
       timeout: {
         describe: "a duration, or null for 'no limit'",
+        hint: 'How long one attempt may take, for the jobs that set none of their own; with no limit jobs.stuckAfter is what recovers a runner that died mid-job',
         oneOf: [{ const: null }, duration()],
       },
     },
@@ -1200,17 +1380,29 @@ const SCHEMA = {
       },
       backoff: {
         describe: 'an object ({ base, factor, jitter, max })',
+        hint: 'The wait before the next attempt is base x factor^(attempt - 1), capped at max and spread by jitter',
         keys: {
-          base: duration({ default: '10s' }),
-          factor: positive({ default: 3, describe: 'a number above zero' }),
+          base: duration({
+            default: '10s',
+            hint: 'The wait before the second attempt; every one after it is multiplied by webhooks.backoff.factor',
+          }),
+          factor: positive({
+            default: 3,
+            describe: 'a number above zero',
+            hint: 'What each attempt multiplies the wait by, until webhooks.backoff.max caps it',
+          }),
           jitter: {
             default: 0.2,
             describe: 'a number between 0 and 1',
+            hint: 'The share of the wait that is randomised, so a receiver that refused a hundred deliveries is not retried by all of them at once',
             max: 1,
             min: 0,
             type: 'number',
           },
-          max: duration({ default: '6h' }),
+          max: duration({
+            default: '6h',
+            hint: 'The cap on the wait, however many attempts a delivery has had',
+          }),
         },
         type: 'object',
       },
@@ -1236,14 +1428,20 @@ const SCHEMA = {
         min: 1,
         type: 'number',
       },
-      queue: text({ default: 'webhooks', describe: 'a queue name' }),
+      queue: text({
+        default: 'webhooks',
+        describe: 'a queue name',
+        hint: 'A queue of its own, so a slow receiver never delays the rest of the work; `henri jobs:list --queue webhooks` is what shows the deliveries',
+      }),
       store: text({
         default: 'default',
         describe: 'the name of a store of `stores`',
+        hint: 'Which of config.stores holds the endpoints; there is no deliveries table, because a delivery is a job',
       }),
       table: text({
         default: 'henri_webhooks',
         describe: 'a table name: letters, digits and underscores only',
+        hint: 'henri creates it and owns it: an endpoint is a row, never a model',
         pattern: /^[A-Za-z_][A-Za-z0-9_]*$/u,
       }),
       timeout: duration({
@@ -1256,6 +1454,7 @@ const SCHEMA = {
 
   rateLimit: {
     describe: 'an object of limits, true for the defaults, or false for none',
+    hint: 'Nothing is counted in development whatever this says; true is the defaults and false lifts every limit',
     oneOf: [
       { type: 'boolean' },
       {
@@ -1263,30 +1462,43 @@ const SCHEMA = {
           auth: {
             describe:
               'false, or an object ({ windowMs, max, paths }) for the login paths',
+            hint: 'A second, tighter limit on the sign-in and account paths; false leaves them to the global one',
             oneOf: [
               { const: false },
               {
                 keys: {
-                  limit: positive({ describe: 'an alias of max' }),
+                  limit: positive({
+                    describe: 'an alias of max',
+                    hint: 'The name express-rate-limit 8 uses; write this one or `max`, never both',
+                  }),
                   max: positive({
                     default: 10,
                     describe: 'a number of requests per window, above zero',
+                    hint: 'Per window and per client, on the auth paths alone; user.lockout is the count kept per account',
                   }),
                   paths: {
                     describe: 'a list of paths to guard',
+                    hint: 'It replaces the list henri guards rather than adding to it',
                     of: text(),
                     type: 'array',
                   },
-                  windowMs: positive({ default: 60000 }),
+                  windowMs: positive({
+                    default: 60000,
+                    hint: 'The window rateLimit.auth.max is counted in',
+                  }),
                 },
                 type: 'object',
               },
             ],
           },
-          limit: positive({ describe: 'an alias of max' }),
+          limit: positive({
+            describe: 'an alias of max',
+            hint: 'The name express-rate-limit 8 uses; write this one or `max`, never both',
+          }),
           max: positive({
             default: 600,
             describe: 'a number of requests per window, above zero',
+            hint: 'Per window and per client over everything outside development; config.trustProxy is what decides which client that is',
           }),
           store: {
             describe:
@@ -1294,7 +1506,10 @@ const SCHEMA = {
             hint: 'defaults to config.shared; without one the count is per process',
             oneOf: [{ const: null }, text()],
           },
-          windowMs: positive({ default: 60000 }),
+          windowMs: positive({
+            default: 60000,
+            hint: 'The window rateLimit.max is counted in',
+          }),
         },
         type: 'object',
       },
@@ -1330,7 +1545,10 @@ const SCHEMA = {
         describe: 'a key prefix',
         hint: 'Two applications sharing one server need one prefix each',
       }),
-      url: text({ describe: 'a connection string (redis://, rediss://)' }),
+      url: text({
+        describe: 'a connection string (redis://, rediss://)',
+        hint: 'Where the backend listens; every other key of this block reaches the driver, so ioredis takes tls, db, password and sentinels next to it',
+      }),
     },
     // Everything else reaches the driver (ioredis takes `tls`, `db`,
     // `password`, `sentinels`, ...), so only a misspelling is worth a word
@@ -1407,6 +1625,7 @@ const SCHEMA = {
 
   helmet: {
     describe: 'an object of helmet options, or false to disable helmet',
+    hint: "What is written here is merged over henri's defaults rather than replacing them; false takes every security header off at once",
     oneOf: [{ const: false }, { type: 'object', unknown: 'allow' }],
   },
 
@@ -1427,11 +1646,13 @@ const SCHEMA = {
   filterParameters: {
     default: ['password', 'token', 'secret', 'authorization'],
     describe: 'a list of parameter names to mask, or false',
+    hint: 'The list replaces the defaults rather than adding to them, so name password, token, secret and authorization again next to your own; they are matched as substrings, and "encryption" is masked whatever this says',
     oneOf: [{ const: false }, { of: text(), type: 'array' }],
   },
 
   logs: {
     describe: 'an object of log settings',
+    hint: 'A block, not a level: `format` is the only key, and nothing here turns a log line off',
     keys: {
       format: {
         default: 'auto',
@@ -1878,6 +2099,7 @@ const SCHEMA = {
   bodyLimit: {
     default: '1mb',
     describe: 'a size, as a string ("1mb") or a number of bytes',
+    hint: 'It bounds a JSON or urlencoded body; a multipart one is bounded by uploads.maxTotalSize and uploads.maxFileSize instead',
     oneOf: [text(), positive({ describe: 'a number of bytes above zero' })],
   },
 
@@ -1898,6 +2120,7 @@ const SCHEMA = {
           maxFieldNameSize: {
             default: 100,
             describe: 'a whole number of bytes, above zero',
+            hint: 'The name of a form field; uploads.maxFieldSize is what bounds its value',
             integer: true,
             min: 1,
             type: 'number',
@@ -1905,8 +2128,13 @@ const SCHEMA = {
           maxFieldSize: sizeLimit({
             hint: 'One non-file part of the form; defaults to config.bodyLimit',
           }),
-          maxFields: limit(100),
-          maxFileSize: sizeLimit({ default: '10mb' }),
+          maxFields: limit(100, {
+            hint: 'How many non-file fields one request may carry; false lifts the bound',
+          }),
+          maxFileSize: sizeLimit({
+            default: '10mb',
+            hint: 'The largest single file; uploads.maxTotalSize is what bounds all the parts together',
+          }),
           maxFilenameLength: {
             default: 255,
             describe: 'a whole number of characters, above zero',
@@ -1915,8 +2143,13 @@ const SCHEMA = {
             min: 1,
             type: 'number',
           },
-          maxFiles: limit(10),
-          maxTotalSize: sizeLimit({ default: '25mb' }),
+          maxFiles: limit(10, {
+            hint: 'How many files one request may carry; false lifts the bound',
+          }),
+          maxTotalSize: sizeLimit({
+            default: '25mb',
+            hint: 'Every part together, checked against Content-Length before a parser is built and then counted as the bytes arrive',
+          }),
           paths: {
             describe: "a list of path prefixes ('/api/artworks')",
             hint: 'Without it a multipart body is read on every route that takes one',
@@ -1946,6 +2179,7 @@ const SCHEMA = {
                   adapter: {
                     describe:
                       "a backend name ('s3'), or the module id of a HenriStorage",
+                    hint: "A name that is not local resolves @usehenri/<name> from the application; the keys next to it are that backend's own (a bucket, a region, an endpoint) and henri reads none of them",
                     required: true,
                     type: 'string',
                   },
@@ -1975,6 +2209,7 @@ const SCHEMA = {
                     default: 300,
                     describe:
                       'a whole number of seconds, from 1 to 604800 (a week)',
+                    hint: 'Until it expires the url is a bearer capability: whoever holds the link gets the file, with no session and no policy. A week is the ceiling because it is what S3 honours',
                     integer: true,
                     max: 604800,
                     min: 1,
@@ -2002,17 +2237,20 @@ const SCHEMA = {
                 fit: {
                   default: 'cover',
                   describe: 'one of contain, cover, fill, inside, outside',
+                  hint: "sharp's, and it decides how the box is filled: cover crops to it, contain fits inside it and pads, fill stretches",
                   enum: ['contain', 'cover', 'fill', 'inside', 'outside'],
                   type: 'string',
                 },
                 format: {
                   default: 'webp',
                   describe: 'one of avif, jpeg, png, webp',
+                  hint: 'What the variant is encoded as, whatever the source was. The build of libvips has to carry it: avif is in the prebuilt binaries and missing from some distribution packages',
                   enum: ['avif', 'jpeg', 'png', 'webp'],
                   type: 'string',
                 },
                 height: {
                   describe: 'a whole number of pixels, from 1 to 8192',
+                  hint: 'With `width` it is the box `fit` fills; one of the two is enough, and a variant needs at least one',
                   integer: true,
                   max: 8192,
                   min: 1,
@@ -2021,6 +2259,7 @@ const SCHEMA = {
                 quality: {
                   default: 80,
                   describe: 'a whole number from 1 to 100',
+                  hint: 'What the encoder is asked for; it does not mean the same thing in two formats, so it is worth setting next to `format`',
                   integer: true,
                   max: 100,
                   min: 1,
@@ -2028,6 +2267,7 @@ const SCHEMA = {
                 },
                 width: {
                   describe: 'a whole number of pixels, from 1 to 8192',
+                  hint: 'With `height` it is the box `fit` fills; one of the two is enough, and a variant needs at least one',
                   integer: true,
                   max: 8192,
                   min: 1,
@@ -2046,11 +2286,13 @@ const SCHEMA = {
   requestTimeout: {
     default: 30000,
     describe: 'a number of milliseconds above zero, or false',
+    hint: 'A request with no answer by then is sent a 503, and nothing is sent once the headers are out (a stream, an event source). The handler keeps running either way: req.timedout is what it can read before doing more work',
     oneOf: [{ const: false }, positive()],
   },
 
   shutdown: {
     describe: 'an object of graceful shutdown settings',
+    hint: 'Keep shutdown.delay plus shutdown.drain under the termination grace period of the platform, which is thirty seconds on Kubernetes, so the process leaves before it is killed',
     keys: {
       delay: {
         default: 0,
@@ -2140,6 +2382,7 @@ const SCHEMA = {
 
   errors: {
     describe: 'an object of error code settings',
+    hint: 'The one key is `url`, the template that turns a code into a link; the codes themselves are always there and this block only decides whether a message carries an address',
     keys: {
       url: {
         describe: 'a url template holding {code}',

--- a/packages/core/src/base/config-validate.js
+++ b/packages/core/src/base/config-validate.js
@@ -426,8 +426,18 @@ function walk(node, value, key, context) {
         return;
       }
 
+      // An item inherits the list's hint the way a branch inherits the
+      // union's, and for the same reason: what to do about `retention.
+      // approved` is what to do about the token that is wrong inside it,
+      // and a schema that had to repeat the sentence on every `of` node
+      // would end up not saying it at all
       value.forEach((entry, index) =>
-        walk(node.of, entry, `${key}[${index}]`, context)
+        walk(
+          { ...node.of, hint: node.of.hint || node.hint },
+          entry,
+          `${key}[${index}]`,
+          context
+        )
       );
 
       return;

--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -936,6 +936,15 @@ config ✖ "secret" must be a string, but it is a number => from the credentials
 
 The source matters: `port must be a number` is unhelpful when the culprit is an environment variable three deployments away. A value the [filters](#headers-logs-and-limits) name, and anything the credentials provided, is printed as its type alone; the password of a connection string is always masked.
 
+**And what to do about it is on the next line.** Nearly every key of the schema carries one, and it says the thing the expectation could not: the command that fixes it, the other key that decides the same thing, the package the value needs, or the consequence of the value that arrived.
+
+```
+config ✖ "filterParameters[1]" must be a string, but it is the number 7 => from config/default.json
+config ✖ The list replaces the defaults rather than adding to them, so name password, token, secret and authorization again next to your own; they are matched as substrings, and "encryption" is masked whatever this says
+```
+
+An item of a list inherits the hint of the list, the way a value of a union inherits the union's: what to do about `retention.approved` is what to do about the token that is wrong inside it. Two keys carry no hint on purpose — where "a path to land on once the address is confirmed" leaves nothing to add, henri says nothing rather than padding.
+
 `henri server` exits `1` and `henri server --json` prints the same thing as `{ "error": { "code": "HENRI_CONFIG_INVALID", "message", "hint", "problems": [...] } }`, where each problem is `{ key, level, message, expected, received, source, hint }`. See [Error codes](/reference/errors/).
 
 **An unknown key is a warning, never a failure.** An application may carry keys of its own — `henri.config.get()` is how it reads them — so henri says it ignores the key and boots:


### PR DESCRIPTION
## What

#414 audited every failure henri raises and made the catalogue's "how to fix it" reach the terminal. It named what it left, and this is that: **140 of the schema's 331 addressable nodes had no `hint`**, so their message said what the value must be and stopped — and configuration is the failure people hit first, before the application has ever run.

**138 gained one**, drawn from `configuration.md`, the guides and the source, and checked against the code wherever the claim was load-bearing: `afterLogin`'s browser/JSON split, `binding.enabled`'s marker-decides rule, pepper rotation, `requestTimeout` not stopping the handler, `mail`'s absent-key warning, `baseRole` as the `roles` default, the graphql parser bound, who enqueues a recurring schedule.

**Two were left on purpose**, named in the test with the reason: `user.confirmation.after` and `user.identities.after`, whose `describe` ("a path to land on once the address is confirmed") leaves nothing to add and whose flows have no neighbouring key to point at. Anything else would have been padding.

## A mechanism gap, found and closed

A union branch inherited the union's hint. **An array item inherited nothing**, so `filterParameters[1]` and `retention.approved[1]` reached the terminal with no next step at all. `config-validate.js` now passes a list's hint down to its items — one line, and the same rule `oneOf` already followed. It changes no validation, only what the message carries.

## The durable half

The two readers `error-codes.spec.js` had inline — commands read out of `packages/cli` itself, keys out of the schema — moved to `__tests__/instructions.js`, and the catalogue spec now requires them instead of duplicating them. The new `instructions.spec.js` runs them over the schema's `hint` and `describe` **and over every hint the command line ships** (162 literals extracted from source).

It fails on: a command henri does not have, a key the schema does not declare, an `@usehenri/` package not in the workspace, a `base/*.js` that moved, a hint that only restates its `describe`, and a key that quietly loses its hint.

**I verified it bites rather than taking it on report.** Poisoning one hint with `` `henri unicorn` `` and `config.nonexistent.thing` fails two rules by name:

```
user|1.identities|1.providers.*.hint: there is no `henri unicorn` command
user|1.identities|1.providers.*.hint: config.nonexistent.thing is not a key
```

and deleting a hint from a node that had one fails the third ("every key a person can be sent to says what to do about it").

Two reader improvements went with it: a **bare** `henri db:status` in a sentence is now read as a command rather than only a backticked one (the colon form is where every renamed subcommand lives), and paths under a node marked `unknown: 'allow'` are accepted — `config.helmet.contentSecurityPolicy` is helmet's to declare, not henri's.

**Nothing false was found in the existing text**: no wrong command, no undeclared key, no stale package or file reference, in the schema or in the catalogue under the widened rule. I spot-checked two of the new hints against the source myself — `requestTimeout` (a 503, nothing once the headers are out, `req.timedout` for a long handler) and `baseRole` (the default of the `roles` column, `[]` without the key) — and both match.

## The command line half, which #414 also left

All 105 `CliError` sites read against the bar. 96 already carried a hint and none of them changed. Four were wrong or thin:

- `build.js` — the catalogue's fix for `HENRI_CLI_NOT_INSTALLED` is *"run the install command the message prints"*, and this site printed none. It now prints one and names the renderer that asked.
- `console.js` — inherited *"run without --sandbox, a sandbox is only honest on drizzle"*, which is the wrong diagnosis: the adapter **does** hold a sandbox and the transaction is what failed to open.
- `credentials.js` — three sites that explained or reassured without a next step now name `EDITOR="code --wait"` and `henri credentials:edit`.

Three catch-all sites keep the catalogue's `--debug=henri:*` fix, which is the right answer there.

## Gates

`pnpm test` (3950), `pnpm test:types`, `pnpm lint --max-warnings 0`, `pnpm format:check`, `scripts/smoke.sh` end to end (`henri audit`: nothing found in 52 checks), and the showcase suite against a live PostgreSQL (170).