### PR TITLE
The scaffolded pages read the model file

### DIFF
--- a/.changeset/generated-pages-read-the-model.md
+++ b/.changeset/generated-pages-read-the-model.md
@@ -1,0 +1,30 @@
+---
+'@usehenri/cli': minor
+'@usehenri/mcp': patch
+---
+
+The scaffolded pages read the model file.
+
+`henri generate scaffold` wrote a page from the `name:type` pairs on the command line and nothing else, so a column that can only hold four values got a plain text input, a required column got an optional one, and a column henri strips from every answer it builds got a table column that is empty forever. The model file next to those pages had said all three the whole time — `--slug` already read it back, which is the mechanism this follows.
+
+The fields still come from the command line. What each of them _is_ now comes from `app/models/<Name>.js`, the one this run wrote or the one that was already there:
+
+| The model says                | The pages write                                                                |
+| ----------------------------- | ------------------------------------------------------------------------------ |
+| `enum: ['draft', 'live']`     | a `<select>` of `Model.enums.<field>`, which the `new` and `edit` actions send |
+| `required: true`              | a `required` input, and only there                                             |
+| `personal: { expose: false }` | nothing at all — no table column, no detail row, no form field                 |
+
+The `enum` list is **sent, never copied**: the controller passes `Model.enums` and the form maps over what it was given, so a value added to the model reaches the form without the page being regenerated. The models guide already said to pass the list rather than write a copy of it; the generator now does what it says.
+
+The `personal` one is the one that was quietly wrong in both directions. A field marked `expose: false` never reaches a page, so a table column showed an empty string forever — and an edit form showed that empty string and posted it back over the stored value. It is written into no page now. The controller's `FIELDS` still names it, with a comment saying why: what the mark governs is answers, and a write is not an answer, so an API client may still set it. A field marked `personal` _without_ `expose: false` is untouched, because whether it is stripped is `config.privacy.expose`, which is per environment, and a page is one file for all of them.
+
+And the generator can now write an `enum` rather than only read one:
+
+```bash
+henri generate scaffold Post title:string! status:string:enum=draft,in_review,live
+```
+
+`:enum=` is the one setting a `name:type` pair takes after its type, and the grammar is closed there on purpose: it is the mark the pages read back, and everything else a column can say — a `default`, `unique`, `index`, a `personal` mark — belongs in the model file, which is where the generators read it. `henri mcp`'s `generate` tool takes the same attribute.
+
+Both renderers: the Inertia pages get a `<select>` and the React ones the `<Select choices={...}>` of `@usehenri/react/forms`. Regenerate the pages of a model whose marks changed with `--force`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1591,6 +1591,28 @@ the LICENSE and a README into every public package at publish time
   of the default store (`scripts/adapters.js` maps it to the mongoose,
   sequelize or drizzle flavour), which `henri new --adapter <name>` configures.
   The `template` and `vue` renderers get no generated pages.
+  **The pages follow the model file, not only the command line**
+  (`fieldsOf()` in `scripts/generate.js`, which reads it off the disk the
+  way `hasSlug()` does): the fields are the `name:type` arguments and what
+  each of them _is_ comes from `app/models/<Name>.js`. An `enum` column is
+  a `<select>` of `Model.enums.<field>` -- **sent by the controller, never
+  copied into the page**, which is what the models guide already told
+  applications to do -- a `required` column gets a `required` input, and a
+  column marked `personal: { expose: false }` is written into no page at
+  all, because henri strips it from every answer it builds: the table
+  column would be empty forever and the form would post the empty string
+  it had to show over the stored value. `FIELDS` in the controller keeps
+  it with a comment, since the mark governs answers and a write is not
+  one. A `personal` field without `expose: false` is left alone -- whether
+  it is stripped is `config.privacy.expose`, which is per environment, and
+  a page is one file for all of them. `:enum=draft,live` is the one
+  setting a `name:type` pair takes after its type (`parseSetting()`), and
+  the grammar is closed there on purpose: it is the mark the pages read
+  back, and everything else a column can say belongs in the model file.
+  `henri new` writes the sample `Task` model by hand for its `default` and
+  the generator reads the `enum` next to it back, which is the worked
+  example. Regenerating with `--force` is how pages catch up with a mark
+  that changed.
 - `@usehenri/uploads` is new in 1.2. It recognizes a file rather than
   validating it: a signature table plus a text inference over the first 4kb,
   so a valid header followed by anything is that type, a `.docx` is
@@ -1818,10 +1840,10 @@ false` columns of the user model), sqlite offline and the live PostgreSQL
   receives the column and compares it, and `Model.enums.<field>` is what
   crosses over. An association that shadows a generated name is not caught,
   because `associate()` runs after the models are built. `henri generate
-model` has **no syntax for an `enum`** (`name:type` only), so the scaffold
-  writes no enum column and there was nothing for a generated controller or
-  page to use a predicate on; giving the generator one is a CLI tranche of
-  its own. Coverage: sqlite and MongoDB offline
+model` gained `status:string:enum=draft,live` in the CLI tranche below,
+  and the pages a scaffold writes read the mark back -- but **a predicate
+  is still never on a page**, so a generated page compares the column or
+  maps over `Model.enums`. Coverage: sqlite and MongoDB offline
   (`packages/{drizzle,mongoose,sequelize}/__tests__/enums.spec.js`, plus
   the demo application in `packages/core/src/__tests__/enums.spec.js`),
   PostgreSQL and MySQL through `pnpm test:sql:live`, and the showcase's

--- a/packages/cli/__tests__/adapters.spec.js
+++ b/packages/cli/__tests__/adapters.spec.js
@@ -427,7 +427,11 @@ describe('the scaffolded resource follows the adapter', () => {
     expect(controller).toContain(
       'req.task = await Task.findById(req.params.id)'
     );
-    expect(controller).toContain("invalid(res, error, '/tasks/new')");
+    // The sample model's `category` column is an enum, so the page it
+    // renders again is sent the values its <select> offers
+    expect(controller).toContain(
+      "invalid(res, error, '/tasks/new', { enums: Task.enums })"
+    );
     expect(controller).toContain('res.inertia.errors(errors)');
     // An API client still gets the 422, on the same route
     expect(controller).toContain('res.boom.badData(error.message, { errors })');

--- a/packages/cli/__tests__/generate.spec.js
+++ b/packages/cli/__tests__/generate.spec.js
@@ -232,6 +232,30 @@ describe('attribute parsing', () => {
     });
   });
 
