### PR TITLE
Slugs, a third identifier that only ever names a url

### DIFF
--- a/.changeset/slugs.md
+++ b/.changeset/slugs.md
@@ -1,0 +1,38 @@
+---
+'@usehenri/cli': minor
+'@usehenri/core': minor
+'@usehenri/drizzle': minor
+'@usehenri/mongoose': minor
+'@usehenri/sequelize': minor
+---
+
+Slugs: `/articles/how-we-ship` rather than the uuid.
+
+A model asks for a name in its options and henri does the rest — a unique, indexed, `NOT NULL` `slug` column, filled on the insert, resolved by `findById()` and printed in every url that names the record:
+
+```js
+// app/models/Article.js
+module.exports = {
+  options: { slug: 'title', timestamps: true },
+  schema: {
+    body: { type: 'text' },
+    title: { type: 'string', required: true },
+  },
+};
+```
+
+`henri generate scaffold Article title:string! --slug title` writes the declaration, the controller and the pages together, and a generator run over a model that already has one reads it back, so nothing needs hand-wiring.
+
+**A slug is a third identifier, and it stays in its lane.** It appears in the record's own `slug` field and in the **url** of that record — `_links`, the path helpers, the `Location` of a `201` — and nowhere else. A foreign key is still published as the `externalId` of the row it names, and the versions table, the access trail, the flags actor and the erasure receipts all keep reading `externalId`. The uuid is what an API client stores; the slug is what a person reads.
+
+**A lookup cannot be talked into a primary key.** `findById()` resolves a uuid against `externalId` as before, and anything else against the **slug column** — a `WHERE slug = ?`, not a fallthrough — and that is the end of it. `findById('42')` asks the slug column for `'42'`; it cannot say whether row 42 exists, and the `null` it answers is the same `null` an unknown name gets. A model with a slug takes the whole non-uuid space with it, `externalIds.lookup: "any"` included, so the primary key is `findByKey()`'s alone. A slug shaped like a uuid is refused, so the two identifier spaces never overlap. `findBySlug()` is the explicit half.
+
+**Two articles called "Getting started" is the normal case**, and henri answers it without a `SELECT` before the `INSERT` — the same position it takes on `unique` in validations. By default the slug carries a six character discriminator taken from the record's own `externalId` (`getting-started-k3f9pq`): unique because the uuid is, stable because the uuid never changes, and free because nothing is read. The cost is those six characters in every url. `slug: { from: 'title', suffix: false }` gives the bare `getting-started` instead, and then the **unique index is what holds**: the second one is refused by the database as `{ slug: 'must be unique' }`.
+
+**A slug does not move.** `on: 'create'` is the default, so the url minted the day the record was written keeps working whatever the title becomes. `on: 'change'` follows the source, and the old url **stops working that instant** — henri keeps no history of slugs and answers no `301`. On such a model a mass update naming the source field is refused (`HENRI_MODEL_SLUG_MASS_WRITE`) with the loop to write instead, because one hook runs for the whole write and every row would get the same name.
+
+**Unicode without a transliteration table.** The title is lowercased, decomposed (NFKD) and reduced to `a-z0-9`, so `Café Crème` is `cafe-creme` — that is `String#normalize`, not a table. Eleven Latin letters Unicode does not decompose get a line each (`æ ð đ ħ ı ł ø œ ß þ ŧ`), so `Straße` is `strasse` and `Łódź` is `lodz`, and that is the whole of it: a Japanese, Chinese, Arabic, Hebrew, Greek or Cyrillic title folds to nothing, deliberately. With the discriminator on, such a record still gets a working url; with `suffix: false` the write is refused (`HENRI_MODEL_SLUG_EMPTY`) rather than writing an empty name. And **a slug the application writes itself always wins and may be in any script** — `slug: 'こんにちは'` is stored, matched and carried percent-encoded — so the choice between folding and percent-encoding is the application's, not henri's.
+
+A supplied slug is measured against the characters that would stop it being one path segment (a space, a control character, and the seventeen that end a segment, start a query, escape an encoding or name a directory), plus `.`, `..` and the paths henri already mounts (`new`; `reserved` adds your own). Nothing in the slugifier is a regular expression: it walks the code points once, with the length bound applied as it goes, because a title arrives through `req.permit()`.
+
+A declaration henri cannot carry out fails the boot naming the model (`HENRI_MODEL_SLUG_DECLARATION_INVALID`). `henri openapi` describes the path parameter as the slug and drops the `uuid` format for that model, and `henri generate agents` lists the mark.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -515,6 +515,40 @@ model }` or Mongoose's `ref` -- which `res.render()`, `res.resource()`,
   `henri.model.errors(error)` (`base/model-errors.js`) normalizes the three
   ORMs' validation failures to `{ field: message }`, `null` for anything else.
   `henri db:seed` runs `db/seeds.js` on any adapter.
+- **A slug is a third identifier and it only ever names a url**
+  (`base/slug.js`, a copy per adapter the way `validations.js` is).
+  `options: { slug: 'title' }` adds a unique, indexed, `NOT NULL` `slug`
+  column, henri fills it on the insert, and `hateoas.identify()` --
+  through `references.nameOf()`, which asks the model table rather than
+  the record, so an application's own `slug` column keeps the urls it had
+  -- prints it in `_links`, the route helpers and the `Location` of a 201.
+  Nowhere else: a foreign key is still the target's `externalId`, and so
+  is every identifier the versions table, the trail, the flags actor and
+  the receipts hold. `findById()` resolves a uuid against `externalId`
+  and **anything else against the slug column** -- a `WHERE slug = ?`,
+  never a fallthrough -- so a primary key answers the same `null` an
+  unknown name answers; a model with a slug takes the whole non-uuid
+  space with it, `externalIds.lookup: "any"` included, and a slug shaped
+  like a uuid is refused so the two spaces never overlap. `findBySlug()`
+  is the explicit half and `internalId()` follows the same rule. **No
+  `SELECT` before the `INSERT`**, the position `validates` already takes
+  on `unique`: the default appends a six character discriminator derived
+  from the record's own `externalId` (`getting-started-k3f9pq`), and
+  `suffix: false` gives the bare name and leaves the unique index to
+  refuse the second one. `on: 'create'` (the default) never moves the
+  url; `on: 'change'` follows the source, the old url 404s -- there is no
+  history table -- and a mass update naming the source is
+  `HENRI_MODEL_SLUG_MASS_WRITE`. Unicode is NFKD plus eleven Latin
+  letters it does not decompose and nothing else, so a Japanese, Arabic
+  or Cyrillic title folds to nothing and the discriminator is what makes
+  its url work (`HENRI_MODEL_SLUG_EMPTY` with `suffix: false`); a slug
+  the application writes itself always wins and may be in any script,
+  carried percent-encoded. **No regular expression anywhere in the
+  file** -- it walks the code points with the bound applied as it goes,
+  because a title arrives through `req.permit()`.
+  `henri generate scaffold --slug <field>` writes the declaration, the
+  controller and the pages, and a later generator reads the mark back off
+  the model file. The guide is `guides/models.md` (`#slugs`).
 - **What must be true of a record is `validates`** (`base/validations.js`,
   a copy per adapter the way `exact.js` is, kept byte identical by
   `src/__tests__/validations.spec.js`): a block keyed by field, in the
@@ -1625,5 +1659,24 @@ filters.spec.js`), on MongoDB through the demo application core's suite
   lockout stay keyed by address; and there is no `henri tenants` command,
   because henri holds no list of tenants.
 
+- Slugs are new. There is **no history table**: `on: 'change'` retires the
+  old url the moment the title is written, and henri answers no `301` --
+  `friendly_id`'s answer is a table on four adapters plus a redirect, a
+  retention rule and a reach for the erasure, and it is a tranche of its
+  own. Also not here: a slug unique per tenant or per parent (a composite
+  index henri would have to write into a migration it does not own), a
+  route that resolves a name across models, and any romanization at all --
+  the fold is `String#normalize` plus eleven letters, so a title with no
+  Latin in it produces nothing and the discriminator is what answers.
+  `privacy:erase` does **not** rewrite a slug, because rewriting an
+  identifier 404s every url that pointed at the record; a `from` marked
+  `personal: { expose: false }` is refused at boot, and a plain
+  `personal: true` one is allowed and said out loud in the guide.
+  Coverage: sqlite and MongoDB offline, PostgreSQL and MySQL through
+  `pnpm test:sql:live`, the demo application's own `Article` resource for
+  the router and the HAL links, and
+  `packages/cli/__tests__/generate.spec.js` for the generator. MSSQL
+  rides the Sequelize wiring with no coverage of its own, like the rest
+  of that adapter.
 - The scaffolded app pins ESLint 9 because `eslint-plugin-react` does not
   support ESLint 10 yet.

--- a/packages/cli/__tests__/generate.spec.js
+++ b/packages/cli/__tests__/generate.spec.js
@@ -985,6 +985,90 @@ describe('henri generate', () => {
     });
   });
 
+  describe('scaffold --slug', () => {
+    beforeAll(() => {
+      const result = henri(
+        [
+          'g',
+          'scaffold',
+          'Article',
+          'title:string!',
+          'body:text',
+          '--slug',
+          'title',
+        ],
+        { cwd: app }
+      );
+
+      if (result.status !== 0) {
+        throw new Error(result.stdout + result.stderr);
+      }
+    });
+
+    test('declares the name on the model', () => {
+      const model = read(app, 'app/models/Article.js');
+
+      expect(model).toContain("slug: 'title'");
+      expect(() => parseFile(app, 'app/models/Article.js')).not.toThrow();
+    });
+
+    test('writes a controller whose redirects carry the slug', () => {
+      const controller = read(app, 'app/controllers/articles.js');
+
+      expect(controller).toContain('/articles/${article.slug}');
+      expect(controller).toContain('/articles/${req.article.slug}');
+      expect(controller).not.toContain('article.externalId');
+      expect(() => parseFile(app, 'app/controllers/articles.js')).not.toThrow();
+    });
+
+    test('writes pages that link with the slug', () => {
+      const index = read(app, 'app/views/pages/articles/index.jsx');
+      const show = read(app, 'app/views/pages/articles/show.jsx');
+
+      expect(index).toContain("getRoute('show_articles_path', item.slug)");
+      expect(index).toContain('key={item.slug}');
+      expect(show).toContain('const id = item.slug;');
+      expect(index).not.toContain('externalId');
+      expect(() =>
+        parseFile(app, 'app/views/pages/articles/index.jsx')
+      ).not.toThrow();
+    });
+
+    test('reads the name back off the model for a later generator', () => {
+      // No flag this time: the model file is what says the resource has a
+      // name, so a controller written over a model that already has one is
+      // never half wired
+      fs.writeFileSync(
+        path.join(app, 'app', 'models', 'Chapter.js'),
+        "module.exports = { options: { slug: 'title', timestamps: true }, schema: { title: { type: 'string' } } };\n"
+      );
+
+      const result = henri(['g', 'crud', 'Chapter', 'title:string'], {
+        cwd: app,
+      });
+
+      expect(result.status).toBe(0);
+      // A crud controller answers JSON and builds no redirect, so what
+      // says the name reached it is the lookup it documents
+      expect(read(app, 'app/controllers/chapters.js')).toContain(
+        'is the slug of the chapter'
+      );
+    });
+
+    test('refuses a --slug naming an attribute the model has not got', () => {
+      const result = henri(
+        ['g', 'scaffold', 'Ghost', 'body:text', '--slug', 'title'],
+        { cwd: app }
+      );
+
+      expect(result.status).not.toBe(0);
+      expect(`${result.stdout}${result.stderr}`).toContain(
+        'no title attribute'
+      );
+      expect(exists(app, 'app/models/Ghost.js')).toBe(false);
+    });
+  });
+
   test('keeps config/routes.js valid after every change', () => {
     expect(() => parseFile(app, 'config/routes.js')).not.toThrow();
     expect(fs.existsSync(path.join(app, 'config', 'routes.js'))).toBe(true);

--- a/packages/cli/__tests__/json.spec.js
+++ b/packages/cli/__tests__/json.spec.js
@@ -70,7 +70,7 @@ describe('--json', () => {
         '--json',
       ]);
       expect(generate.targets.map((target) => target.name)).toContain(
-        'scaffold <Name> [field:type[!] ...]'
+        'scaffold <Name> [field:type[!] ...] [--slug <field>]'
       );
       expect(generate.examples[0].command).toContain('henri generate model');
     });

--- a/packages/cli/scripts/agents.js
+++ b/packages/cli/scripts/agents.js
@@ -328,6 +328,7 @@ const modelFacts = (source, name) => {
       .filter((field) => marked(field.body, 'personal'))
       .map((field) => field.name),
     retention: marked(options, 'retention'),
+    slug: marked(options, 'slug'),
     store: storeOf(source),
   };
 };
@@ -675,6 +676,10 @@ const modelSection = (facts) => {
       held.push('a retention rule');
     }
 
+    if (model.slug) {
+      held.push('a slug (its urls carry the name, not the uuid)');
+    }
+
     if (held.length > 0) {
       marks.push(`\`${model.name}\` carries ${held.join(', ')}`);
     }
