### PR TITLE
Enum predicates and scopes, spelled from a declaration that already exists

### DIFF
--- a/.changeset/enum-predicates-and-scopes.md
+++ b/.changeset/enum-predicates-and-scopes.md
@@ -1,0 +1,54 @@
+---
+'@usehenri/core': minor
+'@usehenri/drizzle': minor
+'@usehenri/mongoose': minor
+'@usehenri/sequelize': minor
+---
+
+Enum predicates, scopes and the list of values.
+
+A column that declares an `enum` already says what it may hold, so henri
+spells it back as methods rather than making every application write the
+strings out by hand:
+
+```js
+// app/models/Post.js
+schema: {
+  status: { type: 'string', enum: ['draft', 'in_review', 'live'] },
+}
+```
+
+gives, on every adapter:
+
+- `post.isDraft()` on every record;
+- `Post.live()` on the model, answering **a condition** — `{ status: 'live' }`
+  — intersected with whatever it is given;
+- `Post.enums.status`, the frozen list of values.
+
+The predicate is the one with no substitute: `post.status === 'darft'` is
+silently false for the life of the application, while `post.isDarft()` is a
+`TypeError` the first time it runs. Writing a wrong value was already
+refused on every adapter and every write path by the `enum` rule, so it is
+the comparison that needed the method — which is also why **Rails' bang
+(`post.archived!`) is not here**: `await post.update({ status: 'archived' })`
+is already one call that says what it does, and a method named after a
+transition invites a state machine henri would not be honouring.
+
+A scope answers a condition rather than records because henri has three
+query builders and wraps none of them: a condition is the value all three
+read identically, and the one that composes. It goes **under**
+`policy.scope(user)` and the client's filters with an `and` spelled for the
+adapter — `Post.paginate({ ...req.pagination(), where: Post.live(where) })`
+— so a scope narrows a list and can never widen it.
+
+`in_review`, `in-review`, `IN_REVIEW` and `InReview` all give `inReview`. A
+value that is not a name (`2fa`) gets no method and stays in the list. A
+generated name that is already a method of the model or of a record is a
+**boot failure** naming it (`HENRI_MODEL_ENUM_NAME_TAKEN`) rather than a
+silent shadow — `new` gives `isNew`, which is how Mongoose and the drizzle
+model tell an insert from an update — and the field is where the way out
+is written: `predicates: 'status'` prefixes both halves
+(`isStatusNew()`, `Post.statusNew()`) and `predicates: false` generates
+nothing and keeps the list. The check covers the names henri puts on a
+model on every adapter, so a model that boots on one store boots on the
+next.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -509,7 +509,7 @@ request-id,redact,headers,pagination,timeout,health}.js`: `res.resource()` and
   with `utils.resolveFrom('@usehenri/<adapter>')`. Model files use the henri
   schema format (`type: 'string'|'text'|'number'|'integer'|'float'|'decimal'|
 'bigint'|'boolean'|'date'|'json'|'uuid'`, `required`, `default`, `enum`,
-  `unique`, `index`),
+  `predicates`, `unique`, `index`),
   normalized by `schema.js` in each adapter (Sequelize and Drizzle throw on
   unknown keys,
   Mongoose passes them through). **`decimal` and `bigint` are the two a
@@ -626,6 +626,36 @@ model }` or Mongoose's `ref` -- which `res.render()`, `res.resource()`,
   (`#validations`), which is also where the boundary with `params` is
   argued: `params` checks what arrives, `validates` what is written, and a
   job, a seed or a console has no request.