+  test('takes the one setting a name:type pair carries: enum=', () => {
+    expect(parseAttributes(['status:string:enum=draft,in_review'])).toEqual({
+      status: { enum: ['draft', 'in_review'], type: 'string' },
+    });
+    expect(parseAttributes(['status!:string:enum=draft,live'])).toEqual({
+      status: { enum: ['draft', 'live'], required: true, type: 'string' },
+    });
+  });
+
+  test('rejects a setting it cannot carry out', () => {
+    expect(() => parseAttributes(['status:string:unique'])).toThrow(
+      /Unknown setting "unique".+The only one is enum=/
+    );
+    expect(() => parseAttributes(['count:integer:enum=1,2'])).toThrow(
+      /only for a string or a text column/
+    );
+    expect(() => parseAttributes(['status:string:enum=live,live'])).toThrow(
+      /each value once/
+    );
+    expect(() => parseAttributes(['status:string:enum='])).toThrow(
+      /each value once/
+    );
+  });
+
   test('rejects unknown types with the list of valid ones', () => {
     expect(() => parseAttributes(['score:varchar'])).toThrow(
       /Unknown type "varchar" for attribute "score"\. Valid types: string, text/
@@ -1067,6 +1091,200 @@ describe('henri generate', () => {
       );
       expect(exists(app, 'app/models/Ghost.js')).toBe(false);
     });
+  });
+
+  describe('the marks the model file carries', () => {
+    // What `henri new` does: a model written by hand, with an `enum` no
+    // `name:type` pair can express, and the generator called right after
+    // with the plain attributes
+    const declared = `module.exports = {
+  options: { timestamps: true },
+  schema: {
+    title: { type: 'string', required: true },
+    status: { type: 'string', enum: ['draft', 'live'], default: 'draft' },
+    note: { type: 'string' },
+    ssn: { type: 'string', personal: { expose: false } },
+    phone: { type: 'string', personal: true },
+  },
+  store: 'default',
+};
+`;
+    const attributes = [
+      'title:string!',
+      'status:string',
+      'note:string',
+      'ssn:string',
+      'phone:string',
+    ];
+
+    /**
+     * The `<input>` or `<select>` a generated form writes for one field
+     *
+     * @param {string} form The form page
+     * @param {string} tag input or select
+     * @param {string} name The field
+     * @returns {string} The element, attributes and all
+     * @throws when the form has no such field (a `not.toContain` over
+     *   nothing at all would pass without meaning anything)
+     */
+    const elementFor = (form, tag, name) => {
+      const found = form.match(
+        new RegExp(`<${tag}[^>]+name="${name}"[^>]*>`, 'u')
+      );
+
+      if (!found) {
+        throw new Error(`the form has no <${tag} name="${name}">`);
+      }
+
+      return found[0];
+    };
+
+    beforeAll(() => {
+      fs.writeFileSync(path.join(app, 'app', 'models', 'Ticket.js'), declared);
+
+      const result = henri(['g', 'scaffold', 'Ticket', ...attributes], {
+        cwd: app,
+      });
+
+      if (result.status !== 0) {
+        throw new Error(result.stdout + result.stderr);
+      }
+    });
+
+    test('an enum column is a select, of the list the controller sends', () => {
+      const form = read(app, 'app/views/pages/tickets/_form.jsx');
+      const controller = read(app, 'app/controllers/tickets.js');
+
+      expect(elementFor(form, 'select', 'status')).toContain(
+        "defaultValue={data.status ?? ''}"
+      );
+      expect(form).toContain('{(enums.status || []).map((value) => (');
+      // The values are never copied into the page: a copy of the schema
+      // stops being true the first time the model changes
+      expect(form).not.toContain('draft');
+      expect(controller).toContain(
+        'new: async () => ({ enums: Ticket.enums })'
+      );
+      expect(controller).toContain(
+        'data: { enums: Ticket.enums, ticket: req.ticket }'
+      );
+      // ... including the page rendered again after a failed write
+      expect(controller).toContain(
+        "invalid(res, error, '/tickets/new', { enums: Ticket.enums })"
+      );
+    });
+
+    test('the new and edit pages hand the form what they were sent', () => {
+      expect(read(app, 'app/views/pages/tickets/new.jsx')).toContain(
+        'enums={data.enums}'
+      );
+      expect(read(app, 'app/views/pages/tickets/edit.jsx')).toContain(
+        'enums={data.enums}'
+      );
+    });
+
+    test('a required column gets a required input, and only it', () => {
+      const form = read(app, 'app/views/pages/tickets/_form.jsx');
+
+      expect(elementFor(form, 'input', 'title')).toContain('required');
+      expect(elementFor(form, 'input', 'note')).not.toContain('required');
+      expect(elementFor(form, 'select', 'status')).not.toContain('required');
+    });
+
+    test('a column that never leaves the server is on no page', () => {
+      // A field marked `personal: { expose: false }` is stripped from every
+      // answer henri builds, so a page showing it shows an empty column
+      // forever -- and a form posts that empty string back over the value
+      for (const page of ['_form', 'index', 'show']) {
+        const file = `app/views/pages/tickets/${page}.jsx`;
+
+        expect(read(app, file)).not.toContain('ssn');
+        expect(() => parseFile(app, file)).not.toThrow();
+      }
+
+      // A personal column that does not say `expose: false` is a field like
+      // any other: whether it is stripped is config.privacy.expose, which
+      // is per environment, and a page is one file for all of them
+      expect(read(app, 'app/views/pages/tickets/show.jsx')).toContain(
+        'item.phone'
+      );
+    });
+
+    test('... but a request may still set it: an answer is not a write', () => {
+      const controller = read(app, 'app/controllers/tickets.js');
+
+      expect(controller).toContain(
+        "const FIELDS = ['title', 'status', 'note', 'ssn', 'phone']"
+      );
+      expect(controller).toContain(
+        'henri drops a field marked personal: { expose: false } from every answer'
+      );
+      expect(controller).toContain('still permitted here: ssn');
+      expect(() => parseFile(app, 'app/controllers/tickets.js')).not.toThrow();
+    });
+
+    test('the command line can write the enum itself, in one run', () => {
+      const result = henri(
+        [
+          'g',
+          'scaffold',
+          'Release',
+          'name:string!',
+          'channel:string:enum=alpha,beta',
+        ],
+        { cwd: app }
+      );
+
+      expect(result.status).toBe(0);
+      expect(read(app, 'app/models/Release.js')).toContain(
+        "enum: ['alpha', 'beta']"
+      );
+      expect(read(app, 'app/views/pages/releases/_form.jsx')).toContain(
+        '{(enums.channel || []).map((value) => ('
+      );
+      expect(read(app, 'app/controllers/releases.js')).toContain(
+        'enums: Release.enums'
+      );
+    });
+
+    test('the React renderer gets a Select and the same required inputs', () => {
+      const { app: other, dir: otherDir } = scaffold([
+        '--no-git',
+        '--renderer',
+        'react',
+      ]);
+
+      try {
+        fs.writeFileSync(
+          path.join(other, 'app', 'models', 'Ticket.js'),
+          declared
+        );
+        expect(
+          henri(['g', 'scaffold', 'Ticket', ...attributes], { cwd: other })
+            .status
+        ).toBe(0);
+
+        const form = read(other, 'app/views/pages/tickets/_form.js');
+
+        expect(form).toContain(
+          "import { Button, Form, FormError, Input, Select } from '@usehenri/react/forms'"
+        );
+        expect(elementFor(form, 'Select', 'status')).toContain(
+          'choices={enums.status || []}'
+        );
+        expect(elementFor(form, 'Input', 'title')).toContain('required');
+        expect(elementFor(form, 'Input', 'note')).not.toContain('required');
+        expect(form).not.toContain('ssn');
+        expect(read(other, 'app/views/pages/tickets/new.js')).toContain(
+          'enums={enums}'
+        );
+        expect(() =>
+          parseFile(other, 'app/views/pages/tickets/_form.js')
+        ).not.toThrow();
+      } finally {
+        cleanup(otherDir);
+      }
+    }, 120000);
   });
 
   test('keeps config/routes.js valid after every change', () => {

--- a/packages/cli/__tests__/json.spec.js
+++ b/packages/cli/__tests__/json.spec.js
@@ -70,7 +70,7 @@ describe('--json', () => {
         '--json',
       ]);
       expect(generate.targets.map((target) => target.name)).toContain(
-        'scaffold <Name> [field:type[!] ...] [--slug <field>]'
+        'scaffold <Name> [field:type[!][:enum=a,b] ...] [--slug <field>]'
       );
       expect(generate.examples[0].command).toContain('henri generate model');
     });

--- a/packages/cli/__tests__/new.spec.js
+++ b/packages/cli/__tests__/new.spec.js
@@ -219,12 +219,16 @@ describe('henri new', () => {
     expect(form).toContain('<p className={message}>{errors.name}</p>');
 
     // A failed write renders the page again with res.inertia.errors(), and
-    // still answers a 422 to an API client
+    // still answers a 422 to an API client. The page gets what it needs to
+    // render: the record on the edit page, and the values of the <select>
+    // the `category` column of the sample model asks for on both
     expect(controller).toContain('res.inertia.errors(errors)');
-    expect(controller).toContain("invalid(res, error, '/tasks/new')");
     expect(controller).toContain(
-      "invalid(res, error, '/tasks/edit', { task: req.task })"
+      "invalid(res, error, '/tasks/new', { enums: Task.enums })"
     );
+    expect(controller).toContain("invalid(res, error, '/tasks/edit', {");
+    expect(controller).toContain('enums: Task.enums,');
+    expect(controller).toContain('task: req.task,');
     expect(controller).toContain('res.boom.badData(error.message, { errors })');
   });
 