@@ -683,7 +688,7 @@ const modelSection = (facts) => {
   const carried =
     marks.length === 0
       ? ''
-      : `\n\nMarks this application already made: ${marks.join('; ')}. Keep them when you edit those models: \`personal\` is what henri masks in the logs, hands to \`henri privacy:export\` and removes in \`henri privacy:erase\`; \`encrypted\` is ciphertext in the column and the plain string on the model; a \`retention\` rule is swept by \`henri retention:sweep\`.`;
+      : `\n\nMarks this application already made: ${marks.join('; ')}. Keep them when you edit those models: \`personal\` is what henri masks in the logs, hands to \`henri privacy:export\` and removes in \`henri privacy:erase\`; \`encrypted\` is ciphertext in the column and the plain string on the model; a \`retention\` rule is swept by \`henri retention:sweep\`; a \`slug\` is the name a url of that record carries, written by henri and resolved by \`findById()\` next to the externalId.`;
 
   return `## Models (\`${facts.api}\`)
 

--- a/packages/cli/scripts/generate.js
+++ b/packages/cli/scripts/generate.js
@@ -62,7 +62,13 @@ const NAMELESS = ['agents', 'authentication'];
 const main = async (args) => {
   const [cmd, target, ...rest] = args._;
   const report = new Report({ command: 'generate', json: args.json === true });
-  const opts = { force: args.force === true, report };
+  const opts = {
+    force: args.force === true,
+    report,
+    // `--slug title`: the model gets a name a person reads in a url, and
+    // the controller and the pages are written to use it (base/slug.js)
+    slug: typeof args.slug === 'string' && args.slug !== '' ? args.slug : null,
+  };
 
   if (!cmd) {
     console.log(usage('generate'));
@@ -160,15 +166,32 @@ const model = async (name, attributes = [], opts = {}) => {
   const { doc } = names(name);
   const schema = parseAttributes(attributes);
 
+  if (opts.slug && !schema[opts.slug]) {
+    throw new CliError(
+      'USAGE',
+      `--slug ${opts.slug}: ${doc} has no ${opts.slug} attribute to build a name from`,
+      {
+        hint: `henri generate scaffold ${doc} ${opts.slug}:string --slug ${opts.slug}`,
+      }
+    );
+  }
+
   const code = `
 // Models are autoloaded from app/models and exposed globally (here: \`${doc}\`).
 // Types: ${TYPES.join(', ')}.
 // Keys: type, required, default, enum, unique, index (anything else is
 // handed to the adapter as is).
-
+${
+  opts.slug
+    ? `// \`slug\` is the name a person reads in a url: henri adds the column,
+// fills it from \`${opts.slug}\` on insert and never moves it again, and
+// \`findById()\` resolves it next to the externalId. See the models guide.
+`
+    : ''
+}
 /** @type {import('@usehenri/core').ModelFile} */
 module.exports = {
-  options: { timestamps: true },
+  options: { ${opts.slug ? `slug: '${opts.slug}', ` : ''}timestamps: true },
   schema: ${util.inspect(schema, { depth: 6 })},
   store: 'default', // a store name from config/default.json
 };
@@ -652,6 +675,7 @@ const resources = async (name, attributes = [], opts = {}) => {
     api: apiOf(process.cwd()),
     keys: extractKeys(attributes),
     renderer: rendererOf(process.cwd()),
+    slug: hasSlug(names(name).doc, opts),
   };
   const generator = require('./generate/controllers');
 
@@ -680,6 +704,7 @@ const crud = async (name, attributes = [], opts = {}) => {
     api: apiOf(process.cwd()),
     keys: extractKeys(attributes),
     renderer: rendererOf(process.cwd()),
+    slug: hasSlug(names(name).doc, opts),
   };
   const generator = require('./generate/controllers');
 
@@ -717,6 +742,46 @@ const extractKeys = (args = []) =>
   args.map((val) => val.split(':')[0].replace(/!$/, ''));
 
 /**
+ * Does this model carry a slug -- the name a person reads in a url?
+ *
+ * `--slug` says so for a model this run is writing; for one that is already
+ * there, the model file itself does. So `henri generate crud Article` over
+ * a model that declared a name writes the controller that uses it, with no
+ * flag repeated (see base/slug.js).
+ *
+ * @param {string} doc The model's global id (ex: Article)
+ * @param {object} [opts] { slug }
+ * @returns {boolean} true when the urls of this resource carry a slug
+ */
+const hasSlug = (doc, opts = {}) => {
+  if (opts.slug) {
+    return true;
+  }
+
+  const location = path.join(process.cwd(), 'app', 'models', `${doc}.js`);
+
+  if (!fs.existsSync(location)) {
+    return false;
+  }
+
+  try {
+    delete require.cache[require.resolve(location)];
+
+    const declared = (require(location).options || {}).slug;
+
+    return Boolean(
+      typeof declared === 'string'
+        ? declared
+        : declared && typeof declared === 'object' && declared.from
+    );
+  } catch {
+    // A model file that will not load is a boot failure, not this
+    // command's to report: it writes the urls it always wrote
+    return false;
+  }
+};
+
+/**
  * Compile one view template into app/views/pages/<plural>/<view>, a `.jsx`
  * page for the Inertia renderer and a `.js` one for the Next.js renderer
  *
@@ -730,6 +795,7 @@ const compileView = async (
     lower,
     plural,
     keys = [],
+    slug = false,
     view = 'index',
     renderer = DEFAULT_RENDERER,
   },
@@ -745,7 +811,13 @@ const compileView = async (
     'view',
     `app/views/pages/${plural}`,
     `${view}.${PAGE_EXTENSIONS[renderer]}`,
-    template({ doc, keys, lower, plural }),
+    template({
+      doc,
+      identifier: slug ? 'slug' : 'externalId',
+      keys,
+      lower,
+      plural,
+    }),
     opts
   );
 };

--- a/packages/cli/scripts/generate/controllers.js
+++ b/packages/cli/scripts/generate/controllers.js
@@ -32,6 +32,14 @@
  * 404 below -- and a redirect is built from `record.externalId`, never from
  * the numeric id, which does not leave the server.
  *
+ * A model that declared `options: { slug: ... }` has a second public name,
+ * and the urls of this resource carry that one instead (`base/slug.js`):
+ * `slug` is true in the resource, the redirects are built from
+ * `record.slug`, and `findById()` resolves the slug and the `externalId`
+ * both. It is still never the primary key. The generator reads the model
+ * file back for this, so a resource written over a model that already has a
+ * name gets the right urls with no flag at all.
+ *
  * Two things do not need a flavour: `Model.paginate()` answers the same
  * `{ records, page, perPage, total, pages }` on the three model APIs, and
  * `henri.model.errors()` normalizes what any of them throws on an invalid
@@ -39,6 +47,15 @@
  */
 
 const DEFAULT_API = 'mongoose';
+
+/**
+ * The field a url of this resource is built from: the slug of a model that
+ * declared one, its public identifier otherwise
+ *
+ * @param {object} opts { slug }
+ * @returns {string} `slug` or `externalId`
+ */
+const identifierOf = ({ slug }) => (slug ? 'slug' : 'externalId');
 
 /**
  * The api of a resource, `mongoose` when it is not one we know
@@ -185,12 +202,20 @@ const page = ({ doc, plural }) => `
  * @param {string} lookup The source code setting `req.<lower>`
  * @returns {string} The source code
  */
-const loadHelper = ({ doc, lower }, lookup) => `
+const loadHelper = ({ doc, lower, slug }, lookup) => `
 /**
  * Loads the ${lower} of \`:id\` into \`req.${lower}\`, the way rails'
  * before_action does. A hook that answers ends the request: the actions
  * below only ever run with a record.
- *
+ *${
+   slug
+     ? `
+ * \`:id\` here is the slug of the ${lower} (\`options: { slug }\` on the
+ * model): \`findById()\` resolves it, and the \`externalId\` next to it,
+ * and never the primary key.
+ *`
+     : ''
+ }
  * \`res.notFound()\` rather than \`res.boom.notFound()\`: a policy that
  * refuses this record answers the same 404, and the two have to be one
  * answer. The reason reaches a developer and is dropped in production,
@@ -389,7 +414,7 @@ const create = (opts) => `
     ${of('create', opts)}
     // 201 with a Location header pointing at the new ${opts.lower}
     return res.negotiate({
-      html: () => res.redirect(\`/${opts.plural}/\${${opts.lower}.externalId}\`),
+      html: () => res.redirect(\`/${opts.plural}/\${${opts.lower}.${identifierOf(opts)}}\`),
       json: () => res.resource(${opts.lower}, { status: 201 }),
     });
   },`;
@@ -423,7 +448,7 @@ const update = (opts) => `
     ${of('update', opts)}
     return res.negotiate({
       html: () =>
-        res.redirect(\`/${opts.plural}/\${req.${opts.lower}.externalId}\`),
+        res.redirect(\`/${opts.plural}/\${req.${opts.lower}.${identifierOf(opts)}}\`),
       json: () => res.resource(req.${opts.lower}),
     });
   },`;

--- a/packages/cli/scripts/generate/inertia-edit.hbs
+++ b/packages/cli/scripts/generate/inertia-edit.hbs
@@ -21,8 +21,8 @@ const Edit = () => {
     );
   }
 
-  // The public identifier: a url never carries the numeric id of a record
-  const id = item.externalId;
+  // The identifier a url of this record carries; never the numeric id
+  const id = item.{{identifier}};
 
   return (
     <main className="mx-auto w-full max-w-lg px-6 py-12">

--- a/packages/cli/scripts/generate/inertia-index.hbs
+++ b/packages/cli/scripts/generate/inertia-index.hbs
@@ -55,23 +55,23 @@ export default function Index() {
             )}
             { {{plural}}.map((item) => (
               <tr
-                key={item.externalId}
+                key={item.{{identifier}} }
                 className="hover:bg-zinc-50 dark:hover:bg-zinc-900"
               >
                 {{#each keys}}
                 <td className={cell}>{String(item.{{this}} ?? '')}</td>
                 {{/each}}
                 <td className={`${cell} space-x-4 whitespace-nowrap text-right`}>
-                  <Link className={link} href={getRoute('show_{{plural}}_path', item.externalId)}>
+                  <Link className={link} href={getRoute('show_{{plural}}_path', item.{{identifier}})}>
                     Show
                   </Link>
-                  <Link className={link} href={getRoute('edit_{{plural}}_path', item.externalId)}>
+                  <Link className={link} href={getRoute('edit_{{plural}}_path', item.{{identifier}})}>
                     Edit
                   </Link>
                   <button
                     className="text-sm text-red-600 hover:underline dark:text-red-400"
                     type="button"
-                    onClick={() => destroy(item.externalId)}
+                    onClick={() => destroy(item.{{identifier}})}
                   >
                     Destroy
                   </button>

--- a/packages/cli/scripts/generate/inertia-show.hbs
+++ b/packages/cli/scripts/generate/inertia-show.hbs
@@ -20,8 +20,8 @@ const Show = () => {
     );
   }
 
-  // The public identifier: a url never carries the numeric id of a record
-  const id = item.externalId;
+  // The identifier a url of this record carries; never the numeric id
+  const id = item.{{identifier}};
 
   return (
     <main className="mx-auto w-full max-w-2xl px-6 py-12">

--- a/packages/cli/scripts/generate/react-edit.hbs
+++ b/packages/cli/scripts/generate/react-edit.hbs
@@ -21,8 +21,8 @@ const Edit = ({ data: { {{lower}} = null }, getRoute, pathFor, router }) => {
     );
   }
 
-  // The public identifier: a url never carries the numeric id of a record
-  const id = item.externalId;
+  // The identifier a url of this record carries; never the numeric id
+  const id = item.{{identifier}};
 
   return (
     <main className="mx-auto w-full max-w-lg px-6 py-12">

--- a/packages/cli/scripts/generate/react-index.hbs
+++ b/packages/cli/scripts/generate/react-index.hbs
@@ -53,23 +53,23 @@ const Index = ({ data: { {{plural}} = [] }, fetch, getRoute, hydrate, pathFor })
             )}
             { {{plural}}.map((item) => (
               <tr
-                key={item.externalId}
+                key={item.{{identifier}} }
                 className="hover:bg-zinc-50 dark:hover:bg-zinc-900"
               >
                 {{#each keys}}
                 <td className={cell}>{String(item.{{this}} ?? '')}</td>
                 {{/each}}
                 <td className={`${cell} space-x-4 whitespace-nowrap text-right`}>
-                  <Link className={link} href={getRoute('show_{{plural}}_path', item.externalId)}>
+                  <Link className={link} href={getRoute('show_{{plural}}_path', item.{{identifier}})}>
                     Show
                   </Link>
-                  <Link className={link} href={getRoute('edit_{{plural}}_path', item.externalId)}>
+                  <Link className={link} href={getRoute('edit_{{plural}}_path', item.{{identifier}})}>
                     Edit
                   </Link>
                   <button
                     className="text-sm text-red-600 hover:underline dark:text-red-400"
                     type="button"
-                    onClick={() => destroy(item.externalId)}
+                    onClick={() => destroy(item.{{identifier}})}
                   >
                     Destroy
                   </button>

--- a/packages/cli/scripts/generate/react-show.hbs
+++ b/packages/cli/scripts/generate/react-show.hbs
@@ -20,8 +20,8 @@ const Show = ({ data: { {{lower}} = null }, getRoute }) => {
     );
   }
 
-  // The public identifier: a url never carries the numeric id of a record
-  const id = item.externalId;
+  // The identifier a url of this record carries; never the numeric id
+  const id = item.{{identifier}};
 
   return (
     <main className="mx-auto w-full max-w-2xl px-6 py-12">

--- a/packages/cli/scripts/help.js
+++ b/packages/cli/scripts/help.js
@@ -740,6 +740,11 @@ const COMMANDS = [
           'Creates a model, a controller with the resources actions, the matching resources routes and the views',
       },
       {
+        command: 'henri g scaffold Article title:string! --slug title',
+        description:
+          'The same, with a slug: the urls carry /articles/how-we-ship rather than the uuid',
+      },
+      {
         command: 'henri g worker cleanup',
         description: 'Creates app/workers/cleanup.js with start and stop',
       },
@@ -815,12 +820,12 @@ const COMMANDS = [
       },
       {
         description: 'model, JSON controller and the crud routes',
-        name: 'crud <Name> [field:type[!] ...]',
+        name: 'crud <Name> [field:type[!] ...] [--slug <field>]',
       },
       {
         description:
-          'model, resources controller, resources routes and the pages',
-        name: 'scaffold <Name> [field:type[!] ...]',
+          'model, resources controller, resources routes and the pages. `--slug <field>` gives the model a name a person reads in a url and writes the controller and the pages to use it',
+        name: 'scaffold <Name> [field:type[!] ...] [--slug <field>]',
       },
       {
         description:

--- a/packages/core/error-codes.json
+++ b/packages/core/error-codes.json
@@ -1492,6 +1492,38 @@
     {
       "area": "model",
       "causes": [
+        "an `options.slug` naming a field the schema does not declare, or one that is not a `string` or a `text`",
+        "an `options.slug` built from an `encrypted` field, which is not public and has nothing a url could carry",
+        "an `options.slug` built from a field marked `personal: { expose: false }`, which henri drops from every answer it builds",
+        "a schema that declares a `slug` field of its own next to `options.slug`: henri adds the column",
+        "an unknown key, or an `on` that is neither `create` nor `change`"
+      ],
+      "code": "HENRI_MODEL_SLUG_DECLARATION_INVALID",
+      "fix": "The message names the model and what is wrong with the declaration. `options: { slug: 'title' }` is the whole of it for most models; the object form takes `from`, `on` (`create` or `change`), `suffix`, `reserved` and `maxLength`, and the column is always called `slug` and always added by henri. See the Models guide.",
+      "what": "A model's `options.slug` asks for a name henri cannot build."
+    },
+    {
+      "area": "model",
+      "causes": [
+        "a title in a script henri folds nothing to (Japanese, Chinese, Arabic, Hebrew, Greek, Cyrillic) on a model that declared `slug: { suffix: false }`",
+        "a source field that is empty, or holds something that is not text, on such a model"
+      ],
+      "code": "HENRI_MODEL_SLUG_EMPTY",
+      "fix": "`suffix: false` means the slug is the folded source and nothing else, so a source that folds to nothing leaves no name to write. Either write the slug yourself (an application-supplied slug always wins and may be in any script) or drop `suffix: false`, which appends a six character discriminator and therefore always answers something. henri ships no transliteration table and folds only what Unicode itself decomposes; the Models guide says which scripts that covers.",
+      "what": "A slug was to be built from a source there is nothing to build one from."
+    },
+    {
+      "area": "model",
+      "causes": [
+        "`Model.update(where, attrs)` or `updateMany` naming the source field, on a model that declared `slug: { on: 'change' }`"
+      ],
+      "code": "HENRI_MODEL_SLUG_MASS_WRITE",
+      "fix": "One hook runs for the whole write and no record is named by it, so henri would either give every row the same slug or leave them all stale. Loop over the records instead (`for (const record of await Model.find(where)) await record.update(attrs)`) and each one gets its own name. A model whose slug is generated once (`on: 'create'`, the default) has nothing to regenerate and mass updates keep working.",
+      "what": "A mass update named the field a model regenerates its slug from."
+    },
+    {
+      "area": "model",
+      "causes": [
         "a `decimal` or a `bigint` on a sqlite store served by `@usehenri/sequelize`, whose driver reads both through a JavaScript number",
         "a Sequelize `DECIMAL` with no precision, which MySQL makes `DECIMAL(10, 0)` -- whole units, so money loses its cents"
       ],

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -619,6 +619,11 @@ declare namespace start {
      * a url answers the same `null` an unknown uuid answers; `'any'`
      * restores the primary key lookup. `findByKey()` always takes the
      * primary key, whatever this says.
+     *
+     * A model that declared `options.slug` takes the whole non-uuid space
+     * with it, `'any'` included: on such a model `findById()` resolves the
+     * slug or the `externalId`, and the primary key is `findByKey()`'s
+     * alone.
      */
     lookup?: 'any' | 'external';
     /**
@@ -2777,6 +2782,21 @@ declare namespace start {
     timestamps?: boolean;
     /** Soft deletes: `deletedAt` instead of a real delete. */
     paranoid?: boolean;
+    /**
+     * The name a person reads in a url: `/articles/how-we-ship` rather than
+     * the uuid. henri adds a unique `slug` column, fills it from the field
+     * named here and resolves it in `findById()` next to the `externalId`
+     * -- never next to the primary key.
+     *
+     * `slug: 'title'` is the shorthand. The object form takes `on`
+     * (`create`, the default, never moves the name again; `change` follows
+     * the source and the old url stops working, since henri keeps no
+     * history), `suffix` (a six character discriminator, on by default, so
+     * two records may share a title without a lookup before the insert),
+     * `reserved` (words a slug may not take, on top of henri's own) and
+     * `maxLength`.
+     */
+    slug?: string | SlugOptions;
     /** What this model is to a person, for the export and the erasure. */
     personal?: {
       /**
@@ -2791,6 +2811,30 @@ declare namespace start {
       export?: boolean;
     };
     [key: string]: unknown;
+  }
+
+  /** `options.slug` in its object form. */
+  interface SlugOptions {
+    /** The field the name is built from: a `string` or a `text`. */
+    from: string;
+    /**
+     * When it is generated: once, on the insert (`create`, the default), or
+     * whenever the source field is written (`change`, which retires the old
+     * url on the spot -- henri keeps no history of slugs, and a mass update
+     * naming the source is refused rather than half done).
+     */
+    on?: 'create' | 'change';
+    /**
+     * Append a six character discriminator taken from the record's own
+     * `externalId` (`true`). With `false` the slug is the folded source and
+     * nothing else, the unique index is what keeps it unique, and a second
+     * record with the same title is refused by the database.
+     */
+    suffix?: boolean;
+    /** Words a slug may not take, on top of the ones henri mounts. */
+    reserved?: string[];
+    /** How long the folded source may be, before the discriminator (80). */
+    maxLength?: number;
   }
 
   /**

--- a/packages/core/src/__tests__/runtime.spec.js
+++ b/packages/core/src/__tests__/runtime.spec.js
@@ -212,6 +212,7 @@ describe('runtime endpoints (demo app, disk store)', () => {
       default: { adapter: 'disk', queryable: false },
     });
     expect(res.body.models.map((model) => model.name).sort()).toEqual([
+      'Article',
       'Artwork',
       'Invoice',
       'Memo',

--- a/packages/core/src/__tests__/slug-api.spec.js
+++ b/packages/core/src/__tests__/slug-api.spec.js
@@ -1,0 +1,145 @@
+/* global Article */
+const supertest = require('supertest');
+const Henri = require('../henri');
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+const SUFFIX = /^how-we-ship-[a-z2-9]{6}$/;
+
+describe('slugs (demo app, disk store)', () => {
+  const skipWorkers = process.env.SKIP_WORKERS;
+  let henri;
+  let request;
+  let article;
+
+  beforeAll(async () => {
+    process.env.SKIP_WORKERS = '1';
+    henri = new Henri();
+    await henri.init();
+    global.henri = henri;
+    request = supertest(henri.server.app);
+    article = await Article.create({
+      body: 'nothing yet',
+      title: 'How we ship',
+    });
+  }, 60000);
+
+  afterAll(async () => {
+    await henri.stop();
+    delete global.henri;
+    if (typeof skipWorkers === 'undefined') {
+      delete process.env.SKIP_WORKERS;
+    } else {
+      process.env.SKIP_WORKERS = skipWorkers;
+    }
+  }, 60000);
+
+  describe('what the model wrote', () => {
+    test('a name built from the title, with its discriminator', () => {
+      expect(article.slug).toMatch(SUFFIX);
+    });
+
+    test('next to the public identifier, which did not move', () => {
+      expect(article.externalId).toMatch(UUID);
+    });
+  });
+
+  describe('the url of a record', () => {
+    test('every href carries the slug and not the uuid', async () => {
+      const res = await request.get(`/articles/${article.slug}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body._links.self.href).toBe(`/articles/${article.slug}`);
+      expect(res.body._links.collection.href).toBe('/articles');
+      expect(JSON.stringify(res.body._links)).not.toContain(article.externalId);
+    });
+
+    test('the payload still carries the public identifier, and never the key', async () => {
+      const res = await request.get(`/articles/${article.slug}`);
+
+      expect(res.body.externalId).toBe(article.externalId);
+      expect(res.body.slug).toBe(article.slug);
+      expect(res.body.id).toBeUndefined();
+      expect(res.body._id).toBeUndefined();
+    });
+
+    test('a collection names each of its rows the same way', async () => {
+      const res = await request.get('/articles');
+
+      expect(res.status).toBe(200);
+
+      const [first] = res.body._embedded.articles;
+
+      expect(first._links.self.href).toBe(`/articles/${first.slug}`);
+      expect(first.externalId).toMatch(UUID);
+      expect(first.id).toBeUndefined();
+    });
+
+    test('the Location of a 201 is the new name', async () => {
+      const res = await request
+        .post('/articles')
+        .send({ title: 'Something new' });
+
+      expect(res.status).toBe(201);
+      expect(res.headers.location).toBe(`/articles/${res.body.slug}`);
+      expect(res.body.slug.startsWith('something-new-')).toBe(true);
+    });
+  });
+
+  describe('what the url resolves', () => {
+    test('the slug', async () => {
+      expect((await request.get(`/articles/${article.slug}`)).status).toBe(200);
+    });
+
+    test('the public identifier, still', async () => {
+      const res = await request.get(`/articles/${article.externalId}`);
+
+      expect(res.status).toBe(200);
+      // And it answers with the name, so a client that followed a uuid
+      // finds the record's url in the answer
+      expect(res.body._links.self.href).toBe(`/articles/${article.slug}`);
+    });
+
+    test('never the primary key', async () => {
+      const key = String(article._id || article.id);
+
+      expect((await request.get(`/articles/${key}`)).status).toBe(404);
+    });
+
+    test('and a name that names nothing is the same 404', async () => {
+      const nothing = await request.get('/articles/no-such-article');
+      const key = await request.get(
+        `/articles/${String(article._id || article.id)}`
+      );
+
+      expect(nothing.status).toBe(404);
+      expect(key.status).toBe(404);
+      expect(key.body).toEqual(nothing.body);
+    });
+  });
+
+  describe('a title in a script henri folds nothing to', () => {
+    test('still answers a working url', async () => {
+      const res = await request.post('/articles').send({ title: 'こんにちは' });
+
+      expect(res.status).toBe(201);
+      expect(res.body.slug).toHaveLength(6);
+      expect((await request.get(`/articles/${res.body.slug}`)).status).toBe(
+        200
+      );
+    });
+  });
+
+  describe('a model with no slug', () => {
+    test('keeps the urls it had', async () => {
+      const created = await request
+        .post('/api/v1/artworks')
+        .set('Accept', 'application/json')
+        .send({ title: 'Nighthawks', year: 1942 });
+
+      expect(created.status).toBe(201);
+      expect(created.body._links.self.href).toMatch(
+        /^\/api\/v1\/artworks\/[0-9a-f]{8}-/
+      );
+    });
+  });
+});

--- a/packages/core/src/__tests__/slug.spec.js
+++ b/packages/core/src/__tests__/slug.spec.js
@@ -1,0 +1,431 @@
+const fs = require('fs');
+const path = require('path');
+
+const {
+  ALPHABET,
+  DECLARATION,
+  EMPTY,
+  KEYS,
+  MASS_WRITE,
+  MAX_LENGTH,
+  RESERVED,
+  SLUG,
+  SUFFIX_LENGTH,
+  discriminate,
+  emptySlug,
+  lengthOf,
+  looksLikeUuid,
+  massWrite,
+  problemOf,
+  slugFor,
+  slugOf,
+  slugify,
+  writesSource,
+} = require('../base/slug');
+
+/** A model file that asks for a slug */
+const model = (slug, schema = { title: { type: 'string' } }) => ({
+  globalId: 'Article',
+  identity: 'article',
+  options: { slug },
+  schema,
+});
+
+/** The compiled declaration of a model that asks for one */
+const declared = (slug, schema) => slugOf(model(slug, schema));
+
+/** What a declaration was refused with */
+const refusalOf = (slug, schema) => {
+  try {
+    slugOf(model(slug, schema));
+  } catch (error) {
+    return `${error.code}: ${error.message}`;
+  }
+
+  return null;
+};
+
+describe('slugs', () => {
+  describe('the copies in the adapters', () => {
+    // Each adapter holds its own, the way `exact.js`, `external-id.js` and
+    // `validations.js` are held: an adapter depends on no part of core at
+    // runtime. Nothing but this test keeps them the same file.
+    const root = path.join(__dirname, '..', '..', '..');
+    const source = fs.readFileSync(
+      path.join(root, 'core', 'src', 'base', 'slug.js'),
+      'utf8'
+    );
+
+    for (const adapter of ['drizzle', 'mongoose', 'sequelize']) {
+      test(`@usehenri/${adapter} carries the same file, byte for byte`, () => {
+        const copy = fs.readFileSync(
+          path.join(root, adapter, 'slug.js'),
+          'utf8'
+        );
+
+        expect(copy).toBe(source);
+      });
+
+      test(`@usehenri/${adapter} publishes it`, () => {
+        const manifest = JSON.parse(
+          fs.readFileSync(path.join(root, adapter, 'package.json'), 'utf8')
+        );
+
+        expect(manifest.files).toContain('slug.js');
+      });
+    }
+
+    test('it reaches for nothing at all', () => {
+      // A copy sits at the root of an adapter, so the safest number of
+      // requires it can make is none
+      expect(source.match(/require\('[^']+'\)/gu)).toBeNull();
+    });
+
+    test('no regular expression touches a title', () => {
+      // A title arrives through `req.permit()`, and a slugifier is the
+      // shape that turns into a quadratic match. Everything here walks, so
+      // the code under the comments holds no pattern and no match at all
+      const code = source
+        .replace(/\/\*[\s\S]*?\*\//gu, '')
+        .replace(/^\s*\/\/.*$/gmu, '');
+
+      for (const forbidden of ['RegExp', '.test(', '.match(', '.replace(']) {
+        expect(code).not.toContain(forbidden);
+      }
+    });
+  });
+
+  describe('slugify', () => {
+    test('makes a name out of a sentence', () => {
+      expect(slugify('How we ship')).toBe('how-we-ship');
+      expect(slugify('  Hello   World  ')).toBe('hello-world');
+      expect(slugify('Getting started!')).toBe('getting-started');
+      expect(slugify('2024')).toBe('2024');
+    });
+
+    test('folds what Unicode decomposes, without a transliteration table', () => {
+      expect(slugify('Café Crème')).toBe('cafe-creme');
+      expect(slugify('Ostrów Wielkopolski')).toBe('ostrow-wielkopolski');
+      expect(slugify('ﬁnal — draft')).toBe('final-draft');
+    });
+
+    test('folds the eleven Latin letters Unicode does not', () => {
+      expect(slugify('Straße in Köln')).toBe('strasse-in-koln');
+      expect(slugify('Æther & Øre')).toBe('aether-ore');
+      expect(slugify('Łódź')).toBe('lodz');
+    });
+
+    test('answers nothing for a script it folds nothing to', () => {
+      // The honest half: henri ships no romanization, and says so
+      expect(slugify('こんにちは')).toBe('');
+      expect(slugify('مرحبا')).toBe('');
+      expect(slugify('Привет мир')).toBe('');
+    });
+
+    test('answers nothing for what is not text', () => {
+      expect(slugify('')).toBe('');
+      expect(slugify(null)).toBe('');
+      expect(slugify(undefined)).toBe('');
+      expect(slugify({})).toBe('');
+      expect(slugify([1, 2])).toBe('');
+    });
+
+    test('is bounded, and the bound is applied while it walks', () => {
+      expect(slugify('a'.repeat(500))).toHaveLength(MAX_LENGTH);
+      expect(slugify('a'.repeat(500), 10)).toHaveLength(10);
+      expect(slugify(`${'a'.repeat(500)} ${'b'.repeat(500)}`, 10)).toBe(
+        'aaaaaaaaaa'
+      );
+    });
+
+    test('never begins or ends with a separator, and never doubles one', () => {
+      for (const title of [
+        '   ',
+        '- a -',
+        '!!a!!b!!',
+        '.. a ..',
+        'a---b',
+        '💥 boom 💥',
+      ]) {
+        const slug = slugify(title);
+
+        expect(slug.startsWith('-')).toBe(false);
+        expect(slug.endsWith('-')).toBe(false);
+        expect(slug.includes('--')).toBe(false);
+      }
+    });
+  });
+
+  describe('looksLikeUuid', () => {
+    test('tells the two identifier spaces apart', () => {
+      expect(looksLikeUuid('01a07d06-e6c4-73cd-9021-31eb06befdd7')).toBe(true);
+      expect(looksLikeUuid('01A07D06-E6C4-73CD-9021-31EB06BEFDD7')).toBe(true);
+      expect(looksLikeUuid('how-we-ship')).toBe(false);
+      expect(looksLikeUuid('4812')).toBe(false);
+      expect(looksLikeUuid('01a07d06-e6c4-73cd-9021-31eb06befdd')).toBe(false);
+      expect(looksLikeUuid('01a07d06-e6c4-73cd-9021-31eb06befdd7x')).toBe(
+        false
+      );
+      expect(looksLikeUuid('zzzzzzzz-e6c4-73cd-9021-31eb06befdd7')).toBe(false);
+    });
+  });
+
+  describe('discriminate', () => {
+    test('is six characters of an alphabet with no look-alikes', () => {
+      expect(discriminate('01a07d06-e6c4-73cd-9021-31eb06befdd7')).toHaveLength(
+        SUFFIX_LENGTH
+      );
+
+      for (const character of discriminate(null)) {
+        expect(ALPHABET).toContain(character);
+      }
+
+      expect(ALPHABET).not.toContain('0');
+      expect(ALPHABET).not.toContain('1');
+      expect(ALPHABET).not.toContain('l');
+      expect(ALPHABET).not.toContain('o');
+    });
+
+    test('is the same for the same public identifier', () => {
+      const seed = '01a07d06-e6c4-73cd-9021-31eb06befdd7';
+
+      expect(discriminate(seed)).toBe(discriminate(seed));
+    });
+
+    test('is not the same for two of them', () => {
+      expect(discriminate('01a07d06-e6c4-73cd-9021-31eb06befdd7')).not.toBe(
+        discriminate('01a07d06-e6c4-73cd-9021-000000000000')
+      );
+    });
+
+    test('falls back to randomness with no seed to take', () => {
+      expect(discriminate(null)).toHaveLength(SUFFIX_LENGTH);
+      expect(discriminate('short')).toHaveLength(SUFFIX_LENGTH);
+    });
+  });
+
+  describe('the declaration', () => {
+    test('is a field name, or an object', () => {
+      expect(declared('title')).toEqual({
+        from: 'title',
+        maxLength: MAX_LENGTH,
+        on: 'create',
+        reserved: new Set(RESERVED),
+        suffix: true,
+      });
+      expect(declared({ from: 'title', on: 'change', suffix: false })).toEqual({
+        from: 'title',
+        maxLength: MAX_LENGTH,
+        on: 'change',
+        reserved: new Set(RESERVED),
+        suffix: false,
+      });
+    });
+
+    test('is null when a model asks for none', () => {
+      expect(slugOf({ globalId: 'Article', schema: {} })).toBeNull();
+      expect(declared(undefined)).toBeNull();
+      expect(declared(null)).toBeNull();
+      expect(declared(false)).toBeNull();
+    });
+
+    test('adds to the reserved words rather than replacing them', () => {
+      const compiled = declared({ from: 'title', reserved: ['Search'] });
+
+      expect(compiled.reserved.has('new')).toBe(true);
+      expect(compiled.reserved.has('search')).toBe(true);
+    });
+
+    test('refuses a "from" the schema does not declare', () => {
+      expect(refusalOf('headline')).toContain(DECLARATION);
+      expect(refusalOf('headline')).toContain('the schema does not declare');
+    });
+
+    test('refuses a "from" that is not made of words', () => {
+      expect(refusalOf('views', { views: { type: 'integer' } })).toContain(
+        'not a string or a text'
+      );
+    });
+
+    test('refuses a "from" that is encrypted', () => {
+      expect(
+        refusalOf('title', { title: { encrypted: true, type: 'string' } })
+      ).toContain('which is encrypted');
+    });
+
+    test('refuses a "from" that never leaves the server', () => {
+      expect(
+        refusalOf('title', {
+          title: { personal: { expose: false }, type: 'string' },
+        })
+      ).toContain('personal: { expose: false }');
+      // A plain `personal: true` field is public, so it may name a record
+      expect(
+        refusalOf('title', { title: { personal: true, type: 'string' } })
+      ).toBeNull();
+    });
+
+    test('refuses a schema that declares the column itself', () => {
+      expect(
+        refusalOf('title', {
+          slug: { type: 'string' },
+          title: { type: 'string' },
+        })
+      ).toContain('a "slug" field of its own');
+    });
+
+    test('refuses a slug built from itself', () => {
+      expect(refusalOf('slug')).toContain('cannot be built from itself');
+    });
+
+    test('refuses an unknown key, naming the ones it takes', () => {
+      const refused = refusalOf({ from: 'title', history: true });
+
+      expect(refused).toContain('the unknown key "history"');
+
+      for (const key of KEYS) {
+        expect(refused).toContain(key);
+      }
+    });
+
+    test('refuses a wrong value for every key', () => {
+      expect(refusalOf({ from: 'title', on: 'save' })).toContain(
+        'an "on" of "save"'
+      );
+      expect(refusalOf({ from: 'title', suffix: 'yes' })).toContain(
+        'a "suffix" that is not true or false'
+      );
+      expect(refusalOf({ from: 'title', maxLength: 0 })).toContain(
+        'a "maxLength" that is not a whole number'
+      );
+      expect(refusalOf({ from: 'title', reserved: 'new' })).toContain(
+        'a "reserved" that is not a list of words'
+      );
+      expect(refusalOf(42)).toContain('number:');
+    });
+  });
+
+  describe('the length of the column', () => {
+    test('holds the name and its discriminator', () => {
+      expect(lengthOf(declared('title'))).toBe(MAX_LENGTH + SUFFIX_LENGTH + 1);
+      expect(lengthOf(declared({ from: 'title', suffix: false }))).toBe(
+        MAX_LENGTH
+      );
+    });
+  });
+
+  describe('slugFor', () => {
+    const seed = '01a07d06-e6c4-73cd-9021-31eb06befdd7';
+
+    test('appends the discriminator by default', () => {
+      const slug = slugFor(declared('title'), 'How we ship', seed);
+
+      expect(slug.startsWith('how-we-ship-')).toBe(true);
+      expect(slug).toHaveLength('how-we-ship-'.length + SUFFIX_LENGTH);
+    });
+
+    test('is the discriminator alone when the source folds to nothing', () => {
+      expect(slugFor(declared('title'), 'こんにちは', seed)).toHaveLength(
+        SUFFIX_LENGTH
+      );
+    });
+
+    test('is the folded source alone with suffix: false', () => {
+      const compiled = declared({ from: 'title', suffix: false });
+
+      expect(slugFor(compiled, 'How we ship', seed)).toBe('how-we-ship');
+      expect(slugFor(compiled, 'こんにちは', seed)).toBe('');
+    });
+  });
+
+  describe('problemOf', () => {
+    const compiled = declared('title');
+
+    test('takes a name in any script', () => {
+      expect(problemOf('how-we-ship', compiled)).toBeNull();
+      expect(problemOf('こんにちは', compiled)).toBeNull();
+      expect(problemOf('привет', compiled)).toBeNull();
+      expect(problemOf('4812', compiled)).toBeNull();
+      expect(problemOf('a.b', compiled)).toBeNull();
+    });
+
+    test('refuses what would stop being one path segment', () => {
+      expect(problemOf('a/b', compiled)).toBe('must not hold "/"');
+      expect(problemOf('a?b', compiled)).toBe('must not hold "?"');
+      expect(problemOf('a#b', compiled)).toBe('must not hold "#"');
+      expect(problemOf('a%2Fb', compiled)).toBe('must not hold "%"');
+      expect(problemOf('a b', compiled)).toBe(
+        'must not hold a space or a control character'
+      );
+      expect(problemOf('a\nb', compiled)).toBe(
+        'must not hold a space or a control character'
+      );
+    });
+
+    test('refuses a name shaped like a public identifier', () => {
+      expect(problemOf('01a07d06-e6c4-73cd-9021-31eb06befdd7', compiled)).toBe(
+        'must not be shaped like a public identifier'
+      );
+    });
+
+    test('refuses a path henri already mounts', () => {
+      expect(problemOf('new', compiled)).toContain('must not be "new"');
+      expect(problemOf('NEW', compiled)).toContain('must not be "NEW"');
+      expect(problemOf('..', compiled)).toContain('must not be ".."');
+    });
+
+    test('refuses nothing, and too much', () => {
+      expect(problemOf('', compiled)).toBe('is required');
+      expect(problemOf(42, compiled)).toBe('must be a string');
+      expect(problemOf('a'.repeat(200), compiled)).toContain(
+        `at most ${lengthOf(compiled)}`
+      );
+    });
+
+    test('measures characters rather than code units', () => {
+      // Four astral characters are eight code units and four columns of a
+      // url, and a bound that counted the other thing would refuse them
+      expect(problemOf('💥💥💥💥', compiled)).toBeNull();
+    });
+  });
+
+  describe('writesSource', () => {
+    const compiled = declared('title');
+
+    test('is true only when the write names the field the slug comes from', () => {
+      expect(writesSource(compiled, { title: 'x' })).toBe(true);
+      expect(writesSource(compiled, { title: null })).toBe(true);
+      expect(writesSource(compiled, { body: 'x' })).toBe(false);
+      expect(writesSource(compiled, null)).toBe(false);
+      expect(writesSource(null, { title: 'x' })).toBe(false);
+    });
+  });
+
+  describe('the refusals', () => {
+    test('the empty one names the field and what it held', () => {
+      const error = emptySlug('Article', declared('title'), 'こんにちは');
+
+      expect(error.code).toBe(EMPTY);
+      expect(error.message).toContain('Article.title');
+      expect(error.message).toContain('こんにちは');
+      expect(error.message).toContain('suffix');
+    });
+
+    test('the mass write one names the loop', () => {
+      const error = massWrite(
+        'Article',
+        declared({ from: 'title', on: 'change' }),
+        'update',
+        'update(attrs)'
+      );
+
+      expect(error.code).toBe(MASS_WRITE);
+      expect(error.message).toContain('Article.update()');
+      expect(error.message).toContain('await record.update(attrs)');
+    });
+  });
+
+  test('the column is always called slug', () => {
+    expect(SLUG).toBe('slug');
+  });
+});

--- a/packages/core/src/__tests__/utils.spec.js
+++ b/packages/core/src/__tests__/utils.spec.js
@@ -115,6 +115,7 @@ describe('utils', () => {
       const models = utils.loadModules(path.join(demo, 'models'));
 
       expect(Object.keys(models).sort()).toEqual([
+        'article',
         'artwork',
         'invoice',
         'memo',
@@ -133,6 +134,7 @@ describe('utils', () => {
 
       expect(Object.keys(controllers).sort()).toEqual([
         'admin/notes',
+        'articles',
         'artwork',
         'artworks',
         'comments',

--- a/packages/core/src/base/hateoas.js
+++ b/packages/core/src/base/hateoas.js
@@ -1,5 +1,5 @@
 const { EXTERNAL_ID, hasExternalId } = require('./external-id');
-const { publish } = require('./references');
+const { nameOf, publish } = require('./references');
 const { check } = require('./arguments');
 const { stamp } = require('./errors');
 const { isInertiaPage, jsonType, noStore, seal } = require('./headers');
@@ -41,17 +41,30 @@ const { linkHeader, pageLinks, paginate } = require('./pagination');
  */
 
 /**
- * The public id of a record as a string: its `externalId` when it has one
- * (every model, unless it opted out), the primary key otherwise. This is
- * what every href of `_links` is made of, so a url never carries the
- * sequential id of a row.
+ * The identifier a url gives a record: its slug when the model declared
+ * one (base/slug.js), its `externalId` otherwise (every model, unless it
+ * opted out), the primary key when there is neither. This is what every
+ * href of `_links` is made of, so a url never carries the sequential id of
+ * a row.
+ *
+ * The slug is passed in rather than read off the record, because only the
+ * model says whether a `slug` field is the name henri gave it: an
+ * application that has always had a column of that name keeps the urls it
+ * had. It is also the **only** place a slug replaces the public identifier
+ * -- the payload still carries the `externalId`, and so does every foreign
+ * key pointing at this record.
  *
  * @param {*} record a model instance or a plain object
+ * @param {?string} [named=null] the record's slug, when the model has one
  * @returns {?string} the id or null
  */
-function identify(record) {
+function identify(record, named = null) {
   if (!record || typeof record !== 'object') {
     return null;
+  }
+
+  if (typeof named === 'string' && named !== '') {
+    return named;
   }
 
   if (hasExternalId(record)) {
@@ -468,7 +481,7 @@ function resource(henri, req, res, record, options = {}) {
       req.user || null,
       Object.assign(
         resourceLinks({
-          id: identify(plain),
+          id: identify(plain, nameOf(henri, asked) || nameOf(henri, record)),
           params: req.params,
           paths,
           type: kind,
@@ -581,7 +594,11 @@ function collection(henri, req, res, records, options = {}) {
             henri,
             user,
             resourceLinks({
-              id: identify(plain),
+              id: identify(
+                plain,
+                nameOf(henri, subjectOf(subject, record, index)) ||
+                  nameOf(henri, record)
+              ),
               params: req.params,
               paths,
               type: kind,

--- a/packages/core/src/base/openapi.js
+++ b/packages/core/src/base/openapi.js
@@ -107,6 +107,7 @@ const { identitiesConfig } = require('./identities');
 const { userConfig } = require('./auth');
 const { mapOf, privacyConfig } = require('./privacy');
 const { DEFAULTS: PAGE_DEFAULTS } = require('./pagination');
+const { SLUG, lengthOf, slugOf } = require('./slug');
 const {
   DEFAULTS: FILTER_DEFAULTS,
   OPERATORS: FILTER_OPERATORS,
@@ -182,6 +183,7 @@ const GENERATED = new Set([
   'externalId',
   'id',
   'passwordChangedAt',
+  'slug',
   'updatedAt',
 ]);
 
@@ -384,6 +386,24 @@ function policyFinder(policies) {
 }
 
 /**
+ * The `options.slug` of a model, compiled, or null.
+ *
+ * A declaration henri cannot carry out fails the boot; this command
+ * describes what an application exposes without booting, so it says nothing
+ * rather than repeating the refusal (`henri doctor` is where that is said).
+ *
+ * @param {object} model a model file
+ * @returns {?object} the compiled declaration, or null
+ */
+function slugFor(model) {
+  try {
+    return slugOf(model);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * The columns of a model as they exist once the adapter is done with it:
  * what the file declares, plus `externalId`, the timestamps, `deletedAt`
  * and, on the user model, `email`, `password`, `roles`, `confirmedAt` and
@@ -420,6 +440,17 @@ function columnsOf(model, settings) {
     fields.externalId = fields.externalId || {
       required: true,
       type: 'uuid',
+      unique: true,
+    };
+  }
+
+  const named = slugFor(model);
+
+  if (named) {
+    fields[SLUG] = {
+      maxLength: lengthOf(named),
+      required: true,
+      type: 'string',
       unique: true,
     };
   }
@@ -508,6 +539,12 @@ function fieldDescription(name, field, reference) {
   if (name === 'externalId') {
     parts.push(
       'The public identifier of the record: the only identifier that leaves the server.'
+    );
+  }
+
+  if (name === SLUG) {
+    parts.push(
+      'The name of the record: what every url of it carries, and a second thing findById() resolves. Written by henri, never a request (base/slug.js).'
     );
   }
 
@@ -1543,20 +1580,28 @@ function pathParameters(names, { declared = {}, findModel, route, settings }) {
         ? findModel(controller)
         : findModel(name.replace(/_id$/u, ''));
     const external = owner && objectOf(owner.options).externalId !== false;
+    const named = owner ? slugFor(owner) : null;
     const rule = Object.prototype.hasOwnProperty.call(declared, name)
       ? declared[name]
       : null;
+    // A model with a name has no format to state: a slug is a string, and
+    // the uuid it sits next to still resolves (base/slug.js)
     const schema =
-      external && settings.lookup === 'external'
+      external && !named && settings.lookup === 'external'
         ? { type: 'string', format: 'uuid' }
         : { type: 'string' };
-    const description = owner
-      ? `The externalId of the ${owner.globalId}${
-          external && settings.lookup === 'external'
-            ? ': the primary key does not resolve (base/references.js)'
-            : ''
-        }.`
-      : 'A path parameter henri knows the name of and nothing else.';
+    let description =
+      'A path parameter henri knows the name of and nothing else.';
+
+    if (owner && named) {
+      description = `The slug of the ${owner.globalId}: its externalId resolves here too, its primary key does not (base/slug.js).`;
+    } else if (owner) {
+      description = `The externalId of the ${owner.globalId}${
+        external && settings.lookup === 'external'
+          ? ': the primary key does not resolve (base/references.js)'
+          : ''
+      }.`;
+    }
 
     return {
       name,

--- a/packages/core/src/base/references.js
+++ b/packages/core/src/base/references.js
@@ -1,4 +1,5 @@
 const { EXTERNAL_ID, hasExternalId, isUuid } = require('./external-id');
+const { SLUG } = require('./slug');
 
 /**
  * The other half of the public identifier: the foreign keys, and the
@@ -271,6 +272,10 @@ function build(stores = {}) {
       models[globalId] = {
         externalId: entry.externalId !== false,
         references: entry.references || {},
+        // Does this model carry the third identifier, the one a person
+        // reads? Only what the model declared says so: an application's own
+        // column called `slug` is a column, and it names no url
+        slug: entry.slug === true,
         store: name,
       };
     }
@@ -616,10 +621,43 @@ async function publish(henri, value, options = {}) {
   return copy;
 }
 
+/**
+ * The name a url gives this record: the slug of a model that declared one,
+ * and nothing at all otherwise.
+ *
+ * The table is what answers, never the value: a record carrying a `slug`
+ * field is not a record henri named, and only a model that said
+ * `options: { slug: ... }` has its urls written in it. So an application
+ * that has always had a column called `slug` keeps the urls it had.
+ *
+ * @param {Henri} henri the henri instance
+ * @param {*} value a live model instance
+ * @returns {?string} the slug, or null
+ */
+function nameOf(henri, value) {
+  const table = henri && henri.model && henri.model.referenceTable;
+
+  if (!table || !value || typeof value !== 'object') {
+    return null;
+  }
+
+  const model = modelOf(table.classes, value);
+  const entry = model ? table.models[model] : null;
+
+  if (!entry || !entry.slug) {
+    return null;
+  }
+
+  const slug = value[SLUG];
+
+  return typeof slug === 'string' && slug !== '' ? slug : null;
+}
+
 module.exports = {
   DEFAULTS,
   build,
   keyOf,
+  nameOf,
   prepare,
   publish,
   settings,

--- a/packages/core/src/base/slug.js
+++ b/packages/core/src/base/slug.js
@@ -1,0 +1,752 @@
+/**
+ * The third identifier, and the only one a person reads.
+ *
+ * `/articles/how-we-ship` rather than
+ * `/articles/01a07d06-e6c4-73cd-9021-31eb06befdd7`. A model asks for one in
+ * its options:
+ *
+ * ```js
+ * module.exports = {
+ *   schema: { body: { type: 'text' }, title: { type: 'string' } },
+ *   options: { slug: 'title' },
+ * };
+ * ```
+ *
+ * and henri adds a `slug` column -- unique, indexed, not null -- fills it
+ * on insert, resolves it in `findById()` and prints it in every url that
+ * names the record.
+ *
+ * ## Where a slug is allowed to appear, and where it is not
+ *
+ * henri has two identifiers and exactly one of them is public
+ * (`base/references.js`): `externalId`, a uuid v7, leaves the server; the
+ * primary key never does. A slug is a **third**, and almost everything
+ * below is about not spending the guarantee that buys.
+ *
+ * The rule is two lines long:
+ *
+ * - a slug appears in the record's own `slug` field, and in the **url** of
+ *   that record (`_links`, the route helpers, the `Location` of a 201);
+ * - it appears **nowhere else**. A foreign key is still published as the
+ *   `externalId` of the row it names, never as that row's slug. The
+ *   versions table, the access trail, the flags actor, the erasure receipt
+ *   and the webhook payloads all keep reading `externalId` and none of them
+ *   learned a second spelling.
+ *
+ * So the uuid is what an API client stores and what henri writes down; the
+ * slug is what a person reads and types. A record answers to both and they
+ * are both public: this is a second **name**, not a second identity.
+ *
+ * ## Why a lookup cannot be talked into a primary key
+ *
+ * `Model.findById()` is the door for what arrived from outside, and it
+ * grew a branch:
+ *
+ * 1. a uuid resolves the `externalId`, exactly as before;
+ * 2. anything else resolves the **slug column**, on a model that has one;
+ * 3. and that is the end of it -- `null`, the same `null` an unknown uuid
+ *    answers.
+ *
+ * Step 2 is a `WHERE slug = ?`, not a fallthrough, which is the whole
+ * safety argument. `findById('4812')` asks the slug column for `'4812'`; it
+ * does not ask the primary key anything, so it cannot say whether row 4812
+ * exists. If some record's slug really is `4812`, that record comes back --
+ * and that is a public fact about a public name, not the number. The
+ * primary key keeps its own door, `findByKey()`, and nothing here reaches
+ * for it.
+ *
+ * The one collision that would matter is a slug **shaped like a uuid**: it
+ * would take branch 1 and quietly name nothing. `problemOf()` refuses one,
+ * so the two identifier spaces never overlap.
+ *
+ * ## Uniqueness: what holds, and what henri will not pretend
+ *
+ * Two articles called "Getting started" is the normal case. henri does not
+ * claim `unique` as a validation -- a `SELECT` before an `INSERT` answers a
+ * question about a moment that has passed (`base/validations.js`) -- and it
+ * does not make an exception for itself here. So there is no lookup before
+ * the write, no counter, and no `-2`:
+ *
+ * - **`suffix: true`, the default.** The slug is the slugified source plus
+ *   a discriminator taken from the record's own `externalId`:
+ *   `getting-started-k3f9pq`. Unique because the uuid is, stable because
+ *   the uuid never changes, and free because nothing is read. The cost,
+ *   said out loud: every url carries six extra characters even when nothing
+ *   would have collided.
+ * - **`suffix: false`.** The slug is exactly the slugified source:
+ *   `getting-started`. The **unique index is what holds**, so the second
+ *   "Getting started" is refused by the database, and
+ *   `henri.model.errors()` turns that into `{ slug: 'must be unique' }` --
+ *   the same sentence any other unique column gives. The cost is that
+ *   refusal, and it lands on a title the author had every reason to think
+ *   was fine.
+ *
+ * Neither is scoped: a slug is unique across the table, not per tenant or
+ * per parent. A scope is a composite index henri would have to write into
+ * a migration it does not own, and it is not here.
+ *
+ * ## What happens when the title changes
+ *
+ * By default, nothing. `on: 'create'` is the default and it is the honest
+ * one: a slug is generated once and never moves, so the url minted the day
+ * the record was written keeps working forever, whatever the title becomes.
+ * An identifier that follows a display string is an identifier that stops
+ * being one.
+ *
+ * `on: 'change'` regenerates whenever the source field is written, and the
+ * old url **stops working that instant**. There is no history table in
+ * henri: friendly_id keeps every retired slug in one and answers a 301 from
+ * it, and that is a table on four adapters, a redirect, a retention rule
+ * and a reach for the erasure -- a tranche of its own. Until it exists,
+ * `on: 'change'` means the old url 404s, and the guide says so in those
+ * words.
+ *
+ * A mass update that names the source field on such a model is **refused**
+ * (`HENRI_MODEL_SLUG_MASS_WRITE`): the hook runs once, without records, so
+ * either every row would get the same slug or none would get a new one, and
+ * both are worse than the refusal. It is the answer
+ * `HENRI_MODEL_VALIDATION_MASS_WRITE` and `HENRI_VERSION_MASS_WRITE`
+ * already give to the same shape of problem, and it names the loop.
+ *
+ * ## A title that is not in English
+ *
+ * `slugify()` lowercases, decomposes (NFKD) and keeps `a-z0-9`. That makes
+ * `Café Crème` into `cafe-creme` without a transliteration table, because
+ * Unicode already knows that `é` is `e` with a mark on it and
+ * `String#normalize` ships in Node.
+ *
+ * What Unicode does **not** decompose is a short list of Latin letters that
+ * are letters in their own right -- `ß`, `ø`, `ł`, `æ`, `þ` -- and `FOLDED`
+ * is a line each for them, eleven in total. That is the whole table and it
+ * is deliberately not the first entry of one per script: a Japanese,
+ * Arabic, Hebrew, Greek or Cyrillic title has no ASCII to fold to, and
+ * shipping the tables that would invent some is how a framework ends up
+ * choosing romanizations on a reader's behalf.
+ *
+ * So a title in one of those scripts **slugifies to nothing**, and that
+ * needed a real answer rather than a shrug. It has two:
+ *
+ * - With `suffix: true` the record still gets a slug -- the discriminator
+ *   alone, `k3f9pq` -- so the write never fails and the url always works.
+ *   With `suffix: false` there is nothing to fall back to and the write is
+ *   refused (`HENRI_MODEL_SLUG_EMPTY`), naming the field and the title.
+ * - **A slug the application writes itself always wins and may be any
+ *   Unicode henri can carry in a path segment.** `slug: 'こんにちは'` is
+ *   accepted, stored, matched by the route and carried percent-encoded on
+ *   the wire, which every browser renders back as the characters. So the
+ *   choice between transliteration and percent-encoding is not made here:
+ *   henri's generator folds to ASCII and ships no romanization, and an
+ *   application that wants its own script in the url writes the slug and
+ *   gets it, byte for byte.
+ *
+ * `problemOf()` is what a supplied slug is measured against, and it is a
+ * list of the structural characters rather than a definition of a letter:
+ * nothing below `!`, none of `"#%/:?@[\]^`{|}<>`, not `.` or `..`, not a
+ * uuid, not a reserved word, not longer than the column. A deny list is the
+ * right shape here precisely because henri is not the one deciding what
+ * counts as a word.
+ *
+ * ## Reserved words
+ *
+ * `resources articles` mounts `GET /articles/new` before `GET /articles/:id`
+ * (`base/routes.js`), so a record slugged `new` is a record with no show
+ * page. henri reserves that one word by default and `reserved` adds more --
+ * which is the honest bound, because a `collection` route an application
+ * declared is a segment henri cannot know when the slug is generated. The
+ * guide says to add it.
+ *
+ * ## No regular expression touches a title
+ *
+ * A title arrives through `req.permit()`, and a slugifier is exactly the
+ * shape that turns into a quadratic match. Everything here walks: one pass
+ * over the code points with a `Set` and a `Map`, no `RegExp` anywhere in
+ * the file, and the length bound applied while walking rather than after.
+ *
+ * ## A copy per adapter
+ *
+ * This file is held four times -- here and in `@usehenri/drizzle`,
+ * `@usehenri/mongoose` and `@usehenri/sequelize` -- byte for byte, the way
+ * `exact.js`, `external-id.js` and `validations.js` are, because an adapter
+ * depends on no part of core at runtime.
+ * `src/__tests__/slug.spec.js` is what keeps them the same file. It
+ * requires nothing at all, and raises its codes through a `coded()` of its
+ * own for the same reason.
+ */
+
+/** The field a slug lives in, and the column it becomes */
+const SLUG = 'slug';
+
+/** The failure a `slug` declaration henri cannot carry out gets */
+const DECLARATION = 'HENRI_MODEL_SLUG_DECLARATION_INVALID';
+
+/** The failure a source that slugifies to nothing gets */
+const EMPTY = 'HENRI_MODEL_SLUG_EMPTY';
+
+/** The failure a mass write that would regenerate many slugs gets */
+const MASS_WRITE = 'HENRI_MODEL_SLUG_MASS_WRITE';
+
+/** How long the slugified source may be, before the discriminator */
+const MAX_LENGTH = 80;
+
+/** How many characters the discriminator adds, plus its separator */
+const SUFFIX_LENGTH = 6;
+
+/** The keys a `slug` declaration may hold */
+const KEYS = ['from', 'maxLength', 'on', 'reserved', 'suffix'];
+
+/** What `on` takes: generate once, or follow the source */
+const EVENTS = ['create', 'change'];
+
+/**
+ * The characters a slug may never carry, whoever wrote it.
+ *
+ * Not "everything but a letter": henri is not the one deciding what counts
+ * as a letter in a script it does not read. These are the ones that end a
+ * path segment, start a query, escape an encoding or name a directory.
+ */
+const REFUSED = new Set([
+  '"',
+  '#',
+  '%',
+  '/',
+  ':',
+  '<',
+  '>',
+  '?',
+  '@',
+  '[',
+  '\\',
+  ']',
+  '^',
+  '`',
+  '{',
+  '|',
+  '}',
+]);
+
+/** The path segments a slug would shadow */
+const RESERVED = ['.', '..', 'new'];
+
+/**
+ * The Latin letters Unicode does not decompose, which is why each needs a
+ * line. This is the whole table and it is deliberately not one per script:
+ * see the header.
+ */
+const FOLDED = new Map([
+  ['æ', 'ae'],
+  ['đ', 'd'],
+  ['ð', 'd'],
+  ['ħ', 'h'],
+  ['ı', 'i'],
+  ['ł', 'l'],
+  ['ø', 'o'],
+  ['œ', 'oe'],
+  ['ß', 'ss'],
+  ['þ', 'th'],
+  ['ŧ', 't'],
+]);
+
+/**
+ * The alphabet of the discriminator: base 32 without the characters a
+ * person mistakes for another when reading a url out loud (`0`/`o`,
+ * `1`/`l`/`i`).
+ */
+const ALPHABET = '23456789abcdefghjkmnpqrstuvwxyz';
+
+/** The separator between words, and before the discriminator */
+const DASH = '-';
+
+/**
+ * An error carrying a henri code, without depending on core
+ *
+ * @param {string} code the henri error code
+ * @param {string} message what is wrong
+ * @returns {Error} the error to throw
+ */
+const coded = (code, message) => Object.assign(new Error(message), { code });
+
+/**
+ * Is the value a plain object?
+ *
+ * @param {*} value any value
+ * @returns {boolean} true for a plain object
+ */
+const isPlainObject = (value) =>
+  value !== null &&
+  typeof value === 'object' &&
+  (Object.getPrototypeOf(value) === Object.prototype ||
+    Object.getPrototypeOf(value) === null);
+
+/**
+ * Is this string a uuid, and therefore an `externalId` rather than a name?
+ *
+ * The shape is checked by walking it: eight hex, a dash, four, a dash,
+ * four, a dash, four, a dash, twelve. The same answer
+ * `base/external-id.js` gives, without the pattern, because this one is
+ * asked about a value that came from a request.
+ *
+ * @param {string} value the candidate
+ * @returns {boolean} true when it is shaped like a uuid
+ */
+const looksLikeUuid = (value) => {
+  const groups = [8, 4, 4, 4, 12];
+  let at = 0;
+
+  for (let group = 0; group < groups.length; group += 1) {
+    if (group > 0) {
+      if (value[at] !== DASH) {
+        return false;
+      }
+
+      at += 1;
+    }
+
+    for (let taken = 0; taken < groups[group]; taken += 1) {
+      const code = value.charCodeAt(at);
+
+      // 0-9, a-f, A-F
+      if (
+        !(code >= 48 && code <= 57) &&
+        !(code >= 97 && code <= 102) &&
+        !(code >= 65 && code <= 70)
+      ) {
+        return false;
+      }
+
+      at += 1;
+    }
+  }
+
+  return at === value.length;
+};
+
+/**
+ * Is this code point a combining mark NFKD left behind?
+ *
+ * The three blocks a decomposed Latin, Greek or Cyrillic letter puts its
+ * accent in. They are dropped rather than turned into a separator, so
+ * `é` is `e` and not `e-`.
+ *
+ * @param {number} code the code point
+ * @returns {boolean} true for a combining mark
+ */
+const isMark = (code) =>
+  (code >= 0x0300 && code <= 0x036f) ||
+  (code >= 0x1ab0 && code <= 0x1aff) ||
+  (code >= 0x20d0 && code <= 0x20f0);
+
+/**
+ * The slug of a value: lowercase, decomposed, `a-z0-9` joined by dashes.
+ *
+ * One walk over the code points, no pattern, and the bound applied as it
+ * goes rather than by cutting at the end -- so a title of any length costs
+ * what the bound costs and not what the title costs.
+ *
+ * @param {*} value what the source field holds
+ * @param {number} [maxLength=MAX_LENGTH] how long the answer may be
+ * @returns {string} the slug, possibly empty
+ */
+const slugify = (value, maxLength = MAX_LENGTH) => {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return '';
+  }
+
+  const source = String(value).toLowerCase().normalize('NFKD');
+  const out = [];
+  let pending = false;
+
+  for (const character of source) {
+    if (out.length >= maxLength) {
+      break;
+    }
+
+    const code = character.codePointAt(0);
+
+    if (isMark(code)) {
+      continue;
+    }
+
+    // The ranges `a-z` and `0-9`, the only two that come out of this file
+    if ((code >= 97 && code <= 122) || (code >= 48 && code <= 57)) {
+      if (pending && out.length > 0) {
+        out.push(DASH);
+      }
+
+      pending = false;
+
+      if (out.length < maxLength) {
+        out.push(character);
+      }
+
+      continue;
+    }
+
+    const folded = FOLDED.get(character);
+
+    if (folded) {
+      if (pending && out.length > 0) {
+        out.push(DASH);
+      }
+
+      pending = false;
+
+      for (const letter of folded) {
+        if (out.length < maxLength) {
+          out.push(letter);
+        }
+      }
+
+      continue;
+    }
+
+    // Anything else -- a space, a comma, an emoji, a kanji -- ends the run
+    // rather than being carried, and a run of them is one dash
+    pending = true;
+  }
+
+  return out.join('');
+};
+
+/**
+ * Six characters of the record's own public identifier, so the
+ * discriminator is unique because the uuid is and stable because the uuid
+ * never changes.
+ *
+ * A model that opted out of `externalId` has no such seed, and neither
+ * does a mass insert on an ORM that fills the column after the hook; both
+ * fall back to `Math.random()`, which is enough because a discriminator is
+ * not a secret -- a slug is a public name, nothing is protected by knowing
+ * one, and a duplicate is caught by the unique index the column carries.
+ *
+ * @param {*} seed the record's `externalId`, when there is one
+ * @returns {string} six characters of the alphabet
+ */
+const discriminate = (seed) => {
+  const out = [];
+
+  if (typeof seed === 'string' && seed.length >= SUFFIX_LENGTH * 2) {
+    // The tail of a uuid v7 is its random half; the head is the clock, and
+    // every record written in the same millisecond shares it
+    const tail = seed
+      .slice(-SUFFIX_LENGTH * 2)
+      .split(DASH)
+      .join('');
+
+    for (
+      let at = 0;
+      at + 1 < tail.length && out.length < SUFFIX_LENGTH;
+      at += 2
+    ) {
+      const pair = parseInt(tail.slice(at, at + 2), 16);
+
+      if (Number.isNaN(pair)) {
+        break;
+      }
+
+      out.push(ALPHABET[pair % ALPHABET.length]);
+    }
+  }
+
+  while (out.length < SUFFIX_LENGTH) {
+    out.push(ALPHABET[Math.floor(Math.random() * ALPHABET.length)]);
+  }
+
+  return out.join('');
+};
+
+/**
+ * Refuses a declaration, naming the model
+ *
+ * @param {string} model the model's global id
+ * @param {string} what what is wrong with it
+ * @returns {void} never returns
+ * @throws {Error} always, HENRI_MODEL_SLUG_DECLARATION_INVALID
+ */
+const refuse = (model, what) => {
+  throw coded(DECLARATION, `${model} declares \`options.slug\` with ${what}`);
+};
+
+/**
+ * The `slug` declaration of a model file, compiled, or null when it wants
+ * no slug.
+ *
+ * `slug: 'title'` is the shorthand every application writes; the object
+ * form takes `from`, `on`, `suffix`, `reserved` and `maxLength`.
+ *
+ * @param {object} model the model file (`schema`, `options`, `globalId`)
+ * @returns {?object} `{ from, maxLength, on, reserved, suffix }` or null
+ * @throws {Error} HENRI_MODEL_SLUG_DECLARATION_INVALID on anything unusable
+ */
+const slugOf = (model) => {
+  const options = (model && model.options) || {};
+  const written = options.slug;
+  const name = (model && (model.globalId || model.identity)) || 'model';
+
+  if (typeof written === 'undefined' || written === null || written === false) {
+    return null;
+  }
+
+  if (typeof written !== 'string' && !isPlainObject(written)) {
+    refuse(
+      name,
+      `${typeof written}: it is the name of the field to build the slug from, or an object of ${KEYS.join(', ')}`
+    );
+  }
+
+  const declared =
+    typeof written === 'string' ? { from: written } : { ...written };
+
+  for (const key of Object.keys(declared)) {
+    if (!KEYS.includes(key)) {
+      refuse(name, `the unknown key "${key}": it takes ${KEYS.join(', ')}`);
+    }
+  }
+
+  const schema = (model && model.schema) || {};
+  const { from } = declared;
+
+  if (typeof from !== 'string' || from === '') {
+    refuse(name, 'no "from": a slug is built from a field of the model');
+  }
+
+  if (from === SLUG) {
+    refuse(name, 'a "from" of "slug": the slug cannot be built from itself');
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(schema, from)) {
+    refuse(name, `a "from" of "${from}", which the schema does not declare`);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(schema, SLUG)) {
+    refuse(
+      name,
+      'a "slug" field of its own in the schema: henri adds the column, so declaring it twice would mean two different things'
+    );
+  }
+
+  const definition = schema[from];
+  const type = isPlainObject(definition) ? definition.type : definition;
+
+  if (type !== 'string' && type !== 'text' && type !== String) {
+    refuse(
+      name,
+      `a "from" of "${from}", which is not a string or a text: a slug is built from words`
+    );
+  }
+
+  if (isPlainObject(definition) && definition.encrypted) {
+    refuse(
+      name,
+      `a "from" of "${from}", which is encrypted: a slug is public and the column it came from is not`
+    );
+  }
+
+  const marked = isPlainObject(definition) ? definition.personal : null;
+
+  if (isPlainObject(marked) && marked.expose === false) {
+    refuse(
+      name,
+      `a "from" of "${from}", which is marked \`personal: { expose: false }\`: that field is dropped from every answer henri builds, and a slug is in every url of the record`
+    );
+  }
+
+  const compiled = {
+    from,
+    maxLength: MAX_LENGTH,
+    on: 'create',
+    reserved: new Set(RESERVED),
+    suffix: true,
+  };
+
+  if ('on' in declared) {
+    if (!EVENTS.includes(declared.on)) {
+      refuse(name, `an "on" of "${declared.on}": it is ${EVENTS.join(' or ')}`);
+    }
+
+    compiled.on = declared.on;
+  }
+
+  if ('suffix' in declared) {
+    if (typeof declared.suffix !== 'boolean') {
+      refuse(name, 'a "suffix" that is not true or false');
+    }
+
+    compiled.suffix = declared.suffix;
+  }
+
+  if ('maxLength' in declared) {
+    if (
+      typeof declared.maxLength !== 'number' ||
+      !Number.isInteger(declared.maxLength) ||
+      declared.maxLength < 1
+    ) {
+      refuse(name, 'a "maxLength" that is not a whole number of characters');
+    }
+
+    compiled.maxLength = declared.maxLength;
+  }
+
+  if ('reserved' in declared) {
+    if (
+      !Array.isArray(declared.reserved) ||
+      declared.reserved.some((word) => typeof word !== 'string')
+    ) {
+      refuse(name, 'a "reserved" that is not a list of words');
+    }
+
+    for (const word of declared.reserved) {
+      compiled.reserved.add(word.toLowerCase());
+    }
+  }
+
+  return compiled;
+};
+
+/**
+ * How long the column has to be: the slugified source, the separator and
+ * the discriminator
+ *
+ * @param {object} declaration the compiled declaration
+ * @returns {number} the column length
+ */
+const lengthOf = (declaration) =>
+  declaration.maxLength + (declaration.suffix ? SUFFIX_LENGTH + 1 : 0);
+
+/**
+ * Everything wrong with a slug an application wrote itself.
+ *
+ * A deny list rather than a definition of a word: any script may name a
+ * record, and what may not is what would stop being one path segment.
+ *
+ * @param {*} value the slug
+ * @param {object} declaration the compiled declaration
+ * @returns {?string} the message, or null when it can be a url segment
+ */
+const problemOf = (value, declaration) => {
+  if (typeof value !== 'string') {
+    return 'must be a string';
+  }
+
+  if (value === '') {
+    return 'is required';
+  }
+
+  if ([...value].length > lengthOf(declaration)) {
+    return `must be at most ${lengthOf(declaration)} characters`;
+  }
+
+  for (const character of value) {
+    const code = character.codePointAt(0);
+
+    if (code < 0x21 || code === 0x7f) {
+      return 'must not hold a space or a control character';
+    }
+
+    if (REFUSED.has(character)) {
+      return `must not hold "${character}"`;
+    }
+  }
+
+  if (looksLikeUuid(value)) {
+    return 'must not be shaped like a public identifier';
+  }
+
+  if (declaration.reserved.has(value.toLowerCase())) {
+    return `must not be "${value}", which is a path henri already mounts`;
+  }
+
+  return null;
+};
+
+/**
+ * The slug of a record about to be written.
+ *
+ * @param {object} declaration the compiled declaration
+ * @param {*} source what the source field holds
+ * @param {*} seed the record's `externalId`, for the discriminator
+ * @returns {string} the slug, or an empty string when there is nothing to
+ *   build one from and no discriminator to fall back to
+ */
+const slugFor = (declaration, source, seed) => {
+  const base = slugify(source, declaration.maxLength);
+
+  if (!declaration.suffix) {
+    return base;
+  }
+
+  const suffix = discriminate(seed);
+
+  return base === '' ? suffix : `${base}${DASH}${suffix}`;
+};
+
+/**
+ * Does this write name the field the slug is built from?
+ *
+ * @param {object} declaration the compiled declaration
+ * @param {*} attrs the attributes being written
+ * @returns {boolean} true when the source field is one of them
+ */
+const writesSource = (declaration, attrs) =>
+  Boolean(declaration) &&
+  isPlainObject(attrs) &&
+  Object.prototype.hasOwnProperty.call(attrs, declaration.from);
+
+/**
+ * The refusal a source that slugified to nothing gets
+ *
+ * @param {string} model the model's global id
+ * @param {object} declaration the compiled declaration
+ * @param {*} source what the source field held
+ * @returns {Error} the error to throw
+ */
+const emptySlug = (model, declaration, source) =>
+  coded(
+    EMPTY,
+    `${model}.${declaration.from} is ${
+      typeof source === 'string' && source !== ''
+        ? `"${source}", which has no letters or digits henri can fold to ASCII`
+        : 'empty'
+    }, and the model declares \`slug: { suffix: false }\`, so there is nothing to build a slug from. ` +
+      'Write the slug yourself, or let henri add its discriminator (`suffix: true`, the default), which always answers something.'
+  );
+
+/**
+ * The refusal a mass write that would regenerate many slugs gets
+ *
+ * @param {string} model the model's global id
+ * @param {object} declaration the compiled declaration
+ * @param {string} what the call that was made (`update`, `updateMany`)
+ * @param {string} instead the single-record call to loop over
+ * @returns {Error} the error to throw
+ */
+const massWrite = (model, declaration, what, instead) =>
+  coded(
+    MASS_WRITE,
+    `${model}.${what}() writes many rows at once and names ${declaration.from}, which ${model} regenerates its slug from (\`slug: { on: 'change' }\`). ` +
+      'One hook runs for the whole write, with no records in it, so every row would get one slug or none would get a new one. henri refuses rather than doing either. ' +
+      `Loop instead: for (const record of await ${model}.find(where)) await record.${instead}`
+  );
+
+module.exports = {
+  ALPHABET,
+  DECLARATION,
+  EMPTY,
+  EVENTS,
+  KEYS,
+  MASS_WRITE,
+  MAX_LENGTH,
+  RESERVED,
+  SLUG,
+  SUFFIX_LENGTH,
+  coded,
+  discriminate,
+  emptySlug,
+  lengthOf,
+  looksLikeUuid,
+  massWrite,
+  problemOf,
+  slugFor,
+  slugOf,
+  slugify,
+  writesSource,
+};

--- a/packages/demo/app/controllers/articles.js
+++ b/packages/demo/app/controllers/articles.js
@@ -1,0 +1,45 @@
+/* global Article */
+
+// Attributes a request may set (see req.permit). `slug` is not one of them:
+// henri writes it, and an application that wants to let a person choose one
+// lists it here on purpose.
+const FIELDS = ['title', 'body'];
+
+/**
+ * Loads the article of `:id` into `req.article`. The `:id` of a slugged
+ * model is its slug, and `findById()` also still takes the public
+ * identifier -- what it never takes is the primary key.
+ *
+ * @param {object} req Express request
+ * @param {object} res Express response
+ * @returns {Promise<object|undefined>} The 404 answer, or nothing
+ */
+const loadArticle = async (req, res) => {
+  req.article = await Article.findById(req.params.id);
+
+  if (!req.article) {
+    return res.notFound(`Article ${req.params.id} not found`);
+  }
+};
+
+module.exports = {
+  before: { show: loadArticle },
+
+  create: async (req, res) => {
+    const article = await Article.create(req.permit(...FIELDS));
+
+    return res.resource(article, { status: 201 });
+  },
+
+  index: async (req, res) => {
+    const { page, perPage, skip, limit } = req.pagination();
+    const [articles, total] = await Promise.all([
+      Article.find().skip(skip).limit(limit),
+      Article.countDocuments(),
+    ]);
+
+    return res.collection(articles, { page, perPage, total });
+  },
+
+  show: async (req, res) => res.resource(req.article),
+};

--- a/packages/demo/app/models/Article.js
+++ b/packages/demo/app/models/Article.js
@@ -1,0 +1,11 @@
+module.exports = {
+  // The third identifier, and the only one a person reads: henri adds the
+  // `slug` column, fills it from the title on insert and prints it in every
+  // url that names the record (base/slug.js). The public identifier is
+  // still there and still resolves; the primary key still does not.
+  options: { slug: 'title', timestamps: true },
+  schema: {
+    body: { type: 'text' },
+    title: { required: true, type: 'string' },
+  },
+};

--- a/packages/demo/app/routes.js
+++ b/packages/demo/app/routes.js
@@ -44,6 +44,12 @@ module.exports = {
   'post /register': 'user#create',
   // Multipart, read by @usehenri/uploads before sessions and csrf
   'post /uploads': { controller: 'uploads#create', idempotent: false },
+  // A model with a name (base/slug.js): the urls of this resource carry the
+  // slug, and `findById()` resolves it and the public identifier
+  'resources articles': {
+    controller: 'articles',
+    only: ['index', 'create', 'show'],
+  },
   // A versioned, scoped resource (/api/v1/artworks)
   'resources artworks': {
     controller: 'artworks',

--- a/packages/drizzle/__tests__/slug.spec.js
+++ b/packages/drizzle/__tests__/slug.spec.js
@@ -1,0 +1,413 @@
+const { build } = require('./helpers');
+
+/**
+ * A model file that asks for a slug
+ *
+ * @param {*} [slug='title'] What `options.slug` says
+ * @returns {object} The model file
+ */
+const articleModel = (slug = 'title') => ({
+  globalId: 'Article',
+  identity: 'article',
+  options: { slug, timestamps: true },
+  schema: {
+    body: { type: 'text' },
+    title: { required: true, type: 'string' },
+  },
+  store: 'default',
+});
+
+/**
+ * The error a write threw, as `{ field: message }` or `{ code }`
+ *
+ * @param {Promise} promise The write
+ * @returns {Promise<object>} What it refused with
+ */
+const errorsOf = async (promise) => {
+  try {
+    await promise;
+  } catch (error) {
+    return error.toJSON ? error.toJSON() : { code: error.code };
+  }
+
+  return null;
+};
+
+describe('slugs on a drizzle store', () => {
+  describe('the column henri adds', () => {
+    let Article;
+    let adapter;
+
+    beforeAll(async () => {
+      ({ adapter } = build());
+      Article = adapter.addModel(articleModel(), 'user');
+      await adapter.start();
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('is unique, not null, and the length of the name plus its suffix', () => {
+      expect(Article.fields.slug).toMatchObject({
+        required: true,
+        type: 'string',
+        unique: true,
+      });
+      expect(Article.fields.slug.length).toBe(87);
+    });
+
+    test('is filled from the source field on insert', async () => {
+      const article = await Article.create({ title: 'How we ship' });
+
+      expect(article.slug.startsWith('how-we-ship-')).toBe(true);
+      expect(article.slug).toHaveLength('how-we-ship-'.length + 6);
+    });
+
+    test('lets two records share a title', async () => {
+      const first = await Article.create({ title: 'Getting started' });
+      const second = await Article.create({ title: 'Getting started' });
+
+      expect(first.slug).not.toBe(second.slug);
+      expect(first.slug.startsWith('getting-started-')).toBe(true);
+      expect(second.slug.startsWith('getting-started-')).toBe(true);
+    });
+
+    test('answers something for a title with no ASCII in it', async () => {
+      const article = await Article.create({ title: 'こんにちは' });
+
+      expect(article.slug).toHaveLength(6);
+    });
+
+    test('does not move when the title changes', async () => {
+      const article = await Article.create({ title: 'First name' });
+      const before = article.slug;
+
+      await article.update({ title: 'Second name' });
+
+      expect(article.slug).toBe(before);
+    });
+  });
+
+  describe('the lookup', () => {
+    let Article;
+    let adapter;
+    let article;
+
+    beforeAll(async () => {
+      ({ adapter } = build());
+      Article = adapter.addModel(articleModel(), 'user');
+      await adapter.start();
+      article = await Article.create({ title: 'How we ship' });
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('findById() takes the slug', async () => {
+      const found = await Article.findById(article.slug);
+
+      expect(found.id).toBe(article.id);
+    });
+
+    test('findById() still takes the public identifier', async () => {
+      const found = await Article.findById(article.externalId);
+
+      expect(found.id).toBe(article.id);
+    });
+
+    test('findById() does not take the primary key', async () => {
+      // The whole point: a slug column answering a `WHERE slug = ?` cannot
+      // say anything about a row named by its number
+      expect(await Article.findById(article.id)).toBeNull();
+      expect(await Article.findById(String(article.id))).toBeNull();
+      expect(await Article.findById(1)).toBeNull();
+    });
+
+    test('a number that names no slug answers the null an unknown slug answers', async () => {
+      expect(await Article.findById('4812')).toBeNull();
+      expect(await Article.findById('no-such-article')).toBeNull();
+      expect(
+        await Article.findById('01a07d06-e6c4-73cd-9021-31eb06befdd7')
+      ).toBeNull();
+    });
+
+    test('a slug that is a number reaches its own row and no other', async () => {
+      const numbered = await Article.create({
+        slug: String(article.id),
+        title: 'Numbered',
+      });
+      const found = await Article.findById(String(article.id));
+
+      expect(found.id).toBe(numbered.id);
+      expect(found.id).not.toBe(article.id);
+    });
+
+    test('findBySlug() takes a slug and nothing else', async () => {
+      expect((await Article.findBySlug(article.slug)).id).toBe(article.id);
+      expect(await Article.findBySlug(article.externalId)).toBeNull();
+      expect(await Article.findBySlug(article.id)).toBeNull();
+    });
+
+    test('findByKey() is still the primary key door', async () => {
+      expect((await Article.findByKey(article.id)).id).toBe(article.id);
+    });
+
+    test('findByIdAndUpdate() reaches the same rows findById() does', async () => {
+      const updated = await Article.findByIdAndUpdate(article.slug, {
+        body: 'written',
+      });
+
+      expect(updated.id).toBe(article.id);
+      expect(await Article.findByIdAndUpdate(article.id, { body: 'no' })).toBe(
+        null
+      );
+      expect(
+        (await Article.findByIdAndUpdate(article.externalId, { body: 'yes' }))
+          .id
+      ).toBe(article.id);
+    });
+  });
+
+  describe('a slug the application writes itself', () => {
+    let Article;
+    let adapter;
+
+    beforeAll(async () => {
+      ({ adapter } = build());
+      Article = adapter.addModel(articleModel(), 'user');
+      await adapter.start();
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('wins over the one henri would have made', async () => {
+      const article = await Article.create({
+        slug: 'how-we-ship',
+        title: 'Something else entirely',
+      });
+
+      expect(article.slug).toBe('how-we-ship');
+    });
+
+    test('may be any script henri ships no table for', async () => {
+      const article = await Article.create({
+        slug: 'こんにちは',
+        title: 'Hello',
+      });
+
+      expect(article.slug).toBe('こんにちは');
+      expect((await Article.findById('こんにちは')).id).toBe(article.id);
+    });
+
+    test('is refused when it cannot be one path segment', async () => {
+      expect(
+        await errorsOf(Article.create({ slug: 'a/b', title: 'x' }))
+      ).toEqual({ slug: 'must not hold "/"' });
+      expect(
+        await errorsOf(Article.create({ slug: 'a b', title: 'x' }))
+      ).toEqual({ slug: 'must not hold a space or a control character' });
+    });
+
+    test('is refused when it is shaped like a public identifier', async () => {
+      expect(
+        await errorsOf(
+          Article.create({
+            slug: '01a07d06-e6c4-73cd-9021-31eb06befdd7',
+            title: 'x',
+          })
+        )
+      ).toEqual({ slug: 'must not be shaped like a public identifier' });
+    });
+
+    test('is refused when it is a path henri already mounts', async () => {
+      expect(
+        await errorsOf(Article.create({ slug: 'new', title: 'x' }))
+      ).toEqual({
+        slug: 'must not be "new", which is a path henri already mounts',
+      });
+    });
+
+    test('is refused when the database already holds it', async () => {
+      await Article.create({ slug: 'taken', title: 'x' });
+
+      expect(
+        await errorsOf(Article.create({ slug: 'taken', title: 'y' }))
+      ).toEqual({ slug: 'must be unique' });
+    });
+  });
+
+  describe('suffix: false', () => {
+    let Article;
+    let adapter;
+
+    beforeAll(async () => {
+      ({ adapter } = build());
+      Article = adapter.addModel(
+        articleModel({ from: 'title', suffix: false }),
+        'user'
+      );
+      await adapter.start();
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('is the slugified source and nothing else', async () => {
+      const article = await Article.create({ title: 'How we ship' });
+
+      expect(article.slug).toBe('how-we-ship');
+    });
+
+    test('leaves the unique index to refuse the second one', async () => {
+      await Article.create({ title: 'Getting started' });
+
+      expect(
+        await errorsOf(Article.create({ title: 'Getting started' }))
+      ).toEqual({ slug: 'must be unique' });
+    });
+
+    test('refuses a title it cannot fold rather than writing an empty name', async () => {
+      expect(await errorsOf(Article.create({ title: 'こんにちは' }))).toEqual({
+        code: 'HENRI_MODEL_SLUG_EMPTY',
+      });
+    });
+  });
+
+  describe("on: 'change'", () => {
+    let Article;
+    let adapter;
+
+    beforeAll(async () => {
+      ({ adapter } = build());
+      Article = adapter.addModel(
+        articleModel({ from: 'title', on: 'change' }),
+        'user'
+      );
+      await adapter.start();
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('follows the source, and the old url stops working', async () => {
+      const article = await Article.create({ title: 'First name' });
+      const before = article.slug;
+
+      await article.update({ title: 'Second name' });
+
+      expect(article.slug.startsWith('second-name-')).toBe(true);
+      expect(await Article.findById(before)).toBeNull();
+    });
+
+    test('leaves the slug alone when the write does not name the source', async () => {
+      const article = await Article.create({ title: 'Third name' });
+      const before = article.slug;
+
+      await article.update({ body: 'written' });
+
+      expect(article.slug).toBe(before);
+    });
+
+    test('refuses a mass update that names the source', async () => {
+      const refused = await errorsOf(
+        Article.update({ body: 'written' }, { title: 'One name for all' })
+      );
+
+      expect(refused).toEqual({ code: 'HENRI_MODEL_SLUG_MASS_WRITE' });
+    });
+
+    test('allows a mass update that does not', async () => {
+      await expect(
+        Article.update({ title: 'Third name' }, { body: 'swept' })
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe('a declaration henri cannot carry out', () => {
+    /**
+     * Adds a model and answers the code it was refused with
+     *
+     * @param {*} slug What `options.slug` says
+     * @param {object} [schema] The schema, when it matters
+     * @returns {?string} The code
+     */
+    const refusalOf = (slug, schema) => {
+      const { adapter } = build();
+      const model = articleModel(slug);
+
+      if (schema) {
+        model.schema = schema;
+      }
+
+      try {
+        adapter.addModel(model, 'user');
+      } catch (error) {
+        return `${error.code}: ${error.message}`;
+      }
+
+      return null;
+    };
+
+    test('a "from" the schema does not declare', () => {
+      expect(refusalOf('headline')).toContain(
+        'HENRI_MODEL_SLUG_DECLARATION_INVALID'
+      );
+      expect(refusalOf('headline')).toContain('the schema does not declare');
+    });
+
+    test('a "from" that is not made of words', () => {
+      expect(refusalOf('views', { views: { type: 'integer' } })).toContain(
+        'not a string or a text'
+      );
+    });
+
+    test('a "from" that is encrypted', () => {
+      expect(
+        refusalOf('title', { title: { encrypted: true, type: 'string' } })
+      ).toContain('which is encrypted');
+    });
+
+    test('a schema that declares the column itself', () => {
+      expect(
+        refusalOf('title', {
+          slug: { type: 'string' },
+          title: { type: 'string' },
+        })
+      ).toContain('a "slug" field of its own');
+    });
+
+    test('an unknown key', () => {
+      expect(refusalOf({ from: 'title', history: true })).toContain(
+        'the unknown key "history"'
+      );
+    });
+
+    test('an "on" henri has no event for', () => {
+      expect(refusalOf({ from: 'title', on: 'save' })).toContain(
+        'an "on" of "save"'
+      );
+    });
+  });
+
+  describe('a model with no slug', () => {
+    let Article;
+    let adapter;
+
+    beforeAll(async () => {
+      ({ adapter } = build());
+      Article = adapter.addModel(
+        { ...articleModel(), options: { timestamps: true } },
+        'user'
+      );
+      await adapter.start();
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('has no column, no declaration and no lookup', async () => {
+      const article = await Article.create({ title: 'How we ship' });
+
+      expect(Article.fields.slug).toBeUndefined();
+      expect(Article.slug).toBeNull();
+      expect(await Article.findBySlug('how-we-ship')).toBeNull();
+      expect(await Article.findById(article.externalId)).not.toBeNull();
+      expect(await Article.findById(article.id)).toBeNull();
+    });
+  });
+});

--- a/packages/drizzle/index.js
+++ b/packages/drizzle/index.js
@@ -19,6 +19,7 @@ const {
   uuidv7,
   wantsExternalId,
 } = require('./external-id');
+const { SLUG, lengthOf, slugOf } = require('./slug');
 const { coded, fatal, normalizeEmail, redact, toRoles } = require('./utils');
 
 /**
@@ -67,14 +68,16 @@ const SESSIONS_KEY = 'HenriSession';
 /**
  * The keys a model file's `options` may hold on a drizzle store:
  * `timestamps` and `paranoid` are read by the model class, `externalId` by
- * `external-id.js`, and `personal` and `retention` are marks core reads
- * (`base/privacy.js`, `base/retention.js`) and this adapter only carries.
+ * `external-id.js`, `slug` by `slug.js`, and `personal` and `retention` are
+ * marks core reads (`base/privacy.js`, `base/retention.js`) and this
+ * adapter only carries.
  */
 const MODEL_OPTIONS = new Set([
   'externalId',
   'paranoid',
   'personal',
   'retention',
+  'slug',
   'tenant',
   'timestamps',
   'versioned',
@@ -228,6 +231,7 @@ class Drizzle {
     }
 
     this.addExternalId(definition);
+    this.addSlug(definition);
 
     if (isUser) {
       this.overload(definition);
@@ -338,6 +342,41 @@ class Drizzle {
       type: 'uuid',
       unique: true,
     };
+
+    return definition;
+  }
+
+  /**
+   * Adds the `slug` column to a model that asked for one: the name a person
+   * reads in a url, unique and indexed like the public identifier next to
+   * it. henri fills it (`model.js`, `prepare()`); the column is henri's, so
+   * a model that declares a `slug` field of its own is refused rather than
+   * quietly overwritten (`slug.js`, `slugOf()`).
+   *
+   * @param {object} definition The model file (copied)
+   * @returns {object} The definition
+   * @throws {Error} HENRI_MODEL_SLUG_DECLARATION_INVALID on a declaration
+   *   this adapter cannot carry out
+   * @memberof Drizzle
+   */
+  addSlug(definition) {
+    const declaration = slugOf(definition);
+
+    if (!declaration) {
+      return definition;
+    }
+
+    definition.schema[SLUG] = {
+      length: lengthOf(declaration),
+      lowercase: true,
+      required: true,
+      trim: true,
+      type: 'string',
+      unique: true,
+    };
+    // Compiled once, here, and read back by the model class: the column and
+    // the declaration are written by the same call, so they cannot drift
+    definition.slugged = declaration;
 
     return definition;
   }
@@ -615,6 +654,7 @@ class Drizzle {
       described[globalId] = {
         externalId: Boolean(Model.externalId),
         references,
+        slug: Boolean(Model.slug),
       };
     }
 

--- a/packages/drizzle/model.js
+++ b/packages/drizzle/model.js
@@ -19,6 +19,14 @@ const {
   wantsRecord,
 } = require('./validations');
 const {
+  SLUG,
+  emptySlug,
+  massWrite: massSlug,
+  problemOf: slugProblem,
+  slugFor,
+  writesSource,
+} = require('./slug');
+const {
   coded,
   isPlainObject,
   lowerFirst,
@@ -426,7 +434,9 @@ class Model {
    */
   static async findById(id, options = {}) {
     if (!this.externalId) {
-      return this.findByKey(id, options);
+      return this.slug
+        ? this.findBySlug(id, options)
+        : this.findByKey(id, options);
     }
 
     if (isUuid(id)) {
@@ -436,9 +446,35 @@ class Model {
       ).first();
     }
 
+    // The slug column, and only the slug column: a `WHERE slug = ?` cannot
+    // answer a question about the primary key, so `/articles/4812` stays as
+    // silent as it was before the model had a name. A model that has a name
+    // takes the whole non-uuid space with it, `externalIds.lookup: "any"`
+    // included -- the stricter of the two rules is the one to keep, and it
+    // is the same one on every adapter (./slug.js)
+    if (this.slug) {
+      return this.findBySlug(id, options);
+    }
+
     return resolvesKeys(this.adapter && this.adapter.henri)
       ? this.findByKey(id, options)
       : null;
+  }
+
+  /**
+   * A row by the name a person reads, on a model that declared one
+   *
+   * @param {*} slug A slug
+   * @param {object} [options={}] Options (`include`, `withHidden`)
+   * @returns {Promise<?Model>} The instance or null
+   * @memberof Model
+   */
+  static async findBySlug(slug, options = {}) {
+    if (!this.slug || typeof slug !== 'string' || slug === '') {
+      return null;
+    }
+
+    return this.relation({ [SLUG]: slug.toLowerCase() }, options).first();
   }
 
   /**
@@ -502,6 +538,23 @@ class Model {
         .toArray();
 
       return found ? found.id : null;
+    }
+
+    if (this.slug) {
+      // The same second identifier `findById()` takes, and the same one
+      // only: a slug names a row here or nothing does
+      if (typeof id !== 'string' || id === '') {
+        return null;
+      }
+
+      const [named] = await this.query()
+        .where({ [SLUG]: id.toLowerCase() })
+        .withDeleted()
+        .select('id')
+        .limit(1)
+        .toArray();
+
+      return named ? named.id : null;
     }
 
     if (this.externalId && !resolvesKeys(this.adapter && this.adapter.henri)) {
@@ -1180,6 +1233,11 @@ class Model {
     data =
       (await this.runHooks('beforeValidate', data, options, instance)) || data;
 
+    // Before the coercion, because the column henri adds is `required` and
+    // this is what fills it: a slug is written by the framework, so it has
+    // to be there by the time the schema is checked (./slug.js)
+    this.applySlug(kind, data, instance);
+
     let values = validate(this.modelName, this.fields, data, {
       partial: kind === 'update',
       skip: kind === 'update' ? [...PROTECTED, ...IMMUTABLE] : PROTECTED,
@@ -1253,6 +1311,133 @@ class Model {
         ])
       )
     );
+  }
+
+  /**
+   * Fills the `slug` column of a model that declared one, or checks the
+   * slug the write supplied.
+   *
+   * A slug the application wrote itself always wins and is never
+   * regenerated: it is the one way a record gets a name henri's ASCII fold
+   * would not have produced, and the only thing measured against it is
+   * whether it can be one path segment (`slug.js`, `problemOf()`).
+   *
+   * @param {string} kind create or update
+   * @param {object} data The attributes being written, written into
+   * @param {?Model} instance The instance being saved (updates)
+   * @returns {void}
+   * @throws {ValidationError} When the supplied slug cannot be a url
+   * @throws {Error} HENRI_MODEL_SLUG_EMPTY when there is nothing to build
+   *   one from and no discriminator to fall back to
+   * @memberof Model
+   */
+  static applySlug(kind, data, instance) {
+    const declaration = this.slug;
+
+    if (!declaration) {
+      return;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, SLUG)) {
+      // Normalized here rather than by the column's own `trim` and
+      // `lowercase`, so what is checked is exactly what is stored
+      const given =
+        typeof data[SLUG] === 'string'
+          ? data[SLUG].trim().toLowerCase()
+          : data[SLUG];
+      const wrong = slugProblem(given, declaration);
+
+      if (wrong) {
+        throw new ValidationError(this.modelName, {
+          [SLUG]: failure('slug', wrong, SLUG, data[SLUG]),
+        });
+      }
+
+      data[SLUG] = given;
+
+      return;
+    }
+
+    if (
+      kind !== 'create' &&
+      !(declaration.on === 'change' && writesSource(declaration, data))
+    ) {
+      return;
+    }
+
+    const source = writesSource(declaration, data)
+      ? data[declaration.from]
+      : instance && instance[declaration.from];
+    const slug = slugFor(
+      declaration,
+      source,
+      this.seedFor(kind, data, instance)
+    );
+
+    if (slug === '') {
+      throw emptySlug(this.modelName, declaration, source);
+    }
+
+    data[SLUG] = slug;
+  }
+
+  /**
+   * The public identifier the discriminator of a slug is taken from.
+   *
+   * On a create it is minted here rather than by the schema's default a
+   * moment later, so the slug and the `externalId` of a record are two
+   * spellings of the same uuid and stay that way if the slug is ever
+   * regenerated. A model that carries no public identifier has no seed and
+   * `slugFor()` falls back to randomness.
+   *
+   * @param {string} kind create or update
+   * @param {object} data The attributes being written
+   * @param {?Model} instance The instance being saved (updates)
+   * @returns {*} The external id, or undefined
+   * @memberof Model
+   */
+  static seedFor(kind, data, instance) {
+    if (data[EXTERNAL_ID]) {
+      return data[EXTERNAL_ID];
+    }
+
+    if (instance && instance[EXTERNAL_ID]) {
+      return instance[EXTERNAL_ID];
+    }
+
+    if (kind !== 'create' || !this.externalId) {
+      return undefined;
+    }
+
+    const mint = this.fields[EXTERNAL_ID].default;
+
+    if (typeof mint !== 'function') {
+      return undefined;
+    }
+
+    data[EXTERNAL_ID] = mint();
+
+    return data[EXTERNAL_ID];
+  }
+
+  /**
+   * Refuses a mass write that would have regenerated many slugs at once
+   *
+   * @param {string} what The call that was made
+   * @param {string} instead The single-record call to loop over
+   * @param {object} attrs The attributes the write names
+   * @returns {void}
+   * @throws {Error} HENRI_MODEL_SLUG_MASS_WRITE
+   * @memberof Model
+   */
+  static checkSlugMassWrite(what, instead, attrs) {
+    if (
+      this.slug &&
+      this.slug.on === 'change' &&
+      writesSource(this.slug, attrs)
+    ) {
+      throw massSlug(this.modelName, this.slug, what, instead);
+    }
   }
 
   /**
@@ -1424,6 +1609,7 @@ class Model {
     checkOptions(this, 'update', options);
     checkMassWrite(this, 'update', options);
     this.checkValidationsMassWrite('update', 'update(attrs)', attrs);
+    this.checkSlugMassWrite('update', 'update(attrs)', attrs);
 
     const values = await this.prepare(
       'update',
@@ -1960,6 +2146,11 @@ const createModel = (adapter, definition, fields) => {
     key: modelName,
     modelName,
     paranoid,
+    // What `options.slug` declared, compiled by the adapter when it added
+    // the column, or null when the model wants no second name (./slug.js).
+    // Compiled once and read from the definition rather than compiled again
+    // here, so the column and the declaration can never be out of step
+    slug: definition.slugged || null,
     tableName: tableNameOf(definition),
     timestamps,
     // What the model's `validates` block and its schema's `required` and

--- a/packages/drizzle/package.json
+++ b/packages/drizzle/package.json
@@ -30,6 +30,7 @@
     "utils.js",
     "validation.js",
     "validations.js",
+    "slug.js",
     "encrypted.js",
     "encryption.js",
     "tenant.js",

--- a/packages/drizzle/slug.js
+++ b/packages/drizzle/slug.js
@@ -1,0 +1,752 @@
+/**
+ * The third identifier, and the only one a person reads.
+ *
+ * `/articles/how-we-ship` rather than
+ * `/articles/01a07d06-e6c4-73cd-9021-31eb06befdd7`. A model asks for one in
+ * its options:
+ *
+ * ```js
+ * module.exports = {
+ *   schema: { body: { type: 'text' }, title: { type: 'string' } },
+ *   options: { slug: 'title' },
+ * };
+ * ```
+ *
+ * and henri adds a `slug` column -- unique, indexed, not null -- fills it
+ * on insert, resolves it in `findById()` and prints it in every url that
+ * names the record.
+ *
+ * ## Where a slug is allowed to appear, and where it is not
+ *
+ * henri has two identifiers and exactly one of them is public
+ * (`base/references.js`): `externalId`, a uuid v7, leaves the server; the
+ * primary key never does. A slug is a **third**, and almost everything
+ * below is about not spending the guarantee that buys.
+ *
+ * The rule is two lines long:
+ *
+ * - a slug appears in the record's own `slug` field, and in the **url** of
+ *   that record (`_links`, the route helpers, the `Location` of a 201);
+ * - it appears **nowhere else**. A foreign key is still published as the
+ *   `externalId` of the row it names, never as that row's slug. The
+ *   versions table, the access trail, the flags actor, the erasure receipt
+ *   and the webhook payloads all keep reading `externalId` and none of them
+ *   learned a second spelling.
+ *
+ * So the uuid is what an API client stores and what henri writes down; the
+ * slug is what a person reads and types. A record answers to both and they
+ * are both public: this is a second **name**, not a second identity.
+ *
+ * ## Why a lookup cannot be talked into a primary key
+ *
+ * `Model.findById()` is the door for what arrived from outside, and it
+ * grew a branch:
+ *
+ * 1. a uuid resolves the `externalId`, exactly as before;
+ * 2. anything else resolves the **slug column**, on a model that has one;
+ * 3. and that is the end of it -- `null`, the same `null` an unknown uuid
+ *    answers.
+ *
+ * Step 2 is a `WHERE slug = ?`, not a fallthrough, which is the whole
+ * safety argument. `findById('4812')` asks the slug column for `'4812'`; it
+ * does not ask the primary key anything, so it cannot say whether row 4812
+ * exists. If some record's slug really is `4812`, that record comes back --
+ * and that is a public fact about a public name, not the number. The
+ * primary key keeps its own door, `findByKey()`, and nothing here reaches
+ * for it.
+ *
+ * The one collision that would matter is a slug **shaped like a uuid**: it
+ * would take branch 1 and quietly name nothing. `problemOf()` refuses one,
+ * so the two identifier spaces never overlap.
+ *
+ * ## Uniqueness: what holds, and what henri will not pretend
+ *
+ * Two articles called "Getting started" is the normal case. henri does not
+ * claim `unique` as a validation -- a `SELECT` before an `INSERT` answers a
+ * question about a moment that has passed (`base/validations.js`) -- and it
+ * does not make an exception for itself here. So there is no lookup before
+ * the write, no counter, and no `-2`:
+ *
+ * - **`suffix: true`, the default.** The slug is the slugified source plus
+ *   a discriminator taken from the record's own `externalId`:
+ *   `getting-started-k3f9pq`. Unique because the uuid is, stable because
+ *   the uuid never changes, and free because nothing is read. The cost,
+ *   said out loud: every url carries six extra characters even when nothing
+ *   would have collided.
+ * - **`suffix: false`.** The slug is exactly the slugified source:
+ *   `getting-started`. The **unique index is what holds**, so the second
+ *   "Getting started" is refused by the database, and
+ *   `henri.model.errors()` turns that into `{ slug: 'must be unique' }` --
+ *   the same sentence any other unique column gives. The cost is that
+ *   refusal, and it lands on a title the author had every reason to think
+ *   was fine.
+ *
+ * Neither is scoped: a slug is unique across the table, not per tenant or
+ * per parent. A scope is a composite index henri would have to write into
+ * a migration it does not own, and it is not here.
+ *
+ * ## What happens when the title changes
+ *
+ * By default, nothing. `on: 'create'` is the default and it is the honest
+ * one: a slug is generated once and never moves, so the url minted the day
+ * the record was written keeps working forever, whatever the title becomes.
+ * An identifier that follows a display string is an identifier that stops
+ * being one.
+ *
+ * `on: 'change'` regenerates whenever the source field is written, and the
+ * old url **stops working that instant**. There is no history table in
+ * henri: friendly_id keeps every retired slug in one and answers a 301 from
+ * it, and that is a table on four adapters, a redirect, a retention rule
+ * and a reach for the erasure -- a tranche of its own. Until it exists,
+ * `on: 'change'` means the old url 404s, and the guide says so in those
+ * words.
+ *
+ * A mass update that names the source field on such a model is **refused**
+ * (`HENRI_MODEL_SLUG_MASS_WRITE`): the hook runs once, without records, so
+ * either every row would get the same slug or none would get a new one, and
+ * both are worse than the refusal. It is the answer
+ * `HENRI_MODEL_VALIDATION_MASS_WRITE` and `HENRI_VERSION_MASS_WRITE`
+ * already give to the same shape of problem, and it names the loop.
+ *
+ * ## A title that is not in English
+ *
+ * `slugify()` lowercases, decomposes (NFKD) and keeps `a-z0-9`. That makes
+ * `Café Crème` into `cafe-creme` without a transliteration table, because
+ * Unicode already knows that `é` is `e` with a mark on it and
+ * `String#normalize` ships in Node.
+ *
+ * What Unicode does **not** decompose is a short list of Latin letters that
+ * are letters in their own right -- `ß`, `ø`, `ł`, `æ`, `þ` -- and `FOLDED`
+ * is a line each for them, eleven in total. That is the whole table and it
+ * is deliberately not the first entry of one per script: a Japanese,
+ * Arabic, Hebrew, Greek or Cyrillic title has no ASCII to fold to, and
+ * shipping the tables that would invent some is how a framework ends up
+ * choosing romanizations on a reader's behalf.
+ *
+ * So a title in one of those scripts **slugifies to nothing**, and that
+ * needed a real answer rather than a shrug. It has two:
+ *
+ * - With `suffix: true` the record still gets a slug -- the discriminator
+ *   alone, `k3f9pq` -- so the write never fails and the url always works.
+ *   With `suffix: false` there is nothing to fall back to and the write is
+ *   refused (`HENRI_MODEL_SLUG_EMPTY`), naming the field and the title.
+ * - **A slug the application writes itself always wins and may be any
+ *   Unicode henri can carry in a path segment.** `slug: 'こんにちは'` is
+ *   accepted, stored, matched by the route and carried percent-encoded on
+ *   the wire, which every browser renders back as the characters. So the
+ *   choice between transliteration and percent-encoding is not made here:
+ *   henri's generator folds to ASCII and ships no romanization, and an
+ *   application that wants its own script in the url writes the slug and
+ *   gets it, byte for byte.
+ *
+ * `problemOf()` is what a supplied slug is measured against, and it is a
+ * list of the structural characters rather than a definition of a letter:
+ * nothing below `!`, none of `"#%/:?@[\]^`{|}<>`, not `.` or `..`, not a
+ * uuid, not a reserved word, not longer than the column. A deny list is the
+ * right shape here precisely because henri is not the one deciding what
+ * counts as a word.
+ *
+ * ## Reserved words
+ *
+ * `resources articles` mounts `GET /articles/new` before `GET /articles/:id`
+ * (`base/routes.js`), so a record slugged `new` is a record with no show
+ * page. henri reserves that one word by default and `reserved` adds more --
+ * which is the honest bound, because a `collection` route an application
+ * declared is a segment henri cannot know when the slug is generated. The
+ * guide says to add it.
+ *
+ * ## No regular expression touches a title
+ *
+ * A title arrives through `req.permit()`, and a slugifier is exactly the
+ * shape that turns into a quadratic match. Everything here walks: one pass
+ * over the code points with a `Set` and a `Map`, no `RegExp` anywhere in
+ * the file, and the length bound applied while walking rather than after.
+ *
+ * ## A copy per adapter
+ *
+ * This file is held four times -- here and in `@usehenri/drizzle`,
+ * `@usehenri/mongoose` and `@usehenri/sequelize` -- byte for byte, the way
+ * `exact.js`, `external-id.js` and `validations.js` are, because an adapter
+ * depends on no part of core at runtime.
+ * `src/__tests__/slug.spec.js` is what keeps them the same file. It
+ * requires nothing at all, and raises its codes through a `coded()` of its
+ * own for the same reason.
+ */
+
+/** The field a slug lives in, and the column it becomes */
+const SLUG = 'slug';
+
+/** The failure a `slug` declaration henri cannot carry out gets */
+const DECLARATION = 'HENRI_MODEL_SLUG_DECLARATION_INVALID';
+
+/** The failure a source that slugifies to nothing gets */
+const EMPTY = 'HENRI_MODEL_SLUG_EMPTY';
+
+/** The failure a mass write that would regenerate many slugs gets */
+const MASS_WRITE = 'HENRI_MODEL_SLUG_MASS_WRITE';
+
+/** How long the slugified source may be, before the discriminator */
+const MAX_LENGTH = 80;
+
+/** How many characters the discriminator adds, plus its separator */
+const SUFFIX_LENGTH = 6;
+
+/** The keys a `slug` declaration may hold */
+const KEYS = ['from', 'maxLength', 'on', 'reserved', 'suffix'];
+
+/** What `on` takes: generate once, or follow the source */
+const EVENTS = ['create', 'change'];
+
+/**
+ * The characters a slug may never carry, whoever wrote it.
+ *
+ * Not "everything but a letter": henri is not the one deciding what counts
+ * as a letter in a script it does not read. These are the ones that end a
+ * path segment, start a query, escape an encoding or name a directory.
+ */
+const REFUSED = new Set([
+  '"',
+  '#',
+  '%',
+  '/',
+  ':',
+  '<',
+  '>',
+  '?',
+  '@',
+  '[',
+  '\\',
+  ']',
+  '^',
+  '`',
+  '{',
+  '|',
+  '}',
+]);
+
+/** The path segments a slug would shadow */
+const RESERVED = ['.', '..', 'new'];
+
+/**
+ * The Latin letters Unicode does not decompose, which is why each needs a
+ * line. This is the whole table and it is deliberately not one per script:
+ * see the header.
+ */
+const FOLDED = new Map([
+  ['æ', 'ae'],
+  ['đ', 'd'],
+  ['ð', 'd'],
+  ['ħ', 'h'],
+  ['ı', 'i'],
+  ['ł', 'l'],
+  ['ø', 'o'],
+  ['œ', 'oe'],
+  ['ß', 'ss'],
+  ['þ', 'th'],
+  ['ŧ', 't'],
+]);
+
+/**
+ * The alphabet of the discriminator: base 32 without the characters a
+ * person mistakes for another when reading a url out loud (`0`/`o`,
+ * `1`/`l`/`i`).
+ */
+const ALPHABET = '23456789abcdefghjkmnpqrstuvwxyz';
+
+/** The separator between words, and before the discriminator */
+const DASH = '-';
+
+/**
+ * An error carrying a henri code, without depending on core
+ *
+ * @param {string} code the henri error code
+ * @param {string} message what is wrong
+ * @returns {Error} the error to throw
+ */
+const coded = (code, message) => Object.assign(new Error(message), { code });
+
+/**
+ * Is the value a plain object?
+ *
+ * @param {*} value any value
+ * @returns {boolean} true for a plain object
+ */
+const isPlainObject = (value) =>
+  value !== null &&
+  typeof value === 'object' &&
+  (Object.getPrototypeOf(value) === Object.prototype ||
+    Object.getPrototypeOf(value) === null);
+
+/**
+ * Is this string a uuid, and therefore an `externalId` rather than a name?
+ *
+ * The shape is checked by walking it: eight hex, a dash, four, a dash,
+ * four, a dash, four, a dash, twelve. The same answer
+ * `base/external-id.js` gives, without the pattern, because this one is
+ * asked about a value that came from a request.
+ *
+ * @param {string} value the candidate
+ * @returns {boolean} true when it is shaped like a uuid
+ */
+const looksLikeUuid = (value) => {
+  const groups = [8, 4, 4, 4, 12];
+  let at = 0;
+
+  for (let group = 0; group < groups.length; group += 1) {
+    if (group > 0) {
+      if (value[at] !== DASH) {
+        return false;
+      }
+
+      at += 1;
+    }
+
+    for (let taken = 0; taken < groups[group]; taken += 1) {
+      const code = value.charCodeAt(at);
+
+      // 0-9, a-f, A-F
+      if (
+        !(code >= 48 && code <= 57) &&
+        !(code >= 97 && code <= 102) &&
+        !(code >= 65 && code <= 70)
+      ) {
+        return false;
+      }
+
+      at += 1;
+    }
+  }
+
+  return at === value.length;
+};
+
+/**
+ * Is this code point a combining mark NFKD left behind?
+ *
+ * The three blocks a decomposed Latin, Greek or Cyrillic letter puts its
+ * accent in. They are dropped rather than turned into a separator, so
+ * `é` is `e` and not `e-`.
+ *
+ * @param {number} code the code point
+ * @returns {boolean} true for a combining mark
+ */
+const isMark = (code) =>
+  (code >= 0x0300 && code <= 0x036f) ||
+  (code >= 0x1ab0 && code <= 0x1aff) ||
+  (code >= 0x20d0 && code <= 0x20f0);
+
+/**
+ * The slug of a value: lowercase, decomposed, `a-z0-9` joined by dashes.
+ *
+ * One walk over the code points, no pattern, and the bound applied as it
+ * goes rather than by cutting at the end -- so a title of any length costs
+ * what the bound costs and not what the title costs.
+ *
+ * @param {*} value what the source field holds
+ * @param {number} [maxLength=MAX_LENGTH] how long the answer may be
+ * @returns {string} the slug, possibly empty
+ */
+const slugify = (value, maxLength = MAX_LENGTH) => {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return '';
+  }
+
+  const source = String(value).toLowerCase().normalize('NFKD');
+  const out = [];
+  let pending = false;
+
+  for (const character of source) {
+    if (out.length >= maxLength) {
+      break;
+    }
+
+    const code = character.codePointAt(0);
+
+    if (isMark(code)) {
+      continue;
+    }
+
+    // The ranges `a-z` and `0-9`, the only two that come out of this file
+    if ((code >= 97 && code <= 122) || (code >= 48 && code <= 57)) {
+      if (pending && out.length > 0) {
+        out.push(DASH);
+      }
+
+      pending = false;
+
+      if (out.length < maxLength) {
+        out.push(character);
+      }
+
+      continue;
+    }
+
+    const folded = FOLDED.get(character);
+
+    if (folded) {
+      if (pending && out.length > 0) {
+        out.push(DASH);
+      }
+
+      pending = false;
+
+      for (const letter of folded) {
+        if (out.length < maxLength) {
+          out.push(letter);
+        }
+      }
+
+      continue;
+    }
+
+    // Anything else -- a space, a comma, an emoji, a kanji -- ends the run
+    // rather than being carried, and a run of them is one dash
+    pending = true;
+  }
+
+  return out.join('');
+};
+
+/**
+ * Six characters of the record's own public identifier, so the
+ * discriminator is unique because the uuid is and stable because the uuid
+ * never changes.
+ *
+ * A model that opted out of `externalId` has no such seed, and neither
+ * does a mass insert on an ORM that fills the column after the hook; both
+ * fall back to `Math.random()`, which is enough because a discriminator is
+ * not a secret -- a slug is a public name, nothing is protected by knowing
+ * one, and a duplicate is caught by the unique index the column carries.
+ *
+ * @param {*} seed the record's `externalId`, when there is one
+ * @returns {string} six characters of the alphabet
+ */
+const discriminate = (seed) => {
+  const out = [];
+
+  if (typeof seed === 'string' && seed.length >= SUFFIX_LENGTH * 2) {
+    // The tail of a uuid v7 is its random half; the head is the clock, and
+    // every record written in the same millisecond shares it
+    const tail = seed
+      .slice(-SUFFIX_LENGTH * 2)
+      .split(DASH)
+      .join('');
+
+    for (
+      let at = 0;
+      at + 1 < tail.length && out.length < SUFFIX_LENGTH;
+      at += 2
+    ) {
+      const pair = parseInt(tail.slice(at, at + 2), 16);
+
+      if (Number.isNaN(pair)) {
+        break;
+      }
+
+      out.push(ALPHABET[pair % ALPHABET.length]);
+    }
+  }
+
+  while (out.length < SUFFIX_LENGTH) {
+    out.push(ALPHABET[Math.floor(Math.random() * ALPHABET.length)]);
+  }
+
+  return out.join('');
+};
+
+/**
+ * Refuses a declaration, naming the model
+ *
+ * @param {string} model the model's global id
+ * @param {string} what what is wrong with it
+ * @returns {void} never returns
+ * @throws {Error} always, HENRI_MODEL_SLUG_DECLARATION_INVALID
+ */
+const refuse = (model, what) => {
+  throw coded(DECLARATION, `${model} declares \`options.slug\` with ${what}`);
+};
+
+/**
+ * The `slug` declaration of a model file, compiled, or null when it wants
+ * no slug.
+ *
+ * `slug: 'title'` is the shorthand every application writes; the object
+ * form takes `from`, `on`, `suffix`, `reserved` and `maxLength`.
+ *
+ * @param {object} model the model file (`schema`, `options`, `globalId`)
+ * @returns {?object} `{ from, maxLength, on, reserved, suffix }` or null
+ * @throws {Error} HENRI_MODEL_SLUG_DECLARATION_INVALID on anything unusable
+ */
+const slugOf = (model) => {
+  const options = (model && model.options) || {};
+  const written = options.slug;
+  const name = (model && (model.globalId || model.identity)) || 'model';
+
+  if (typeof written === 'undefined' || written === null || written === false) {
+    return null;
+  }
+
+  if (typeof written !== 'string' && !isPlainObject(written)) {
+    refuse(
+      name,
+      `${typeof written}: it is the name of the field to build the slug from, or an object of ${KEYS.join(', ')}`
+    );
+  }
+
+  const declared =
+    typeof written === 'string' ? { from: written } : { ...written };
+
+  for (const key of Object.keys(declared)) {
+    if (!KEYS.includes(key)) {
+      refuse(name, `the unknown key "${key}": it takes ${KEYS.join(', ')}`);
+    }
+  }
+
+  const schema = (model && model.schema) || {};
+  const { from } = declared;
+
+  if (typeof from !== 'string' || from === '') {
+    refuse(name, 'no "from": a slug is built from a field of the model');
+  }
+
+  if (from === SLUG) {
+    refuse(name, 'a "from" of "slug": the slug cannot be built from itself');
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(schema, from)) {
+    refuse(name, `a "from" of "${from}", which the schema does not declare`);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(schema, SLUG)) {
+    refuse(
+      name,
+      'a "slug" field of its own in the schema: henri adds the column, so declaring it twice would mean two different things'
+    );
+  }
+
+  const definition = schema[from];
+  const type = isPlainObject(definition) ? definition.type : definition;
+
+  if (type !== 'string' && type !== 'text' && type !== String) {
+    refuse(
+      name,
+      `a "from" of "${from}", which is not a string or a text: a slug is built from words`
+    );
+  }
+
+  if (isPlainObject(definition) && definition.encrypted) {
+    refuse(
+      name,
+      `a "from" of "${from}", which is encrypted: a slug is public and the column it came from is not`
+    );
+  }
+
+  const marked = isPlainObject(definition) ? definition.personal : null;
+
+  if (isPlainObject(marked) && marked.expose === false) {
+    refuse(
+      name,
+      `a "from" of "${from}", which is marked \`personal: { expose: false }\`: that field is dropped from every answer henri builds, and a slug is in every url of the record`
+    );
+  }
+
+  const compiled = {
+    from,
+    maxLength: MAX_LENGTH,
+    on: 'create',
+    reserved: new Set(RESERVED),
+    suffix: true,
+  };
+
+  if ('on' in declared) {
+    if (!EVENTS.includes(declared.on)) {
+      refuse(name, `an "on" of "${declared.on}": it is ${EVENTS.join(' or ')}`);
+    }
+
+    compiled.on = declared.on;
+  }
+
+  if ('suffix' in declared) {
+    if (typeof declared.suffix !== 'boolean') {
+      refuse(name, 'a "suffix" that is not true or false');
+    }
+
+    compiled.suffix = declared.suffix;
+  }
+
+  if ('maxLength' in declared) {
+    if (
+      typeof declared.maxLength !== 'number' ||
+      !Number.isInteger(declared.maxLength) ||
+      declared.maxLength < 1
+    ) {
+      refuse(name, 'a "maxLength" that is not a whole number of characters');
+    }
+
+    compiled.maxLength = declared.maxLength;
+  }
+
+  if ('reserved' in declared) {
+    if (
+      !Array.isArray(declared.reserved) ||
+      declared.reserved.some((word) => typeof word !== 'string')
+    ) {
+      refuse(name, 'a "reserved" that is not a list of words');
+    }
+
+    for (const word of declared.reserved) {
+      compiled.reserved.add(word.toLowerCase());
+    }
+  }
+
+  return compiled;
+};
+
+/**
+ * How long the column has to be: the slugified source, the separator and
+ * the discriminator
+ *
+ * @param {object} declaration the compiled declaration
+ * @returns {number} the column length
+ */
+const lengthOf = (declaration) =>
+  declaration.maxLength + (declaration.suffix ? SUFFIX_LENGTH + 1 : 0);
+
+/**
+ * Everything wrong with a slug an application wrote itself.
+ *
+ * A deny list rather than a definition of a word: any script may name a
+ * record, and what may not is what would stop being one path segment.
+ *
+ * @param {*} value the slug
+ * @param {object} declaration the compiled declaration
+ * @returns {?string} the message, or null when it can be a url segment
+ */
+const problemOf = (value, declaration) => {
+  if (typeof value !== 'string') {
+    return 'must be a string';
+  }
+
+  if (value === '') {
+    return 'is required';
+  }
+
+  if ([...value].length > lengthOf(declaration)) {
+    return `must be at most ${lengthOf(declaration)} characters`;
+  }
+
+  for (const character of value) {
+    const code = character.codePointAt(0);
+
+    if (code < 0x21 || code === 0x7f) {
+      return 'must not hold a space or a control character';
+    }
+
+    if (REFUSED.has(character)) {
+      return `must not hold "${character}"`;
+    }
+  }
+
+  if (looksLikeUuid(value)) {
+    return 'must not be shaped like a public identifier';
+  }
+
+  if (declaration.reserved.has(value.toLowerCase())) {
+    return `must not be "${value}", which is a path henri already mounts`;
+  }
+
+  return null;
+};
+
+/**
+ * The slug of a record about to be written.
+ *
+ * @param {object} declaration the compiled declaration
+ * @param {*} source what the source field holds
+ * @param {*} seed the record's `externalId`, for the discriminator
+ * @returns {string} the slug, or an empty string when there is nothing to
+ *   build one from and no discriminator to fall back to
+ */
+const slugFor = (declaration, source, seed) => {
+  const base = slugify(source, declaration.maxLength);
+
+  if (!declaration.suffix) {
+    return base;
+  }
+
+  const suffix = discriminate(seed);
+
+  return base === '' ? suffix : `${base}${DASH}${suffix}`;
+};
+
+/**
+ * Does this write name the field the slug is built from?
+ *
+ * @param {object} declaration the compiled declaration
+ * @param {*} attrs the attributes being written
+ * @returns {boolean} true when the source field is one of them
+ */
+const writesSource = (declaration, attrs) =>
+  Boolean(declaration) &&
+  isPlainObject(attrs) &&
+  Object.prototype.hasOwnProperty.call(attrs, declaration.from);
+
+/**
+ * The refusal a source that slugified to nothing gets
+ *
+ * @param {string} model the model's global id
+ * @param {object} declaration the compiled declaration
+ * @param {*} source what the source field held
+ * @returns {Error} the error to throw
+ */
+const emptySlug = (model, declaration, source) =>
+  coded(
+    EMPTY,
+    `${model}.${declaration.from} is ${
+      typeof source === 'string' && source !== ''
+        ? `"${source}", which has no letters or digits henri can fold to ASCII`
+        : 'empty'
+    }, and the model declares \`slug: { suffix: false }\`, so there is nothing to build a slug from. ` +
+      'Write the slug yourself, or let henri add its discriminator (`suffix: true`, the default), which always answers something.'
+  );
+
+/**
+ * The refusal a mass write that would regenerate many slugs gets
+ *
+ * @param {string} model the model's global id
+ * @param {object} declaration the compiled declaration
+ * @param {string} what the call that was made (`update`, `updateMany`)
+ * @param {string} instead the single-record call to loop over
+ * @returns {Error} the error to throw
+ */
+const massWrite = (model, declaration, what, instead) =>
+  coded(
+    MASS_WRITE,
+    `${model}.${what}() writes many rows at once and names ${declaration.from}, which ${model} regenerates its slug from (\`slug: { on: 'change' }\`). ` +
+      'One hook runs for the whole write, with no records in it, so every row would get one slug or none would get a new one. henri refuses rather than doing either. ' +
+      `Loop instead: for (const record of await ${model}.find(where)) await record.${instead}`
+  );
+
+module.exports = {
+  ALPHABET,
+  DECLARATION,
+  EMPTY,
+  EVENTS,
+  KEYS,
+  MASS_WRITE,
+  MAX_LENGTH,
+  RESERVED,
+  SLUG,
+  SUFFIX_LENGTH,
+  coded,
+  discriminate,
+  emptySlug,
+  lengthOf,
+  looksLikeUuid,
+  massWrite,
+  problemOf,
+  slugFor,
+  slugOf,
+  slugify,
+  writesSource,
+};

--- a/packages/mcp/__tests__/server.spec.js
+++ b/packages/mcp/__tests__/server.spec.js
@@ -874,6 +874,7 @@ describe('henri mcp against a running application', () => {
 
     expect(identity.app.pid).toBe(server.pid);
     expect(identity.models.map((model) => model.name).sort()).toEqual([
+      'Article',
       'Artwork',
       'Invoice',
       'Memo',

--- a/packages/mongoose/__tests__/slug.spec.js
+++ b/packages/mongoose/__tests__/slug.spec.js
@@ -1,0 +1,319 @@
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const Mongoose = require('../index');
+const { modelErrors } = require('@usehenri/core/src/base/model-errors');
+
+let mongod;
+let sequence = 0;
+
+/**
+ * Builds a minimal henri stand-in for the adapter
+ *
+ * @returns {object} fake henri
+ */
+const fakeHenri = () => {
+  const pen = {};
+
+  ['error', 'fatal', 'info', 'warn'].forEach((level) => {
+    pen[level] = () => undefined;
+  });
+
+  return {
+    _user: null,
+    config: { get: () => undefined, has: () => false },
+    isTest: true,
+    pen,
+    user: { encrypt: async (password) => `hashed:${password}` },
+  };
+};
+
+/**
+ * A model file that asks for a slug
+ *
+ * @param {*} [slug='title'] What `options.slug` says
+ * @returns {object} The model file
+ */
+const articleModel = (slug = 'title') => ({
+  globalId: 'Article',
+  identity: 'article',
+  options: { slug, timestamps: true },
+  schema: {
+    body: { type: 'text' },
+    title: { required: true, type: 'string' },
+  },
+  store: 'default',
+});
+
+/**
+ * An adapter with the model on a database of its own
+ *
+ * @param {*} [slug] What `options.slug` says
+ * @returns {Promise<{adapter: object, Article: object}>} Both
+ */
+const boot = async (slug) => {
+  const adapter = new Mongoose(
+    'default',
+    { url: mongod.getUri(`slug${(sequence += 1)}`) },
+    fakeHenri()
+  );
+  const Article = adapter.addModel(articleModel(slug), 'user');
+
+  await adapter.start();
+  await Article.syncIndexes();
+
+  return { Article, adapter };
+};
+
+/**
+ * The error a write threw, as `{ field: message }` or `{ code }`
+ *
+ * @param {Promise} promise The write
+ * @returns {Promise<object>} What it refused with
+ */
+const errorsOf = async (promise) => {
+  try {
+    await promise;
+  } catch (error) {
+    return modelErrors(error) || { code: error.code };
+  }
+
+  return null;
+};
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+}, 60000);
+
+afterAll(() => mongod && mongod.stop());
+
+describe('slugs on a mongoose store', () => {
+  describe('the path henri adds', () => {
+    let Article;
+    let adapter;
+
+    beforeAll(async () => {
+      ({ Article, adapter } = await boot());
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('is filled from the source field on insert', async () => {
+      const article = await Article.create({ title: 'How we ship' });
+
+      expect(article.slug.startsWith('how-we-ship-')).toBe(true);
+      expect(article.slug).toHaveLength('how-we-ship-'.length + 6);
+    });
+
+    test('lets two documents share a title', async () => {
+      const first = await Article.create({ title: 'Getting started' });
+      const second = await Article.create({ title: 'Getting started' });
+
+      expect(first.slug).not.toBe(second.slug);
+    });
+
+    test('answers something for a title with no ASCII in it', async () => {
+      const article = await Article.create({ title: 'こんにちは' });
+
+      expect(article.slug).toHaveLength(6);
+    });
+
+    test('does not move when the title changes', async () => {
+      const article = await Article.create({ title: 'First name' });
+      const before = article.slug;
+
+      article.title = 'Second name';
+      await article.save();
+
+      expect(article.slug).toBe(before);
+    });
+
+    test('is not moved by a query update either', async () => {
+      const article = await Article.create({ title: 'Third name' });
+
+      await Article.updateOne({ _id: article._id }, { title: 'Fourth name' });
+
+      expect((await Article.findByKey(article._id)).slug).toBe(article.slug);
+    });
+  });
+
+  describe('the lookup', () => {
+    let Article;
+    let adapter;
+    let article;
+
+    beforeAll(async () => {
+      ({ Article, adapter } = await boot());
+      article = await Article.create({ title: 'How we ship' });
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('findById() takes the slug', async () => {
+      expect(String((await Article.findById(article.slug))._id)).toBe(
+        String(article._id)
+      );
+    });
+
+    test('findById() still takes the public identifier', async () => {
+      expect(String((await Article.findById(article.externalId))._id)).toBe(
+        String(article._id)
+      );
+    });
+
+    test('findById() does not take the document id', async () => {
+      expect(await Article.findById(article._id)).toBeNull();
+      expect(await Article.findById(String(article._id))).toBeNull();
+    });
+
+    test('a name that names nothing answers the same null', async () => {
+      expect(await Article.findById('4812')).toBeNull();
+      expect(await Article.findById('no-such-article')).toBeNull();
+    });
+
+    test('findBySlug() takes a slug and nothing else', async () => {
+      expect(await Article.findBySlug(article.slug)).not.toBeNull();
+      expect(await Article.findBySlug(article.externalId)).toBeNull();
+      expect(await Article.findBySlug(String(article._id))).toBeNull();
+    });
+
+    test('findByKey() is still the document id door', async () => {
+      expect(await Article.findByKey(article._id)).not.toBeNull();
+    });
+
+    test('findByIdAndUpdate() reaches the same documents findById() does', async () => {
+      expect(
+        await Article.findByIdAndUpdate(article.slug, { body: 'written' })
+      ).not.toBeNull();
+      expect(
+        await Article.findByIdAndUpdate(String(article._id), { body: 'no' })
+      ).toBeNull();
+    });
+  });
+
+  describe('a slug the application writes itself', () => {
+    let Article;
+    let adapter;
+
+    beforeAll(async () => {
+      ({ Article, adapter } = await boot());
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('wins over the one henri would have made', async () => {
+      const article = await Article.create({
+        slug: 'how-we-ship',
+        title: 'Something else entirely',
+      });
+
+      expect(article.slug).toBe('how-we-ship');
+    });
+
+    test('may be any script henri ships no table for', async () => {
+      await Article.create({ slug: 'こんにちは', title: 'Hello' });
+
+      expect(await Article.findById('こんにちは')).not.toBeNull();
+    });
+
+    test('is refused when it cannot be one path segment', async () => {
+      expect(
+        await errorsOf(Article.create({ slug: 'a/b', title: 'x' }))
+      ).toEqual({ slug: 'must not hold "/"' });
+    });
+
+    test('is refused when it is shaped like a public identifier', async () => {
+      expect(
+        await errorsOf(
+          Article.create({
+            slug: '01a07d06-e6c4-73cd-9021-31eb06befdd7',
+            title: 'x',
+          })
+        )
+      ).toEqual({ slug: 'must not be shaped like a public identifier' });
+    });
+
+    test('is refused when the database already holds it', async () => {
+      await Article.create({ slug: 'taken', title: 'x' });
+
+      expect(
+        await errorsOf(Article.create({ slug: 'taken', title: 'y' }))
+      ).toEqual({ slug: 'must be unique' });
+    });
+  });
+
+  describe("on: 'change'", () => {
+    let Article;
+    let adapter;
+
+    beforeAll(async () => {
+      ({ Article, adapter } = await boot({ from: 'title', on: 'change' }));
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('follows the source on a save, and the old url stops working', async () => {
+      const article = await Article.create({ title: 'First name' });
+      const before = article.slug;
+
+      article.title = 'Second name';
+      await article.save();
+
+      expect(article.slug.startsWith('second-name-')).toBe(true);
+      expect(await Article.findById(before)).toBeNull();
+    });
+
+    test('follows the source on a query update naming one document', async () => {
+      const article = await Article.create({ title: 'Third name' });
+
+      await Article.updateOne({ _id: article._id }, { title: 'Fourth name' });
+
+      const found = await Article.findByKey(article._id);
+
+      expect(found.slug.startsWith('fourth-name-')).toBe(true);
+    });
+
+    test('refuses a mass update that names the source', async () => {
+      expect(
+        await errorsOf(
+          Article.updateMany({ body: null }, { title: 'One name for all' })
+        )
+      ).toEqual({ code: 'HENRI_MODEL_SLUG_MASS_WRITE' });
+    });
+
+    test('allows a mass update that does not', async () => {
+      await expect(
+        Article.updateMany({ body: null }, { body: 'swept' })
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe('suffix: false', () => {
+    let Article;
+    let adapter;
+
+    beforeAll(async () => {
+      ({ Article, adapter } = await boot({ from: 'title', suffix: false }));
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('is the slugified source and nothing else', async () => {
+      const article = await Article.create({ title: 'How we ship' });
+
+      expect(article.slug).toBe('how-we-ship');
+    });
+
+    test('leaves the unique index to refuse the second one', async () => {
+      await Article.create({ title: 'Getting started' });
+
+      expect(
+        await errorsOf(Article.create({ title: 'Getting started' }))
+      ).toEqual({ slug: 'must be unique' });
+    });
+
+    test('refuses a title it cannot fold rather than writing an empty name', async () => {
+      expect(await errorsOf(Article.create({ title: 'こんにちは' }))).toEqual({
+        code: 'HENRI_MODEL_SLUG_EMPTY',
+      });
+    });
+  });
+});

--- a/packages/mongoose/index.js
+++ b/packages/mongoose/index.js
@@ -6,6 +6,7 @@ const {
   owned,
   paginate,
   paranoid,
+  slugged,
   validations,
 } = require('./plugins');
 const { validationsOf } = require('./validations');
@@ -24,6 +25,7 @@ const {
   uuidv7,
   wantsExternalId,
 } = require('./external-id');
+const { slugOf } = require('./slug');
 const { buildUrl, coded, fatal, normalizeEmail, redact } = require('./utils');
 
 /**
@@ -166,6 +168,7 @@ class Mongoose {
       // Mongoose schema options
       personal,
       retention,
+      slug: named,
       // `tenant` is core's mark and not a Mongoose schema option: the
       // adapter reads it through `henri.tenancy` a line below (./tenant.js)
       tenant: belongsToTenant,
@@ -216,6 +219,15 @@ class Mongoose {
     // Every model carries a public identifier; the document id is internal
     if (wantsExternalId({ options: { externalId: external } })) {
       externalId(schema);
+    }
+
+    // The third identifier, and the only one a person reads. After the
+    // public one, because the discriminator of a generated slug is taken
+    // from it (./slug.js)
+    const declaredSlug = slugOf(model);
+
+    if (declaredSlug) {
+      slugged(schema, declaredSlug, model.globalId);
     }
 
     // Before the soft delete, so a tenanted model that also soft deletes
@@ -612,6 +624,7 @@ class Mongoose {
       described[globalId] = {
         externalId: Boolean(Model.schema.path(EXTERNAL_ID)),
         references,
+        slug: Boolean(slugOf(this.definitions[globalId].model)),
       };
     }
 

--- a/packages/mongoose/package.json
+++ b/packages/mongoose/package.json
@@ -32,6 +32,7 @@
     "types.js",
     "utils.js",
     "validations.js",
+    "slug.js",
     "CHANGELOG.md",
     "encrypted.js",
     "encryption.js",

--- a/packages/mongoose/plugins.js
+++ b/packages/mongoose/plugins.js
@@ -7,6 +7,15 @@ const {
   uuidv7,
 } = require('./external-id');
 const {
+  SLUG,
+  emptySlug,
+  lengthOf,
+  massWrite: massSlug,
+  problemOf: slugProblem,
+  slugFor,
+  writesSource,
+} = require('./slug');
+const {
   massWrite,
   problemsOf,
   uncheckedWrite,
@@ -32,6 +41,11 @@ const NOTHING = () => ({ _id: null });
 // `externalIds.lookup` without a global. Weak, so a reloaded schema is
 // collected with its entry.
 const owners = new WeakMap();
+
+// The compiled `options.slug` of a schema that declared one, read by the
+// lookup below so a name is resolved and a document id still is not. Weak,
+// for the same reason.
+const slugs = new WeakMap();
 
 /**
  * Remembers which henri instance a schema belongs to
@@ -84,12 +98,25 @@ const keyFilter = (model, value) => {
  * @returns {object} The filter
  */
 const idFilter = (model, value) => {
+  const named =
+    slugs.has(model.schema) && typeof value === 'string' && value !== ''
+      ? { [SLUG]: value.toLowerCase() }
+      : null;
+
   if (!model.schema.path(EXTERNAL_ID)) {
-    return keyFilter(model, value);
+    return named || keyFilter(model, value);
   }
 
   if (isUuid(value)) {
     return { [EXTERNAL_ID]: normalizeExternalId(value) };
+  }
+
+  // The slug column, and only the slug column. A model that has a name
+  // takes the whole non-uuid space with it: `externalIds.lookup: "any"`
+  // does not put the document id back, because a filter is one filter and
+  // the stricter of the two is the one to keep (see ./slug.js)
+  if (named) {
+    return named;
   }
 
   return resolvesKeys(owners.get(model.schema))
@@ -159,6 +186,24 @@ const lookups = (schema) => {
     return this.findOne(
       isUuid(id) && this.schema.path(EXTERNAL_ID)
         ? { [EXTERNAL_ID]: normalizeExternalId(id) }
+        : NOTHING(),
+      projection,
+      options
+    );
+  };
+
+  /**
+   * A document by the name a person reads, on a model that declared one
+   *
+   * @param {*} slug A slug
+   * @param {*} [projection] The projection
+   * @param {object} [options] Query options
+   * @returns {object} A query
+   */
+  schema.statics.findBySlug = function findBySlug(slug, projection, options) {
+    return this.findOne(
+      slugs.has(this.schema) && typeof slug === 'string' && slug !== ''
+        ? { [SLUG]: slug.toLowerCase() }
         : NOTHING(),
       projection,
       options
@@ -466,6 +511,142 @@ const externalId = (schema) => {
   return schema;
 };
 
+/**
+ * The `slug` path and the two hooks that fill it: the name a person reads
+ * in a url, on a model that declared `options: { slug: ... }`.
+ *
+ * Registered as document middleware and as query middleware for the same
+ * reason `validations` is: Mongoose runs `pre('validate')` for `save()`,
+ * `create()` and `insertMany()` and for nothing else, so an
+ * `updateOne`/`findOneAndUpdate` that changed the title would have written
+ * past a regeneration.
+ *
+ * @param {object} schema The Mongoose schema
+ * @param {object} declaration The compiled declaration (./slug.js)
+ * @param {string} model The model's global id, for the messages
+ * @returns {object} The schema
+ */
+const slugged = (schema, declaration, model) => {
+  slugs.set(schema, declaration);
+
+  schema.add({
+    [SLUG]: {
+      index: true,
+      lowercase: true,
+      maxlength: lengthOf(declaration),
+      required: true,
+      trim: true,
+      type: String,
+      unique: true,
+    },
+  });
+
+  /**
+   * The error a slug that cannot be a url segment gets, in the shape a
+   * Mongoose validation failure has
+   *
+   * @param {string} message What is wrong with it
+   * @param {*} value The slug
+   * @returns {Error} A ValidationError
+   */
+  const failure = (message, value) => {
+    const error = new Error(`${model} validation failed: ${SLUG}: ${message}`);
+
+    error.name = 'ValidationError';
+    error.errors = {
+      [SLUG]: { kind: 'slug', message, path: SLUG, value },
+    };
+
+    return error;
+  };
+
+  /**
+   * Everything wrong with a slug an application wrote itself
+   *
+   * @param {*} value The slug
+   * @returns {string} The slug, normalized
+   * @throws {Error} When it cannot be one path segment
+   */
+  const checked = (value) => {
+    const given =
+      typeof value === 'string' ? value.trim().toLowerCase() : value;
+    const wrong = slugProblem(given, declaration);
+
+    if (wrong) {
+      throw failure(wrong, value);
+    }
+
+    return given;
+  };
+
+  /**
+   * The slug of a source, refusing a source there is nothing to build one
+   * from
+   *
+   * @param {*} source What the source field holds
+   * @param {*} seed The record's external id, for the discriminator
+   * @returns {string} The slug
+   * @throws {Error} HENRI_MODEL_SLUG_EMPTY
+   */
+  const made = (source, seed) => {
+    const slug = slugFor(declaration, source, seed);
+
+    if (slug === '') {
+      throw emptySlug(model, declaration, source);
+    }
+
+    return slug;
+  };
+
+  schema.pre('validate', function henriSlugs() {
+    const given = this.get(SLUG);
+
+    // A slug the application wrote itself always wins, and the only thing
+    // asked of it is whether it can be one path segment
+    if (
+      this.isModified(SLUG) &&
+      typeof given !== 'undefined' &&
+      given !== null &&
+      given !== ''
+    ) {
+      this.set(SLUG, checked(given));
+
+      return;
+    }
+
+    if (
+      !this.isNew &&
+      !(declaration.on === 'change' && this.isModified(declaration.from))
+    ) {
+      return;
+    }
+
+    this.set(SLUG, made(this.get(declaration.from), this.get(EXTERNAL_ID)));
+  });
+
+  schema.pre(WRITE_HOOKS, function henriSlugsUpdate() {
+    const { values } = updateValues(this.getUpdate());
+    const follows =
+      declaration.on === 'change' && writesSource(declaration, values);
+
+    if (follows && !ONE_HOOKS.has(this.op)) {
+      throw massSlug(model, declaration, this.op, 'update(attrs)');
+    }
+
+    if (Object.prototype.hasOwnProperty.call(values, SLUG)) {
+      this.set(SLUG, checked(values[SLUG]));
+
+      return;
+    }
+
+    if (follows) {
+      this.set(SLUG, made(values[declaration.from], null));
+    }
+  });
+
+  return schema;
+};
+
 /** The query middleware a write with attributes goes through */
 const WRITE_HOOKS = [
   'findOneAndReplace',
@@ -645,6 +826,7 @@ module.exports = {
   DELETE_STATICS,
   NOTHING,
   READ_HOOKS,
+  SLUG,
   WRITE_HOOKS,
   externalId,
   idFilter,
@@ -653,6 +835,7 @@ module.exports = {
   owned,
   paginate,
   paranoid,
+  slugged,
   updateValues,
   validations,
 };

--- a/packages/mongoose/slug.js
+++ b/packages/mongoose/slug.js
@@ -1,0 +1,752 @@
+/**
+ * The third identifier, and the only one a person reads.
+ *
+ * `/articles/how-we-ship` rather than
+ * `/articles/01a07d06-e6c4-73cd-9021-31eb06befdd7`. A model asks for one in
+ * its options:
+ *
+ * ```js
+ * module.exports = {
+ *   schema: { body: { type: 'text' }, title: { type: 'string' } },
+ *   options: { slug: 'title' },
+ * };
+ * ```
+ *
+ * and henri adds a `slug` column -- unique, indexed, not null -- fills it
+ * on insert, resolves it in `findById()` and prints it in every url that
+ * names the record.
+ *
+ * ## Where a slug is allowed to appear, and where it is not
+ *
+ * henri has two identifiers and exactly one of them is public
+ * (`base/references.js`): `externalId`, a uuid v7, leaves the server; the
+ * primary key never does. A slug is a **third**, and almost everything
+ * below is about not spending the guarantee that buys.
+ *
+ * The rule is two lines long:
+ *
+ * - a slug appears in the record's own `slug` field, and in the **url** of
+ *   that record (`_links`, the route helpers, the `Location` of a 201);
+ * - it appears **nowhere else**. A foreign key is still published as the
+ *   `externalId` of the row it names, never as that row's slug. The
+ *   versions table, the access trail, the flags actor, the erasure receipt
+ *   and the webhook payloads all keep reading `externalId` and none of them
+ *   learned a second spelling.
+ *
+ * So the uuid is what an API client stores and what henri writes down; the
+ * slug is what a person reads and types. A record answers to both and they
+ * are both public: this is a second **name**, not a second identity.
+ *
+ * ## Why a lookup cannot be talked into a primary key
+ *
+ * `Model.findById()` is the door for what arrived from outside, and it
+ * grew a branch:
+ *
+ * 1. a uuid resolves the `externalId`, exactly as before;
+ * 2. anything else resolves the **slug column**, on a model that has one;
+ * 3. and that is the end of it -- `null`, the same `null` an unknown uuid
+ *    answers.
+ *
+ * Step 2 is a `WHERE slug = ?`, not a fallthrough, which is the whole
+ * safety argument. `findById('4812')` asks the slug column for `'4812'`; it
+ * does not ask the primary key anything, so it cannot say whether row 4812
+ * exists. If some record's slug really is `4812`, that record comes back --
+ * and that is a public fact about a public name, not the number. The
+ * primary key keeps its own door, `findByKey()`, and nothing here reaches
+ * for it.
+ *
+ * The one collision that would matter is a slug **shaped like a uuid**: it
+ * would take branch 1 and quietly name nothing. `problemOf()` refuses one,
+ * so the two identifier spaces never overlap.
+ *
+ * ## Uniqueness: what holds, and what henri will not pretend
+ *
+ * Two articles called "Getting started" is the normal case. henri does not
+ * claim `unique` as a validation -- a `SELECT` before an `INSERT` answers a
+ * question about a moment that has passed (`base/validations.js`) -- and it
+ * does not make an exception for itself here. So there is no lookup before
+ * the write, no counter, and no `-2`:
+ *
+ * - **`suffix: true`, the default.** The slug is the slugified source plus
+ *   a discriminator taken from the record's own `externalId`:
+ *   `getting-started-k3f9pq`. Unique because the uuid is, stable because
+ *   the uuid never changes, and free because nothing is read. The cost,
+ *   said out loud: every url carries six extra characters even when nothing
+ *   would have collided.
+ * - **`suffix: false`.** The slug is exactly the slugified source:
+ *   `getting-started`. The **unique index is what holds**, so the second
+ *   "Getting started" is refused by the database, and
+ *   `henri.model.errors()` turns that into `{ slug: 'must be unique' }` --
+ *   the same sentence any other unique column gives. The cost is that
+ *   refusal, and it lands on a title the author had every reason to think
+ *   was fine.
+ *
+ * Neither is scoped: a slug is unique across the table, not per tenant or
+ * per parent. A scope is a composite index henri would have to write into
+ * a migration it does not own, and it is not here.
+ *
+ * ## What happens when the title changes
+ *
+ * By default, nothing. `on: 'create'` is the default and it is the honest
+ * one: a slug is generated once and never moves, so the url minted the day
+ * the record was written keeps working forever, whatever the title becomes.
+ * An identifier that follows a display string is an identifier that stops
+ * being one.
+ *
+ * `on: 'change'` regenerates whenever the source field is written, and the
+ * old url **stops working that instant**. There is no history table in
+ * henri: friendly_id keeps every retired slug in one and answers a 301 from
+ * it, and that is a table on four adapters, a redirect, a retention rule
+ * and a reach for the erasure -- a tranche of its own. Until it exists,
+ * `on: 'change'` means the old url 404s, and the guide says so in those
+ * words.
+ *
+ * A mass update that names the source field on such a model is **refused**
+ * (`HENRI_MODEL_SLUG_MASS_WRITE`): the hook runs once, without records, so
+ * either every row would get the same slug or none would get a new one, and
+ * both are worse than the refusal. It is the answer
+ * `HENRI_MODEL_VALIDATION_MASS_WRITE` and `HENRI_VERSION_MASS_WRITE`
+ * already give to the same shape of problem, and it names the loop.
+ *
+ * ## A title that is not in English
+ *
+ * `slugify()` lowercases, decomposes (NFKD) and keeps `a-z0-9`. That makes
+ * `Café Crème` into `cafe-creme` without a transliteration table, because
+ * Unicode already knows that `é` is `e` with a mark on it and
+ * `String#normalize` ships in Node.
+ *
+ * What Unicode does **not** decompose is a short list of Latin letters that
+ * are letters in their own right -- `ß`, `ø`, `ł`, `æ`, `þ` -- and `FOLDED`
+ * is a line each for them, eleven in total. That is the whole table and it
+ * is deliberately not the first entry of one per script: a Japanese,
+ * Arabic, Hebrew, Greek or Cyrillic title has no ASCII to fold to, and
+ * shipping the tables that would invent some is how a framework ends up
+ * choosing romanizations on a reader's behalf.
+ *
+ * So a title in one of those scripts **slugifies to nothing**, and that
+ * needed a real answer rather than a shrug. It has two:
+ *
+ * - With `suffix: true` the record still gets a slug -- the discriminator
+ *   alone, `k3f9pq` -- so the write never fails and the url always works.
+ *   With `suffix: false` there is nothing to fall back to and the write is
+ *   refused (`HENRI_MODEL_SLUG_EMPTY`), naming the field and the title.
+ * - **A slug the application writes itself always wins and may be any
+ *   Unicode henri can carry in a path segment.** `slug: 'こんにちは'` is
+ *   accepted, stored, matched by the route and carried percent-encoded on
+ *   the wire, which every browser renders back as the characters. So the
+ *   choice between transliteration and percent-encoding is not made here:
+ *   henri's generator folds to ASCII and ships no romanization, and an
+ *   application that wants its own script in the url writes the slug and
+ *   gets it, byte for byte.
+ *
+ * `problemOf()` is what a supplied slug is measured against, and it is a
+ * list of the structural characters rather than a definition of a letter:
+ * nothing below `!`, none of `"#%/:?@[\]^`{|}<>`, not `.` or `..`, not a
+ * uuid, not a reserved word, not longer than the column. A deny list is the
+ * right shape here precisely because henri is not the one deciding what
+ * counts as a word.
+ *
+ * ## Reserved words
+ *
+ * `resources articles` mounts `GET /articles/new` before `GET /articles/:id`
+ * (`base/routes.js`), so a record slugged `new` is a record with no show
+ * page. henri reserves that one word by default and `reserved` adds more --
+ * which is the honest bound, because a `collection` route an application
+ * declared is a segment henri cannot know when the slug is generated. The
+ * guide says to add it.
+ *
+ * ## No regular expression touches a title
+ *
+ * A title arrives through `req.permit()`, and a slugifier is exactly the
+ * shape that turns into a quadratic match. Everything here walks: one pass
+ * over the code points with a `Set` and a `Map`, no `RegExp` anywhere in
+ * the file, and the length bound applied while walking rather than after.
+ *
+ * ## A copy per adapter
+ *
+ * This file is held four times -- here and in `@usehenri/drizzle`,
+ * `@usehenri/mongoose` and `@usehenri/sequelize` -- byte for byte, the way
+ * `exact.js`, `external-id.js` and `validations.js` are, because an adapter
+ * depends on no part of core at runtime.
+ * `src/__tests__/slug.spec.js` is what keeps them the same file. It
+ * requires nothing at all, and raises its codes through a `coded()` of its
+ * own for the same reason.
+ */
+
+/** The field a slug lives in, and the column it becomes */
+const SLUG = 'slug';
+
+/** The failure a `slug` declaration henri cannot carry out gets */
+const DECLARATION = 'HENRI_MODEL_SLUG_DECLARATION_INVALID';
+
+/** The failure a source that slugifies to nothing gets */
+const EMPTY = 'HENRI_MODEL_SLUG_EMPTY';
+
+/** The failure a mass write that would regenerate many slugs gets */
+const MASS_WRITE = 'HENRI_MODEL_SLUG_MASS_WRITE';
+
+/** How long the slugified source may be, before the discriminator */
+const MAX_LENGTH = 80;
+
+/** How many characters the discriminator adds, plus its separator */
+const SUFFIX_LENGTH = 6;
+
+/** The keys a `slug` declaration may hold */
+const KEYS = ['from', 'maxLength', 'on', 'reserved', 'suffix'];
+
+/** What `on` takes: generate once, or follow the source */
+const EVENTS = ['create', 'change'];
+
+/**
+ * The characters a slug may never carry, whoever wrote it.
+ *
+ * Not "everything but a letter": henri is not the one deciding what counts
+ * as a letter in a script it does not read. These are the ones that end a
+ * path segment, start a query, escape an encoding or name a directory.
+ */
+const REFUSED = new Set([
+  '"',
+  '#',
+  '%',
+  '/',
+  ':',
+  '<',
+  '>',
+  '?',
+  '@',
+  '[',
+  '\\',
+  ']',
+  '^',
+  '`',
+  '{',
+  '|',
+  '}',
+]);
+
+/** The path segments a slug would shadow */
+const RESERVED = ['.', '..', 'new'];
+
+/**
+ * The Latin letters Unicode does not decompose, which is why each needs a
+ * line. This is the whole table and it is deliberately not one per script:
+ * see the header.
+ */
+const FOLDED = new Map([
+  ['æ', 'ae'],
+  ['đ', 'd'],
+  ['ð', 'd'],
+  ['ħ', 'h'],
+  ['ı', 'i'],
+  ['ł', 'l'],
+  ['ø', 'o'],
+  ['œ', 'oe'],
+  ['ß', 'ss'],
+  ['þ', 'th'],
+  ['ŧ', 't'],
+]);
+
+/**
+ * The alphabet of the discriminator: base 32 without the characters a
+ * person mistakes for another when reading a url out loud (`0`/`o`,
+ * `1`/`l`/`i`).
+ */
+const ALPHABET = '23456789abcdefghjkmnpqrstuvwxyz';
+
+/** The separator between words, and before the discriminator */
+const DASH = '-';
+
+/**
+ * An error carrying a henri code, without depending on core
+ *
+ * @param {string} code the henri error code
+ * @param {string} message what is wrong
+ * @returns {Error} the error to throw
+ */
+const coded = (code, message) => Object.assign(new Error(message), { code });
+
+/**
+ * Is the value a plain object?
+ *
+ * @param {*} value any value
+ * @returns {boolean} true for a plain object
+ */
+const isPlainObject = (value) =>
+  value !== null &&
+  typeof value === 'object' &&
+  (Object.getPrototypeOf(value) === Object.prototype ||
+    Object.getPrototypeOf(value) === null);
+
+/**
+ * Is this string a uuid, and therefore an `externalId` rather than a name?
+ *
+ * The shape is checked by walking it: eight hex, a dash, four, a dash,
+ * four, a dash, four, a dash, twelve. The same answer
+ * `base/external-id.js` gives, without the pattern, because this one is
+ * asked about a value that came from a request.
+ *
+ * @param {string} value the candidate
+ * @returns {boolean} true when it is shaped like a uuid
+ */
+const looksLikeUuid = (value) => {
+  const groups = [8, 4, 4, 4, 12];
+  let at = 0;
+
+  for (let group = 0; group < groups.length; group += 1) {
+    if (group > 0) {
+      if (value[at] !== DASH) {
+        return false;
+      }
+
+      at += 1;
+    }
+
+    for (let taken = 0; taken < groups[group]; taken += 1) {
+      const code = value.charCodeAt(at);
+
+      // 0-9, a-f, A-F
+      if (
+        !(code >= 48 && code <= 57) &&
+        !(code >= 97 && code <= 102) &&
+        !(code >= 65 && code <= 70)
+      ) {
+        return false;
+      }
+
+      at += 1;
+    }
+  }
+
+  return at === value.length;
+};
+
+/**
+ * Is this code point a combining mark NFKD left behind?
+ *
+ * The three blocks a decomposed Latin, Greek or Cyrillic letter puts its
+ * accent in. They are dropped rather than turned into a separator, so
+ * `é` is `e` and not `e-`.
+ *
+ * @param {number} code the code point
+ * @returns {boolean} true for a combining mark
+ */
+const isMark = (code) =>
+  (code >= 0x0300 && code <= 0x036f) ||
+  (code >= 0x1ab0 && code <= 0x1aff) ||
+  (code >= 0x20d0 && code <= 0x20f0);
+
+/**
+ * The slug of a value: lowercase, decomposed, `a-z0-9` joined by dashes.
+ *
+ * One walk over the code points, no pattern, and the bound applied as it
+ * goes rather than by cutting at the end -- so a title of any length costs
+ * what the bound costs and not what the title costs.
+ *
+ * @param {*} value what the source field holds
+ * @param {number} [maxLength=MAX_LENGTH] how long the answer may be
+ * @returns {string} the slug, possibly empty
+ */
+const slugify = (value, maxLength = MAX_LENGTH) => {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return '';
+  }
+
+  const source = String(value).toLowerCase().normalize('NFKD');
+  const out = [];
+  let pending = false;
+
+  for (const character of source) {
+    if (out.length >= maxLength) {
+      break;
+    }
+
+    const code = character.codePointAt(0);
+
+    if (isMark(code)) {
+      continue;
+    }
+
+    // The ranges `a-z` and `0-9`, the only two that come out of this file
+    if ((code >= 97 && code <= 122) || (code >= 48 && code <= 57)) {
+      if (pending && out.length > 0) {
+        out.push(DASH);
+      }
+
+      pending = false;
+
+      if (out.length < maxLength) {
+        out.push(character);
+      }
+
+      continue;
+    }
+
+    const folded = FOLDED.get(character);
+
+    if (folded) {
+      if (pending && out.length > 0) {
+        out.push(DASH);
+      }
+
+      pending = false;
+
+      for (const letter of folded) {
+        if (out.length < maxLength) {
+          out.push(letter);
+        }
+      }
+
+      continue;
+    }
+
+    // Anything else -- a space, a comma, an emoji, a kanji -- ends the run
+    // rather than being carried, and a run of them is one dash
+    pending = true;
+  }
+
+  return out.join('');
+};
+
+/**
+ * Six characters of the record's own public identifier, so the
+ * discriminator is unique because the uuid is and stable because the uuid
+ * never changes.
+ *
+ * A model that opted out of `externalId` has no such seed, and neither
+ * does a mass insert on an ORM that fills the column after the hook; both
+ * fall back to `Math.random()`, which is enough because a discriminator is
+ * not a secret -- a slug is a public name, nothing is protected by knowing
+ * one, and a duplicate is caught by the unique index the column carries.
+ *
+ * @param {*} seed the record's `externalId`, when there is one
+ * @returns {string} six characters of the alphabet
+ */
+const discriminate = (seed) => {
+  const out = [];
+
+  if (typeof seed === 'string' && seed.length >= SUFFIX_LENGTH * 2) {
+    // The tail of a uuid v7 is its random half; the head is the clock, and
+    // every record written in the same millisecond shares it
+    const tail = seed
+      .slice(-SUFFIX_LENGTH * 2)
+      .split(DASH)
+      .join('');
+
+    for (
+      let at = 0;
+      at + 1 < tail.length && out.length < SUFFIX_LENGTH;
+      at += 2
+    ) {
+      const pair = parseInt(tail.slice(at, at + 2), 16);
+
+      if (Number.isNaN(pair)) {
+        break;
+      }
+
+      out.push(ALPHABET[pair % ALPHABET.length]);
+    }
+  }
+
+  while (out.length < SUFFIX_LENGTH) {
+    out.push(ALPHABET[Math.floor(Math.random() * ALPHABET.length)]);
+  }
+
+  return out.join('');
+};
+
+/**
+ * Refuses a declaration, naming the model
+ *
+ * @param {string} model the model's global id
+ * @param {string} what what is wrong with it
+ * @returns {void} never returns
+ * @throws {Error} always, HENRI_MODEL_SLUG_DECLARATION_INVALID
+ */
+const refuse = (model, what) => {
+  throw coded(DECLARATION, `${model} declares \`options.slug\` with ${what}`);
+};
+
+/**
+ * The `slug` declaration of a model file, compiled, or null when it wants
+ * no slug.
+ *
+ * `slug: 'title'` is the shorthand every application writes; the object
+ * form takes `from`, `on`, `suffix`, `reserved` and `maxLength`.
+ *
+ * @param {object} model the model file (`schema`, `options`, `globalId`)
+ * @returns {?object} `{ from, maxLength, on, reserved, suffix }` or null
+ * @throws {Error} HENRI_MODEL_SLUG_DECLARATION_INVALID on anything unusable
+ */
+const slugOf = (model) => {
+  const options = (model && model.options) || {};
+  const written = options.slug;
+  const name = (model && (model.globalId || model.identity)) || 'model';
+
+  if (typeof written === 'undefined' || written === null || written === false) {
+    return null;
+  }
+
+  if (typeof written !== 'string' && !isPlainObject(written)) {
+    refuse(
+      name,
+      `${typeof written}: it is the name of the field to build the slug from, or an object of ${KEYS.join(', ')}`
+    );
+  }
+
+  const declared =
+    typeof written === 'string' ? { from: written } : { ...written };
+
+  for (const key of Object.keys(declared)) {
+    if (!KEYS.includes(key)) {
+      refuse(name, `the unknown key "${key}": it takes ${KEYS.join(', ')}`);
+    }
+  }
+
+  const schema = (model && model.schema) || {};
+  const { from } = declared;
+
+  if (typeof from !== 'string' || from === '') {
+    refuse(name, 'no "from": a slug is built from a field of the model');
+  }
+
+  if (from === SLUG) {
+    refuse(name, 'a "from" of "slug": the slug cannot be built from itself');
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(schema, from)) {
+    refuse(name, `a "from" of "${from}", which the schema does not declare`);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(schema, SLUG)) {
+    refuse(
+      name,
+      'a "slug" field of its own in the schema: henri adds the column, so declaring it twice would mean two different things'
+    );
+  }
+
+  const definition = schema[from];
+  const type = isPlainObject(definition) ? definition.type : definition;
+
+  if (type !== 'string' && type !== 'text' && type !== String) {
+    refuse(
+      name,
+      `a "from" of "${from}", which is not a string or a text: a slug is built from words`
+    );
+  }
+
+  if (isPlainObject(definition) && definition.encrypted) {
+    refuse(
+      name,
+      `a "from" of "${from}", which is encrypted: a slug is public and the column it came from is not`
+    );
+  }
+
+  const marked = isPlainObject(definition) ? definition.personal : null;
+
+  if (isPlainObject(marked) && marked.expose === false) {
+    refuse(
+      name,
+      `a "from" of "${from}", which is marked \`personal: { expose: false }\`: that field is dropped from every answer henri builds, and a slug is in every url of the record`
+    );
+  }
+
+  const compiled = {
+    from,
+    maxLength: MAX_LENGTH,
+    on: 'create',
+    reserved: new Set(RESERVED),
+    suffix: true,
+  };
+
+  if ('on' in declared) {
+    if (!EVENTS.includes(declared.on)) {
+      refuse(name, `an "on" of "${declared.on}": it is ${EVENTS.join(' or ')}`);
+    }
+
+    compiled.on = declared.on;
+  }
+
+  if ('suffix' in declared) {
+    if (typeof declared.suffix !== 'boolean') {
+      refuse(name, 'a "suffix" that is not true or false');
+    }
+
+    compiled.suffix = declared.suffix;
+  }
+
+  if ('maxLength' in declared) {
+    if (
+      typeof declared.maxLength !== 'number' ||
+      !Number.isInteger(declared.maxLength) ||
+      declared.maxLength < 1
+    ) {
+      refuse(name, 'a "maxLength" that is not a whole number of characters');
+    }
+
+    compiled.maxLength = declared.maxLength;
+  }
+
+  if ('reserved' in declared) {
+    if (
+      !Array.isArray(declared.reserved) ||
+      declared.reserved.some((word) => typeof word !== 'string')
+    ) {
+      refuse(name, 'a "reserved" that is not a list of words');
+    }
+
+    for (const word of declared.reserved) {
+      compiled.reserved.add(word.toLowerCase());
+    }
+  }
+
+  return compiled;
+};
+
+/**
+ * How long the column has to be: the slugified source, the separator and
+ * the discriminator
+ *
+ * @param {object} declaration the compiled declaration
+ * @returns {number} the column length
+ */
+const lengthOf = (declaration) =>
+  declaration.maxLength + (declaration.suffix ? SUFFIX_LENGTH + 1 : 0);
+
+/**
+ * Everything wrong with a slug an application wrote itself.
+ *
+ * A deny list rather than a definition of a word: any script may name a
+ * record, and what may not is what would stop being one path segment.
+ *
+ * @param {*} value the slug
+ * @param {object} declaration the compiled declaration
+ * @returns {?string} the message, or null when it can be a url segment
+ */
+const problemOf = (value, declaration) => {
+  if (typeof value !== 'string') {
+    return 'must be a string';
+  }
+
+  if (value === '') {
+    return 'is required';
+  }
+
+  if ([...value].length > lengthOf(declaration)) {
+    return `must be at most ${lengthOf(declaration)} characters`;
+  }
+
+  for (const character of value) {
+    const code = character.codePointAt(0);
+
+    if (code < 0x21 || code === 0x7f) {
+      return 'must not hold a space or a control character';
+    }
+
+    if (REFUSED.has(character)) {
+      return `must not hold "${character}"`;
+    }
+  }
+
+  if (looksLikeUuid(value)) {
+    return 'must not be shaped like a public identifier';
+  }
+
+  if (declaration.reserved.has(value.toLowerCase())) {
+    return `must not be "${value}", which is a path henri already mounts`;
+  }
+
+  return null;
+};
+
+/**
+ * The slug of a record about to be written.
+ *
+ * @param {object} declaration the compiled declaration
+ * @param {*} source what the source field holds
+ * @param {*} seed the record's `externalId`, for the discriminator
+ * @returns {string} the slug, or an empty string when there is nothing to
+ *   build one from and no discriminator to fall back to
+ */
+const slugFor = (declaration, source, seed) => {
+  const base = slugify(source, declaration.maxLength);
+
+  if (!declaration.suffix) {
+    return base;
+  }
+
+  const suffix = discriminate(seed);
+
+  return base === '' ? suffix : `${base}${DASH}${suffix}`;
+};
+
+/**
+ * Does this write name the field the slug is built from?
+ *
+ * @param {object} declaration the compiled declaration
+ * @param {*} attrs the attributes being written
+ * @returns {boolean} true when the source field is one of them
+ */
+const writesSource = (declaration, attrs) =>
+  Boolean(declaration) &&
+  isPlainObject(attrs) &&
+  Object.prototype.hasOwnProperty.call(attrs, declaration.from);
+
+/**
+ * The refusal a source that slugified to nothing gets
+ *
+ * @param {string} model the model's global id
+ * @param {object} declaration the compiled declaration
+ * @param {*} source what the source field held
+ * @returns {Error} the error to throw
+ */
+const emptySlug = (model, declaration, source) =>
+  coded(
+    EMPTY,
+    `${model}.${declaration.from} is ${
+      typeof source === 'string' && source !== ''
+        ? `"${source}", which has no letters or digits henri can fold to ASCII`
+        : 'empty'
+    }, and the model declares \`slug: { suffix: false }\`, so there is nothing to build a slug from. ` +
+      'Write the slug yourself, or let henri add its discriminator (`suffix: true`, the default), which always answers something.'
+  );
+
+/**
+ * The refusal a mass write that would regenerate many slugs gets
+ *
+ * @param {string} model the model's global id
+ * @param {object} declaration the compiled declaration
+ * @param {string} what the call that was made (`update`, `updateMany`)
+ * @param {string} instead the single-record call to loop over
+ * @returns {Error} the error to throw
+ */
+const massWrite = (model, declaration, what, instead) =>
+  coded(
+    MASS_WRITE,
+    `${model}.${what}() writes many rows at once and names ${declaration.from}, which ${model} regenerates its slug from (\`slug: { on: 'change' }\`). ` +
+      'One hook runs for the whole write, with no records in it, so every row would get one slug or none would get a new one. henri refuses rather than doing either. ' +
+      `Loop instead: for (const record of await ${model}.find(where)) await record.${instead}`
+  );
+
+module.exports = {
+  ALPHABET,
+  DECLARATION,
+  EMPTY,
+  EVENTS,
+  KEYS,
+  MASS_WRITE,
+  MAX_LENGTH,
+  RESERVED,
+  SLUG,
+  SUFFIX_LENGTH,
+  coded,
+  discriminate,
+  emptySlug,
+  lengthOf,
+  looksLikeUuid,
+  massWrite,
+  problemOf,
+  slugFor,
+  slugOf,
+  slugify,
+  writesSource,
+};

--- a/packages/react/__tests__/templates.test.js
+++ b/packages/react/__tests__/templates.test.js
@@ -11,6 +11,9 @@ const dir = path.resolve(__dirname, '../../cli/scripts/generate');
 const views = ['_form', 'index', 'new', 'edit', 'show'];
 const context = {
   doc: 'Post',
+  // What a url of one record carries: `externalId`, or the `slug` of a
+  // model that declared one (see base/slug.js)
+  identifier: 'externalId',
   keys: ['title', 'body'],
   lower: 'post',
   plural: 'posts',
@@ -122,5 +125,17 @@ describe('react scaffold templates', () => {
     expect(() =>
       compile('_form', { ...context, keys: ['a', 'b', 'c', 'd'] })
     ).not.toThrow();
+  });
+
+  test('a model with a slug links with the slug and never the uuid', () => {
+    const slugged = { ...context, identifier: 'slug' };
+
+    for (const view of ['index', 'show', 'edit']) {
+      const { code } = compile(view, slugged);
+
+      expect(code).toContain('item.slug');
+      expect(code).not.toContain('externalId');
+      expect(() => compile(view, slugged).ast).not.toThrow();
+    }
   });
 });

--- a/packages/sequelize/__tests__/slug.spec.js
+++ b/packages/sequelize/__tests__/slug.spec.js
@@ -1,0 +1,250 @@
+const { build } = require('./helpers');
+const { modelErrors } = require('@usehenri/core/src/base/model-errors');
+
+/**
+ * A model file that asks for a slug
+ *
+ * @param {*} [slug='title'] What `options.slug` says
+ * @returns {object} The model file
+ */
+const articleModel = (slug = 'title') => ({
+  globalId: 'Article',
+  identity: 'article',
+  options: { slug, timestamps: true },
+  schema: {
+    body: { type: 'text' },
+    title: { required: true, type: 'string' },
+  },
+  store: 'default',
+});
+
+/**
+ * The `{ field: message }` a controller would answer with
+ *
+ * @param {Promise} promise The write
+ * @returns {Promise<object>} What it refused with
+ */
+const errorsOf = async (promise) => {
+  try {
+    await promise;
+  } catch (error) {
+    return modelErrors(error) || { code: error.code };
+  }
+
+  return null;
+};
+
+describe('slugs on a sequelize store', () => {
+  describe('the column henri adds', () => {
+    let Article;
+    let adapter;
+
+    beforeAll(async () => {
+      ({ adapter } = build());
+      Article = adapter.addModel(articleModel(), 'user');
+      await adapter.start();
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('is unique and not null', () => {
+      expect(Article.rawAttributes.slug.allowNull).toBe(false);
+      expect(Article.rawAttributes.slug.unique).toBe(true);
+    });
+
+    test('is filled from the source field on insert', async () => {
+      const article = await Article.create({ title: 'How we ship' });
+
+      expect(article.slug.startsWith('how-we-ship-')).toBe(true);
+      expect(article.slug).toHaveLength('how-we-ship-'.length + 6);
+    });
+
+    test('is filled on a bulk insert too', async () => {
+      const created = await Article.bulkCreate([
+        { title: 'One thing' },
+        { title: 'One thing' },
+      ]);
+
+      expect(created[0].slug.startsWith('one-thing-')).toBe(true);
+      expect(created[0].slug).not.toBe(created[1].slug);
+    });
+
+    test('answers something for a title with no ASCII in it', async () => {
+      const article = await Article.create({ title: 'こんにちは' });
+
+      expect(article.slug).toHaveLength(6);
+    });
+
+    test('does not move when the title changes', async () => {
+      const article = await Article.create({ title: 'First name' });
+      const before = article.slug;
+
+      await article.update({ title: 'Second name' });
+
+      expect(article.slug).toBe(before);
+    });
+  });
+
+  describe('the lookup', () => {
+    let Article;
+    let adapter;
+    let article;
+
+    beforeAll(async () => {
+      ({ adapter } = build());
+      Article = adapter.addModel(articleModel(), 'user');
+      await adapter.start();
+      article = await Article.create({ title: 'How we ship' });
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('findById() takes the slug and the public identifier', async () => {
+      expect((await Article.findById(article.slug)).id).toBe(article.id);
+      expect((await Article.findById(article.externalId)).id).toBe(article.id);
+    });
+
+    test('findById() does not take the primary key', async () => {
+      expect(await Article.findById(article.id)).toBeNull();
+      expect(await Article.findById(String(article.id))).toBeNull();
+    });
+
+    test('a name that names nothing answers the same null', async () => {
+      expect(await Article.findById('4812')).toBeNull();
+      expect(await Article.findById('no-such-article')).toBeNull();
+    });
+
+    test('findBySlug() takes a slug and nothing else', async () => {
+      expect((await Article.findBySlug(article.slug)).id).toBe(article.id);
+      expect(await Article.findBySlug(article.externalId)).toBeNull();
+      expect(await Article.findBySlug(article.id)).toBeNull();
+    });
+
+    test('findByKey() is still the primary key door', async () => {
+      expect((await Article.findByKey(article.id)).id).toBe(article.id);
+    });
+  });
+
+  describe('a slug the application writes itself', () => {
+    let Article;
+    let adapter;
+
+    beforeAll(async () => {
+      ({ adapter } = build());
+      Article = adapter.addModel(articleModel(), 'user');
+      await adapter.start();
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('wins over the one henri would have made', async () => {
+      const article = await Article.create({
+        slug: 'how-we-ship',
+        title: 'Something else entirely',
+      });
+
+      expect(article.slug).toBe('how-we-ship');
+    });
+
+    test('is refused when it cannot be one path segment', async () => {
+      expect(
+        await errorsOf(Article.create({ slug: 'a/b', title: 'x' }))
+      ).toEqual({ slug: 'must not hold "/"' });
+    });
+
+    test('is refused when it is shaped like a public identifier', async () => {
+      expect(
+        await errorsOf(
+          Article.create({
+            slug: '01a07d06-e6c4-73cd-9021-31eb06befdd7',
+            title: 'x',
+          })
+        )
+      ).toEqual({ slug: 'must not be shaped like a public identifier' });
+    });
+
+    test('is refused when the database already holds it', async () => {
+      await Article.create({ slug: 'taken', title: 'x' });
+
+      expect(
+        await errorsOf(Article.create({ slug: 'taken', title: 'y' }))
+      ).toEqual({ slug: 'slug must be unique' });
+    });
+  });
+
+  describe("on: 'change'", () => {
+    let Article;
+    let adapter;
+
+    beforeAll(async () => {
+      ({ adapter } = build());
+      Article = adapter.addModel(
+        articleModel({ from: 'title', on: 'change' }),
+        'user'
+      );
+      await adapter.start();
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('follows the source, and the old url stops working', async () => {
+      const article = await Article.create({ title: 'First name' });
+      const before = article.slug;
+
+      await article.update({ title: 'Second name' });
+
+      expect(article.slug.startsWith('second-name-')).toBe(true);
+      expect(await Article.findById(before)).toBeNull();
+    });
+
+    test('refuses a mass update that names the source', async () => {
+      expect(
+        await errorsOf(
+          Article.update({ title: 'One name for all' }, { where: {} })
+        )
+      ).toEqual({ code: 'HENRI_MODEL_SLUG_MASS_WRITE' });
+    });
+
+    test('allows a mass update that does not', async () => {
+      await expect(
+        Article.update({ body: 'swept' }, { where: {} })
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe('suffix: false', () => {
+    let Article;
+    let adapter;
+
+    beforeAll(async () => {
+      ({ adapter } = build());
+      Article = adapter.addModel(
+        articleModel({ from: 'title', suffix: false }),
+        'user'
+      );
+      await adapter.start();
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('is the slugified source and nothing else', async () => {
+      const article = await Article.create({ title: 'How we ship' });
+
+      expect(article.slug).toBe('how-we-ship');
+    });
+
+    test('leaves the unique index to refuse the second one', async () => {
+      await Article.create({ title: 'Getting started' });
+
+      expect(
+        await errorsOf(Article.create({ title: 'Getting started' }))
+      ).toEqual({ slug: 'slug must be unique' });
+    });
+
+    test('refuses a title it cannot fold rather than writing an empty name', async () => {
+      expect(await errorsOf(Article.create({ title: 'こんにちは' }))).toEqual({
+        code: 'HENRI_MODEL_SLUG_EMPTY',
+      });
+    });
+  });
+});

--- a/packages/sequelize/index.js
+++ b/packages/sequelize/index.js
@@ -4,7 +4,13 @@ const { Drift, describeDifference } = require('./drift');
 const { decorateAttributes, decorateModel } = require('./encryption');
 const { decorateModel: decorateVersions } = require('./versions');
 const { decorateModel: decorateTenant, tenantAttribute } = require('./tenant');
-const { lookup, paginate, publicId, validations } = require('./plugins');
+const {
+  lookup,
+  paginate,
+  publicId,
+  slugged,
+  validations,
+} = require('./plugins');
 const { validationsOf } = require('./validations');
 const { instrument: instrumentQueries } = require('./queries');
 const { normalizeSchema } = require('./schema');
@@ -16,6 +22,7 @@ const {
   wantsExternalId,
   withoutInternalIds,
 } = require('./external-id');
+const { SLUG, lengthOf, slugOf } = require('./slug');
 const { fatal, normalizeEmail, redact } = require('./utils');
 
 const { DataTypes } = Sequelize;
@@ -253,6 +260,7 @@ class Sql {
     delete options.externalId;
     delete options.personal;
     delete options.retention;
+    delete options.slug;
     delete options.tenant;
     delete options.versioned;
 
@@ -283,6 +291,15 @@ class Sql {
       this.addExternalId(attributes);
     }
 
+    // The third identifier, and the only one a person reads (./slug.js).
+    // Compiled from the model file rather than from `attributes`, so the
+    // column henri adds is never mistaken for one the application declared
+    const declaredSlug = slugOf(model);
+
+    if (declaredSlug) {
+      this.addSlug(attributes, declaredSlug);
+    }
+
     if (isUser) {
       this.overload(attributes, options, model);
     }
@@ -302,8 +319,16 @@ class Sql {
     const instance = lookup(
       paginate(connector.define(model.globalId, attributes, options)),
       external,
-      this.henri
+      this.henri,
+      declaredSlug
     );
+
+    // Before the validations and everything else: what a rule measures and
+    // what a `beforeCreate` hook sees is a record whose name is already
+    // written, the way it is on the other two adapters
+    if (declaredSlug) {
+      slugged(instance, declaredSlug);
+    }
 
     // First of the hooks, so what a rule measures is the value the
     // application wrote: the encryption hooks below turn it into an
@@ -372,6 +397,26 @@ class Sql {
       defaultValue: uuidv7,
       field: EXTERNAL_ID_COLUMN,
       type: DataTypes.UUID,
+      unique: true,
+    };
+
+    return attributes;
+  }
+
+  /**
+   * Adds the `slug` column to a model that asked for one: the name a
+   * person reads in a url, unique and indexed like the public identifier
+   * next to it. henri fills it (`plugins.js`, `slugged()`).
+   *
+   * @param {object} attributes The Sequelize attributes
+   * @param {object} declaration The compiled declaration (./slug.js)
+   * @returns {object} The attributes
+   * @memberof Sql
+   */
+  addSlug(attributes, declaration) {
+    attributes[SLUG] = {
+      allowNull: false,
+      type: DataTypes.STRING(lengthOf(declaration)),
       unique: true,
     };
 
@@ -759,6 +804,7 @@ class Sql {
           Model.rawAttributes && Model.rawAttributes[EXTERNAL_ID]
         ),
         references,
+        slug: Boolean(slugOf(this.definitions[globalId].model)),
       };
     }
 

--- a/packages/sequelize/package.json
+++ b/packages/sequelize/package.json
@@ -32,6 +32,7 @@
     "types.js",
     "utils.js",
     "validations.js",
+    "slug.js",
     "CHANGELOG.md",
     "encrypted.js",
     "encryption.js",

--- a/packages/sequelize/plugins.js
+++ b/packages/sequelize/plugins.js
@@ -11,6 +11,14 @@ const {
   withoutInternalIds,
 } = require('./external-id');
 const {
+  SLUG,
+  emptySlug,
+  massWrite: massSlug,
+  problemOf: slugProblem,
+  slugFor,
+  writesSource,
+} = require('./slug');
+const {
   massWrite,
   problemsOf,
   uncheckedWrite,
@@ -107,7 +115,7 @@ const paginate = (Model) => {
  * @param {object} henri The henri instance (for `externalIds.lookup`)
  * @returns {object} The model
  */
-const lookup = (Model, external, henri) => {
+const lookup = (Model, external, henri, named = null) => {
   const findByPk = Model.findByPk;
 
   /**
@@ -176,22 +184,168 @@ const lookup = (Model, external, henri) => {
    * @returns {Promise<?object>} The row or null
    */
   Model.findById = function findById(value, options) {
-    if (!external) {
-      return this.findByKey(value, options);
-    }
-
-    if (isUuid(value)) {
+    if (external && isUuid(value)) {
       return this.findByExternalId(value, options);
     }
 
-    if (resolvesKeys(henri)) {
+    // The slug column, and only the slug column. A model that has a name
+    // takes the whole non-uuid space with it, `externalIds.lookup: "any"`
+    // included -- the stricter of the two rules is the one to keep, and it
+    // is the same one on every adapter (./slug.js)
+    if (named) {
+      return this.findBySlug(value, options);
+    }
+
+    if (!external || resolvesKeys(henri)) {
       return this.findByKey(value, options);
     }
 
     return Promise.resolve(null);
   };
 
+  /**
+   * A row by the name a person reads, on a model that declared one
+   *
+   * @param {*} value A slug
+   * @param {object} [options] findOne options
+   * @returns {Promise<?object>} The row or null
+   */
+  Model.findBySlug = function findBySlug(value, options) {
+    if (!named || typeof value !== 'string' || value === '') {
+      return Promise.resolve(null);
+    }
+
+    return this.findOne({
+      ...options,
+      where: {
+        ...((options && options.where) || {}),
+        [SLUG]: value.toLowerCase(),
+      },
+    });
+  };
+
   Model.findByPk = Model.findByKey;
+
+  return Model;
+};
+
+/**
+ * The `slug` column filled on every write Sequelize runs a hook for.
+ *
+ * The two hooks are the ones `validations` uses and for the same reason:
+ * `beforeValidate` covers `create`, `save`, `instance.update`, `upsert`
+ * and the mass `Model.update`, and `beforeBulkCreate` is the one it does
+ * not reach. A mass update naming the source of a model that follows it is
+ * refused rather than written, because one hook runs for the whole write
+ * and no row is named by it (./slug.js).
+ *
+ * @param {object} Model A Sequelize model
+ * @param {object} declaration The compiled declaration (./slug.js)
+ * @returns {object} The model
+ */
+const slugged = (Model, declaration) => {
+  const name = Model.name;
+
+  /**
+   * The error a slug that cannot be a url segment gets, in the shape
+   * Sequelize answers a validation failure with
+   *
+   * @param {string} message What is wrong with it
+   * @param {*} value The slug
+   * @returns {Error} A SequelizeValidationError
+   */
+  const failure = (message, value) =>
+    validationError(name, { [SLUG]: message }, { [SLUG]: value });
+
+  /**
+   * Fills or checks the slug of one record about to be written
+   *
+   * @param {object} record The Sequelize instance
+   * @param {object} [options] The write options, whose `fields` decides
+   *   which columns the statement names: a column henri filled in a hook
+   *   is not one the caller listed, so it is added here or it is set in
+   *   memory and never written
+   * @returns {void}
+   * @throws {Error} When the slug cannot be a url, or there is nothing to
+   *   build one from
+   */
+  const apply = (record, options) => {
+    const written = () => {
+      if (
+        options &&
+        Array.isArray(options.fields) &&
+        !options.fields.includes(SLUG)
+      ) {
+        options.fields.push(SLUG);
+      }
+    };
+    const given = record.get(SLUG);
+
+    // A slug the application wrote itself always wins, and the only thing
+    // asked of it is whether it can be one path segment
+    if (
+      record.changed(SLUG) &&
+      typeof given !== 'undefined' &&
+      given !== null &&
+      given !== ''
+    ) {
+      const wanted =
+        typeof given === 'string' ? given.trim().toLowerCase() : given;
+      const wrong = slugProblem(wanted, declaration);
+
+      if (wrong) {
+        throw failure(wrong, given);
+      }
+
+      record.set(SLUG, wanted);
+      written();
+
+      return;
+    }
+
+    if (
+      !record.isNewRecord &&
+      !(declaration.on === 'change' && record.changed(declaration.from))
+    ) {
+      return;
+    }
+
+    const source = record.get(declaration.from);
+    const slug = slugFor(declaration, source, record.get(EXTERNAL_ID));
+
+    if (slug === '') {
+      throw emptySlug(name, declaration, source);
+    }
+
+    record.set(SLUG, slug);
+    written();
+  };
+
+  Model.addHook('beforeValidate', 'henriSlugs', (record, options) =>
+    apply(record, options)
+  );
+  Model.addHook('beforeBulkCreate', 'henriSlugs', (records, options) => {
+    for (const record of records) {
+      apply(record, options);
+    }
+  });
+
+  const update = Model.update.bind(Model);
+
+  /**
+   * The mass update, refused when it would regenerate many slugs at once
+   *
+   * @param {object} values The values
+   * @param {object} [options] The options (`where`)
+   * @returns {Promise<*>} What Sequelize answers
+   */
+  Model.update = async (values, options) => {
+    if (declaration.on === 'change' && writesSource(declaration, values)) {
+      throw massSlug(name, declaration, 'update', 'update(attrs)');
+    }
+
+    return update(values, options);
+  };
 
   return Model;
 };
@@ -416,4 +570,4 @@ const validations = (Model, rules) => {
   return Model;
 };
 
-module.exports = { lookup, paginate, publicId, validations };
+module.exports = { lookup, paginate, publicId, slugged, validations };

--- a/packages/sequelize/slug.js
+++ b/packages/sequelize/slug.js
@@ -1,0 +1,752 @@
+/**
+ * The third identifier, and the only one a person reads.
+ *
+ * `/articles/how-we-ship` rather than
+ * `/articles/01a07d06-e6c4-73cd-9021-31eb06befdd7`. A model asks for one in
+ * its options:
+ *
+ * ```js
+ * module.exports = {
+ *   schema: { body: { type: 'text' }, title: { type: 'string' } },
+ *   options: { slug: 'title' },
+ * };
+ * ```
+ *
+ * and henri adds a `slug` column -- unique, indexed, not null -- fills it
+ * on insert, resolves it in `findById()` and prints it in every url that
+ * names the record.
+ *
+ * ## Where a slug is allowed to appear, and where it is not
+ *
+ * henri has two identifiers and exactly one of them is public
+ * (`base/references.js`): `externalId`, a uuid v7, leaves the server; the
+ * primary key never does. A slug is a **third**, and almost everything
+ * below is about not spending the guarantee that buys.
+ *
+ * The rule is two lines long:
+ *
+ * - a slug appears in the record's own `slug` field, and in the **url** of
+ *   that record (`_links`, the route helpers, the `Location` of a 201);
+ * - it appears **nowhere else**. A foreign key is still published as the
+ *   `externalId` of the row it names, never as that row's slug. The
+ *   versions table, the access trail, the flags actor, the erasure receipt
+ *   and the webhook payloads all keep reading `externalId` and none of them
+ *   learned a second spelling.
+ *
+ * So the uuid is what an API client stores and what henri writes down; the
+ * slug is what a person reads and types. A record answers to both and they
+ * are both public: this is a second **name**, not a second identity.
+ *
+ * ## Why a lookup cannot be talked into a primary key
+ *
+ * `Model.findById()` is the door for what arrived from outside, and it
+ * grew a branch:
+ *
+ * 1. a uuid resolves the `externalId`, exactly as before;
+ * 2. anything else resolves the **slug column**, on a model that has one;
+ * 3. and that is the end of it -- `null`, the same `null` an unknown uuid
+ *    answers.
+ *
+ * Step 2 is a `WHERE slug = ?`, not a fallthrough, which is the whole
+ * safety argument. `findById('4812')` asks the slug column for `'4812'`; it
+ * does not ask the primary key anything, so it cannot say whether row 4812
+ * exists. If some record's slug really is `4812`, that record comes back --
+ * and that is a public fact about a public name, not the number. The
+ * primary key keeps its own door, `findByKey()`, and nothing here reaches
+ * for it.
+ *
+ * The one collision that would matter is a slug **shaped like a uuid**: it
+ * would take branch 1 and quietly name nothing. `problemOf()` refuses one,
+ * so the two identifier spaces never overlap.
+ *
+ * ## Uniqueness: what holds, and what henri will not pretend
+ *
+ * Two articles called "Getting started" is the normal case. henri does not
+ * claim `unique` as a validation -- a `SELECT` before an `INSERT` answers a
+ * question about a moment that has passed (`base/validations.js`) -- and it
+ * does not make an exception for itself here. So there is no lookup before
+ * the write, no counter, and no `-2`:
+ *
+ * - **`suffix: true`, the default.** The slug is the slugified source plus
+ *   a discriminator taken from the record's own `externalId`:
+ *   `getting-started-k3f9pq`. Unique because the uuid is, stable because
+ *   the uuid never changes, and free because nothing is read. The cost,
+ *   said out loud: every url carries six extra characters even when nothing
+ *   would have collided.
+ * - **`suffix: false`.** The slug is exactly the slugified source:
+ *   `getting-started`. The **unique index is what holds**, so the second
+ *   "Getting started" is refused by the database, and
+ *   `henri.model.errors()` turns that into `{ slug: 'must be unique' }` --
+ *   the same sentence any other unique column gives. The cost is that
+ *   refusal, and it lands on a title the author had every reason to think
+ *   was fine.
+ *
+ * Neither is scoped: a slug is unique across the table, not per tenant or
+ * per parent. A scope is a composite index henri would have to write into
+ * a migration it does not own, and it is not here.
+ *
+ * ## What happens when the title changes
+ *
+ * By default, nothing. `on: 'create'` is the default and it is the honest
+ * one: a slug is generated once and never moves, so the url minted the day
+ * the record was written keeps working forever, whatever the title becomes.
+ * An identifier that follows a display string is an identifier that stops
+ * being one.
+ *
+ * `on: 'change'` regenerates whenever the source field is written, and the
+ * old url **stops working that instant**. There is no history table in
+ * henri: friendly_id keeps every retired slug in one and answers a 301 from
+ * it, and that is a table on four adapters, a redirect, a retention rule
+ * and a reach for the erasure -- a tranche of its own. Until it exists,
+ * `on: 'change'` means the old url 404s, and the guide says so in those
+ * words.
+ *
+ * A mass update that names the source field on such a model is **refused**
+ * (`HENRI_MODEL_SLUG_MASS_WRITE`): the hook runs once, without records, so
+ * either every row would get the same slug or none would get a new one, and
+ * both are worse than the refusal. It is the answer
+ * `HENRI_MODEL_VALIDATION_MASS_WRITE` and `HENRI_VERSION_MASS_WRITE`
+ * already give to the same shape of problem, and it names the loop.
+ *
+ * ## A title that is not in English
+ *
+ * `slugify()` lowercases, decomposes (NFKD) and keeps `a-z0-9`. That makes
+ * `Café Crème` into `cafe-creme` without a transliteration table, because
+ * Unicode already knows that `é` is `e` with a mark on it and
+ * `String#normalize` ships in Node.
+ *
+ * What Unicode does **not** decompose is a short list of Latin letters that
+ * are letters in their own right -- `ß`, `ø`, `ł`, `æ`, `þ` -- and `FOLDED`
+ * is a line each for them, eleven in total. That is the whole table and it
+ * is deliberately not the first entry of one per script: a Japanese,
+ * Arabic, Hebrew, Greek or Cyrillic title has no ASCII to fold to, and
+ * shipping the tables that would invent some is how a framework ends up
+ * choosing romanizations on a reader's behalf.
+ *
+ * So a title in one of those scripts **slugifies to nothing**, and that
+ * needed a real answer rather than a shrug. It has two:
+ *
+ * - With `suffix: true` the record still gets a slug -- the discriminator
+ *   alone, `k3f9pq` -- so the write never fails and the url always works.
+ *   With `suffix: false` there is nothing to fall back to and the write is
+ *   refused (`HENRI_MODEL_SLUG_EMPTY`), naming the field and the title.
+ * - **A slug the application writes itself always wins and may be any
+ *   Unicode henri can carry in a path segment.** `slug: 'こんにちは'` is
+ *   accepted, stored, matched by the route and carried percent-encoded on
+ *   the wire, which every browser renders back as the characters. So the
+ *   choice between transliteration and percent-encoding is not made here:
+ *   henri's generator folds to ASCII and ships no romanization, and an
+ *   application that wants its own script in the url writes the slug and
+ *   gets it, byte for byte.
+ *
+ * `problemOf()` is what a supplied slug is measured against, and it is a
+ * list of the structural characters rather than a definition of a letter:
+ * nothing below `!`, none of `"#%/:?@[\]^`{|}<>`, not `.` or `..`, not a
+ * uuid, not a reserved word, not longer than the column. A deny list is the
+ * right shape here precisely because henri is not the one deciding what
+ * counts as a word.
+ *
+ * ## Reserved words
+ *
+ * `resources articles` mounts `GET /articles/new` before `GET /articles/:id`
+ * (`base/routes.js`), so a record slugged `new` is a record with no show
+ * page. henri reserves that one word by default and `reserved` adds more --
+ * which is the honest bound, because a `collection` route an application
+ * declared is a segment henri cannot know when the slug is generated. The
+ * guide says to add it.
+ *
+ * ## No regular expression touches a title
+ *
+ * A title arrives through `req.permit()`, and a slugifier is exactly the
+ * shape that turns into a quadratic match. Everything here walks: one pass
+ * over the code points with a `Set` and a `Map`, no `RegExp` anywhere in
+ * the file, and the length bound applied while walking rather than after.
+ *
+ * ## A copy per adapter
+ *
+ * This file is held four times -- here and in `@usehenri/drizzle`,
+ * `@usehenri/mongoose` and `@usehenri/sequelize` -- byte for byte, the way
+ * `exact.js`, `external-id.js` and `validations.js` are, because an adapter
+ * depends on no part of core at runtime.
+ * `src/__tests__/slug.spec.js` is what keeps them the same file. It
+ * requires nothing at all, and raises its codes through a `coded()` of its
+ * own for the same reason.
+ */
+
+/** The field a slug lives in, and the column it becomes */
+const SLUG = 'slug';
+
+/** The failure a `slug` declaration henri cannot carry out gets */
+const DECLARATION = 'HENRI_MODEL_SLUG_DECLARATION_INVALID';
+
+/** The failure a source that slugifies to nothing gets */
+const EMPTY = 'HENRI_MODEL_SLUG_EMPTY';
+
+/** The failure a mass write that would regenerate many slugs gets */
+const MASS_WRITE = 'HENRI_MODEL_SLUG_MASS_WRITE';
+
+/** How long the slugified source may be, before the discriminator */
+const MAX_LENGTH = 80;
+
+/** How many characters the discriminator adds, plus its separator */
+const SUFFIX_LENGTH = 6;
+
+/** The keys a `slug` declaration may hold */
+const KEYS = ['from', 'maxLength', 'on', 'reserved', 'suffix'];
+
+/** What `on` takes: generate once, or follow the source */
+const EVENTS = ['create', 'change'];
+
+/**
+ * The characters a slug may never carry, whoever wrote it.
+ *
+ * Not "everything but a letter": henri is not the one deciding what counts
+ * as a letter in a script it does not read. These are the ones that end a
+ * path segment, start a query, escape an encoding or name a directory.
+ */
+const REFUSED = new Set([
+  '"',
+  '#',
+  '%',
+  '/',
+  ':',
+  '<',
+  '>',
+  '?',
+  '@',
+  '[',
+  '\\',
+  ']',
+  '^',
+  '`',
+  '{',
+  '|',
+  '}',
+]);
+
+/** The path segments a slug would shadow */
+const RESERVED = ['.', '..', 'new'];
+
+/**
+ * The Latin letters Unicode does not decompose, which is why each needs a
+ * line. This is the whole table and it is deliberately not one per script:
+ * see the header.
+ */
+const FOLDED = new Map([
+  ['æ', 'ae'],
+  ['đ', 'd'],
+  ['ð', 'd'],
+  ['ħ', 'h'],
+  ['ı', 'i'],
+  ['ł', 'l'],
+  ['ø', 'o'],
+  ['œ', 'oe'],
+  ['ß', 'ss'],
+  ['þ', 'th'],
+  ['ŧ', 't'],
+]);
+
+/**
+ * The alphabet of the discriminator: base 32 without the characters a
+ * person mistakes for another when reading a url out loud (`0`/`o`,
+ * `1`/`l`/`i`).
+ */
+const ALPHABET = '23456789abcdefghjkmnpqrstuvwxyz';
+
+/** The separator between words, and before the discriminator */
+const DASH = '-';
+
+/**
+ * An error carrying a henri code, without depending on core
+ *
+ * @param {string} code the henri error code
+ * @param {string} message what is wrong
+ * @returns {Error} the error to throw
+ */
+const coded = (code, message) => Object.assign(new Error(message), { code });
+
+/**
+ * Is the value a plain object?
+ *
+ * @param {*} value any value
+ * @returns {boolean} true for a plain object
+ */
+const isPlainObject = (value) =>
+  value !== null &&
+  typeof value === 'object' &&
+  (Object.getPrototypeOf(value) === Object.prototype ||
+    Object.getPrototypeOf(value) === null);
+
+/**
+ * Is this string a uuid, and therefore an `externalId` rather than a name?
+ *
+ * The shape is checked by walking it: eight hex, a dash, four, a dash,
+ * four, a dash, four, a dash, twelve. The same answer
+ * `base/external-id.js` gives, without the pattern, because this one is
+ * asked about a value that came from a request.
+ *
+ * @param {string} value the candidate
+ * @returns {boolean} true when it is shaped like a uuid
+ */
+const looksLikeUuid = (value) => {
+  const groups = [8, 4, 4, 4, 12];
+  let at = 0;
+
+  for (let group = 0; group < groups.length; group += 1) {
+    if (group > 0) {
+      if (value[at] !== DASH) {
+        return false;
+      }
+
+      at += 1;
+    }
+
+    for (let taken = 0; taken < groups[group]; taken += 1) {
+      const code = value.charCodeAt(at);
+
+      // 0-9, a-f, A-F
+      if (
+        !(code >= 48 && code <= 57) &&
+        !(code >= 97 && code <= 102) &&
+        !(code >= 65 && code <= 70)
+      ) {
+        return false;
+      }
+
+      at += 1;
+    }
+  }
+
+  return at === value.length;
+};
+
+/**
+ * Is this code point a combining mark NFKD left behind?
+ *
+ * The three blocks a decomposed Latin, Greek or Cyrillic letter puts its
+ * accent in. They are dropped rather than turned into a separator, so
+ * `é` is `e` and not `e-`.
+ *
+ * @param {number} code the code point
+ * @returns {boolean} true for a combining mark
+ */
+const isMark = (code) =>
+  (code >= 0x0300 && code <= 0x036f) ||
+  (code >= 0x1ab0 && code <= 0x1aff) ||
+  (code >= 0x20d0 && code <= 0x20f0);
+
+/**
+ * The slug of a value: lowercase, decomposed, `a-z0-9` joined by dashes.
+ *
+ * One walk over the code points, no pattern, and the bound applied as it
+ * goes rather than by cutting at the end -- so a title of any length costs
+ * what the bound costs and not what the title costs.
+ *
+ * @param {*} value what the source field holds
+ * @param {number} [maxLength=MAX_LENGTH] how long the answer may be
+ * @returns {string} the slug, possibly empty
+ */
+const slugify = (value, maxLength = MAX_LENGTH) => {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return '';
+  }
+
+  const source = String(value).toLowerCase().normalize('NFKD');
+  const out = [];
+  let pending = false;
+
+  for (const character of source) {
+    if (out.length >= maxLength) {
+      break;
+    }
+
+    const code = character.codePointAt(0);
+
+    if (isMark(code)) {
+      continue;
+    }
+
+    // The ranges `a-z` and `0-9`, the only two that come out of this file
+    if ((code >= 97 && code <= 122) || (code >= 48 && code <= 57)) {
+      if (pending && out.length > 0) {
+        out.push(DASH);
+      }
+
+      pending = false;
+
+      if (out.length < maxLength) {
+        out.push(character);
+      }
+
+      continue;
+    }
+
+    const folded = FOLDED.get(character);
+
+    if (folded) {
+      if (pending && out.length > 0) {
+        out.push(DASH);
+      }
+
+      pending = false;
+
+      for (const letter of folded) {
+        if (out.length < maxLength) {
+          out.push(letter);
+        }
+      }
+
+      continue;
+    }
+
+    // Anything else -- a space, a comma, an emoji, a kanji -- ends the run
+    // rather than being carried, and a run of them is one dash
+    pending = true;
+  }
+
+  return out.join('');
+};
+
+/**
+ * Six characters of the record's own public identifier, so the
+ * discriminator is unique because the uuid is and stable because the uuid
+ * never changes.
+ *
+ * A model that opted out of `externalId` has no such seed, and neither
+ * does a mass insert on an ORM that fills the column after the hook; both
+ * fall back to `Math.random()`, which is enough because a discriminator is
+ * not a secret -- a slug is a public name, nothing is protected by knowing
+ * one, and a duplicate is caught by the unique index the column carries.
+ *
+ * @param {*} seed the record's `externalId`, when there is one
+ * @returns {string} six characters of the alphabet
+ */
+const discriminate = (seed) => {
+  const out = [];
+
+  if (typeof seed === 'string' && seed.length >= SUFFIX_LENGTH * 2) {
+    // The tail of a uuid v7 is its random half; the head is the clock, and
+    // every record written in the same millisecond shares it
+    const tail = seed
+      .slice(-SUFFIX_LENGTH * 2)
+      .split(DASH)
+      .join('');
+
+    for (
+      let at = 0;
+      at + 1 < tail.length && out.length < SUFFIX_LENGTH;
+      at += 2
+    ) {
+      const pair = parseInt(tail.slice(at, at + 2), 16);
+
+      if (Number.isNaN(pair)) {
+        break;
+      }
+
+      out.push(ALPHABET[pair % ALPHABET.length]);
+    }
+  }
+
+  while (out.length < SUFFIX_LENGTH) {
+    out.push(ALPHABET[Math.floor(Math.random() * ALPHABET.length)]);
+  }
+
+  return out.join('');
+};
+
+/**
+ * Refuses a declaration, naming the model
+ *
+ * @param {string} model the model's global id
+ * @param {string} what what is wrong with it
+ * @returns {void} never returns
+ * @throws {Error} always, HENRI_MODEL_SLUG_DECLARATION_INVALID
+ */
+const refuse = (model, what) => {
+  throw coded(DECLARATION, `${model} declares \`options.slug\` with ${what}`);
+};
+
+/**
+ * The `slug` declaration of a model file, compiled, or null when it wants
+ * no slug.
+ *
+ * `slug: 'title'` is the shorthand every application writes; the object
+ * form takes `from`, `on`, `suffix`, `reserved` and `maxLength`.
+ *
+ * @param {object} model the model file (`schema`, `options`, `globalId`)
+ * @returns {?object} `{ from, maxLength, on, reserved, suffix }` or null
+ * @throws {Error} HENRI_MODEL_SLUG_DECLARATION_INVALID on anything unusable
+ */
+const slugOf = (model) => {
+  const options = (model && model.options) || {};
+  const written = options.slug;
+  const name = (model && (model.globalId || model.identity)) || 'model';
+
+  if (typeof written === 'undefined' || written === null || written === false) {
+    return null;
+  }
+
+  if (typeof written !== 'string' && !isPlainObject(written)) {
+    refuse(
+      name,
+      `${typeof written}: it is the name of the field to build the slug from, or an object of ${KEYS.join(', ')}`
+    );
+  }
+
+  const declared =
+    typeof written === 'string' ? { from: written } : { ...written };
+
+  for (const key of Object.keys(declared)) {
+    if (!KEYS.includes(key)) {
+      refuse(name, `the unknown key "${key}": it takes ${KEYS.join(', ')}`);
+    }
+  }
+
+  const schema = (model && model.schema) || {};
+  const { from } = declared;
+
+  if (typeof from !== 'string' || from === '') {
+    refuse(name, 'no "from": a slug is built from a field of the model');
+  }
+
+  if (from === SLUG) {
+    refuse(name, 'a "from" of "slug": the slug cannot be built from itself');
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(schema, from)) {
+    refuse(name, `a "from" of "${from}", which the schema does not declare`);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(schema, SLUG)) {
+    refuse(
+      name,
+      'a "slug" field of its own in the schema: henri adds the column, so declaring it twice would mean two different things'
+    );
+  }
+
+  const definition = schema[from];
+  const type = isPlainObject(definition) ? definition.type : definition;
+
+  if (type !== 'string' && type !== 'text' && type !== String) {
+    refuse(
+      name,
+      `a "from" of "${from}", which is not a string or a text: a slug is built from words`
+    );
+  }
+
+  if (isPlainObject(definition) && definition.encrypted) {
+    refuse(
+      name,
+      `a "from" of "${from}", which is encrypted: a slug is public and the column it came from is not`
+    );
+  }
+
+  const marked = isPlainObject(definition) ? definition.personal : null;
+
+  if (isPlainObject(marked) && marked.expose === false) {
+    refuse(
+      name,
+      `a "from" of "${from}", which is marked \`personal: { expose: false }\`: that field is dropped from every answer henri builds, and a slug is in every url of the record`
+    );
+  }
+
+  const compiled = {
+    from,
+    maxLength: MAX_LENGTH,
+    on: 'create',
+    reserved: new Set(RESERVED),
+    suffix: true,
+  };
+
+  if ('on' in declared) {
+    if (!EVENTS.includes(declared.on)) {
+      refuse(name, `an "on" of "${declared.on}": it is ${EVENTS.join(' or ')}`);
+    }
+
+    compiled.on = declared.on;
+  }
+
+  if ('suffix' in declared) {
+    if (typeof declared.suffix !== 'boolean') {
+      refuse(name, 'a "suffix" that is not true or false');
+    }
+
+    compiled.suffix = declared.suffix;
+  }
+
+  if ('maxLength' in declared) {
+    if (
+      typeof declared.maxLength !== 'number' ||
+      !Number.isInteger(declared.maxLength) ||
+      declared.maxLength < 1
+    ) {
+      refuse(name, 'a "maxLength" that is not a whole number of characters');
+    }
+
+    compiled.maxLength = declared.maxLength;
+  }
+
+  if ('reserved' in declared) {
+    if (
+      !Array.isArray(declared.reserved) ||
+      declared.reserved.some((word) => typeof word !== 'string')
+    ) {
+      refuse(name, 'a "reserved" that is not a list of words');
+    }
+
+    for (const word of declared.reserved) {
+      compiled.reserved.add(word.toLowerCase());
+    }
+  }
+
+  return compiled;
+};
+
+/**
+ * How long the column has to be: the slugified source, the separator and
+ * the discriminator
+ *
+ * @param {object} declaration the compiled declaration
+ * @returns {number} the column length
+ */
+const lengthOf = (declaration) =>
+  declaration.maxLength + (declaration.suffix ? SUFFIX_LENGTH + 1 : 0);
+
+/**
+ * Everything wrong with a slug an application wrote itself.
+ *
+ * A deny list rather than a definition of a word: any script may name a
+ * record, and what may not is what would stop being one path segment.
+ *
+ * @param {*} value the slug
+ * @param {object} declaration the compiled declaration
+ * @returns {?string} the message, or null when it can be a url segment
+ */
+const problemOf = (value, declaration) => {
+  if (typeof value !== 'string') {
+    return 'must be a string';
+  }
+
+  if (value === '') {
+    return 'is required';
+  }
+
+  if ([...value].length > lengthOf(declaration)) {
+    return `must be at most ${lengthOf(declaration)} characters`;
+  }
+
+  for (const character of value) {
+    const code = character.codePointAt(0);
+
+    if (code < 0x21 || code === 0x7f) {
+      return 'must not hold a space or a control character';
+    }
+
+    if (REFUSED.has(character)) {
+      return `must not hold "${character}"`;
+    }
+  }
+
+  if (looksLikeUuid(value)) {
+    return 'must not be shaped like a public identifier';
+  }
+
+  if (declaration.reserved.has(value.toLowerCase())) {
+    return `must not be "${value}", which is a path henri already mounts`;
+  }
+
+  return null;
+};
+
+/**
+ * The slug of a record about to be written.
+ *
+ * @param {object} declaration the compiled declaration
+ * @param {*} source what the source field holds
+ * @param {*} seed the record's `externalId`, for the discriminator
+ * @returns {string} the slug, or an empty string when there is nothing to
+ *   build one from and no discriminator to fall back to
+ */
+const slugFor = (declaration, source, seed) => {
+  const base = slugify(source, declaration.maxLength);
+
+  if (!declaration.suffix) {
+    return base;
+  }
+
+  const suffix = discriminate(seed);
+
+  return base === '' ? suffix : `${base}${DASH}${suffix}`;
+};
+
+/**
+ * Does this write name the field the slug is built from?
+ *
+ * @param {object} declaration the compiled declaration
+ * @param {*} attrs the attributes being written
+ * @returns {boolean} true when the source field is one of them
+ */
+const writesSource = (declaration, attrs) =>
+  Boolean(declaration) &&
+  isPlainObject(attrs) &&
+  Object.prototype.hasOwnProperty.call(attrs, declaration.from);
+
+/**
+ * The refusal a source that slugified to nothing gets
+ *
+ * @param {string} model the model's global id
+ * @param {object} declaration the compiled declaration
+ * @param {*} source what the source field held
+ * @returns {Error} the error to throw
+ */
+const emptySlug = (model, declaration, source) =>
+  coded(
+    EMPTY,
+    `${model}.${declaration.from} is ${
+      typeof source === 'string' && source !== ''
+        ? `"${source}", which has no letters or digits henri can fold to ASCII`
+        : 'empty'
+    }, and the model declares \`slug: { suffix: false }\`, so there is nothing to build a slug from. ` +
+      'Write the slug yourself, or let henri add its discriminator (`suffix: true`, the default), which always answers something.'
+  );
+
+/**
+ * The refusal a mass write that would regenerate many slugs gets
+ *
+ * @param {string} model the model's global id
+ * @param {object} declaration the compiled declaration
+ * @param {string} what the call that was made (`update`, `updateMany`)
+ * @param {string} instead the single-record call to loop over
+ * @returns {Error} the error to throw
+ */
+const massWrite = (model, declaration, what, instead) =>
+  coded(
+    MASS_WRITE,
+    `${model}.${what}() writes many rows at once and names ${declaration.from}, which ${model} regenerates its slug from (\`slug: { on: 'change' }\`). ` +
+      'One hook runs for the whole write, with no records in it, so every row would get one slug or none would get a new one. henri refuses rather than doing either. ' +
+      `Loop instead: for (const record of await ${model}.find(where)) await record.${instead}`
+  );
+
+module.exports = {
+  ALPHABET,
+  DECLARATION,
+  EMPTY,
+  EVENTS,
+  KEYS,
+  MASS_WRITE,
+  MAX_LENGTH,
+  RESERVED,
+  SLUG,
+  SUFFIX_LENGTH,
+  coded,
+  discriminate,
+  emptySlug,
+  lengthOf,
+  looksLikeUuid,
+  massWrite,
+  problemOf,
+  slugFor,
+  slugOf,
+  slugify,
+  writesSource,
+};

--- a/types/core.test-d.ts
+++ b/types/core.test-d.ts
@@ -798,6 +798,44 @@ const badStrategy: ModelFile = {
   schema: { title: 'string' },
 };
 
+// The third identifier: a field name, or the object form
+const named: ModelFile = {
+  options: { slug: 'title' },
+  schema: { title: 'string' },
+};
+
+expectType<ModelFile>(named);
+
+const namedAtLength: ModelFile = {
+  options: {
+    slug: {
+      from: 'title',
+      maxLength: 40,
+      on: 'change',
+      reserved: ['search'],
+      suffix: false,
+    },
+  },
+  schema: { title: 'string' },
+};
+
+expectType<ModelFile>(namedAtLength);
+
+const badSlugEvent: ModelFile = {
+  // @ts-expect-error a slug is generated on a create or on a change
+  options: { slug: { from: 'title', on: 'save' } },
+  schema: { title: 'string' },
+};
+
+const badSlugSource: ModelFile = {
+  // @ts-expect-error the object form names the field it is built from
+  options: { slug: { on: 'create' } },
+  schema: { title: 'string' },
+};
+
+expectType<ModelFile>(badSlugEvent);
+expectType<ModelFile>(badSlugSource);
+
 const derived: ModelFile = {
   graphql: true,
   schema: { title: 'string' },

--- a/website/src/content/docs/guides/models.md
+++ b/website/src/content/docs/guides/models.md
@@ -395,6 +395,157 @@ In the database, the foreign keys are unaffected. `belongsTo` and `hasMany` keep
 
 [`externalIds`](/configuration/#the-externalids-object) holds both switches, and `henri audit` reports either of them turned off.
 
+## Slugs
+
+`/articles/how-we-ship` rather than `/articles/0199a5c1-1f7e-7a3c-bb0d-2b1a4f6d9c11`. A model asks for a name in its options:
+
+```js
+// app/models/Article.js
+module.exports = {
+  options: { slug: 'title', timestamps: true },
+  schema: {
+    body: { type: 'text' },
+    title: { type: 'string', required: true },
+  },
+};
+```
+
+and henri adds a `slug` column -- unique, indexed, `NOT NULL` -- fills it on the insert, resolves it in `findById()` and prints it in every url that names the record.
+
+```js
+const article = await Article.create({ title: 'How we ship' });
+
+article.slug; // 'how-we-ship-k3f9pq'
+article.externalId; // '0199a5c1-1f7e-7a3c-bb0d-2b1a4f6d9c11'
+article.id; // 42, on the server
+```
+
+`henri generate scaffold Article title:string! body:text --slug title` writes the declaration, the controller and the pages together, and a generator run over a model that already has one reads it back -- so nothing is hand-wired.
+
+### Where a slug appears, and where it does not
+
+A slug is a **third** identifier, and the rule that keeps it from spending what the other two buy is two lines long:
+
+- it appears in the record's own `slug` field, and in the **url** of that record -- `_links`, the path helpers, the `Location` of a `201`;
+- it appears **nowhere else**. A foreign key is still published as the `externalId` of the row it names, never as that row's slug; the versions table, the access trail, the flags actor and the erasure receipts all keep reading `externalId`.
+
+So the uuid is what an API client stores and what henri writes down; the slug is what a person reads and types. A record answers to both, and both are public: this is a second **name**, not a second identity.
+
+```json
+{
+  "_links": { "self": { "href": "/articles/how-we-ship-k3f9pq" } },
+  "externalId": "0199a5c1-1f7e-7a3c-bb0d-2b1a4f6d9c11",
+  "slug": "how-we-ship-k3f9pq",
+  "title": "How we ship"
+}
+```
+
+### The lookup, and why it cannot reach a primary key
+
+`findById()` grew one branch:
+
+```js
+await Article.findById('how-we-ship-k3f9pq'); // the record, by name
+await Article.findById(article.externalId); // the record, as before
+await Article.findById(42); // null
+await Article.findById('42'); // null
+await Article.findById('no-such-article'); // null
+```
+
+A uuid resolves the `externalId`, exactly as before. Anything else resolves the **slug column** -- a `WHERE slug = ?`, not a fallthrough -- and that is the end of it. `findById('42')` asks the slug column for `'42'`; it does not ask the primary key anything, so it cannot say whether row 42 exists. If some record's slug really is `42`, that record comes back, and that is a public fact about a public name rather than the number.
+
+A model with a name takes the whole non-uuid space with it, [`externalIds.lookup: "any"`](/configuration/#the-externalids-object) included: on such a model the primary key belongs to `findByKey()` alone. `findBySlug()` is the explicit half, the way `findByExternalId()` is, and `findByIdAndUpdate()`/`findByIdAndDelete()` reach exactly the rows `findById()` reaches.
+
+A slug shaped like a uuid would take the first branch and quietly name nothing, so henri refuses one.
+
+### Two articles called "Getting started"
+
+That is the normal case, not the edge one, and henri answers it without a `SELECT` before the `INSERT` -- the same position it takes on `unique` in [validations](#validations): a check before a write answers a question about a moment that has passed.
+
+**`suffix: true`, the default.** The slug is the folded title plus a six character discriminator taken from the record's own `externalId`: `getting-started-k3f9pq`. Unique because the uuid is, stable because the uuid never changes, and free because nothing is read. The cost, said out loud: every url carries six extra characters even when nothing would have collided.
+
+**`suffix: false`.** The slug is exactly the folded title: `getting-started`. The **unique index is what holds**, so the second "Getting started" is refused by the database and `henri.model.errors()` turns that into `{ slug: 'must be unique' }`, the same sentence any other unique column gives. The cost is that refusal, and it lands on a title its author had every reason to think was fine -- so this is the choice to make when the source is something a person already keeps unique, like a product code.
+
+```js
+options: { slug: { from: 'title', suffix: false } },
+```
+
+Neither is scoped. A slug is unique across the table, not per tenant or per parent: a scope is a composite index henri would have to write into a migration it does not own.
+
+### When the title changes
+
+By default, nothing happens. `on: 'create'` is the default and it is the honest one: the slug is generated once, and the url minted the day the record was written keeps working forever, whatever the title becomes. An identifier that follows a display string is an identifier that has stopped being one.
+
+`on: 'change'` regenerates whenever the source field is written, **and the old url stops working that instant**. henri keeps no history of slugs: `friendly_id` puts every retired one in a table and answers a `301` from it, which is a table on four adapters, a redirect, a retention rule and a reach for the erasure -- and it is not here. Until it is, `on: 'change'` means the old url 404s.
+
+A mass update naming the source field on such a model is refused (`HENRI_MODEL_SLUG_MASS_WRITE`), because one hook runs for the whole write with no records in it, so either every row would get the same slug or none would get a new one:
+
+```js
+// refused
+await Article.update({ author: 'ada' }, { title: 'One name for all' });
+
+// what to write instead
+for (const article of await Article.find({ author: 'ada' })) {
+  await article.update({ title: 'One name for all' });
+}
+```
+
+It is the answer `HENRI_MODEL_VALIDATION_MASS_WRITE` and `HENRI_VERSION_MASS_WRITE` already give to the same shape of problem. A model whose slug is generated once has nothing to regenerate, and its mass updates are untouched.
+
+### A title that is not in English
+
+henri lowercases the title, decomposes it (NFKD) and keeps `a-z0-9`. `Café Crème` becomes `cafe-creme` with no transliteration table at all, because Unicode already knows that `é` is `e` with a mark on it.
+
+What Unicode does not decompose is a short list of Latin letters that are letters in their own right, and those get a line each -- eleven of them: `æ ð đ ħ ı ł ø œ ß þ ŧ`. So `Straße in Köln` is `strasse-in-koln` and `Łódź` is `lodz`. **That is the whole table**, and it is deliberately not the first entry of one per script: a Japanese, Chinese, Arabic, Hebrew, Greek or Cyrillic title has no ASCII to fold to, and shipping the tables that would invent some is how a framework ends up choosing romanizations on a reader's behalf.
+
+So a title in one of those scripts folds to nothing, and that has two real answers rather than a shrug:
+
+- with `suffix: true` the record still gets a slug -- the discriminator alone, `k3f9pq` -- so the write never fails and the url always works. With `suffix: false` there is nothing to fall back to and the write is refused (`HENRI_MODEL_SLUG_EMPTY`), naming the field and what it held;
+- **a slug the application writes itself always wins, and may be in any script**:
+
+```js
+await Article.create({ slug: 'こんにちは', title: 'Hello' });
+// GET /articles/%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF
+```
+
+Every browser shows that as `こんにちは` in the address bar. So henri makes neither choice for you: its generator folds to ASCII and ships no romanization, and an application that wants its own script in the url writes the slug and gets it, byte for byte.
+
+`req.permit()` decides whether a request may set one -- the generated controller does not list `slug`, so by default nothing outside can.
+
+### What a slug may be
+
+A supplied slug is measured against a list of the structural characters rather than a definition of a letter, because henri is not the one deciding what counts as a word. It is refused when it:
+
+- is empty, or longer than the column;
+- holds a space, a control character, or one of the seventeen that end a path segment, start a query, escape an encoding or name a directory (`"`, `#`, `%`, `/`, `:`, `?`, `@`, `[`, `\`, `]`, `^`, `{`, `|`, `}`, `<`, `>` and the backtick);
+- is `.` or `..`, or a path henri already mounts -- `new`, because `resources articles` puts `GET /articles/new` ahead of `GET /articles/:id`. A `collection` route of your own is a segment henri cannot know when the slug is written, so add it: `reserved: ['search']`;
+- is shaped like a public identifier.
+
+The message is a `{ slug: '...' }` a controller answers `422` with, like any other validation failure. henri lowercases and trims what it stores.
+
+### The declaration
+
+| Key         | Default    | What it says                                                                                                                |
+| ----------- | ---------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `from`      | --         | The field the name is built from: a `string` or a `text`, never an `encrypted` one. `slug: 'title'` is the shorthand for it |
+| `on`        | `'create'` | `'create'` generates it once; `'change'` follows the source and retires the old url                                         |
+| `suffix`    | `true`     | Append the six character discriminator                                                                                      |
+| `reserved`  | `[]`       | Words a slug may not take, on top of henri's own                                                                            |
+| `maxLength` | `80`       | How long the folded source may be, before the discriminator                                                                 |
+
+A declaration henri cannot carry out fails the boot naming the model (`HENRI_MODEL_SLUG_DECLARATION_INVALID`): a `from` the schema does not declare, one that is not text, an `encrypted` one, one marked `personal: { expose: false }` -- both of those are fields henri keeps off every answer, and a slug is in every url -- a schema that declares a `slug` field of its own next to it, or an unknown key.
+
+### Slugs and personal data
+
+A slug is public, by construction: it is in the url, in the browser history, in the proxy logs. So `/authors/ada-lovelace` is a decision to publish that name, and it is one henri lets you make -- a field marked `personal: true` may name a record -- but not one it makes quietly:
+
+- a field marked `personal: { expose: false }` cannot be a `from` at all, because that mark says the value never leaves the server;
+- `henri privacy:erase` anonymizes the columns it was told about and **does not rewrite the slug**, because the slug is an identifier and rewriting it would 404 every url that ever pointed at the record. A model whose records are about a person and whose name is built from them wants `slug` off the person's own field -- a title, a reference, a number -- rather than an erasure that only half happened.
+
+### What is not here
+
+No history table, so no `301` from a retired slug -- see above. No scoped uniqueness. No slug on the user model by default. No route that resolves a slug across models, and no redirect engine: a url is a route, and the router is where routes are.
+
 ## Soft deletes
 
 `options: { paranoid: true }` is Rails' `acts_as_paranoid` (and Sequelize's own name for it): deleting a record stamps `deletedAt` instead of removing the row, and every query hides the stamped records.

--- a/website/src/content/docs/reference/errors.md
+++ b/website/src/content/docs/reference/errors.md
@@ -1617,6 +1617,41 @@ Usually:
 
 **Fix.** Configure `stores.default`, or give the model a `store` naming one of the stores that exist.
 
+### `HENRI_MODEL_SLUG_DECLARATION_INVALID`
+
+A model's `options.slug` asks for a name henri cannot build.
+
+Usually:
+
+- an `options.slug` naming a field the schema does not declare, or one that is not a `string` or a `text`
+- an `options.slug` built from an `encrypted` field, which is not public and has nothing a url could carry
+- an `options.slug` built from a field marked `personal: { expose: false }`, which henri drops from every answer it builds
+- a schema that declares a `slug` field of its own next to `options.slug`: henri adds the column
+- an unknown key, or an `on` that is neither `create` nor `change`
+
+**Fix.** The message names the model and what is wrong with the declaration. `options: { slug: 'title' }` is the whole of it for most models; the object form takes `from`, `on` (`create` or `change`), `suffix`, `reserved` and `maxLength`, and the column is always called `slug` and always added by henri. See the Models guide.
+
+### `HENRI_MODEL_SLUG_EMPTY`
+
+A slug was to be built from a source there is nothing to build one from.
+
+Usually:
+
+- a title in a script henri folds nothing to (Japanese, Chinese, Arabic, Hebrew, Greek, Cyrillic) on a model that declared `slug: { suffix: false }`
+- a source field that is empty, or holds something that is not text, on such a model
+
+**Fix.** `suffix: false` means the slug is the folded source and nothing else, so a source that folds to nothing leaves no name to write. Either write the slug yourself (an application-supplied slug always wins and may be in any script) or drop `suffix: false`, which appends a six character discriminator and therefore always answers something. henri ships no transliteration table and folds only what Unicode itself decomposes; the Models guide says which scripts that covers.
+
+### `HENRI_MODEL_SLUG_MASS_WRITE`
+
+A mass update named the field a model regenerates its slug from.
+
+Usually:
+
+- `Model.update(where, attrs)` or `updateMany` naming the source field, on a model that declared `slug: { on: 'change' }`
+
+**Fix.** One hook runs for the whole write and no record is named by it, so henri would either give every row the same slug or leave them all stale. Loop over the records instead (`for (const record of await Model.find(where)) await record.update(attrs)`) and each one gets its own name. A model whose slug is generated once (`on: 'create'`, the default) has nothing to regenerate and mass updates keep working.
+
 ### `HENRI_MODEL_TYPE_UNSUPPORTED`
 
 A model field asks for a type this store cannot carry without changing the value.


### PR DESCRIPTION
## What

`options: { slug: 'title' }` on a model. henri adds the column, fills it on insert and prints it in every url that names the record: `/articles/getting-started-k3f9pq`.

The tranche is mostly about **not breaking the two-identifier rule**. A slug sits *beside* `externalId` and replaces it in exactly one place — the url. The payload still carries `externalId` (an API client stores that), a declared foreign key still publishes as the target's `externalId`, and the versions table, the access trail, the flags actor and the erasure receipts all still read `externalId`. The single seam changed is `hateoas.identify()`, through a new `references.nameOf()` that asks the **model table** rather than the record — so an application that has always had a column called `slug` keeps the urls it had. `_links`, the path helpers and a 201's `Location` follow from that one change.

## The decisions

**A lookup cannot be talked into a primary key.** `findById()` resolves a uuid against `externalId` as before; anything else resolves the **slug column** — a `WHERE slug = ?`, never a fallthrough — and stops. A model with a slug takes the whole non-uuid space with it, `externalIds.lookup: "any"` included, which is the stricter direction. A slug shaped like a uuid is refused, so the two spaces never overlap.

**Uniqueness: no `SELECT` before the `INSERT`**, the position the validations tranche took last week. `suffix: true` (the default) appends six characters derived from the record's own `externalId` — unique because the uuid is, stable when regenerated, free, and the cost is stated: six characters in every url. `suffix: false` gives the bare name and leaves the unique index to refuse the second one as `{ slug: 'must be unique' }`. No counter, no `-2`.

**A slug does not move.** `on: 'create'` is the default, so the url minted on day one keeps working. `on: 'change'` follows the source and the old url 404s immediately — **the history table is deliberately left** (a table on four adapters plus a redirect, a retention rule and an erasure reach), and on such a model a mass update naming the source is refused rather than silently missed.

**Unicode: neither transliteration nor percent-encoding.** NFKD plus the eleven Latin letters Unicode does not decompose (`æ ð đ ħ ı ł ø œ ß þ ŧ`) and nothing more: `Café Crème` → `cafe-creme`, `Straße` → `strasse`, `Łódź` → `lodz`. A Japanese, Arabic or Cyrillic title folds to nothing on purpose — the discriminator is what answers, and with `suffix: false` the write is refused rather than writing an empty name. A slug the application writes itself wins and may be any script, so that choice stays the application's.

One refusal added on the `encrypted` principle: a `from` marked `personal: { expose: false }` fails the boot, because that field never leaves the server and a slug is in every url. A plain `personal: true` field is allowed, and the guide says plainly that `privacy:erase` does **not** rewrite a slug.

## What I verified myself

**The primary key is still not an identifier**, on the demo application:

| `Article.findById(…)` | answer |
| --- | --- |
| the slug | found |
| the `externalId` | found |
| the primary key as a string | **null** |
| `1` | **null** |
| an unknown name | null |

and the served payload carries the `externalId` and the slug, and **not** the primary key.

**The two 404s are one answer where it counts.** Over HTTP the demo's controller echoes the identifier it was given, so in *test* mode `/articles/<primary key>` and `/articles/no-such-article` differ by that echo — same template, the client's own input, no oracle. Under #418's rule they collapse: passing both messages through `spoken()` with a production instance answers `"Not Found"` for each, identical; with a test instance they echo. That is the designed behaviour and it is worth saying precisely rather than claiming byte-identity everywhere.

**No regex touches a title**, and it is linear. The file contains no `RegExp` (the single grep hit is a comment saying so) and `looksLikeUuid` is a hand-written walk over fixed group lengths. Timed rather than read, since this repository has been bitten three times: 0.5–6 ms for 200 000 characters of letters, spaces, dashes, accents or emoji.

## Gates

`pnpm test` (4253), `pnpm test:types`, `pnpm lint --max-warnings 0`, `pnpm format:check`, `scripts/smoke.sh` end to end after the generator changes (`henri audit`: nothing found in 54 checks), the SQL suites against live PostgreSQL (757), and the showcase against live PostgreSQL (170). The teammate's slug suites also ran on live PostgreSQL and MySQL, which is what proves the unique index is what refuses the second slug.

## Left, and named in the guide

The history table and its `301`; a slug unique per tenant or per parent (a composite index henri would have to write into a migration it does not own); a route resolving a name across models; any romanization. No end-to-end boot of a *scaffolded drizzle app serving a slug url* — the generator's output is asserted, the drizzle model is unit-tested and the router/HAL path is covered on the demo app, but those three are not joined in one run. MSSQL rides the Sequelize wiring with no coverage of its own, like the rest of that adapter.

## Integration note

The branch predates #422, so all three adapters, `CLAUDE.md` and the model registration needed hand merges to carry the tenant mark and the slug mark at once.