+- **An `enum` column is spelled back as methods** (`base/enums.js`, applied
+  by `3.model.js` right after `addModel`). One file in core rather than a
+  copy per adapter, unlike `validates`: a method on a model is a property,
+  and core already knows how to read a model on all three (`kindOf()` in
+  `base/erasure.js`, `narrow()` in `base/filters.js`). Three of Rails' four:
+  `post.isDraft()` on the record, `Post.live()` on the model -- **a
+  condition, not records**, because henri has three query builders and wraps
+  none of them, and a condition is the value all three read identically and
+  the one that composes -- and `Post.enums.status`, the frozen list. It goes
+  under `policy.scope(user)` and the client's filters with the same `and`
+  `narrow()` spells, so a scope narrows a list and can never widen it. **The
+  bang is dropped**: `post.update({ status: 'archived' })` is already one
+  call, the wrong value in a _write_ is already refused by the `enum` rule,
+  and only the wrong value in a _comparison_ was silently false forever --
+  which is the whole argument for the predicate. `in_review`, `in-review`,
+  `IN_REVIEW` and `InReview` all give `inReview` (`names()` in
+  `packages/cli/scripts/utils.js` is a _resource_ name and lives where core
+  cannot require it); a value that is not a name gets no method and stays in
+  the list. A generated name that is already something else is a boot
+  failure (`HENRI_MODEL_ENUM_NAME_TAKEN`) rather than a silent shadow, and
+  the measurement is why: the record's namespace holds eight `is<Name>`
+  methods across the three ORMs and exactly one is a plausible value
+  (`new` -> `isNew`, how Mongoose and the drizzle model tell an insert from
+  an update), while the model's is crowded (`find`, `create`, `count`,
+  `name`, `length`). It is checked against `MODEL_API`/`RECORD_API` -- henri's
+  own surface, held as data so the answer is the same on every adapter --
+  and then `name in Model`, which is exact and covers the ORM's own. The
+  field carries the way out next to the `enum`: `predicates: 'status'`
+  prefixes both halves, `predicates: false` generates none. The guide is
+  `guides/models.md` (`#enums-predicates-scopes-and-the-list`).
 - The user module (`4.user.js`) mounts express-session (`henri.sid`),
   passport (`local` and `jwt` strategies), `POST /login`, `POST /logout`
   (`GET` answers 405), the double-submit CSRF middleware (`base/csrf.js`,
@@ -1675,6 +1705,25 @@ filters.spec.js`), on MongoDB through the demo application core's suite
   a validation leaves the refused value on the in-memory instance and the
   next `update()` on that same instance is measured against it. A record
   read again is fine; only the object in hand is stale.
+- Enum predicates and scopes are new. What was **deliberately left**: the
+  bang (argued above), a scope that answers records, an `or` between two
+  values (`{ status: { $in: [...] } }` is not portable by hand -- that is
+  `filters`' `in` operator, or a condition written for the adapter), a
+  scope on the **record** side of an association, and any state machine at
+  all -- no transition table, no guard, no callback. **A predicate is a
+  method of a record, so a page never has one**: a React or Inertia page
+  receives the column and compares it, and `Model.enums.<field>` is what
+  crosses over. An association that shadows a generated name is not caught,
+  because `associate()` runs after the models are built. `henri generate
+model` has **no syntax for an `enum`** (`name:type` only), so the scaffold
+  writes no enum column and there was nothing for a generated controller or
+  page to use a predicate on; giving the generator one is a CLI tranche of
+  its own. Coverage: sqlite and MongoDB offline
+  (`packages/{drizzle,mongoose,sequelize}/__tests__/enums.spec.js`, plus
+  the demo application in `packages/core/src/__tests__/enums.spec.js`),
+  PostgreSQL and MySQL through `pnpm test:sql:live`, and the showcase's
+  `Proposal` on a real application. MSSQL rides the Sequelize wiring with
+  no coverage of its own, like the rest of that adapter.
 - Multi-tenancy (`config.tenancy`) is new, and this tranche landed the
   column, the resolution, the query default and the refusals. The negative
   property -- tenant A cannot read or write tenant B's rows -- is proved on

--- a/packages/core/error-codes.json
+++ b/packages/core/error-codes.json
@@ -1460,6 +1460,38 @@
     {
       "area": "model",
       "causes": [
+        "`predicates` given something that is neither true, false nor a name",
+        "`predicates: 'in review'`, or any string that is not one word"
+      ],
+      "code": "HENRI_MODEL_ENUM_INVALID",
+      "fix": "`predicates` sits next to an `enum` and says what methods it generates: `true` (the default) gives `isDraft()` and `Model.draft()`, `false` gives none and leaves `Model.enums.<field>` as the list of values, and a name prefixes them -- `predicates: 'status'` gives `isStatusDraft()` and `Model.statusDraft()`. See the Models guide.",
+      "what": "A model field's `predicates` key is not one henri can read."
+    },
+    {
+      "area": "model",
+      "causes": [
+        "a value whose predicate is already a method of the ORM: `new` gives `isNew()`, which Mongoose and the drizzle model define on every record",
+        "a value whose scope is already a method of the model: `find`, `create`, `count`, `all`, `first`, `last`, `name`, `length`",
+        "two values of one model that camel case to the same name (`in_review` and `IN_REVIEW`)",
+        "a value whose predicate is also a column of the same model"
+      ],
+      "code": "HENRI_MODEL_ENUM_NAME_TAKEN",
+      "fix": "Generating the method would shadow something that already works, so henri refuses instead. Rename the value where you can, or name that column's methods after the field -- `status: { enum: [...], predicates: 'status' }` gives `isStatusNew()` and `Model.statusNew()`. `predicates: false` turns them off for that column and `Model.enums.<field>` is still the list of values. The check covers the names henri puts on a model on every adapter, so a model that boots on one store boots on the next.",
+      "what": "An `enum` value would generate a method name that is already something else."
+    },
+    {
+      "area": "model",
+      "causes": [
+        "`Model.live(true)`, `Model.live('draft')` or a scope given an array",
+        "a `policy.scope(user)` that is not a plain object handed to a scope"
+      ],
+      "code": "HENRI_MODEL_ENUM_UNMERGEABLE",
+      "fix": "An enum scope answers a condition and takes one, so `Model.live(where)` is `where AND status = 'live'` -- pass a plain object, or nothing. A scope that is not a plain object cannot have a condition put under it: answer one from `scope(user)`, or intersect it yourself.",
+      "what": "An enum scope was given something that is not a condition to narrow."
+    },
+    {
+      "area": "model",
+      "causes": [
         "a field with `required`, `default` or `unique` and no `type`",
         "a field written as `{ required: true }` instead of `{ type: 'string', required: true }`"
       ],

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -2699,6 +2699,18 @@ declare namespace start {
     default?: unknown;
     /** Allowed values (an ENUM on mysql and postgres, a validation elsewhere). */
     enum?: unknown[];
+    /**
+     * The methods an `enum` generates: `record.isDraft()` on every record,
+     * `Model.draft()` -- the condition, intersected with whatever it is
+     * given -- on the model, and `Model.enums.<field>`, the list of values.
+     *
+     * `true` is the default. `false` generates none and leaves the list.
+     * A string prefixes both halves, which is the way out when a value
+     * would shadow something (`predicates: 'status'` gives
+     * `isStatusNew()` and `Model.statusNew()`); a generated name that is
+     * already a method of the model or of a record is a boot failure.
+     */
+    predicates?: boolean | string;
     unique?: boolean;
     index?: boolean;
     /**

--- a/packages/core/src/3.model.js
+++ b/packages/core/src/3.model.js
@@ -9,6 +9,7 @@ const { userConfig } = require('./base/auth');
 const { modelErrors } = require('./base/model-errors');
 const { engine: graphqlEngine } = require('./base/graphql');
 const { blocksOf: graphqlBlocks } = require('./base/graphql-schema');
+const { attach: attachEnums } = require('./base/enums');
 const {
   build: buildReferences,
   publish: publishRecords,
@@ -109,6 +110,14 @@ class Model extends BaseModule {
         const store = await this.getStore(storeName);
 
         global[model.globalId] = store.addModel(model, user);
+
+        // What an `enum` column already said, spelled as methods: the
+        // predicates on the record, the scopes on the model and the list of
+        // values (base/enums.js). Here rather than in each adapter, because
+        // a method on a model is a property and core already knows how to
+        // read a model on all three -- unlike `validates`, which has to
+        // hook write paths and is a copy per adapter for that reason
+        attachEnums(global[model.globalId], model);
         this.ids.push(model.globalId);
         configuration.adapters[storeName] = store;
 

--- a/packages/core/src/__tests__/enums.spec.js
+++ b/packages/core/src/__tests__/enums.spec.js
@@ -1,0 +1,548 @@
+/* global Article */
+const Henri = require('../henri');
+
+const {
+  ATTACHED,
+  INVALID,
+  LIST,
+  MODEL_API,
+  RECORD_API,
+  TAKEN,
+  UNMERGEABLE,
+  attach,
+  conditionOf,
+  enumsOf,
+  nameOf,
+} = require('../base/enums');
+
+/** A model file with one enum column */
+const model = (schema, name = 'Post') => ({
+  globalId: name,
+  identity: name.toLowerCase(),
+  schema,
+});
+
+/** A model shaped the way `kindOf()` reads a Mongoose one */
+const mongooseModel = (name = 'Post') => {
+  const Model = function Mongoose() {};
+
+  Model.modelName = name;
+  Model.schema = {};
+  Model.findOneAndUpdate = () => null;
+
+  return Model;
+};
+
+/** ... and a Sequelize one, with the `Op` symbols of its connection */
+const sequelizeModel = (Op, name = 'Post') => {
+  const Model = function Sequelize() {};
+
+  Model.modelName = name;
+  Model.findByPk = () => null;
+  Model.sequelize = { Sequelize: { Op } };
+
+  return Model;
+};
+
+/** ... and a Drizzle one */
+const drizzleModel = (name = 'Post') => {
+  const Model = function Drizzle() {};
+
+  Model.modelName = name;
+  Model.fields = {};
+  Model.table = {};
+  Model.withDeleted = () => null;
+
+  return Model;
+};
+
+/** What a declaration was refused with */
+const refusalOf = (fn) => {
+  try {
+    fn();
+  } catch (error) {
+    return `${error.code}: ${error.message}`;
+  }
+
+  return null;
+};
+
+const STATUS = {
+  status: { enum: ['draft', 'live', 'archived'], type: 'string' },
+  title: { type: 'string' },
+};
+
+describe('enum predicates and scopes', () => {
+  describe('the name a value gives', () => {
+    test('the four spellings of one word all answer the same name', () => {
+      expect(nameOf('in_review')).toBe('inReview');
+      expect(nameOf('in-review')).toBe('inReview');
+      expect(nameOf('IN_REVIEW')).toBe('inReview');
+      expect(nameOf('InReview')).toBe('inReview');
+      expect(nameOf('inReview')).toBe('inReview');
+    });
+
+    test('a plain word is itself', () => {
+      expect(nameOf('draft')).toBe('draft');
+      expect(nameOf('USD')).toBe('usd');
+      expect(nameOf('level_1')).toBe('level1');
+    });
+
+    test('a value that is not a name answers none', () => {
+      expect(nameOf('2fa')).toBeNull();
+      expect(nameOf('')).toBeNull();
+      expect(nameOf('---')).toBeNull();
+      expect(nameOf(3)).toBeNull();
+      expect(nameOf(null)).toBeNull();
+    });
+  });
+
+  describe('what a model declares', () => {
+    test('one entry per enum column, with the two names of each value', () => {
+      expect(enumsOf(model(STATUS))).toEqual([
+        {
+          field: 'status',
+          methods: [
+            { predicate: 'isDraft', scope: 'draft', value: 'draft' },
+            { predicate: 'isLive', scope: 'live', value: 'live' },
+            { predicate: 'isArchived', scope: 'archived', value: 'archived' },
+          ],
+          values: ['draft', 'live', 'archived'],
+        },
+      ]);
+    });
+
+    test('a model without one declares nothing', () => {
+      expect(enumsOf(model({ title: { type: 'string' } }))).toBeNull();
+      expect(enumsOf({})).toBeNull();
+    });
+
+    test('a value that is not a name is still a value, and gets no method', () => {
+      const [column] = enumsOf(
+        model({ kind: { enum: ['application/pdf', '2fa'], type: 'string' } })
+      );
+
+      expect(column.values).toEqual(['application/pdf', '2fa']);
+      expect(column.methods.map((one) => one.scope)).toEqual([
+        'applicationPdf',
+      ]);
+    });
+
+    test('`predicates: false` keeps the values and generates no method', () => {
+      const [column] = enumsOf(
+        model({
+          status: { enum: ['draft'], predicates: false, type: 'string' },
+        })
+      );
+
+      expect(column.values).toEqual(['draft']);
+      expect(column.methods).toEqual([]);
+    });
+
+    test('a string prefixes both halves', () => {
+      const [column] = enumsOf(
+        model({
+          status: { enum: ['new'], predicates: 'status', type: 'string' },
+        })
+      );
+
+      expect(column.methods).toEqual([
+        { predicate: 'isStatusNew', scope: 'statusNew', value: 'new' },
+      ]);
+    });
+
+    test('the schema is the source, not the validates block', () => {
+      const [column] = enumsOf({
+        ...model(STATUS),
+        validates: { status: { enum: ['draft'] } },
+      });
+
+      expect(column.values).toEqual(['draft', 'live', 'archived']);
+    });
+
+    test('a `predicates` henri cannot read fails the boot', () => {
+      expect(
+        refusalOf(() =>
+          enumsOf(model({ status: { enum: ['a'], predicates: 3, type: 'x' } }))
+        )
+      ).toBe(
+        `${INVALID}: Post.status declares \`predicates: number\`, which is not a name`
+      );
+      expect(
+        refusalOf(() =>
+          enumsOf(
+            model({ status: { enum: ['a'], predicates: '!!', type: 'x' } })
+          )
+        )
+      ).toContain(INVALID);
+    });
+  });
+
+  describe('what lands on the model', () => {
+    let Post = null;
+
+    beforeEach(() => {
+      Post = mongooseModel();
+      attach(Post, model(STATUS));
+    });
+
+    test('a predicate per value, on the record', () => {
+      const post = Object.create(Post.prototype);
+
+      post.status = 'draft';
+
+      expect(post.isDraft()).toBe(true);
+      expect(post.isLive()).toBe(false);
+      expect(post.isArchived()).toBe(false);
+    });
+
+    test('a record whose column is empty answers false to all of them', () => {
+      const post = Object.create(Post.prototype);
+
+      expect(post.isDraft()).toBe(false);
+      expect(post.isLive()).toBe(false);
+    });
+
+    test('a scope per value, answering a condition', () => {
+      expect(Post.live()).toEqual({ status: 'live' });
+      expect(Post.archived()).toEqual({ status: 'archived' });
+    });
+
+    test('a fresh condition every call, because an ORM casts one in place', () => {
+      const first = Post.live();
+
+      expect(Post.live()).not.toBe(first);
+    });
+
+    test('the value list, frozen', () => {
+      expect(Post[LIST]).toEqual({ status: ['draft', 'live', 'archived'] });
+      expect(Object.isFrozen(Post[LIST])).toBe(true);
+      expect(Object.isFrozen(Post[LIST].status)).toBe(true);
+    });
+
+    test('nothing generated is enumerable', () => {
+      expect(Object.keys(Post)).not.toContain('live');
+      expect(Object.keys(Post)).not.toContain(LIST);
+      expect(Object.keys(Post.prototype)).not.toContain('isLive');
+    });
+
+    test('a model with no enum column is left alone', () => {
+      const Plain = mongooseModel('Plain');
+
+      expect(attach(Plain, model({ title: { type: 'string' } }))).toBeNull();
+      expect(Plain[LIST]).toBeUndefined();
+    });
+
+    test('a reload attaches again without colliding with itself', () => {
+      expect(() => attach(Post, model(STATUS))).not.toThrow();
+      expect(Post.live()).toEqual({ status: 'live' });
+      expect(Post[ATTACHED].names.has('isLive')).toBe(true);
+    });
+  });
+
+  describe('a scope composes, and can only narrow', () => {
+    test('nothing given is the condition itself', () => {
+      const Post = mongooseModel();
+
+      attach(Post, model(STATUS));
+
+      expect(Post.live(null)).toEqual({ status: 'live' });
+      expect(Post.live(undefined)).toEqual({ status: 'live' });
+    });
+
+    test('an `and` on Mongoose and Drizzle, never a merge of keys', () => {
+      const Post = mongooseModel();
+      const Drizzle = drizzleModel();
+
+      attach(Post, model(STATUS));
+      attach(Drizzle, model(STATUS));
+
+      expect(Post.live({ ownerId: 7 })).toEqual({
+        $and: [{ ownerId: 7 }, { status: 'live' }],
+      });
+      expect(Drizzle.live({ ownerId: 7 })).toEqual({
+        $and: [{ ownerId: 7 }, { status: 'live' }],
+      });
+    });
+
+    test('a scope on the very column the enum names keeps both', () => {
+      const Post = mongooseModel();
+
+      attach(Post, model(STATUS));
+
+      const merged = Post.live({ status: { $ne: 'archived' } });
+
+      expect(merged.$and).toHaveLength(2);
+      expect(merged.$and[1]).toEqual({ status: 'live' });
+    });
+
+    test('Sequelize gets the `Op.and` of its own connection', () => {
+      const Op = { and: Symbol('and') };
+      const Post = sequelizeModel(Op);
+
+      attach(Post, model(STATUS));
+
+      expect(Post.live({ ownerId: 7 })[Op.and]).toEqual([
+        { ownerId: 7 },
+        { status: 'live' },
+      ]);
+    });
+
+    test('something that is not a condition is refused, not ignored', () => {
+      const Post = mongooseModel();
+
+      attach(Post, model(STATUS));
+
+      expect(refusalOf(() => Post.live('everything'))).toContain(UNMERGEABLE);
+      expect(refusalOf(() => Post.live(['draft']))).toContain(UNMERGEABLE);
+      expect(refusalOf(() => Post.live(true))).toContain(UNMERGEABLE);
+    });
+
+    test('conditionOf is what a scope is made of', () => {
+      const Post = mongooseModel();
+
+      expect(conditionOf(Post, 'status', 'live', undefined)).toEqual({
+        status: 'live',
+      });
+    });
+  });
+
+  describe('a name that is already something else', () => {
+    test("`new` is refused, because `isNew` is the ORM's", () => {
+      const Ticket = mongooseModel('Ticket');
+
+      Ticket.prototype.isNew = true;
+
+      expect(
+        refusalOf(() =>
+          attach(
+            Ticket,
+            model(
+              { status: { enum: ['new', 'open'], type: 'string' } },
+              'Ticket'
+            )
+          )
+        )
+      ).toBe(
+        `${TAKEN}: Ticket: isNew() is part of what henri puts on a record, so the value "new" of status cannot generate it`
+      );
+    });
+
+    test('... on every adapter, so a model that boots on one boots on the next', () => {
+      // Sequelize instances have no `isNew`, and the refusal is the same
+      const Ticket = sequelizeModel({ and: Symbol('and') }, 'Ticket');
+
+      expect('isNew' in Ticket.prototype).toBe(false);
+      expect(RECORD_API.has('isNew')).toBe(true);
+      expect(
+        refusalOf(() =>
+          attach(
+            Ticket,
+            model({ status: { enum: ['new'], type: 'string' } }, 'Ticket')
+          )
+        )
+      ).toContain(TAKEN);
+    });
+
+    test('a value whose scope is a method of the model is refused', () => {
+      const Doc = mongooseModel('Doc');
+
+      expect(MODEL_API.has('find')).toBe(true);
+      expect(
+        refusalOf(() =>
+          attach(
+            Doc,
+            model({ state: { enum: ['find'], type: 'string' } }, 'Doc')
+          )
+        )
+      ).toContain('find() is part of what henri puts on a model');
+    });
+
+    test("`name` and `length` are the function's own, and the `in` catches them", () => {
+      const Doc = mongooseModel('Doc');
+
+      expect(MODEL_API.has('name')).toBe(false);
+      expect(
+        refusalOf(() =>
+          attach(
+            Doc,
+            model({ state: { enum: ['name'], type: 'string' } }, 'Doc')
+          )
+        )
+      ).toContain('name() already exists on a model');
+    });
+
+    test('two values of one model that give one name are refused', () => {
+      const Doc = mongooseModel('Doc');
+
+      expect(
+        refusalOf(() =>
+          attach(
+            Doc,
+            model(
+              { state: { enum: ['in_review', 'IN_REVIEW'], type: 'x' } },
+              'Doc'
+            )
+          )
+        )
+      ).toContain('is already the one "in_review" of state generates');
+    });
+
+    test('two enum columns that give one name are refused too', () => {
+      const Doc = mongooseModel('Doc');
+
+      expect(
+        refusalOf(() =>
+          attach(
+            Doc,
+            model(
+              {
+                state: { enum: ['live'], type: 'string' },
+                visibility: { enum: ['live'], type: 'string' },
+              },
+              'Doc'
+            )
+          )
+        )
+      ).toContain('is already the one "live" of state generates');
+    });
+
+    test('a predicate that is also a column of the model is refused', () => {
+      const Doc = mongooseModel('Doc');
+
+      expect(
+        refusalOf(() =>
+          attach(
+            Doc,
+            model(
+              {
+                isDraft: { type: 'boolean' },
+                state: { enum: ['draft'], type: 'string' },
+              },
+              'Doc'
+            )
+          )
+        )
+      ).toContain('isDraft() is a column of this model');
+    });
+
+    test('the prefix is the way out, and it is the one the message names', () => {
+      const Ticket = mongooseModel('Ticket');
+
+      Ticket.prototype.isNew = true;
+      attach(
+        Ticket,
+        model(
+          {
+            status: { enum: ['new', 'open'], predicates: 'status', type: 'x' },
+          },
+          'Ticket'
+        )
+      );
+
+      const ticket = Object.create(Ticket.prototype);
+
+      ticket.status = 'new';
+
+      expect(ticket.isStatusNew()).toBe(true);
+      expect(ticket.isNew).toBe(true);
+      expect(Ticket.statusOpen()).toEqual({ status: 'open' });
+      expect(Ticket[LIST].status).toEqual(['new', 'open']);
+    });
+
+    test('nothing is defined when a name is refused', () => {
+      const Doc = mongooseModel('Doc');
+
+      refusalOf(() =>
+        attach(
+          Doc,
+          model({ state: { enum: ['draft', 'find'], type: 'string' } }, 'Doc')
+        )
+      );
+
+      expect(Doc.draft).toBeUndefined();
+      expect(Doc[LIST]).toBeUndefined();
+      expect(Doc.prototype.isDraft).toBeUndefined();
+    });
+  });
+
+  describe('on the demo application (disk store)', () => {
+    const skipWorkers = process.env.SKIP_WORKERS;
+    let henri = null;
+
+    beforeAll(async () => {
+      process.env.SKIP_WORKERS = '1';
+      henri = new Henri();
+      await henri.init();
+      global.henri = henri;
+    }, 60000);
+
+    afterAll(async () => {
+      await henri.stop();
+      delete global.henri;
+      if (typeof skipWorkers === 'undefined') {
+        delete process.env.SKIP_WORKERS;
+      } else {
+        process.env.SKIP_WORKERS = skipWorkers;
+      }
+    }, 60000);
+
+    test('the list of values is on the model', () => {
+      expect(Article.enums).toEqual({
+        status: ['draft', 'live', 'archived'],
+      });
+    });
+
+    test('a predicate reads the record back', async () => {
+      const article = await Article.create({ title: 'A draft of ours' });
+
+      expect(article.status).toBe('draft');
+      expect(article.isDraft()).toBe(true);
+      expect(article.isLive()).toBe(false);
+
+      article.status = 'live';
+      await article.save();
+
+      expect(article.isLive()).toBe(true);
+    });
+
+    test('a scope is a condition the adapter runs', async () => {
+      const live = await Article.create({
+        status: 'live',
+        title: 'Published for the scope',
+      });
+
+      const found = await Article.find(Article.live());
+
+      expect(found.map((one) => one.externalId)).toContain(live.externalId);
+      expect(found.every((one) => one.isLive())).toBe(true);
+    });
+
+    test('and it narrows a condition rather than replacing it', async () => {
+      const mine = await Article.create({
+        status: 'live',
+        title: 'Mine and live',
+      });
+
+      await Article.create({ status: 'draft', title: 'Mine and draft' });
+
+      const found = await Article.find(
+        Article.live({ title: { $in: ['Mine and live', 'Mine and draft'] } })
+      );
+
+      expect(found).toHaveLength(1);
+      expect(found[0].externalId).toBe(mine.externalId);
+    });
+
+    test('a page of a scope, which is what an index writes', async () => {
+      const { records, total } = await Article.paginate({
+        page: 1,
+        perPage: 2,
+        where: Article.archived(),
+      });
+
+      expect(total).toBe(0);
+      expect(records).toEqual([]);
+    });
+  });
+});