--- a/packages/cli/scripts/agents.js
+++ b/packages/cli/scripts/agents.js
@@ -644,7 +644,7 @@ const generators = (facts) => {
 ${lines.join('\n')}
 \`\`\`
 
-Types are \`string, text, number, integer, float, decimal, bigint, boolean, date, json, uuid\`, and a trailing \`!\` makes the field required. \`Post\` gives \`posts\` (\`Category\` -> \`categories\`, \`Person\` -> \`people\`). An existing file is skipped unless \`--force\`; \`--json\` prints the files written or removed and the routes added. The generators rewrite \`config/routes.js\` through prettier, so comments in that file are lost. Regenerate this file with \`henri generate agents\` whenever the application changes shape.`;
+Types are \`string, text, number, integer, float, decimal, bigint, boolean, date, json, uuid\`, a trailing \`!\` makes the field required and \`status:string:enum=draft,live\` says the values a column may hold. \`Post\` gives \`posts\` (\`Category\` -> \`categories\`, \`Person\` -> \`people\`). The scaffolded pages follow the model file, so regenerating them (\`--force\`) after a mark changed is how they catch up: an \`enum\` column is a \`<select>\` of \`Model.enums\`, a required one a required input, and a field marked \`personal: { expose: false }\` is on no page at all. An existing file is skipped unless \`--force\`; \`--json\` prints the files written or removed and the routes added. The generators rewrite \`config/routes.js\` through prettier, so comments in that file are lost. Regenerate this file with \`henri generate agents\` whenever the application changes shape.`;
 };
 
 /**

--- a/packages/cli/scripts/generate.js
+++ b/packages/cli/scripts/generate.js
@@ -101,17 +101,72 @@ const main = async (args) => {
 };
 
 /**
+ * The values of `status:string:enum=draft,live`, the one setting an
+ * attribute takes after its type.
+ *
+ * It is the one mark of the schema a `name:type` pair could not express and
+ * the one the generated pages read back (a `<select>` rather than a text
+ * input, see `fieldsOf`), which is what earns it a spelling of its own; the
+ * grammar is closed at that single word on purpose, and everything else a
+ * column can say is written in the model file, where it is read.
+ *
+ * @param {string} attribute The attribute as typed
+ * @param {string} type The type it declared
+ * @param {string[]} rest What followed the type, split on `:`
+ * @returns {object} `{ enum: [...] }`, or nothing at all
+ * @throws {CliError} USAGE on anything but one readable `enum=`
+ */
+const parseSetting = (attribute, type, rest) => {
+  const hint = 'ex: status:string:enum=draft,live';
+
+  if (rest.length === 0) {
+    return {};
+  }
+
+  const [key, ...value] = rest.join(':').split('=');
+
+  if (key !== 'enum') {
+    throw new CliError(
+      'USAGE',
+      `Unknown setting "${key}" in "${attribute}". The only one is enum=<values>`,
+      { hint }
+    );
+  }
+
+  if (type !== 'string' && type !== 'text') {
+    throw new CliError(
+      'USAGE',
+      `enum= is only for a string or a text column ("${attribute}" is a ${type})`,
+      { hint }
+    );
+  }
+
+  const values = value.join('=').split(',');
+  const listed = new Set(values);
+
+  if (value.length === 0 || listed.has('') || listed.size !== values.length) {
+    throw new CliError(
+      'USAGE',
+      `Invalid enum values in "${attribute}": expected a comma separated list, each value once`,
+      { hint }
+    );
+  }
+
+  return { enum: values };
+};
+
+/**
  * Parse `name:type!` attributes into a schema
  *
  * @param {string[]} [attributes=[]] Attributes as typed on the command line
  * @returns {object} The schema ({ name: { type, required } })
- * @throws {CliError} USAGE on an unknown type
+ * @throws {CliError} USAGE on an unknown type or an unreadable setting
  */
 const parseAttributes = (attributes = []) => {
   const schema = {};
 
   for (const attribute of attributes) {
-    let [name, rawType = 'string'] = attribute.split(':');
+    let [name, rawType = 'string', ...rest] = attribute.split(':');
     let required = false;
 
     if (name.endsWith('!')) {
@@ -144,7 +199,10 @@ const parseAttributes = (attributes = []) => {
 
     // A decimal with no settings is 19 digits with 4 after the point,
     // which is not what somebody who typed `price:decimal` meant
-    const settings = type === 'decimal' ? DECIMAL_SETTINGS : {};
+    const settings = {
+      ...(type === 'decimal' ? DECIMAL_SETTINGS : {}),
+      ...parseSetting(attribute, type, rest),
+    };
 
     schema[name] = required
       ? { required: true, ...settings, type }
@@ -670,13 +728,7 @@ const scaffold = async (name, attributes = [], opts = {}) => {
  * @return {Promise<void>} Resolves when done
  */
 const resources = async (name, attributes = [], opts = {}) => {
-  const resource = {
-    ...names(name),
-    api: apiOf(process.cwd()),
-    keys: extractKeys(attributes),
-    renderer: rendererOf(process.cwd()),
-    slug: hasSlug(names(name).doc, opts),
-  };
+  const resource = resourceOf(name, attributes, opts);
   const generator = require('./generate/controllers');
 
   await output(
@@ -699,16 +751,15 @@ const resources = async (name, attributes = [], opts = {}) => {
  * @return {Promise<void>} Resolves when done
  */
 const crud = async (name, attributes = [], opts = {}) => {
-  const resource = {
-    ...names(name),
-    api: apiOf(process.cwd()),
-    keys: extractKeys(attributes),
-    renderer: rendererOf(process.cwd()),
-    slug: hasSlug(names(name).doc, opts),
-  };
   const generator = require('./generate/controllers');
 
+  // The model first, then read it back: the controller of a resource is
+  // written from what the model file says, whether this run wrote it or it
+  // was already there (see resourceOf)
   await model(name, attributes, opts);
+
+  const resource = resourceOf(name, attributes, opts);
+
   await output(
     'controller',
     'app/controllers',
@@ -722,7 +773,7 @@ const crud = async (name, attributes = [], opts = {}) => {
 /**
  * Handle views processing
  *
- * @param {object} resource { doc, lower, plural, keys, renderer }
+ * @param {object} resource { doc, lower, plural, fields, renderer }
  * @param {object} [opts] { force, report }
  * @returns {Promise<void>} Resolves when written
  */
@@ -742,6 +793,42 @@ const extractKeys = (args = []) =>
   args.map((val) => val.split(':')[0].replace(/!$/, ''));
 
 /**
+ * Is this an object with keys -- a mark, rather than a bare value?
+ *
+ * @param {*} value anything
+ * @returns {boolean} true for a plain object
+ */
+const isObject = (value) =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+/**
+ * The model file of a resource, read off the disk without booting henri.
+ *
+ * The one way this command reads a model: `--slug` was the first caller and
+ * the marks a page honours are the second. A file that will not load is a
+ * boot failure, not this command's to report, so it answers null and every
+ * caller writes what it always wrote.
+ *
+ * @param {string} doc The model's global id (ex: Article)
+ * @returns {?object} The model file, or null
+ */
+const modelFileOf = (doc) => {
+  const location = path.join(process.cwd(), 'app', 'models', `${doc}.js`);
+
+  if (!fs.existsSync(location)) {
+    return null;
+  }
+
+  try {
+    delete require.cache[require.resolve(location)];
+
+    return require(location);
+  } catch {
+    return null;
+  }
+};
+
+/**
  * Does this model carry a slug -- the name a person reads in a url?
  *
  * `--slug` says so for a model this run is writing; for one that is already
@@ -758,34 +845,107 @@ const hasSlug = (doc, opts = {}) => {
     return true;
   }
 
-  const location = path.join(process.cwd(), 'app', 'models', `${doc}.js`);
+  const declared = ((modelFileOf(doc) || {}).options || {}).slug;
 
-  if (!fs.existsSync(location)) {
-    return false;
+  return Boolean(
+    typeof declared === 'string'
+      ? declared
+      : isObject(declared) && declared.from
+  );
+};
+
+/**
+ * What the model file says about the fields the command line named.
+ *
+ * The command line names the fields (`title:string!`) and the model file
+ * says what each of them is -- the one this run just wrote, or the one that
+ * was already there, read the way the slug is. Which is what makes a mark
+ * no `name:type` pair can express reach the pages anyway: `henri new`
+ * writes the sample `Task` model by hand, with an `enum` on `category`, and
+ * calls this generator with `category:string` right after.
+ *
+ * Three marks change a page:
+ *
+ * - **`enum`** is the values the column may hold, so the field is a
+ *   `<select>` rather than a text input. Its options are `Model.enums`,
+ *   which the controller sends: a list written into the page would be a
+ *   copy of the schema that stops being true (`guides/models.md`).
+ * - **`required`** is the `required` attribute of the input, from the model
+ *   file or from the `!` of the command line.
+ * - **`personal: { expose: false }`** is a column henri drops from every
+ *   answer it builds, at every depth, so the field is not written at all: a
+ *   table column that is empty forever, and a form that shows the empty
+ *   string it had to show and posts it back over the stored value. The
+ *   controller still permits it -- an answer is not a write -- and the
+ *   FIELDS comment says so.
+ *
+ * A field that is `personal` without saying `expose: false` is left alone:
+ * whether it is stripped is `config.privacy.expose`, which is per
+ * environment, and a page is one file for all of them.
+ *
+ * @param {string} doc The model's global id (ex: Task)
+ * @param {string[]} [attributes=[]] The attributes as typed on the command line
+ * @returns {{fields: Array<object>, hidden: Array<string>}} what to write
+ *   ({ enum, name, required } per visible field) and what never leaves
+ */
+const fieldsOf = (doc, attributes = []) => {
+  const typed = parseAttributes(attributes);
+  const model = modelFileOf(doc);
+  const declared =
+    isObject(model) && isObject(model.schema) ? model.schema : {};
+  const fields = [];
+  const hidden = [];
+
+  for (const name of Object.keys(typed)) {
+    const definition = isObject(declared[name]) ? declared[name] : typed[name];
+    const personal = definition.personal;
+
+    if (isObject(personal) && personal.expose === false) {
+      hidden.push(name);
+      continue;
+    }
+
+    fields.push({
+      enum: Array.isArray(definition.enum) ? definition.enum : null,
+      name,
+      required: definition.required === true,
+    });
   }
 
-  try {
-    delete require.cache[require.resolve(location)];
+  return { fields, hidden };
+};
 
-    const declared = (require(location).options || {}).slug;
+/**
+ * What a controller and its pages are written from: the names, the model
+ * API of the store, the renderer of the application, the fields the command
+ * line named and what the model file says about them
+ *
+ * @param {string} name Model name (singular, ex: Post)
+ * @param {string[]} [attributes=[]] Attributes (name:type!)
+ * @param {object} [opts] { slug }
+ * @returns {object} The resource
+ */
+const resourceOf = (name, attributes = [], opts = {}) => {
+  const named = names(name);
+  const { fields, hidden } = fieldsOf(named.doc, attributes);
 
-    return Boolean(
-      typeof declared === 'string'
-        ? declared
-        : declared && typeof declared === 'object' && declared.from
-    );
-  } catch {
-    // A model file that will not load is a boot failure, not this
-    // command's to report: it writes the urls it always wrote
-    return false;
-  }
+  return {
+    ...named,
+    api: apiOf(process.cwd()),
+    fields,
+    hasEnums: fields.some((field) => field.enum),
+    hidden,
+    keys: extractKeys(attributes),
+    renderer: rendererOf(process.cwd()),
+    slug: hasSlug(named.doc, opts),
+  };
 };
 
 /**
  * Compile one view template into app/views/pages/<plural>/<view>, a `.jsx`
  * page for the Inertia renderer and a `.js` one for the Next.js renderer
  *
- * @param {object} resource { doc, lower, plural, keys, view, renderer }
+ * @param {object} resource { doc, lower, plural, fields, view, renderer }
  * @param {object} [opts] { force, report }
  * @return {Promise<boolean>} True when written
  */
@@ -794,7 +954,8 @@ const compileView = async (
     doc,
     lower,
     plural,
-    keys = [],
+    fields = [],
+    hasEnums = false,
     slug = false,
     view = 'index',
     renderer = DEFAULT_RENDERER,
@@ -813,8 +974,9 @@ const compileView = async (
     `${view}.${PAGE_EXTENSIONS[renderer]}`,
     template({
       doc,
+      fields,
+      hasEnums,
       identifier: slug ? 'slug' : 'externalId',
-      keys,
       lower,
       plural,
     }),

--- a/packages/cli/scripts/generate/controllers.js
+++ b/packages/cli/scripts/generate/controllers.js
@@ -32,6 +32,13 @@
  * 404 below -- and a redirect is built from `record.externalId`, never from
  * the numeric id, which does not leave the server.
  *
+ * The model file is read back for more than the names: `hidden` is the
+ * columns marked `personal: { expose: false }`, which the pages leave out
+ * and FIELDS keeps -- henri strips them from every *answer* it builds, and
+ * a write is not an answer -- and `hasEnums` says the model declares an
+ * `enum` column, so `new` and `edit` send `Model.enums` for the `<select>`s
+ * of the form. See `fieldsOf()` in ../generate.js.
+ *
  * A model that declared `options: { slug: ... }` has a second public name,
  * and the urls of this resource carry that one instead (`base/slug.js`):
  * `slug` is true in the resource, the redirects are built from
@@ -98,10 +105,39 @@ const pageFile = ({ plural, renderer }, view) =>
 
 // --- the helpers every flavour shares --------------------------------------
 
-const fields = ({ keys }) => `
-// Attributes a request may set (see req.permit)
+const fields = (opts) => {
+  const { hidden = [], keys } = opts;
+  // A column marked `personal: { expose: false }` is dropped from every
+  // answer henri builds -- but a write is not an answer, so it stays in the
+  // list a request may set, and the comment says why it is still here
+  const note =
+    hidden.length === 0
+      ? ''
+      : `
+//
+// henri drops a field marked personal: { expose: false } from every answer
+// it builds${opts.pages === false ? '' : ', and no page shows one'}. A write is not an answer, so ${
+        hidden.length > 1 ? 'these are' : 'this one is'
+      }
+// still permitted here: ${hidden.join(', ')}`;
+
+  return `
+// Attributes a request may set (see req.permit)${note}
 const FIELDS = ${JSON.stringify(keys)};
 `;
+};
+
+/**
+ * The `enums` a page of this resource is rendered with: the model's own
+ * `{ column: [values] }`, which is what the <select> of an enum column
+ * offers. Sent rather than written into the page, because a list copied
+ * into a form is a copy of the schema that stops being true.
+ *
+ * @param {object} opts { doc, hasEnums }
+ * @returns {string} `enums: Post.enums, ` or nothing at all
+ */
+const enumsData = ({ doc, hasEnums }) =>
+  hasEnums ? `enums: ${doc}.enums, ` : '';
 
 const validationHelper = (opts) =>
   rendersInertia(opts) ? inertiaValidation(opts) : jsonValidation(opts);
@@ -172,11 +208,13 @@ const invalidCall = (opts, view) => {
     return 'return invalid(res, error);';
   }
 
-  // The edit page needs its record back; the new page renders without data
-  const data =
-    view === 'edit' ? `, { ${opts.lower}: req.${opts.lower} }` : '';
+  // The page is rendered again with what it needs: the edit page its
+  // record, and both pages the values their <select>s offer
+  const record = view === 'edit' ? `${opts.lower}: req.${opts.lower} ` : '';
+  const carried =
+    record || enumsData(opts) ? `, { ${enumsData(opts)}${record}}` : '';
 
-  return `return invalid(res, error, '/${opts.plural}/${view}'${data});`;
+  return `return invalid(res, error, '/${opts.plural}/${view}'${carried});`;
 };
 
 /**
@@ -406,8 +444,14 @@ const indexJson = (opts) => `
 
 const newC = (opts) => `
   // No answer, no res.render(): what an action returns is the data of its
-  // own page, here ${pageFile(opts, 'new')}
-  new: async () => ({}),`;
+  // own page, here ${pageFile(opts, 'new')}${
+    opts.hasEnums
+      ? `.
+  // ${opts.doc}.enums is { column: [values] } for every enum column of the
+  // model: the form's <select>s offer that list rather than a copy of it`
+      : ''
+  }
+  new: async () => ({ ${enumsData(opts)}}),`;
 
 const create = (opts) => `
   create: async (req, res) => {
@@ -439,7 +483,9 @@ const edit = (opts) => `
   edit: async (req, res) =>
     res.negotiate({
       html: () =>
-        res.render('/${opts.plural}/edit', { data: { ${opts.lower}: req.${opts.lower} } }),
+        res.render('/${opts.plural}/edit', {
+          data: { ${enumsData(opts)}${opts.lower}: req.${opts.lower} },
+        }),
       json: () => res.resource(req.${opts.lower}),
     }),`;
 

--- a/packages/cli/scripts/generate/inertia-_form.hbs
+++ b/packages/cli/scripts/generate/inertia-_form.hbs
@@ -5,6 +5,10 @@ import { Form } from '@usehenri/inertia';
 // Inertia's router, so the controller answers with a redirect on success, or
 // renders this page again after `res.inertia.errors()`; those messages arrive
 // as `errors` below, keyed by field name.
+{{#if hasEnums}}
+// `enums` is what the controller sent as `{{doc}}.enums`: the values each
+// column may hold, which is what the <select>s below offer.
+{{/if}}
 // The className props style the fields with Tailwind CSS (see
 // app/views/styles/index.css).
 const field =
@@ -14,20 +18,41 @@ const submit =
 const caption = 'text-xs font-medium text-zinc-500 dark:text-zinc-400';
 const message = 'text-sm text-red-600 dark:text-red-400';
 
-const {{doc}}Form = ({ action, data = {}, button = 'Create' }) => (
+const {{doc}}Form = ({ action, data = {}, {{#if hasEnums}}enums = {}, {{/if}}button = 'Create' }) => (
   <Form action={action} className="flex flex-col gap-4">
     {({ errors, processing }) => (
       <>
-        {{#each keys}}
+        {{#each fields}}
         <label className="flex flex-col gap-1">
-          <span className={caption}>{{this}}</span>
+          <span className={caption}>{{name}}</span>
+          {{#if enum}}
+          <select
+            className={field}
+            defaultValue={data.{{name}} ?? ''}
+            name="{{name}}"
+            {{#if required}}
+            required
+            {{/if}}
+          >
+            <option value="">Choose...</option>
+            {(enums.{{name}} || []).map((value) => (
+              <option key={value} value={value}>
+                {value}
+              </option>
+            ))}
+          </select>
+          {{else}}
           <input
             className={field}
-            defaultValue={data.{{this}} ?? ''}
-            name="{{this}}"
-            placeholder="{{this}}"
+            defaultValue={data.{{name}} ?? ''}
+            name="{{name}}"
+            placeholder="{{name}}"
+            {{#if required}}
+            required
+            {{/if}}
           />
-          {errors.{{this}} ? <p className={message}>{errors.{{this}} }</p> : null}
+          {{/if}}
+          {errors.{{name}} ? <p className={message}>{errors.{{name}} }</p> : null}
         </label>
         {{/each}}
         <button className={submit} disabled={processing} type="submit">

--- a/packages/cli/scripts/generate/inertia-edit.hbs
+++ b/packages/cli/scripts/generate/inertia-edit.hbs
@@ -35,6 +35,9 @@ const Edit = () => {
         <{{doc}}Form
           action={pathFor('update_{{plural}}_path', { id })}
           data={item}
+          {{#if hasEnums}}
+          enums={data.enums}
+          {{/if}}
           button="Update"
         />
       </div>

--- a/packages/cli/scripts/generate/inertia-index.hbs
+++ b/packages/cli/scripts/generate/inertia-index.hbs
@@ -36,8 +36,8 @@ export default function Index() {
         <table className="w-full text-left">
           <thead className="border-b border-zinc-200 bg-zinc-50 text-xs uppercase text-zinc-500 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400">
             <tr>
-              {{#each keys}}
-              <th className="px-4 py-2 font-medium">{{this}}</th>
+              {{#each fields}}
+              <th className="px-4 py-2 font-medium">{{name}}</th>
               {{/each}}
               <th className="px-4 py-2 text-right font-medium">Actions</th>
             </tr>
@@ -47,7 +47,7 @@ export default function Index() {
               <tr>
                 <td
                   className="px-4 py-12 text-center text-sm text-zinc-500 dark:text-zinc-400"
-                  colSpan={ {{keys.length}} + 1}
+                  colSpan={ {{fields.length}} + 1}
                 >
                   Nothing to show
                 </td>
@@ -58,8 +58,8 @@ export default function Index() {
                 key={item.{{identifier}} }
                 className="hover:bg-zinc-50 dark:hover:bg-zinc-900"
               >
-                {{#each keys}}
-                <td className={cell}>{String(item.{{this}} ?? '')}</td>
+                {{#each fields}}
+                <td className={cell}>{String(item.{{name}} ?? '')}</td>
                 {{/each}}
                 <td className={`${cell} space-x-4 whitespace-nowrap text-right`}>
                   <Link className={link} href={getRoute('show_{{plural}}_path', item.{{identifier}})}>

--- a/packages/cli/scripts/generate/inertia-new.hbs
+++ b/packages/cli/scripts/generate/inertia-new.hbs
@@ -1,11 +1,12 @@
 import { Link, useHenri } from '@usehenri/inertia';
 import {{doc}}Form from './_form';
 
-// Rendered by the `new` action (no data). The form posts to the `create`
-// action, which redirects to the new {{lower}}, or renders this page again with
-// the validation errors of the store.
+{{#if hasEnums}}// Rendered by the `new` action, whose only data is `enums`: the values the
+// <select>s of the form offer.
+{{/if}}// The form posts to the `create` action, which redirects to the new {{lower}}, or
+// renders this page again with the validation errors of the store.
 const New = () => {
-  const { getRoute, pathFor } = useHenri();
+  const { {{#if hasEnums}}data, {{/if}}getRoute, pathFor } = useHenri();
 
   return (
     <main className="mx-auto w-full max-w-lg px-6 py-12">
@@ -18,7 +19,13 @@ const New = () => {
       <h1 className="mt-3 text-2xl font-semibold tracking-tight">New {{doc}}</h1>
 
       <div className="mt-8 rounded-xl border border-zinc-200 p-6 dark:border-zinc-800">
-        <{{doc}}Form action={pathFor('create_{{plural}}_path')} button="Create" />
+        <{{doc}}Form
+          action={pathFor('create_{{plural}}_path')}
+          {{#if hasEnums}}
+          enums={data.enums}
+          {{/if}}
+          button="Create"
+        />
       </div>
     </main>
   );

--- a/packages/cli/scripts/generate/inertia-show.hbs
+++ b/packages/cli/scripts/generate/inertia-show.hbs
@@ -32,10 +32,10 @@ const Show = () => {
       <p className="mt-1 font-mono text-xs text-zinc-500 dark:text-zinc-400">{id}</p>
 
       <dl className="mt-8 overflow-hidden rounded-xl border border-zinc-200 text-sm dark:border-zinc-800">
-        {{#each keys}}
+        {{#each fields}}
         <div className="flex gap-4 border-b border-zinc-200 px-5 py-3 last:border-0 dark:border-zinc-800">
-          <dt className="w-32 shrink-0 text-zinc-500 dark:text-zinc-400">{{this}}</dt>
-          <dd className="min-w-0 flex-1">{String(item.{{this}} ?? '')}</dd>
+          <dt className="w-32 shrink-0 text-zinc-500 dark:text-zinc-400">{{name}}</dt>
+          <dd className="min-w-0 flex-1">{String(item.{{name}} ?? '')}</dd>
         </div>
         {{/each}}
       </dl>

--- a/packages/cli/scripts/generate/react-_form.hbs
+++ b/packages/cli/scripts/generate/react-_form.hbs
@@ -1,8 +1,12 @@
-import { Button, Form, FormError, Input } from '@usehenri/react/forms';
+import { Button, Form, FormError, Input{{#if hasEnums}}, Select{{/if}} } from '@usehenri/react/forms';
 
 // Shared by new and edit: `action` is a pathFor() result ({ method, route })
 // or a route string; the Form submits it as JSON and reports the errors the
 // controller answers with (a 422 boom body maps `data.errors` to the fields).
+{{#if hasEnums}}
+// `enums` is what the controller sent as `{{doc}}.enums`: the values each
+// column may hold, which is what the <Select>s below offer.
+{{/if}}
 // The className props style henri's form components with Tailwind CSS (see
 // app/views/styles/index.css).
 const field =
@@ -10,7 +14,7 @@ const field =
 const submit =
   'inline-flex w-full items-center justify-center rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200';
 
-const {{doc}}Form = ({ action, data = {}, button = 'Create', onSuccess }) => (
+const {{doc}}Form = ({ action, data = {}, {{#if hasEnums}}enums = {}, {{/if}}button = 'Create', onSuccess }) => (
   <Form
     action={action}
     className="flex flex-col gap-4"
@@ -18,17 +22,33 @@ const {{doc}}Form = ({ action, data = {}, button = 'Create', onSuccess }) => (
     onSuccess={onSuccess}
   >
     <FormError className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-300" />
-    {{#each keys}}
-    <Input
-      name="{{this}}"
-      placeholder="{{this}}"
-      required
+    {{#each fields}}
+    {{#if enum}}
+    <Select
+      name="{{name}}"
+      choices={enums.{{name}} || []}
+      placeholder="{{name}}"
       className={field}
       baseClassName="flex flex-col gap-1"
       errorClassName="text-sm text-red-600 dark:text-red-400"
-      validation=\{{ isLength: { min: 1 } }}
-      errorMsg=\{{ isLength: 'Minimum 1 char' }}
+      {{#if required}}
+      required
+      {{/if}}
     />
+    {{else}}
+    <Input
+      name="{{name}}"
+      placeholder="{{name}}"
+      className={field}
+      baseClassName="flex flex-col gap-1"
+      errorClassName="text-sm text-red-600 dark:text-red-400"
+      {{#if required}}
+      required
+      validation=\{{ isLength: { min: 1 } }}
+      errorMsg=\{{ isLength: 'This field is required' }}
+      {{/if}}
+    />
+    {{/if}}
     {{/each}}
     <Button className={submit}>{button} {{doc}}</Button>
   </Form>

--- a/packages/cli/scripts/generate/react-edit.hbs
+++ b/packages/cli/scripts/generate/react-edit.hbs
@@ -7,7 +7,7 @@ import {{doc}}Form from './_form';
 // page moves to the record once the controller answered.
 const back = 'text-sm text-zinc-500 hover:underline dark:text-zinc-400';
 
-const Edit = ({ data: { {{lower}} = null }, getRoute, pathFor, router }) => {
+const Edit = ({ data: { {{lower}} = null{{#if hasEnums}}, enums = {}{{/if}} }, getRoute, pathFor, router }) => {
   const item = Array.isArray({{lower}}) ? {{lower}}[0] : {{lower}};
 
   if (!item) {
@@ -35,6 +35,9 @@ const Edit = ({ data: { {{lower}} = null }, getRoute, pathFor, router }) => {
         <{{doc}}Form
           action={pathFor('update_{{plural}}_path', { id })}
           data={item}
+          {{#if hasEnums}}
+          enums={enums}
+          {{/if}}
           button="Update"
           onSuccess={() => router.push(getRoute('show_{{plural}}_path', id))}
         />

--- a/packages/cli/scripts/generate/react-index.hbs
+++ b/packages/cli/scripts/generate/react-index.hbs
@@ -34,8 +34,8 @@ const Index = ({ data: { {{plural}} = [] }, fetch, getRoute, hydrate, pathFor })
         <table className="w-full text-left">
           <thead className="border-b border-zinc-200 bg-zinc-50 text-xs uppercase text-zinc-500 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400">
             <tr>
-              {{#each keys}}
-              <th className="px-4 py-2 font-medium">{{this}}</th>
+              {{#each fields}}
+              <th className="px-4 py-2 font-medium">{{name}}</th>
               {{/each}}
               <th className="px-4 py-2 text-right font-medium">Actions</th>
             </tr>
@@ -45,7 +45,7 @@ const Index = ({ data: { {{plural}} = [] }, fetch, getRoute, hydrate, pathFor })
               <tr>
                 <td
                   className="px-4 py-12 text-center text-sm text-zinc-500 dark:text-zinc-400"
-                  colSpan={ {{keys.length}} + 1}
+                  colSpan={ {{fields.length}} + 1}
                 >
                   Nothing to show
                 </td>
@@ -56,8 +56,8 @@ const Index = ({ data: { {{plural}} = [] }, fetch, getRoute, hydrate, pathFor })
                 key={item.{{identifier}} }
                 className="hover:bg-zinc-50 dark:hover:bg-zinc-900"
               >
-                {{#each keys}}
-                <td className={cell}>{String(item.{{this}} ?? '')}</td>
+                {{#each fields}}
+                <td className={cell}>{String(item.{{name}} ?? '')}</td>
                 {{/each}}
                 <td className={`${cell} space-x-4 whitespace-nowrap text-right`}>
                   <Link className={link} href={getRoute('show_{{plural}}_path', item.{{identifier}})}>

--- a/packages/cli/scripts/generate/react-new.hbs
+++ b/packages/cli/scripts/generate/react-new.hbs
@@ -2,9 +2,13 @@ import Link from 'next/link';
 import withHenri from '@usehenri/react';
 import {{doc}}Form from './_form';
 
-// Rendered by the `new` action (no data). The form posts to the `create`
-// action and the page moves to the listing once the controller answered.
-const New = ({ getRoute, pathFor, router }) => (
+{{#if hasEnums}}
+// Rendered by the `new` action, whose only data is `enums`: the values the
+// <Select>s of the form offer.
+{{/if}}
+// The form posts to the `create` action and the page moves to the listing
+// once the controller answered.
+const New = ({ {{#if hasEnums}}data: { enums = {} }, {{/if}}getRoute, pathFor, router }) => (
   <main className="mx-auto w-full max-w-lg px-6 py-12">
     <Link
       className="text-sm text-zinc-500 hover:underline dark:text-zinc-400"
@@ -17,6 +21,9 @@ const New = ({ getRoute, pathFor, router }) => (
     <div className="mt-8 rounded-xl border border-zinc-200 p-6 dark:border-zinc-800">
       <{{doc}}Form
         action={pathFor('create_{{plural}}_path')}
+        {{#if hasEnums}}
+        enums={enums}
+        {{/if}}
         button="Create"
         onSuccess={() => router.push(getRoute('index_{{plural}}_path'))}
       />

--- a/packages/cli/scripts/generate/react-show.hbs
+++ b/packages/cli/scripts/generate/react-show.hbs
@@ -32,10 +32,10 @@ const Show = ({ data: { {{lower}} = null }, getRoute }) => {
       <p className="mt-1 font-mono text-xs text-zinc-500 dark:text-zinc-400">{id}</p>
 
       <dl className="mt-8 overflow-hidden rounded-xl border border-zinc-200 text-sm dark:border-zinc-800">
-        {{#each keys}}
+        {{#each fields}}
         <div className="flex gap-4 border-b border-zinc-200 px-5 py-3 last:border-0 dark:border-zinc-800">
-          <dt className="w-32 shrink-0 text-zinc-500 dark:text-zinc-400">{{this}}</dt>
-          <dd className="min-w-0 flex-1">{String(item.{{this}} ?? '')}</dd>
+          <dt className="w-32 shrink-0 text-zinc-500 dark:text-zinc-400">{{name}}</dt>
+          <dd className="min-w-0 flex-1">{String(item.{{name}} ?? '')}</dd>
         </div>
         {{/each}}
       </dl>

--- a/packages/cli/scripts/help.js
+++ b/packages/cli/scripts/help.js
@@ -716,7 +716,12 @@ const COMMANDS = [
       'in the henri layout. Existing files are skipped; --force overwrites',
       'them.',
       `Field types: ${FIELD_TYPES} (default: string).`,
-      'A trailing ! makes the field required.',
+      'A trailing ! makes the field required, and :enum=draft,live says the',
+      'values a string column may hold.',
+      'The pages follow the model file: an enum column is a <select> of the',
+      "list the controller sends (Model.enums), a required column's input is",
+      'required, and a column marked personal: { expose: false } -- which',
+      'henri strips from every answer it builds -- is on no page at all.',
       'Scaffolded controllers answer HAL to JSON clients (Accept:',
       'application/json or application/hal+json): res.collection() for the',
       'index (paginated with ?page=&per_page=), res.resource() for one',
@@ -743,6 +748,12 @@ const COMMANDS = [
         command: 'henri g scaffold Article title:string! --slug title',
         description:
           'The same, with a slug: the urls carry /articles/how-we-ship rather than the uuid',
+      },
+      {
+        command:
+          'henri g scaffold Post title:string! status:string:enum=draft,live',
+        description:
+          'A column that can only hold those values: the form gets a <select> of them, not a text input',
       },
       {
         command: 'henri g worker cleanup',
@@ -789,8 +800,9 @@ const COMMANDS = [
       'write models, controllers, routes, views, mailers, workers and tests',
     targets: [
       {
-        description: 'app/models/<Name>.js (singular, PascalCase)',
-        name: 'model <Name> [field:type[!] ...]',
+        description:
+          'app/models/<Name>.js (singular, PascalCase). A field is name:type, ! marks it required and :enum=a,b,c the values it may hold',
+        name: 'model <Name> [field:type[!][:enum=a,b] ...]',
       },
       {
         description: 'app/controllers/<name>.js and one route per action',
@@ -820,12 +832,12 @@ const COMMANDS = [
       },
       {
         description: 'model, JSON controller and the crud routes',
-        name: 'crud <Name> [field:type[!] ...] [--slug <field>]',
+        name: 'crud <Name> [field:type[!][:enum=a,b] ...] [--slug <field>]',
       },
       {
         description:
-          'model, resources controller, resources routes and the pages. `--slug <field>` gives the model a name a person reads in a url and writes the controller and the pages to use it',
-        name: 'scaffold <Name> [field:type[!] ...] [--slug <field>]',
+          'model, resources controller, resources routes and the pages. The pages follow the model file: an enum column is a <select>, a required one a required input, and a column marked personal: { expose: false } is on no page at all. `--slug <field>` gives the model a name a person reads in a url and writes the controller and the pages to use it',
+        name: 'scaffold <Name> [field:type[!][:enum=a,b] ...] [--slug <field>]',
       },
       {
         description:

--- a/packages/cli/scripts/init.js
+++ b/packages/cli/scripts/init.js
@@ -820,6 +820,12 @@ const storeNotice = (store) => {
 /**
  * The sample Task resource: model, controller, routes, views and a test
  *
+ * The model is written here rather than by the generator because of the
+ * `default` on `category`, which no `name:type` pair can express. The
+ * `enum` next to it is read back: the generator runs over the file this
+ * wrote, so the scaffolded form gets a `<select>` of those four values
+ * (`fieldsOf` in scripts/generate.js).
+ *
  * @param {boolean} force Overwrite existing files
  * @returns {Promise<void>} Resolves when written
  */

--- a/packages/mcp/src/server.js
+++ b/packages/mcp/src/server.js
@@ -21,7 +21,8 @@ const { version } = require('../package.json');
  */
 const NAME = /^[A-Za-z][A-Za-z0-9_]*$/;
 const CONTROLLER = /^[A-Za-z][A-Za-z0-9_]*(\/[A-Za-z][A-Za-z0-9_]*)*$/;
-const ATTRIBUTE = /^[A-Za-z_][A-Za-z0-9_]*!?(:[A-Za-z]+!?)?$/;
+const ATTRIBUTE =
+  /^[A-Za-z_][A-Za-z0-9_]*!?(:[A-Za-z]+!?(:enum=[A-Za-z0-9_-]+(,[A-Za-z0-9_-]+)*)?)?$/;
 const ACTION = /^[a-z][A-Za-z0-9_]*$/;
 const ROUTE_KEY = /^([a-z-]+ )?\/[A-Za-z0-9_\-/:.]*$/i;
 const TEST_FILE = /^(?!-)[A-Za-z0-9_.\-/]+$/;
@@ -609,7 +610,7 @@ const createServer = ({ cwd = process.cwd() } = {}) => {
     {
       annotations: { destructiveHint: false, idempotentHint: false },
       description:
-        'Runs a henri generator (the same as `henri generate`) and returns the files written, the files skipped and the routes added. scaffold/model/crud take attributes ("title:string!", "body:text"; types: string, text, number, integer, float, decimal, bigint, boolean, date, json, uuid; ! = required), controller and mailer take action names, authentication and agents take nothing. `authentication` turns the account flows on in config/*.json and writes the pages, the controller, the mailer and the tests around the endpoints henri mounts. Existing files are skipped unless force is true.',
+        'Runs a henri generator (the same as `henri generate`) and returns the files written, the files skipped and the routes added. scaffold/model/crud take attributes ("title:string!", "body:text", "status:string:enum=draft,live"; types: string, text, number, integer, float, decimal, bigint, boolean, date, json, uuid; ! = required, :enum= the values a string column may hold), controller and mailer take action names, authentication and agents take nothing. `authentication` turns the account flows on in config/*.json and writes the pages, the controller, the mailer and the tests around the endpoints henri mounts. Existing files are skipped unless force is true.',
       inputSchema: {
         actions: zod
           .array(zod.string().regex(ACTION))
@@ -618,7 +619,9 @@ const createServer = ({ cwd = process.cwd() } = {}) => {
         attributes: zod
           .array(zod.string().regex(ATTRIBUTE))
           .optional()
-          .describe('scaffold, model, crud: name:type! attributes'),
+          .describe(
+            'scaffold, model, crud: name:type! attributes, optionally :enum=a,b'
+          ),
         force: zod
           .boolean()
           .optional()

--- a/packages/react/__tests__/templates.test.js
+++ b/packages/react/__tests__/templates.test.js
@@ -9,14 +9,31 @@ const { parse } = require('@babel/parser');
 
 const dir = path.resolve(__dirname, '../../cli/scripts/generate');
 const views = ['_form', 'index', 'new', 'edit', 'show'];
+// What `resourceOf()` in packages/cli/scripts/generate.js hands a template:
+// the fields the command line named, annotated with what the model file
+// says about each of them
 const context = {
   doc: 'Post',
+  fields: [
+    { enum: null, name: 'title', required: true },
+    { enum: null, name: 'body', required: false },
+  ],
+  hasEnums: false,
   // What a url of one record carries: `externalId`, or the `slug` of a
   // model that declared one (see base/slug.js)
   identifier: 'externalId',
-  keys: ['title', 'body'],
   lower: 'post',
   plural: 'posts',
+};
+
+/** The same resource with an enum column, which is a <Select> */
+const withEnum = {
+  ...context,
+  fields: [
+    ...context.fields,
+    { enum: ['draft', 'live'], name: 'status', required: false },
+  ],
+  hasEnums: true,
 };
 
 /**
@@ -39,7 +56,9 @@ describe('react scaffold templates', () => {
     const { ast, code } = compile(view);
 
     expect(ast.program.body.length).toBeGreaterThan(1);
-    expect(code).not.toMatch(/\{\{\s*(doc|lower|plural|this|keys|#|\/)/);
+    expect(code).not.toMatch(
+      /\{\{\s*(doc|lower|plural|this|fields|name|enum|hasEnums|#|\/)/
+    );
     expect(code).not.toContain('_scaffold');
   });
 
@@ -100,13 +119,31 @@ describe('react scaffold templates', () => {
     }
   });
 
-  test('the form renders an input per key', () => {
+  test('the form renders an input per field, required where it is', () => {
     const { code } = compile('_form');
 
     expect(code).toContain('name="title"');
     expect(code).toContain('name="body"');
     expect(code).toContain('const PostForm');
     expect(code).toContain('<FormError');
+    // The model says which: `title` is required and `body` is not
+    expect(code).toMatch(/name="title"[^>]+required/);
+    expect(code).not.toMatch(/name="body"[^>]+required/);
+    expect(code).not.toContain('<Select');
+  });
+
+  test('an enum column is a Select of the list the controller sends', () => {
+    const { ast, code } = compile('_form', withEnum);
+
+    expect(ast.program.body.length).toBeGreaterThan(1);
+    expect(code).toContain(
+      "import { Button, Form, FormError, Input, Select } from '@usehenri/react/forms'"
+    );
+    expect(code).toMatch(/<Select[^>]+choices=\{enums\.status \|\| \[\]\}/);
+    // The values themselves are never written into the page
+    expect(code).not.toContain('draft');
+    expect(compile('new', withEnum).code).toContain('enums={enums}');
+    expect(compile('edit', withEnum).code).toContain('enums={enums}');
   });
 
   test('the pages are styled with tailwind, dark mode included', () => {
@@ -120,10 +157,15 @@ describe('react scaffold templates', () => {
     }
   });
 
-  test('templates survive names with several keys and none', () => {
-    expect(() => compile('index', { ...context, keys: [] }).ast).not.toThrow();
+  test('templates survive several fields and none', () => {
+    expect(
+      () => compile('index', { ...context, fields: [] }).ast
+    ).not.toThrow();
     expect(() =>
-      compile('_form', { ...context, keys: ['a', 'b', 'c', 'd'] })
+      compile('_form', {
+        ...context,
+        fields: ['a', 'b', 'c', 'd'].map((name) => ({ name })),
+      })
     ).not.toThrow();
   });
 

--- a/website/src/content/docs/getting-started.md
+++ b/website/src/content/docs/getting-started.md
@@ -73,7 +73,7 @@ henri server
 └── vitest.config.js
 ```
 
-If you have a Ruby on Rails background, this should look familiar. The sample resource is a regular scaffold (`henri generate scaffold Task name:string! category:string done:boolean` writes the same files); `henri destroy scaffold Task` removes it.
+If you have a Ruby on Rails background, this should look familiar. The sample resource is a regular scaffold (`henri generate scaffold Task name:string! category:string:enum=urgent,high,medium,low done:boolean` writes the same files, bar the default the sample `category` carries); `henri destroy scaffold Task` removes it. Its form shows what the generator reads off the model: `name` is required so its input is, and `category` can only hold four values so it is a `<select>` of them.
 
 The pages are styled: [Tailwind CSS](https://tailwindcss.com) v4 is wired for the renderer you picked, `app/views/styles/index.css` is the whole stylesheet, and dark mode follows the operating system. Everything the generators write from now on is styled the same way. See [Views](/guides/views/#styles) for the theme, the `@source` globs and how to opt out.
 

--- a/website/src/content/docs/guides/models.md
+++ b/website/src/content/docs/guides/models.md
@@ -251,6 +251,8 @@ Never index a model with a string that came from a request: `Post[req.query.stat
 res.render('/posts', { data: { states: Post.enums.status, posts } });
 ```
 
+This is what a scaffolded page already does: `henri generate scaffold` writes a `new` and an `edit` action that send `Post.enums`, and a form whose `<select>` maps over the list it was given. Regenerate the pages of a model that grew an `enum` (`--force`) to pick it up.
+
 ### The names
 
 `draft` gives `isDraft` and `draft`. `in_review`, `in-review`, `IN_REVIEW` and `InReview` all give `inReview`: the value is split on everything that is not a letter or a digit and at every lower-to-upper boundary, then camel cased. Two values of one model that come out the same name are refused, because they would be the same method.
@@ -694,7 +696,13 @@ On Mongoose the behaviour is a schema plugin: it adds the `deletedAt` path, a qu
 henri generate model Post title:string! body:text published:boolean views:integer
 ```
 
-writes `app/models/Post.js` with one field per `name:type` argument (`string` when the type is omitted, `!` marks it required) and refuses unknown types. `henri generate scaffold` and `crud` start with the same model and add the controller, routes and views; see the [CLI reference](/reference/cli/#generators).
+writes `app/models/Post.js` with one field per `name:type` argument (`string` when the type is omitted, `!` marks it required) and refuses unknown types. One setting follows the type, `:enum=draft,in_review,live`, and it is there because it is the mark the generated pages read back:
+
+```bash
+henri generate scaffold Post title:string! status:string:enum=draft,in_review,live
+```
+
+writes the column, the [predicates and the scopes](#enums-predicates-scopes-and-the-list) that come with it, and a form whose `status` field is a `<select>` of those values rather than a text input. Everything else a column can say — a `default`, `unique`, `index`, a `personal` mark — is written in the model file, which is where the generators read it: a `henri generate scaffold` or `crud` run over a model that already exists follows what that file says. `henri generate scaffold` and `crud` start with the same model and add the controller, routes and views; see the [CLI reference](/reference/cli/#generators).
 
 ## Querying
 

--- a/website/src/content/docs/guides/privacy.md
+++ b/website/src/content/docs/guides/privacy.md
@@ -139,6 +139,14 @@ marked `expose: false` fails the boot unless the rule says `expose: true`.
 field is then private unless it says `personal: { expose: true }`. It is one
 line, and it is the strict reading of the same rule.
 
+`henri generate scaffold` reads the mark too: a column marked
+`expose: false` is written into no page — not the table, not the detail
+list, not the form — because a page showing it would show an empty column
+forever, and a form posting it would write the empty string it had to
+display over the stored value. The controller's `FIELDS` still names it,
+with a comment saying so: what the mark governs is answers, and a write is
+not an answer.
+
 ## Which model is a person
 
 The user model (`config.user.model`). henri's notion of a person is the one it

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -245,8 +245,11 @@ Model and resource names are given in the singular with a capital: `Post` gives 
 
 Fields are `name:type`, `string` when the type is omitted; a trailing `!` (`name:string!` or `name!:string`) makes the field required. Types: `string`, `text`, `number`, `integer`, `float`, `decimal`, `bigint`, `boolean`, `date`, `json`, `uuid`, mapped by each adapter (see [Models](/guides/models/#the-schema-format)); anything else is refused. A generated `decimal` is written out as `{ type: 'decimal', precision: 12, scale: 2 }`, because a field somebody spells `price:decimal` is money and the default (19, 4) is not — see [Exact numbers](/guides/models/#exact-numbers).
 
+One setting follows the type: `status:string:enum=draft,in_review,live`, the values a `string` or `text` column may hold ([Enums](/guides/models/#enums-predicates-scopes-and-the-list)). It is the only one, and it is there because it is the mark the pages read back; everything else a column says — `default`, `unique`, `index`, a `personal` mark — is written in the model file. Anything else after the type is refused, as is an `enum=` on a column whose values a command line cannot spell.
+
 ```bash
 henri generate model User name:string! birthday:date
+henri g scaffold Post title:string! status:string:enum=draft,live
 henri generate controller locations index show
 henri g scaffold HighScore game:string! score:integer
 henri g job welcome
@@ -262,7 +265,18 @@ henri g authentication
 
 The scaffolded controllers follow the adapter of the default store: the Drizzle model API on `drizzle`, `postgresql` and `mysql`, the Mongoose API on `disk` and `mongoose`, Sequelize on `mssql` (see [Models](/guides/models/)). What they load a record with differs; their `index` is [`Model.paginate(req.pagination())`](/guides/models/#pagination) and their 422 is [`henri.model.errors(error)`](/guides/models/#validation-errors) on all three, because both answer the same shape on every adapter. They declare no [`params`](/guides/controllers/#params-what-an-action-accepts) block, so that model refusal is the only 422 a generated action gives.
 
-The pages follow the `renderer` of the application, read back from `config/default.json`: Inertia `.jsx` pages using `useHenri()` and `<Form>`, or Next.js `.js` pages using `withHenri` and `@usehenri/react/forms`. The renderer is also what a failed write answers a browser with: the Inertia controllers call `res.inertia.errors()` and render the form again, the React ones answer the `422` their forms read. API clients get the same `422` either way, and `henri generate test` writes the matching test (the Inertia page object plus the HAL answers, or the HAL answers alone).
+The pages follow the model file as well as the command line. The fields come from the `name:type` arguments; what each of them _is_ comes from `app/models/<Name>.js` — the one this run wrote, or the one that was already there, read off the disk the way `--slug` is:
+
+| The model says                | The pages write                                                                                                                 |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `enum: ['draft', 'live']`     | a `<select>` of `Model.enums.<field>`, which the `new` and `edit` actions send — never a copy of the list written into the page |
+| `required: true`              | a `required` input (and only there: a column that is not required does not get one)                                             |
+| `personal: { expose: false }` | nothing at all: no table column, no detail row, no form field. `FIELDS` in the controller keeps it, with a comment saying why   |
+| `options: { slug: 'title' }`  | urls built from `record.slug` rather than the `externalId`                                                                      |
+
+The `personal` one is the case worth stating: henri drops a field marked `expose: false` from [every answer it builds](/guides/privacy/#what-the-mark-does), at every depth, so a page showing it would show an empty column forever and a form posting it would write the empty string it had to display over the stored value. A write is not an answer, so the controller still permits it — an API client, or a form you write yourself, may set it. A field marked `personal` _without_ `expose: false` is a field like any other here: whether it is stripped is `config.privacy.expose`, which is per environment, and a page is one file for all of them.
+
+The pages follow the `renderer` of the application, read back from `config/default.json`: Inertia `.jsx` pages using `useHenri()` and `<Form>`, or Next.js `.js` pages using `withHenri` and `@usehenri/react/forms` (where an `enum` column is the package's own `<Select choices={...}>`). The renderer is also what a failed write answers a browser with: the Inertia controllers call `res.inertia.errors()` and render the form again, the React ones answer the `422` their forms read. API clients get the same `422` either way, and `henri generate test` writes the matching test (the Inertia page object plus the HAL answers, or the HAL answers alone).
 
 ## `destroy`
 


### PR DESCRIPTION
## What was wrong

`henri generate scaffold` wrote pages from `name:type` pairs and nothing else, so a column that can hold exactly four values got a text input — including in the sample application `henri new` writes, whose `Task.category` is an enum. The generator never saw it: `init.js` writes that model **by hand** (for the `default`, which no `name:type` pair can express) and then calls the generator with `category:string`.

Reading the model file back is not new — `--slug` already did it, off disk, without booting. That mechanism is now `modelFileOf()` and both callers share it.

## Marks honoured

| mark | what the pages do now |
| --- | --- |
| `enum` | a `<select>` of `Model.enums.<field>`; the controller's `new`/`edit` (and the re-render after a failed write) send `enums: Model.enums`, and the form maps over what it was given |
| `required` | a `required` input — **and only there** |
| `personal: { expose: false }` | in no page at all: no table column, no detail row, no form field. `FIELDS` keeps it, with a generated comment saying why |
| `slug` | unchanged; it is the precedent |

**Two things it found on the way in.** The React `_form.hbs` put `required` *and* a `minLength` validation on **every** input, so an optional column was required in the browser — a bug in the opposite direction, fixed by honouring the mark. And a field marked `expose: false` in an edit form was worse than cosmetic: the value never *arrives*, so the form showed an empty string and posted it back over the stored one.

**My brief was wrong on one point and the teammate checked rather than accepting it.** I wrote that `req.permit()` drops `expose: false` fields; it does not — `base/params.js` contains no privacy logic at all, which I confirmed. The mark is an *answer*-side rule (#412's floor), and that asymmetry is exactly why the field leaves the pages and stays in `FIELDS`: a write is not an answer.

## Declined, with reasons

- **Predicates on the show page.** A predicate is a method of a record and is gone by the time the record is JSON — `base/enums.js` and the models guide both say so.
- **Copying the enum values into the page.** The guide says pass the list, not a hand-written copy; a copy silently stops offering a value the model gained.
- **`config.privacy.expose: false`**, the app-wide switch: it is per *environment* and a page is one file for every environment. Only the absolute field-level mark is read.
- Type-aware inputs (a checkbox for `boolean`): not a mark, and not this tranche.

## The model-generator syntax

Landed rather than deferred: `status:string:enum=draft,in_review,live`, the one setting a `name:type` pair takes after its type. It refuses an unknown setting, an `enum=` on a non-text column, empty values and duplicates. The grammar is closed at that single word on purpose — it is the only mark the pages read back, and a `default`, `unique` or `personal` belongs in the model file, which is where the generators now read it. `henri mcp`'s `generate` tool accepts the same attribute.

`henri new` still hand-writes the sample `Task` model, which makes it the worked example of "the generator reads a mark you wrote".

## What I verified myself

Scaffolded an application with this branch's CLI and read the generated files. `Task.category` (an enum written by hand into the model) produces:

```jsx
<select className={field} defaultValue={data.category ?? ''} name="category">
  <option value="">Choose...</option>
  {(enums.category || []).map((value) => (…))}
</select>
```

with `enums: Task.enums` sent from `new`, `edit` and both failure re-renders — the list, not a copy — while `name` (declared `name:string!`) is the only `required` input. The output reads like something a person would have written, which is the standing bar for these templates.

## Gates

`pnpm test` (4514), `pnpm test:types`, `pnpm lint --max-warnings 0`, `pnpm format:check`, the showcase against live PostgreSQL (172), and **`scripts/smoke.sh` on both renderers** — the inertia default and `SMOKE_RENDERER=react`, each scaffolding an application from the packed workspace and booting it, which is the only gate that catches a generated page that does not compile.

## Left

The generated pages are still a snapshot in every other respect: regenerate with `--force` after a mark changes, which the CLI reference, the models guide and AGENTS.md all now say. The command line still decides *which* fields appear; the model file only says what they are.