--- a/packages/core/src/base/enums.js
+++ b/packages/core/src/base/enums.js
@@ -1,0 +1,678 @@
+/**
+ * What an `enum` column already said, spelled as methods.
+ *
+ * A model declares the domain of a column and then the application writes
+ * the same three strings by hand, everywhere, forever:
+ *
+ * ```js
+ * if (post.status === 'draft') { … }
+ * const live = await Post.find({ status: 'live' });
+ * ```
+ *
+ * Rails answers that with `post.draft?`, `Post.live`, `post.archived!` and
+ * `Post.statuses`. The declaration is already in the model file, so this is
+ * generated behaviour rather than a new concept -- but four methods per
+ * value on every model is a real cost, and each of the four has to earn its
+ * place separately. Three did not.
+ *
+ * ## The predicate: `post.isDraft()`
+ *
+ * The one with no substitute. `post.status === 'darft'` is **silently false
+ * for the life of the application**: no adapter, no validation and no test
+ * that does not already know the answer will ever say otherwise, because a
+ * comparison against a wrong string is a legal comparison. `post.isDarft()`
+ * is a `TypeError` on the first run.
+ *
+ * That asymmetry is the whole argument, and it is worth stating because it
+ * is also what kills the bang below: henri already refuses a wrong value
+ * where a value is *written*, on every adapter and every write path, since
+ * the validations tranche (`base/validations.js`). What it cannot refuse is
+ * a wrong value in a *comparison*. So the comparison is the half that gets
+ * a method.
+ *
+ * ## The scope: `Post.live()`, which answers a condition
+ *
+ * A Rails scope is a relation, and it composes because ActiveRecord has one
+ * query object. henri has three -- a Mongoose `Query`, a Sequelize promise,
+ * a Drizzle `Relation` -- and the models guide says so on purpose: the
+ * global is the ORM model and nothing is wrapped. So a `Post.live()` that
+ * answered *records* would have to pick one of those three shapes under one
+ * name, which is the thing this tranche exists to prevent, or answer a plain
+ * array and lose `.sort()`, `.limit()` and `.paginate()` on the two adapters
+ * that have them.
+ *
+ * It answers the one value all three read identically: **a condition**. It
+ * is what `find`, `findAll`, `where`, `count` and `paginate` all take; it is
+ * the same kind of value `policy.scope(user)` and the tenant mark already
+ * are; and it is what `req.filters()` hands a controller. Which means it
+ * composes with them instead of replacing them:
+ *
+ * ```js
+ * const { order, where } = await req.filters();
+ * const page = await Post.paginate({ ...req.pagination(), order,
+ *   where: Post.live(where) });
+ * ```
+ *
+ * The intersection is `narrow()` from `base/filters.js` and deliberately
+ * nothing else: an `and` spelled for the adapter, never a merge of keys, so
+ * a scope and a filter on the same column both hold rather than one
+ * replacing the other. A filter narrows a list and can never widen it, and
+ * neither can this.
+ *
+ * ## The value list: `Post.enums`
+ *
+ * `{ status: ['draft', 'live', 'archived'] }`, frozen. A `<select>`, a
+ * filter declaration, a seed and a test all want the list, and reading it
+ * back from three ORMs is three different pieces of code. One property per
+ * *model* rather than one per value, which is what makes it cheap enough to
+ * keep.
+ *
+ * ## What was dropped: the bang
+ *
+ * `post.archived!` has no spelling in JavaScript, so the name would have
+ * been invented (`post.toArchived()`, `post.makeArchived()`) rather than
+ * transcribed -- and once it is invented it has to be better than the line
+ * it replaces:
+ *
+ * ```js
+ * await post.update({ status: 'archived' });
+ * ```
+ *
+ * which is already one call, already says what it does, and already refuses
+ * a value outside the enum on every adapter. What would be left is a second
+ * way to write a one-field update, plus the expectations a method named
+ * after a transition brings with it -- guards, a legal-transition table,
+ * callbacks -- none of which henri has and none of which it would be
+ * honouring. A state machine is a decision an application makes; this file
+ * only knows what the column may hold.
+ *
+ * ## Where a name comes from
+ *
+ * `draft` -> `isDraft` / `Post.draft()`. `in_review`, `in-review`,
+ * `IN_REVIEW` and `InReview` are all values people write, and all four give
+ * `inReview`: the value is split on everything that is not a letter or a
+ * digit and at every lower-to-upper boundary, and the parts are camel
+ * cased. Two values of one model that come out the same name are refused,
+ * because they would be the same method.
+ *
+ * `names()` in `packages/cli/scripts/utils.js` is the other place that
+ * turns a word into a name and it is not this one: it lowercases a whole
+ * word and pluralises it for a *resource* name (`Post` -> `posts`), it
+ * would answer `inreview` here, and it lives in `@usehenri/cli`, which core
+ * cannot require -- core is that package's dependency and not the other way
+ * around. `base/graphql-schema.js` is the closer neighbour: it derives an
+ * enum *type* from the same declaration and refuses a value that is not
+ * already a GraphQL name, because it has a schema to print and no freedom
+ * to rename. This has neither, so it renames.
+ *
+ * A value that cannot become a name at all -- `2fa`, `application/pdf` is
+ * fine but `''` and `---` are not -- gets no predicate and no scope. It is
+ * still in `Post.enums`, still validated, still queryable: nothing was
+ * shadowed and nothing is silently wrong, there is simply no method, which
+ * is what a value that is not a name deserves.
+ *
+ * ## Collisions, which are refused
+ *
+ * The two namespaces are not equally crowded, and the measurement is what
+ * decided the policy rather than a principle:
+ *
+ * - **The record's** is nearly empty. Eight names shaped like `is<Name>`
+ *   exist across the three ORMs (`isNew`, `isModified`, `isSelected`,
+ *   `isDirectModified`, `isDirectSelected`, `isInit`, `isSoftDeleted`,
+ *   `isPrototypeOf`), and exactly one of them is a plausible enum value:
+ *   **`new`**. `status: ['new', 'open', 'closed']` is an ordinary ticket,
+ *   and `isNew` is the flag Mongoose and the Drizzle model use to decide
+ *   between an insert and an update. Shadowing it would break saving.
+ * - **The model's** is crowded: `find`, `create`, `update`, `count`,
+ *   `exists`, `build`, `all`, `first`, `last`, `where`, and `name` and
+ *   `length`, which every function has.
+ *
+ * So a generated name that is already something else is a **boot failure**
+ * naming the model, the field, the value, the name and who owns it
+ * (`HENRI_MODEL_ENUM_NAME_TAKEN`) -- henri's habit, and the only safe
+ * answer: skipping the name silently would leave `Post.find` answering
+ * records to a caller who asked for a condition, and `ticket.isNew()`
+ * calling a boolean.
+ *
+ * A refusal that fires on a reasonable model is its own problem, though,
+ * and `new` is a reasonable value that nobody can rename once it is in a
+ * database. So the field says what it wants, next to the `enum` it is
+ * about:
+ *
+ * ```js
+ * status: { type: 'string', enum: ['new', 'open'], predicates: 'status' },
+ * // ticket.isStatusNew(), Ticket.statusNew()
+ * status: { type: 'string', enum: ['new', 'open'], predicates: false },
+ * // no methods for this column; Ticket.enums.status is still the list
+ * ```
+ *
+ * ## What is checked against what
+ *
+ * Two lists and one operator, and the split is deliberate:
+ *
+ * - `MODEL_API` and `RECORD_API` are **henri's own** model surface, held
+ *   here as data. They are what makes the answer the same on all three
+ *   adapters: `first()` and `last()` exist on the Drizzle model and not on
+ *   the Mongoose one, and a model that boots on one store has to boot on
+ *   the next.
+ * - `name in Model` catches the rest -- everything the ORM itself defines,
+ *   including whatever the next version of it adds, plus `name`, `length`
+ *   and `constructor`, which are the function's. That half is exact and
+ *   needs no maintenance.
+ *
+ * What it does not catch is an association: `associate()` runs in the
+ * adapter's `start()`, after the models are built, so a `hasMany` named
+ * after an enum value would win. The two namespaces barely overlap (an
+ * association is a plural noun, a state is an adjective) and the guide says
+ * it rather than henri pretending to check it.
+ */
+
+const { narrow } = require('./filters');
+const { fail } = require('./errors');
+
+/** A declaration henri cannot carry out */
+const INVALID = 'HENRI_MODEL_ENUM_INVALID';
+
+/** A generated name that is already something else */
+const TAKEN = 'HENRI_MODEL_ENUM_NAME_TAKEN';
+
+/** A scope given something that is not a condition */
+const UNMERGEABLE = 'HENRI_MODEL_ENUM_UNMERGEABLE';
+
+/** The name of the value list on a model */
+const LIST = 'enums';
+
+/** The name of a field definition's opt-out */
+const KEY = 'predicates';
+
+/** What this file already put on a model, so a reload redefines it */
+const ATTACHED = Symbol('henri.enums');
+
+/**
+ * The names henri itself puts on a model, on at least one adapter.
+ *
+ * Data, and read as such: it is the Drizzle model class -- which is henri's
+ * own, statics and all -- plus the three the Mongoose and Sequelize plugins
+ * add that it does not have. `name in Model` covers everything the ORM
+ * brought; this list is what keeps the refusal from depending on which
+ * store the application happens to be running.
+ */
+const MODEL_API = new Set([
+  'addField',
+  'all',
+  'applySlug',
+  'belongsTo',
+  'bindable',
+  'build',
+  'castId',
+  'checkSlugMassWrite',
+  'checkValidations',
+  'checkValidationsMassWrite',
+  'column',
+  'count',
+  'countDocuments',
+  'create',
+  'db',
+  'deleteMany',
+  'destroy',
+  'destroyWhere',
+  'exists',
+  'externalIdsWhere',
+  'find',
+  'findAll',
+  'findByExternalId',
+  'findById',
+  'findByIdAndDelete',
+  'findByIdAndRemove',
+  'findByIdAndUpdate',
+  'findByKey',
+  'findByPk',
+  'findBySlug',
+  'findOne',
+  'findOneAndDelete',
+  'findOneAndUpdate',
+  'first',
+  'hasAssociation',
+  'hasMany',
+  'hasOne',
+  'hydrate',
+  'include',
+  'insert',
+  'internalId',
+  'isValidId',
+  'last',
+  'limit',
+  'onlyDeleted',
+  'order',
+  'paginate',
+  'pluck',
+  'prepare',
+  'publicUser',
+  'query',
+  'relation',
+  'restore',
+  'run',
+  'runHooks',
+  'seedFor',
+  'selection',
+  'setRoles',
+  'setWhere',
+  'table',
+  'translateError',
+  'update',
+  'updateById',
+  'updateMany',
+  'updateWhere',
+  'where',
+  'withDeleted',
+  'withHidden',
+]);
+
+/**
+ * The names henri itself puts on a record, plus the `is<Name>` ones the
+ * three ORMs define. Only a handful can ever collide with a predicate, and
+ * `isNew` is the one that matters (see the header).
+ */
+const RECORD_API = new Set([
+  'changed',
+  'destroy',
+  'dirtyAttributes',
+  'get',
+  'hasRole',
+  'isDirectModified',
+  'isDirectSelected',
+  'isInit',
+  'isModified',
+  'isNew',
+  'isSelected',
+  'isSoftDeleted',
+  'merge',
+  'previousAttributes',
+  'reload',
+  'restore',
+  'save',
+  'set',
+  'setRoles',
+  'toJSON',
+  'toObject',
+  'update',
+]);
+
+/** A name JavaScript can hold and a person can type */
+const NAME = /^[A-Za-z][A-Za-z0-9]*$/u;
+
+/**
+ * Is it a plain object?
+ *
+ * @param {*} value anything
+ * @returns {boolean} true when it is
+ */
+const isObject = (value) =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/**
+ * The first letter of a name, uppercased (`draft` -> `Draft`)
+ *
+ * @param {string} word the name
+ * @returns {string} the name
+ */
+const upperFirst = (word) => word.charAt(0).toUpperCase() + word.slice(1);
+/**
+ * The method name one enum value gives, or null when it gives none.
+ *
+ * `in_review`, `in-review`, `IN_REVIEW` and `InReview` all answer
+ * `inReview`: split on everything that is not a letter or a digit, split
+ * again at every lower-to-upper boundary, camel case what is left. A value
+ * that does not come out a name answers null and gets no method.
+ *
+ * @param {*} value one value of an `enum`
+ * @returns {?string} the name, or null
+ */
+const nameOf = (value) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const parts = value
+    .split(/[^A-Za-z0-9]+/u)
+    .flatMap((part) => part.split(/(?<=[a-z0-9])(?=[A-Z])/u))
+    .filter(Boolean);
+
+  if (parts.length === 0) {
+    return null;
+  }
+
+  const name = parts
+    .map((part, index) =>
+      index === 0 ? part.toLowerCase() : upperFirst(part.toLowerCase())
+    )
+    .join('');
+
+  return NAME.test(name) ? name : null;
+};
+
+/**
+ * A coded failure carrying what to do about it.
+ *
+ * `fail()` hands its options to the `Error` constructor, which reads
+ * `cause` and nothing else, so a `hint` is set here rather than passed --
+ * `@usehenri/cli` prints the one it finds in the chain (`scripts/errors.js`)
+ * and falls back to the catalogue's `fix` when there is none.
+ *
+ * @param {string} code the code
+ * @param {string} message what happened
+ * @param {string} hint what to do about it
+ * @returns {Error} the error to throw
+ */
+const failing = (code, message, hint) => {
+  const error = fail(code, message);
+
+  error.hint = hint;
+
+  return error;
+};
+
+/**
+ * What a field's `predicates` key asks for
+ *
+ * @param {string} model the model name
+ * @param {string} field the field name
+ * @param {*} written what the field declared
+ * @returns {?string} the prefix (`''` for none), or null for no methods
+ * @throws {Error} HENRI_MODEL_ENUM_INVALID on a key henri cannot read
+ */
+const prefixOf = (model, field, written) => {
+  if (typeof written === 'undefined' || written === true) {
+    return '';
+  }
+
+  if (written === false) {
+    return null;
+  }
+
+  const prefix = typeof written === 'string' ? nameOf(written) : null;
+
+  if (!prefix) {
+    const named = nameOf(field) || field;
+
+    throw failing(
+      INVALID,
+      `${model}.${field} declares \`${KEY}: ${
+        typeof written === 'string' ? JSON.stringify(written) : typeof written
+      }\`, which is not a name`,
+      `\`${KEY}\` is true (the default), false (no methods for this column), or the name to prefix them with -- ${KEY}: '${field}' gives is${upperFirst(
+        named
+      )}Draft() and Model.${named}Draft()`
+    );
+  }
+
+  return prefix;
+};
+
+/**
+ * The enum columns of a model file, compiled.
+ *
+ * Read from the **schema**, never from the `validates` block: the schema
+ * says what the column may hold, which is what a record read back from the
+ * database can be. A `validates` entry may bound what a write accepts more
+ * tightly than that, and a row written before it did is still in the table.
+ *
+ * @param {object} [model] the model file (`globalId`, `schema`)
+ * @returns {?Array<object>} one entry per enum column, or null
+ * @throws {Error} HENRI_MODEL_ENUM_INVALID on a `predicates` key henri
+ *   cannot read
+ */
+const enumsOf = (model = {}) => {
+  const name = model.globalId || model.identity || 'the model';
+  const schema = isObject(model.schema) ? model.schema : {};
+  const columns = [];
+
+  for (const field of Object.keys(schema)) {
+    const definition = schema[field];
+
+    if (!isObject(definition) || !Array.isArray(definition.enum)) {
+      continue;
+    }
+
+    const prefix = prefixOf(name, field, definition[KEY]);
+    const values = definition.enum.slice();
+    const methods = [];
+
+    for (const value of prefix === null ? [] : values) {
+      const derived = nameOf(value);
+
+      if (!derived) {
+        continue;
+      }
+
+      const stem = prefix ? `${prefix}${upperFirst(derived)}` : derived;
+
+      methods.push({ predicate: `is${upperFirst(stem)}`, scope: stem, value });
+    }
+
+    columns.push({ field, methods, values: Object.freeze(values) });
+  }
+
+  return columns.length > 0 ? columns : null;
+};
+
+/**
+ * The failure a name that is already something else raises
+ *
+ * @param {string} model the model name
+ * @param {object} where `{ field, name, owner, what }`
+ * @returns {Error} the error to throw
+ */
+const taken = (model, { field, name, owner, what }) =>
+  failing(
+    TAKEN,
+    `${model}: ${name}() ${owner}, so ${what} cannot generate it`,
+    `Rename the value, or name this column's methods after the field: ${field}: { enum: [...], ${KEY}: '${field}' }. \`${KEY}: false\` turns them off and leaves ${model}.${LIST}.${field} as the list of values`
+  );
+
+/**
+ * The one name check, run before anything is defined.
+ *
+ * Three questions in one order, and the header says why the first two are
+ * lists and the third is an operator: what this model already generated,
+ * what henri puts there on every adapter, and what this ORM defines.
+ *
+ * @param {object} at `{ name, previous }` -- the model, and what this file
+ *   already put on it
+ * @param {object} one `{ api, claimed, field, name, owner, target, what }`
+ * @returns {void}
+ * @throws {Error} HENRI_MODEL_ENUM_NAME_TAKEN
+ */
+const claim = (at, one) => {
+  const { api, claimed, field, name, owner, target, what } = one;
+
+  if (at.previous && at.previous.names.has(name)) {
+    claimed.set(name, owner);
+
+    return;
+  }
+
+  const held = claimed.get(name);
+  const reason =
+    (held &&
+      `is already the one ${JSON.stringify(held.value)} of ${held.field} generates`) ||
+    (api.has(name) && `is part of what henri puts on ${what}`) ||
+    (name in target && `already exists on ${what}`) ||
+    null;
+
+  if (reason) {
+    throw taken(at.name, { field, name, owner: reason, what: owner.about });
+  }
+
+  claimed.set(name, owner);
+};
+
+/**
+ * The condition one scope answers, intersected with what it was given.
+ *
+ * A fresh object every call: the value is handed to an ORM as a filter, and
+ * Mongoose casts a filter in place, so two calls may never share one.
+ *
+ * @param {*} Model the ORM model
+ * @param {string} field the column
+ * @param {*} value the value
+ * @param {*} given what the caller wants it intersected with
+ * @returns {*} the condition
+ * @throws {Error} HENRI_MODEL_ENUM_UNMERGEABLE on an argument that is not
+ *   a condition
+ */
+const conditionOf = (Model, field, value, given) => {
+  const mine = { [field]: value };
+
+  if (typeof given === 'undefined' || given === null) {
+    return mine;
+  }
+
+  if (!isObject(given)) {
+    throw failing(
+      UNMERGEABLE,
+      `${(Model && Model.modelName) || 'a model'}: the ${field} scope was given ${
+        Array.isArray(given) ? 'an array' : typeof given
+      } to narrow, which is not a condition`,
+      'A scope answers a condition and takes one, so Model.live(where) is `where AND the value`: pass a plain object, or nothing'
+    );
+  }
+
+  return narrow(Model, given, mine);
+};
+
+/**
+ * Puts the predicates, the scopes and the value list on a model.
+ *
+ * Called once per model as the store builds it (`3.model.js`), with the
+ * model *file* next to the ORM model, because the declaration is in the file
+ * and the methods go on the object. Every name is checked before any is
+ * defined, so a model that is refused is left exactly as the adapter built
+ * it.
+ *
+ * @param {*} Model the ORM model the adapter answered
+ * @param {object} [model] the model file (`globalId`, `schema`)
+ * @returns {?Array<object>} what it generated, or null when the model
+ *   declares no enum column
+ * @throws {Error} HENRI_MODEL_ENUM_INVALID, HENRI_MODEL_ENUM_NAME_TAKEN
+ */
+const attach = (Model, model = {}) => {
+  const columns = enumsOf(model);
+
+  if (!Model || !columns) {
+    return null;
+  }
+
+  const schema = isObject(model.schema) ? model.schema : {};
+  const record = Model.prototype || {};
+  const at = {
+    name: model.globalId || model.identity || Model.modelName || 'a model',
+    // A reload rebuilds the model, but nothing promises it is a new object:
+    // what this file put there last time is not a collision with itself
+    previous: Model[ATTACHED] || null,
+  };
+  const scopes = new Map();
+  const predicates = new Map();
+
+  claim(at, {
+    api: MODEL_API,
+    claimed: scopes,
+    field: columns[0].field,
+    name: LIST,
+    owner: { about: 'the list of values', field: null, value: LIST },
+    target: Model,
+    what: 'a model',
+  });
+
+  for (const { field, methods } of columns) {
+    for (const { predicate, scope, value } of methods) {
+      const owner = {
+        about: `the value ${JSON.stringify(value)} of ${field}`,
+        field,
+        value,
+      };
+
+      claim(at, {
+        api: RECORD_API,
+        claimed: predicates,
+        field,
+        name: predicate,
+        owner,
+        target: record,
+        what: 'a record',
+      });
+
+      // A column is on the record too, and on the drizzle adapter it is an
+      // own property of the instance rather than a path on the prototype,
+      // so the `in` above cannot see it
+      if (predicate in schema) {
+        throw taken(at.name, {
+          field,
+          name: predicate,
+          owner: 'is a column of this model',
+          what: owner.about,
+        });
+      }
+
+      claim(at, {
+        api: MODEL_API,
+        claimed: scopes,
+        field,
+        name: scope,
+        owner,
+        target: Model,
+        what: 'a model',
+      });
+    }
+  }
+
+  const names = new Set([LIST]);
+  const define = (target, key, value) =>
+    Object.defineProperty(target, key, {
+      configurable: true,
+      enumerable: false,
+      value,
+      writable: true,
+    });
+
+  for (const { field, methods } of columns) {
+    for (const { predicate, scope, value } of methods) {
+      define(record, predicate, function is() {
+        return this[field] === value;
+      });
+
+      define(Model, scope, function where(given) {
+        return conditionOf(Model, field, value, given);
+      });
+
+      names.add(predicate);
+      names.add(scope);
+    }
+  }
+
+  define(
+    Model,
+    LIST,
+    Object.freeze(
+      Object.fromEntries(columns.map(({ field, values }) => [field, values]))
+    )
+  );
+  define(Model, ATTACHED, { columns, names });
+
+  return columns;
+};
+
+module.exports = {
+  ATTACHED,
+  INVALID,
+  KEY,
+  LIST,
+  MODEL_API,
+  RECORD_API,
+  TAKEN,
+  UNMERGEABLE,
+  attach,
+  conditionOf,
+  enumsOf,
+  nameOf,
+};

--- a/packages/demo/app/models/Article.js
+++ b/packages/demo/app/models/Article.js
@@ -6,6 +6,15 @@ module.exports = {
   options: { slug: 'title', timestamps: true },
   schema: {
     body: { type: 'text' },
+    // An `enum` says what the column may hold, and henri spells it back as
+    // methods (base/enums.js): `article.isDraft()` on the record and
+    // `Article.live()` -- a condition, intersected with whatever it is
+    // given -- on the model, plus `Article.enums.status`, the list
+    status: {
+      default: 'draft',
+      enum: ['draft', 'live', 'archived'],
+      type: 'string',
+    },
     title: { required: true, type: 'string' },
   },
 };

--- a/packages/drizzle/__tests__/enums.spec.js
+++ b/packages/drizzle/__tests__/enums.spec.js
@@ -1,0 +1,109 @@
+// The enum predicates and scopes of `@usehenri/core` against a real Drizzle
+// store.
+//
+// `base/enums.js` puts the methods on the model the adapter built and spells
+// the scope's condition for it, so what has to be proved here is that the
+// condition is one this adapter runs, that the predicate reads a row that
+// came back from the database, and that a scope narrows a condition rather
+// than replacing it. This file runs on whatever the environment points at --
+// sqlite offline, a PostgreSQL or a MySQL server with HENRI_TEST_POSTGRES_URL
+// or HENRI_TEST_MYSQL_URL (`pnpm test:sql:live`).
+const { build, target } = require('./helpers');
+
+const { attach } = require('../../core/src/base/enums');
+
+const model = {
+  globalId: 'Post',
+  identity: 'post',
+  options: { timestamps: true },
+  schema: {
+    ownerId: { type: 'integer' },
+    status: {
+      default: 'draft',
+      enum: ['draft', 'in_review', 'live'],
+      type: 'string',
+    },
+    title: { type: 'string' },
+  },
+  store: 'default',
+};
+
+describe(`enum predicates and scopes on ${target.name}`, () => {
+  let adapter = null;
+  let Post = null;
+
+  beforeAll(async () => {
+    ({ adapter } = build());
+    Post = adapter.addModel(model, 'user');
+    attach(Post, model);
+    await adapter.start();
+
+    await Post.create([
+      { ownerId: 1, status: 'draft', title: 'One' },
+      { ownerId: 1, status: 'live', title: 'Two' },
+      { ownerId: 2, status: 'live', title: 'Three' },
+      { ownerId: 2, status: 'in_review', title: 'Four' },
+    ]);
+  }, 60000);
+
+  afterAll(async () => {
+    await adapter.stop();
+  });
+
+  test('the list of values is on the model', () => {
+    expect(Post.enums).toEqual({ status: ['draft', 'in_review', 'live'] });
+  });
+
+  test('the predicate reads a row that came back from the database', async () => {
+    const post = await Post.findOne({ title: 'Two' });
+
+    expect(post.isLive()).toBe(true);
+    expect(post.isDraft()).toBe(false);
+    expect(post.isInReview()).toBe(false);
+  });
+
+  test('a scope is a condition this adapter runs', async () => {
+    const live = await Post.find(Post.live());
+
+    expect(live.map((row) => row.title).sort()).toEqual(['Three', 'Two']);
+    expect(live.every((row) => row.isLive())).toBe(true);
+  });
+
+  test('and the fluent form takes the same value', async () => {
+    const rows = await Post.where(Post.inReview()).order('title');
+
+    expect(rows.map((row) => row.title)).toEqual(['Four']);
+  });
+
+  test('a scope narrows a condition rather than replacing it', async () => {
+    const mine = await Post.find(Post.live({ ownerId: 1 }));
+
+    expect(mine.map((row) => row.title)).toEqual(['Two']);
+  });
+
+  test('two conditions on the column both hold, so nothing widens', async () => {
+    expect(await Post.find(Post.live({ status: 'draft' }))).toEqual([]);
+  });
+
+  test('it pages, which is what an index writes', async () => {
+    const { records, total } = await Post.paginate({
+      order: 'title',
+      page: 1,
+      perPage: 1,
+      where: Post.live({ ownerId: 2 }),
+    });
+
+    expect(total).toBe(1);
+    expect(records.map((row) => row.title)).toEqual(['Three']);
+  });
+
+  test('and it counts', async () => {
+    expect(await Post.count(Post.live())).toBe(2);
+  });
+
+  test('a value outside the enum is still refused by the validations', async () => {
+    await expect(
+      Post.create({ status: 'nope', title: 'Five' })
+    ).rejects.toThrow(/must be one of/u);
+  });
+});

--- a/packages/drizzle/schema.js
+++ b/packages/drizzle/schema.js
@@ -27,6 +27,9 @@ const KNOWN_KEYS = new Set([
   'personal',
   // The two a `decimal` column carries; see ./exact.js
   'precision',
+  // Metadata, not a column: what the methods an `enum` generates are
+  // called, or whether it generates any (core's base/enums.js)
+  'predicates',
   'primaryKey',
   'references',
   'required',

--- a/packages/mongoose/__tests__/enums.spec.js
+++ b/packages/mongoose/__tests__/enums.spec.js
@@ -1,0 +1,134 @@
+// The enum predicates and scopes of `@usehenri/core` against a real
+// Mongoose store. The methods are core's (`base/enums.js`); what is proved
+// here is that they land on this adapter's model and its documents, and
+// that the condition a scope answers is one MongoDB runs.
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const Mongoose = require('../index');
+const { attach } = require('@usehenri/core/src/base/enums');
+
+let mongod;
+let sequence = 0;
+
+/**
+ * Builds a minimal henri stand-in for the adapter
+ *
+ * @returns {object} fake henri
+ */
+const fakeHenri = () => {
+  const pen = {};
+
+  ['error', 'fatal', 'info', 'warn'].forEach((level) => {
+    pen[level] = () => undefined;
+  });
+
+  return {
+    _user: null,
+    config: { get: () => undefined, has: () => false },
+    isTest: true,
+    pen,
+    user: { encrypt: async (password) => `hashed:${password}` },
+  };
+};
+
+const postModel = {
+  globalId: 'Post',
+  identity: 'post',
+  options: { timestamps: true },
+  schema: {
+    ownerId: { type: 'integer' },
+    status: {
+      default: 'draft',
+      enum: ['draft', 'in_review', 'live'],
+      type: 'string',
+    },
+    title: { type: 'string' },
+  },
+  store: 'default',
+};
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+}, 60000);
+
+afterAll(() => mongod && mongod.stop());
+
+describe('enum predicates and scopes on a mongoose store', () => {
+  let Post;
+  let adapter;
+
+  beforeAll(async () => {
+    adapter = new Mongoose(
+      'default',
+      { url: mongod.getUri(`enums${(sequence += 1)}`) },
+      fakeHenri()
+    );
+    Post = adapter.addModel(postModel, 'user');
+    attach(Post, postModel);
+    await adapter.start();
+
+    await Post.create([
+      { ownerId: 1, status: 'draft', title: 'One' },
+      { ownerId: 1, status: 'live', title: 'Two' },
+      { ownerId: 2, status: 'live', title: 'Three' },
+      { ownerId: 2, status: 'in_review', title: 'Four' },
+    ]);
+  }, 60000);
+
+  afterAll(() => adapter.stop());
+
+  test('the list of values is on the model', () => {
+    expect(Post.enums).toEqual({ status: ['draft', 'in_review', 'live'] });
+  });
+
+  test('the predicate reads a document that came back from the server', async () => {
+    const post = await Post.findOne({ title: 'Two' });
+
+    expect(post.isLive()).toBe(true);
+    expect(post.isDraft()).toBe(false);
+    expect(post.isInReview()).toBe(false);
+  });
+
+  test('and it is not part of what the document serializes', async () => {
+    const post = await Post.findOne({ title: 'Two' });
+
+    expect(Object.keys(post.toJSON())).not.toContain('isLive');
+  });
+
+  test('a scope is a condition this adapter runs', async () => {
+    const live = await Post.find(Post.live());
+
+    expect(live.map((row) => row.title).sort()).toEqual(['Three', 'Two']);
+    expect(live.every((row) => row.isLive())).toBe(true);
+  });
+
+  test('and it chains, because it is a filter and not a query', async () => {
+    const rows = await Post.find(Post.live()).sort({ title: 1 }).limit(1);
+
+    expect(rows.map((row) => row.title)).toEqual(['Three']);
+  });
+
+  test('a scope narrows a condition rather than replacing it', async () => {
+    const mine = await Post.find(Post.live({ ownerId: 1 }));
+
+    expect(mine.map((row) => row.title)).toEqual(['Two']);
+  });
+
+  test('two conditions on the column both hold, so nothing widens', async () => {
+    expect(await Post.find(Post.live({ status: 'draft' }))).toEqual([]);
+  });
+
+  test('it pages, which is what an index writes', async () => {
+    const { records, total } = await Post.paginate({
+      page: 1,
+      perPage: 10,
+      where: Post.inReview(),
+    });
+
+    expect(total).toBe(1);
+    expect(records.map((row) => row.title)).toEqual(['Four']);
+  });
+
+  test('and it counts', async () => {
+    expect(await Post.countDocuments(Post.live())).toBe(2);
+  });
+});

--- a/packages/mongoose/schema.js
+++ b/packages/mongoose/schema.js
@@ -55,14 +55,16 @@ const normalizeField = (
   }
 
   // Marks for henri: `personal` for base/privacy.js, `encrypted` for
-  // base/encryption.js. Neither is a Mongoose option, and neither are the
-  // `precision` and `scale` of a decimal column
+  // base/encryption.js, `predicates` for base/enums.js. None of them is a
+  // Mongoose option, and neither are the `precision` and `scale` of a
+  // decimal column
   const {
     allowNull,
     defaultValue,
     encrypted,
     personal,
     precision,
+    predicates,
     scale,
     type,
     ...rest

--- a/packages/sequelize/__tests__/enums.spec.js
+++ b/packages/sequelize/__tests__/enums.spec.js
@@ -1,0 +1,92 @@
+// The enum predicates and scopes of `@usehenri/core` against a real
+// Sequelize store. The methods are core's (`base/enums.js`); what is proved
+// here is that they land on this adapter's model and its instances, and
+// that the condition a scope answers -- an `Op.and` taken from this model's
+// own connection -- is one Sequelize runs.
+const { build, target } = require('./helpers');
+
+const { attach } = require('@usehenri/core/src/base/enums');
+
+const postModel = {
+  globalId: 'Post',
+  identity: 'post',
+  options: { timestamps: true },
+  schema: {
+    ownerId: { type: 'integer' },
+    status: {
+      default: 'draft',
+      enum: ['draft', 'in_review', 'live'],
+      type: 'string',
+    },
+    title: { type: 'string' },
+  },
+  store: 'default',
+};
+
+describe(`enum predicates and scopes on ${target.name}`, () => {
+  let Post;
+  let adapter;
+
+  beforeAll(async () => {
+    ({ adapter } = build());
+    Post = adapter.addModel(postModel, 'user');
+    attach(Post, postModel);
+    await adapter.start();
+
+    await Post.bulkCreate([
+      { ownerId: 1, status: 'draft', title: 'One' },
+      { ownerId: 1, status: 'live', title: 'Two' },
+      { ownerId: 2, status: 'live', title: 'Three' },
+      { ownerId: 2, status: 'in_review', title: 'Four' },
+    ]);
+  }, 60000);
+
+  afterAll(() => adapter.stop());
+
+  test('the list of values is on the model', () => {
+    expect(Post.enums).toEqual({ status: ['draft', 'in_review', 'live'] });
+  });
+
+  test('the predicate reads a row that came back from the database', async () => {
+    const post = await Post.findOne({ where: { title: 'Two' } });
+
+    expect(post.isLive()).toBe(true);
+    expect(post.isDraft()).toBe(false);
+    expect(post.isInReview()).toBe(false);
+  });
+
+  test('a scope is a condition this adapter runs', async () => {
+    const live = await Post.findAll({ where: Post.live() });
+
+    expect(live.map((row) => row.title).sort()).toEqual(['Three', 'Two']);
+    expect(live.every((row) => row.isLive())).toBe(true);
+  });
+
+  test('a scope narrows a condition rather than replacing it', async () => {
+    const mine = await Post.findAll({ where: Post.live({ ownerId: 1 }) });
+
+    expect(mine.map((row) => row.title)).toEqual(['Two']);
+  });
+
+  test('two conditions on the column both hold, so nothing widens', async () => {
+    expect(
+      await Post.findAll({ where: Post.live({ status: 'draft' }) })
+    ).toEqual([]);
+  });
+
+  test('it pages, which is what an index writes', async () => {
+    const { records, total } = await Post.paginate({
+      order: [['title', 'ASC']],
+      page: 1,
+      perPage: 10,
+      where: Post.inReview(),
+    });
+
+    expect(total).toBe(1);
+    expect(records.map((row) => row.title)).toEqual(['Four']);
+  });
+
+  test('and it counts', async () => {
+    expect(await Post.count({ where: Post.live() })).toBe(2);
+  });
+});

--- a/packages/sequelize/schema.js
+++ b/packages/sequelize/schema.js
@@ -26,6 +26,9 @@ const HENRI_KEYS = {
   personal: 'henri.privacy',
   // The two a `decimal` carries; they build DECIMAL(p, s) below
   precision: 'DataTypes.DECIMAL(precision, scale)',
+  // Metadata, not a column: what the methods an `enum` generates are called
+  // (core's base/enums.js, read back through the model file like `personal`)
+  predicates: 'henri.enums',
   required: 'allowNull: false',
   scale: 'DataTypes.DECIMAL(precision, scale)',
   type: 'type',
@@ -394,11 +397,13 @@ const normalizeField = (
       key === 'personal' ||
       key === 'encrypted' ||
       key === 'precision' ||
+      key === 'predicates' ||
       key === 'scale'
     ) {
       // Marks for henri, and nothing Sequelize has to know about: the
       // encryption one and the decimal column are applied below, once the
-      // type has resolved
+      // type has resolved, and `predicates` is read off the model file by
+      // core's base/enums.js once this model is built
     } else if (key === 'validate' && typeof value === 'function') {
       // Sequelize's `validate` is an object of named validators, so a
       // function there is read as nothing and does nothing -- while the

--- a/showcase/app/controllers/admin/proposals.js
+++ b/showcase/app/controllers/admin/proposals.js
@@ -65,7 +65,9 @@ module.exports = {
       });
     }
 
-    if (req.proposal.state === 'draft') {
+    // The predicate the `enum` generates, rather than the string: a typo in
+    // `state === 'darft'` is silently false forever, and `isDarft()` is not
+    if (req.proposal.isDraft()) {
       req.flash('alert', 'That proposal has not been submitted yet.');
 
       return res.redirect(`/admin/proposals/${req.proposal.externalId}`);
@@ -78,15 +80,12 @@ module.exports = {
   },
 
   index: async (req, res) => {
-    const where = {};
-
-    if (
-      ['accepted', 'draft', 'rejected', 'submitted'].includes(req.query.state)
-    ) {
-      where.state = req.query.state;
-    } else {
-      where.state = 'submitted';
-    }
+    // The list of states is the model's own (`Proposal.enums.state`), so a
+    // state added to the schema does not need this line changed
+    const asked = Proposal.enums.state.includes(req.query.state)
+      ? req.query.state
+      : 'submitted';
+    const where = { state: asked };
 
     const { records, page, perPage, total, pages } = await Proposal.paginate({
       ...req.pagination(),

--- a/showcase/test/proposals.test.js
+++ b/showcase/test/proposals.test.js
@@ -580,5 +580,43 @@ describe('proposals', () => {
       expect(answer.status).toBe(422);
       expect((await Proposal.findByKey(proposal.id)).state).toBe('submitted');
     });
+
+    test('will not decide on a draft, which the enum predicate is what asks', async () => {
+      const proposal = await create('proposal', {
+        eventId: event.id,
+        speakerId: speaker.id,
+        title: 'A proposal still being written',
+      });
+
+      expect(proposal.isDraft()).toBe(true);
+      expect(proposal.isSubmitted()).toBe(false);
+
+      const { browser, csrf } = await signIn(admin);
+      const answer = await browser
+        .post(`/admin/proposals/${proposal.externalId}/decide`)
+        .set('Accept', 'text/html')
+        .set('X-CSRF-Token', csrf)
+        .send({ state: 'accepted' });
+
+      expect(answer.status).toBe(302);
+      expect((await Proposal.findByKey(proposal.id)).state).toBe('draft');
+    });
+
+    test('the states of the review queue are the model’s own list', async () => {
+      expect(Proposal.enums.state).toEqual([
+        'draft',
+        'submitted',
+        'accepted',
+        'rejected',
+      ]);
+      // ... and the scope of one of them is a condition, intersected with
+      // whatever it is given rather than replacing it
+      const submitted = await Proposal.find(
+        Proposal.submitted({ eventId: event.id })
+      );
+
+      expect(submitted.every((one) => one.isSubmitted())).toBe(true);
+      expect(submitted.every((one) => one.eventId === event.id)).toBe(true);
+    });
   });
 });

--- a/types/core.test-d.ts
+++ b/types/core.test-d.ts
@@ -726,6 +726,10 @@ const model: ModelFile = {
     title: { type: 'string', required: true, unique: true },
     body: 'text',
     status: { type: 'string', enum: ['todo', 'done'], default: 'todo' },
+    // The methods an enum generates, named after the field rather than
+    // after the value: `isStageNew()` and `Task.stageNew()`
+    stage: { type: 'string', enum: ['new', 'closed'], predicates: 'stage' },
+    kind: { type: 'string', enum: ['bug', 'chore'], predicates: false },
     meta: { type: 'json' },
     author: { type: 'string', personal: true },
     phone: { type: 'string', personal: { expose: false, erase: 'retain' } },

--- a/website/src/content/docs/guides/models.md
+++ b/website/src/content/docs/guides/models.md
@@ -77,17 +77,18 @@ A field is `{ type, ...keys }` or a bare type. The type names and the keys below
 
 `decimal` and `bigint` are the two whose value a JavaScript number cannot carry, so they cross into JavaScript as exact decimal strings on every adapter. See [Exact numbers](#exact-numbers).
 
-| Key         | Description                                                                                                                                                                                              |
-| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `required`  | The field has to hold something, on every write path of every adapter ([Validations](#validations)); the column is `NOT NULL` as well, where the store has columns.                                      |
-| `default`   | Default value. `Date.now` becomes `NOW` on SQL.                                                                                                                                                          |
-| `enum`      | The values accepted, refused by henri before the write ([Validations](#validations)); still an `ENUM` column on MySQL, MariaDB and PostgreSQL underneath.                                                |
-| `unique`    | Unique index or constraint.                                                                                                                                                                              |
-| `index`     | `index: true` adds an index on the field.                                                                                                                                                                |
-| `precision` | A `decimal` only: the total number of digits, 19 by default and 38 at most — the widest every dialect henri writes carries. See [Exact numbers](#exact-numbers).                                         |
-| `scale`     | A `decimal` only: the digits after the point, 4 by default. A value with more of them is refused, not rounded.                                                                                           |
-| `personal`  | This field is about a person: masked in the logs, exported and erased. See [Personal data](/guides/privacy/).                                                                                            |
-| `encrypted` | The column holds ciphertext and the model the string. `true` is randomised (not queryable), `{ deterministic: true }` keeps an equality and a `unique`. See [Encrypted attributes](/guides/encryption/). |
+| Key          | Description                                                                                                                                                                                              |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `required`   | The field has to hold something, on every write path of every adapter ([Validations](#validations)); the column is `NOT NULL` as well, where the store has columns.                                      |
+| `default`    | Default value. `Date.now` becomes `NOW` on SQL.                                                                                                                                                          |
+| `enum`       | The values accepted, refused by henri before the write ([Validations](#validations)); still an `ENUM` column on MySQL, MariaDB and PostgreSQL underneath.                                                |
+| `predicates` | The methods an `enum` generates: `false` for none, a name to prefix them with. See [Enums](#enums-predicates-scopes-and-the-list).                                                                       |
+| `unique`     | Unique index or constraint.                                                                                                                                                                              |
+| `index`      | `index: true` adds an index on the field.                                                                                                                                                                |
+| `precision`  | A `decimal` only: the total number of digits, 19 by default and 38 at most — the widest every dialect henri writes carries. See [Exact numbers](#exact-numbers).                                         |
+| `scale`      | A `decimal` only: the digits after the point, 4 by default. A value with more of them is refused, not rounded.                                                                                           |
+| `personal`   | This field is about a person: masked in the logs, exported and erased. See [Personal data](/guides/privacy/).                                                                                            |
+| `encrypted`  | The column holds ciphertext and the model the string. `true` is randomised (not queryable), `{ deterministic: true }` keeps an equality and a `unique`. See [Encrypted attributes](/guides/encryption/). |
 
 What the adapters do with anything else differs:
 
@@ -178,6 +179,101 @@ The refusal is measured against the fields the write actually names, so a mass u
 - **`unique` is not a validation, and henri does not pretend otherwise.** A `SELECT` before an `INSERT` answers a question about a moment that has already passed: two requests both find nothing and both write. The unique index is what actually holds, so the database refuses the second one and `henri.model.errors()` turns that refusal into `{ field: 'must be unique' }` — [the same shape](#validation-errors) as everything above. What you give up is the message arriving before the round trip; what you get is a guarantee rather than a near-miss.
 - **A write no hook of the ORM reaches is refused, not skipped** (`HENRI_MODEL_VALIDATION_UNCHECKED_WRITE`). Mongoose runs no middleware for the operations inside a `bulkWrite`, Sequelize runs none for `increment` and `decrement`, and an update operator that describes a change rather than a value (`$inc`, `$push`) has nothing to measure until the server has applied it. None of the three exists on all three adapters, so none of them is part of what a `validates` block means. Read the record, change it and save it.
 - **Cross-record rules are yours.** "No two posts published the same day" is a query, and a query in a validator is a race with a nicer message.
+
+## Enums: predicates, scopes and the list
+
+A column that declares an `enum` already says what it may hold, so henri spells it back as methods rather than making every application write the strings out by hand:
+
+```js
+// app/models/Post.js
+module.exports = {
+  schema: {
+    title: { type: 'string', required: true },
+    status: { type: 'string', enum: ['draft', 'in_review', 'live'] },
+  },
+};
+```
+
+gives you three things, on every adapter:
+
+| What                | Where        | Answers                                                               |
+| ------------------- | ------------ | --------------------------------------------------------------------- |
+| `post.isDraft()`    | every record | `true` when the column holds that value                               |
+| `Post.draft()`      | the model    | **the condition** `{ status: 'draft' }`, narrowed by what it is given |
+| `Post.enums.status` | the model    | `['draft', 'in_review', 'live']`, frozen                              |
+
+```js
+if (post.isLive()) { … }
+
+// every live post, however this adapter spells a list
+await Post.find(Post.live());              // mongoose
+await Post.where(Post.live());             // drizzle
+await Post.findAll({ where: Post.live() }); // sequelize
+```
+
+The predicate is the one with no substitute: `post.status === 'darft'` is silently false for the life of the application, while `post.isDarft()` is a `TypeError` the first time it runs. Writing a wrong value is already refused — that is what [the `enum` rule](#validations) does, on every adapter and every write path — so it is the _comparison_ that needed the method.
+
+### A scope is a condition, not a query
+
+`Post.live()` answers a condition. It is not a Rails relation, because henri has three query builders and [wraps none of them](#querying): a method that answered records would have to be a Mongoose `Query` on one adapter, a promise on another and a Drizzle `Relation` on the third. A condition is the one value all three read the same way — and the one that composes:
+
+```js
+index: async (req, res) => {
+  const { order, where } = await req.filters();
+  const { records, page, perPage, total } = await Post.paginate({
+    ...req.pagination(),
+    order,
+    where: Post.live(where),
+  });
+
+  return res.collection(records, { page, perPage, total });
+},
+```
+
+`where` there is already `policy.scope(user)` intersected with what the client asked for ([Filtering](/guides/filtering/)), and the scope goes _under_ it: an `and` spelled for the adapter, never a merge of keys, so **a scope narrows a list and can never widen it** — the same promise a filter makes. Two conditions on the same column both hold. Anything that is not a plain object is refused (`HENRI_MODEL_ENUM_UNMERGEABLE`) rather than dropped.
+
+The list is what a `<select>`, a seed and a test want, and it is also how you reach a scope whose value is in a variable:
+
+```js
+for (const state of Post.enums.status) {
+  counts[state] = await Post.count(Post[state]());
+}
+```
+
+Never index a model with a string that came from a request: `Post[req.query.state]()` is a method of the model, not a scope. That is what [`filters`](/guides/filtering/) is for.
+
+### A predicate is on the record, and a page has none
+
+`isDraft()` is a method of a record, so it is gone by the time the record is JSON — a React or Inertia page receives the column and compares it itself. The value list crosses over, so a page that has to compare gets the strings from one place:
+
+```jsx
+// pass the list, not a hand-written copy of it
+res.render('/posts', { data: { states: Post.enums.status, posts } });
+```
+
+### The names
+
+`draft` gives `isDraft` and `draft`. `in_review`, `in-review`, `IN_REVIEW` and `InReview` all give `inReview`: the value is split on everything that is not a letter or a digit and at every lower-to-upper boundary, then camel cased. Two values of one model that come out the same name are refused, because they would be the same method.
+
+A value that is not a name at all — `2fa`, `''` — gets no predicate and no scope. It is still in `Post.enums`, still validated and still queryable; there is simply no method for it.
+
+### When a name is already taken
+
+A generated name that already exists is a **boot failure** naming the model, the field, the value and who owns the name (`HENRI_MODEL_ENUM_NAME_TAKEN`). Skipping it silently is the worse answer: `Post.find` would go on answering records to a caller who asked for a condition, and `ticket.isNew()` would call a boolean.
+
+The two namespaces are not equally crowded. Only eight names shaped like `is<Name>` exist across the three ORMs, and exactly one of them is a value a real model writes: **`new`**, whose `isNew` is how Mongoose and the Drizzle model tell an insert from an update. The model's own namespace is the crowded one — `find`, `create`, `update`, `count`, `exists`, `build`, `all`, `first`, `last`, `where`, and `name` and `length`, which every function has.
+
+`new` is also a value nobody can rename once it is in a database, so the field says what it wants:
+
+```js
+// ticket.isStatusNew(), Ticket.statusNew()
+status: { type: 'string', enum: ['new', 'open'], predicates: 'status' },
+
+// no methods for this column; Ticket.enums.status is still the list
+status: { type: 'string', enum: ['new', 'open'], predicates: false },
+```
+
+The check covers the names henri puts on a model on **every** adapter, not only the one you are running, so a model that boots on sqlite boots on MongoDB. What it does not cover is an association: `associate()` runs after the models are built, so a `hasMany` named after an enum value wins. In practice they do not collide — an association is a plural noun and a state is an adjective.
 
 ## Exact numbers
 

--- a/website/src/content/docs/reference/errors.md
+++ b/website/src/content/docs/reference/errors.md
@@ -1582,6 +1582,41 @@ Usually:
 
 The model files of app/models and the schema the adapters normalize.
 
+### `HENRI_MODEL_ENUM_INVALID`
+
+A model field's `predicates` key is not one henri can read.
+
+Usually:
+
+- `predicates` given something that is neither true, false nor a name
+- `predicates: 'in review'`, or any string that is not one word
+
+**Fix.** `predicates` sits next to an `enum` and says what methods it generates: `true` (the default) gives `isDraft()` and `Model.draft()`, `false` gives none and leaves `Model.enums.<field>` as the list of values, and a name prefixes them -- `predicates: 'status'` gives `isStatusDraft()` and `Model.statusDraft()`. See the Models guide.
+
+### `HENRI_MODEL_ENUM_NAME_TAKEN`
+
+An `enum` value would generate a method name that is already something else.
+
+Usually:
+
+- a value whose predicate is already a method of the ORM: `new` gives `isNew()`, which Mongoose and the drizzle model define on every record
+- a value whose scope is already a method of the model: `find`, `create`, `count`, `all`, `first`, `last`, `name`, `length`
+- two values of one model that camel case to the same name (`in_review` and `IN_REVIEW`)
+- a value whose predicate is also a column of the same model
+
+**Fix.** Generating the method would shadow something that already works, so henri refuses instead. Rename the value where you can, or name that column's methods after the field -- `status: { enum: [...], predicates: 'status' }` gives `isStatusNew()` and `Model.statusNew()`. `predicates: false` turns them off for that column and `Model.enums.<field>` is still the list of values. The check covers the names henri puts on a model on every adapter, so a model that boots on one store boots on the next.
+
+### `HENRI_MODEL_ENUM_UNMERGEABLE`
+
+An enum scope was given something that is not a condition to narrow.
+
+Usually:
+
+- `Model.live(true)`, `Model.live('draft')` or a scope given an array
+- a `policy.scope(user)` that is not a plain object handed to a scope
+
+**Fix.** An enum scope answers a condition and takes one, so `Model.live(where)` is `where AND status = 'live'` -- pass a plain object, or nothing. A scope that is not a plain object cannot have a condition put under it: answer one from `scope(user)`, or intersect it yourself.
+
 ### `HENRI_MODEL_FIELD_INCOMPLETE`
 
 A model field carries options but no type.


### PR DESCRIPTION
## What

A model already declares `status: { enum: ['draft', 'live', 'archived'], type: 'string' }`, and since #420 that enum is enforced identically on all three adapters. This spells it back:

```js
post.isDraft()                 // the predicate
Post.live()                    // the scope — a condition
Post.enums.status              // the list, frozen
```

Three of Rails' four, and the fourth was dropped on purpose.

## The decisions

**The predicate is the one with no substitute.** `post.status === 'darft'` is silently false for the life of the application; `post.isDarft()` is a `TypeError` on the first run.

**A scope answers a condition, not records.** henri has three query builders and wraps none of them, so a scope returning records would be a Mongoose `Query`, a promise and a Drizzle `Relation` under one name — or a plain array that has lost `.sort()`, `.limit()` and `.paginate()` on two adapters. A condition is what all three read identically and the only shape that composes with `paginate()`, which is the list call henri actually pushes.

`Post.live(where)` intersects through `narrow()` from `base/filters.js` — an `and` spelled per adapter, never a key merge — so it composes with the policy scope and the tenant condition rather than replacing them.

**Dropped: the bang** (`post.archived!()`). `await post.update({ status: 'archived' })` is already one call that says what it does, and since #420 a wrong value in a *write* is refused on every adapter and every write path. Only a wrong value in a *comparison* had no defence — that asymmetry is the whole argument for the predicate and against its twin. A method named after a transition also implies a state machine henri would not be honouring.

## Collisions, measured before deciding

Refused at boot naming model, field, value and owner. The namespaces were counted rather than assumed:

- **The record side is nearly empty** — 8 `is<Name>` methods across the three ORMs, and exactly one is a plausible enum value: **`new` → `isNew`**, which is how Mongoose and the Drizzle model tell an insert from an update. A ticket with `status: ['new', 'open', 'closed']` is an entirely reasonable model, so a bare refusal would have fired on one.
- **The model side is crowded**: `find`, `create`, `update`, `count`, `exists`, `build`, `all`, `first`, `last`, plus `name` and `length` off `Function.prototype`.

So the check is two lists of henri's *own* model surface held as data — identical on all three adapters, so a model that boots on sqlite boots on MongoDB — plus `name in Model`, which is exact and catches whatever the ORM brought. Skipping silently was rejected: `Post.find` would go on answering records to a caller who asked for a condition. The way out sits on the field next to the `enum`: `predicates: 'status'` prefixes both halves, `predicates: false` generates none and keeps the list.

`in_review`, `in-review`, `IN_REVIEW` and `InReview` all give `inReview`; a value that is not a name (`2fa`, `''`) gets no method and stays in `enums`. `names()` in the CLI was read first and does not fit — it lowercases a whole word and pluralises for a *resource* name, and it lives in a package core cannot require.

## What I verified myself

The property that matters is that a scope **narrows and cannot widen**, since it now sits next to the policy scope and the tenant condition. On the demo application with three articles:

| | answer |
| --- | --- |
| `Article.live()` | the live one |
| `Article.live({ title: 'A draft' })` | **`[]`** — the intersection, not the union |
| `Article.live({ title: 'A live one' })` | the live one |
| `Article.live({ status: 'draft' })` | **`[]`** — a caller cannot overrule the enum by passing the same key |
| `countDocuments({})` vs `countDocuments(Article.live())` | 3 vs 1 |

and the predicates answer correctly while a typo'd one is `undefined`, which is the whole argument for the feature.

## What it leaves

**The generator, and the teammate checked before deciding rather than after.** `henri generate model` has no syntax for an `enum` at all, so no generated model has one; `henri new` writes one by hand and then calls the scaffold with `category:string`, so the generator never sees it and the page renders a text input. The real find is that a scaffolded `_form` for an enum column should be a `<select>` of `Model.enums.<field>` — which needs the generator to read the mark back off the model file the way `--slug` does. That is a CLI tranche, not a rider on this one, and it is on the backlog.

Also left: a predicate is a method of a record, so an Inertia or React page never has one (`Model.enums.<field>` is what crosses); no `or` between two values; no state machine.

## Gates

`pnpm test` (4410), `pnpm test:types`, `pnpm lint --max-warnings 0`, `pnpm format:check`, `scripts/smoke.sh` end to end — which now boots a scaffolded app whose `Task.category` enum generates methods — the SQL suites against live PostgreSQL (828), and the showcase against live PostgreSQL (172), where `isDraft()` and `Proposal.enums.state` are now used in a real controller.