### PR TITLE
A job bounds how many of it run at once, across every runner

### DIFF
--- a/.changeset/loud-pans-search.md
+++ b/.changeset/loud-pans-search.md
@@ -1,0 +1,26 @@
+---
+'@usehenri/jobs': minor
+'@usehenri/core': minor
+'@usehenri/drizzle': minor
+'@usehenri/cli': minor
+---
+
+Per-job concurrency limits. `henri jobs --concurrency` bounds a runner; a job
+now bounds itself across every runner: `concurrency: 1` for one at a time,
+`concurrency: { limit: 3, key: 'tenantId' }` for three per key, and `group` for
+several jobs sharing one bound. The permit is taken before the work, from a
+table the queue owns whose primary key is the bound — the one primitive that
+means the same thing on PostgreSQL, MySQL, MSSQL, sqlite and MongoDB, which an
+in-claim `COUNT(*)` does not. The claim statement keeps its shape and an
+application with no limited job sends the one it always sent.
+
+An existing queue gains one column, added by the same idempotent
+`henri jobs:install` the boot already runs. It is tolerated: an application
+with no limited job is unaffected whether it applied or not, and one that
+declares a limit whose table cannot hold it refuses to start
+(`HENRI_JOB_LIMIT_UNINSTALLED`) rather than running unbounded. A job already in
+the queue when the limit was declared is bounded too.
+
+`henri jobs:status` and `henri.jobs.limits()` report what was asked for and
+which slots are held. The guide says why henri mounts no dashboard, and what
+to build one from.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1201,12 +1201,36 @@ duration, rows, requestId, source, callsite }` -- and the N+1 detector is
   dialect (`FOR UPDATE SKIP LOCKED`, `UPDATE ... ORDER BY ... LIMIT`,
   `UPDLOCK, READPAST`, a subquery on sqlite, `findOneAndUpdate` on MongoDB)
   and the claimed rows are read back by the token it stamped, so two runners
-  never perform one job. `henri.jobs.recur(name, entry)` is the seam a
+  never perform one job. **A job bounds itself across every runner**
+  (`concurrency: 1`, or `{ limit, key, group }`), which `--concurrency` --
+  a bound on one _runner_ -- never could. The bound is **not** counted
+  inside the claim: a `COUNT(*)` there reads the statement's own snapshot,
+  so two runners both see the same room, and `SKIP LOCKED` locks the
+  candidate rows rather than the count. Making it exact needs a lock per key,
+  which is `pg_advisory_xact_lock`, `GET_LOCK`, `sp_getapplock` and nothing
+  at all on MongoDB. So it lives in a third table the queue owns
+  (`henri_jobs_limits`), one row per slot with `(limit_key, slot)` as its
+  primary key: **a unique index refusing a duplicate**, the one primitive
+  that means the same thing on all five backends. The permit is taken
+  _before_ the row is claimed, never after -- claim-then-put-back spins the
+  loop, which only sleeps when a tick claimed nothing. The claim keeps its
+  shape and gains one predicate: `name NOT IN (...)` on the unlimited pass
+  (byte identical when nothing is limited) and
+  `name IN (...) AND concurrency_key = ?` with a limit of one on the other,
+  partitioned by **name** so a job that gains or loses a limit is always in
+  exactly one pass. The bound rests on the heartbeat, the same clock the
+  recovery does. The one column it stores (`concurrency_key`) is added by a
+  **tolerated** `ALTER` inside the idempotent install, and the store _asks
+  the table_ rather than trusting it ran: an application with no limit is
+  unaffected either way, and one that declares a limit the table cannot hold
+  fails the boot (`HENRI_JOB_LIMIT_UNINSTALLED`) rather than running it
+  unbounded. `henri.jobs.recur(name, entry)` is the seam a
   framework module uses to ask for a schedule the configuration did not
   write (`henri.retention` is the one that does); an entry the application
   declared under the same name wins. `henri jobs` runs a worker (`--queue`,
   `--concurrency`, `--once`), `henri jobs:install|status|list|dead|show|
-perform|retry|discard` drive it. The module also registers
+perform|retry|discard` drive it; `jobs:status` and `henri.jobs.limits()`
+  report the limits and the slots held. The module also registers
   `henri.mailers.onDeliverLater()`, so `deliverLater()` enqueues the rendered
   message as the built-in `henri/mail` job.
 - Outbound webhooks live in `@usehenri/webhooks`, which peer-depends on core
@@ -1678,7 +1702,8 @@ the LICENSE and a README into every public package at publish time
   collations. On a drizzle store the answer carries `migrations` rather
   than `drift`, which is what `henri db:status` answers there.
 - The tables henri owns in a drizzle store (`henri_jobs`,
-  `henri_jobs_schedules`, `henri_trail`, `henri_calls`, `henri_versions`)
+  `henri_jobs_schedules`, `henri_jobs_limits`, `henri_trail`, `henri_calls`,
+  `henri_versions`)
   are created through
   raw SQL, so drizzle-kit sees them as tables the schema no longer wants.
   `Drizzle#reservedTables()` is what keeps a push from dropping them, and
@@ -1797,6 +1822,27 @@ the LICENSE and a README into every public package at publish time
   `mongo.spec.js`; `pnpm test:sql:live` runs the SQL ones on real servers with
   concurrent connection pools). MSSQL only has its generated DDL and claim
   statement covered offline, like the rest of that adapter.
+- The **concurrency limits** are new. `packages/jobs/__tests__/
+concurrency.spec.js` proves the negative property the way `claim.spec.js`
+  proves the claim -- a queue and a connection pool per runner, and the jobs
+  themselves recording their overlap (`__tests__/live.js`), because a count
+  taken afterwards cannot tell two jobs that overlapped from two that did
+  not. It runs on sqlite offline and on the live PostgreSQL and MySQL, and
+  the same file also downgrades a table (`ALTER TABLE ... DROP COLUMN`) to
+  prove the upgrade path on a real server; MongoDB has its own in
+  `mongo.spec.js`, MSSQL only its DDL. What is **left**: **batching** (a set
+  of jobs plus one that runs when they are all done) -- the promises are
+  decided and written in `guides/jobs.md#what-is-not-here`, and what it needs
+  is another column plus a table, which is the same upgrade question and so
+  a tranche of its own. There is **no dashboard and there will not be one**;
+  the argument is in the same guide (`#no-dashboard-and-what-to-build-one-from`)
+  and it is that `/_routes`, `/_openapi.json` and `/_mailers` describe the
+  _application_ while a queue page would display its _data_ -- job arguments,
+  which the privacy tranche marks personal -- and that the place a dashboard
+  is wanted is production, where henri must mount none. `henri.jobs.limits()`
+  next to `stats()`, `list()` and `dead.*`, plus `--json` on every command,
+  is what an application builds its own read-only page from, behind its own
+  policy.
 - The call log (`config.calls`) is new. Its table, its join, its bodies and
   its bounded delete are covered on sqlite offline and on the live
   PostgreSQL and MySQL of `pnpm test:sql:live`

--- a/packages/cli/__tests__/fixtures/jobs-app/app/jobs/import.js
+++ b/packages/cli/__tests__/fixtures/jobs-app/app/jobs/import.js
@@ -1,0 +1,6 @@
+// One at a time per account, across every runner
+module.exports = {
+  concurrency: { key: 'account', limit: 1 },
+
+  perform: async (args) => args,
+};

--- a/packages/cli/__tests__/jobs.spec.js
+++ b/packages/cli/__tests__/jobs.spec.js
@@ -119,6 +119,7 @@ describe('henri jobs', () => {
         store: 'default',
         tables: {
           jobs: 'henri_jobs',
+          limits: 'henri_jobs_limits',
           schedules: 'henri_jobs_schedules',
         },
       });
@@ -196,8 +197,12 @@ describe('henri jobs', () => {
       expect(status).toBe(0);
       expect(result.totals.done).toBe(1);
       expect(result.jobs).toEqual(
-        expect.arrayContaining(['boom', 'henri/mail', 'ping'])
+        expect.arrayContaining(['boom', 'henri/mail', 'import', 'ping'])
       );
+      expect(result.limits.declared).toEqual([
+        { group: 'import', job: 'import', keyed: true, limit: 1 },
+      ]);
+      expect(result.limits.held).toEqual([]);
       expect(result.recurring).toEqual([
         { job: 'ping', name: 'nightly', spec: 'cron:0 3 * * *' },
       ]);
@@ -311,6 +316,8 @@ describe('henri jobs', () => {
       expect(answer.stdout).toContain('pending');
       expect(answer.stdout).toContain('Recurring:');
       expect(answer.stdout).toContain('nightly -> ping');
+      expect(answer.stdout).toContain('Concurrency:');
+      expect(answer.stdout).toContain('import -> 1 at a time per key');
     });
   }, 300000);
 });

--- a/packages/cli/scripts/generate.js
+++ b/packages/cli/scripts/generate.js
@@ -556,6 +556,12 @@ module.exports = {
   // How long one attempt may take; the job is failed when it runs over
   timeout: '5m',
 
+  // How many of this job may run at once, across every runner. Uncomment to
+  // bound it: \`1\` for one at a time, \`{ limit: 3, key: 'tenantId' }\` for
+  // three per key of the arguments. \`henri jobs --concurrency\` bounds a
+  // runner; this bounds the job
+  // concurrency: 1,
+
   perform: async (args, { henri, job, signal }) => {
     henri.pen.info('${lower}', job.id, \`attempt \${job.attempt}\`);
     // Throw to fail the attempt: it is retried with an exponential backoff.

--- a/packages/cli/scripts/jobs.js
+++ b/packages/cli/scripts/jobs.js
@@ -179,14 +179,16 @@ const status = async (args) => {
     spec: entry.spec,
   }));
   let stats;
+  let limits;
 
   try {
     stats = await jobs.stats();
+    limits = await jobs.limits();
   } finally {
     await henri.stop();
   }
 
-  return { command: 'status', ok: true, recurring, ...stats };
+  return { command: 'status', limits, ok: true, recurring, ...stats };
 };
 
 /**
@@ -482,6 +484,23 @@ const print = (result) => {
       console.log('  Recurring:');
       result.recurring.forEach((entry) =>
         console.log(`    ${entry.name} -> ${entry.job} (${entry.spec})`)
+      );
+    }
+
+    if (result.limits && result.limits.declared.length > 0) {
+      console.log('');
+      console.log('  Concurrency:');
+      result.limits.declared.forEach((entry) =>
+        console.log(
+          `    ${entry.job} -> ${entry.limit} at a time${entry.keyed ? ' per key' : ''}${entry.group === entry.job ? '' : ` (group ${entry.group})`}`
+        )
+      );
+
+      // What is holding a limit up right now, which no other command says
+      result.limits.held.forEach((held) =>
+        console.log(
+          `    held ${held.key}#${held.slot} by ${held.runner}${held.job ? ` for ${held.job}` : ''}`
+        )
       );
     }
   }

--- a/packages/core/error-codes.json
+++ b/packages/core/error-codes.json
@@ -1212,12 +1212,35 @@
     {
       "area": "job",
       "causes": [
+        "two jobs of one `concurrency.group` asking for different limits",
+        "a group renamed in one file and not in the other"
+      ],
+      "code": "HENRI_JOB_CONCURRENCY_CONFLICT",
+      "fix": "Jobs that share a concurrency group share one bound, so they have to agree on it: give them the same `limit`, or a `group` each.",
+      "what": "Two jobs share a concurrency group and disagree on how many may run."
+    },
+    {
+      "area": "job",
+      "causes": [
         "an argument that is a function, a class, a bigint or a cycle",
         "a model instance passed whole instead of its id"
       ],
       "code": "HENRI_JOB_INVALID_ARGUMENTS",
       "fix": "The arguments of a job are stored as JSON: pass ids and plain values, and look the records up inside `perform()`.",
       "what": "The arguments of a job cannot be stored."
+    },
+    {
+      "area": "job",
+      "causes": [
+        "a `concurrency` that is neither a number nor `{ limit }`",
+        "a limit that is not a whole number above zero",
+        "a `key` that is neither the name of an argument nor a function",
+        "a key function that threw, or answered an object",
+        "a key longer than the 190 characters the column holds"
+      ],
+      "code": "HENRI_JOB_INVALID_CONCURRENCY",
+      "fix": "`concurrency: 3` bounds the job itself; `concurrency: { limit: 3, key: 'tenantId' }` bounds each key of its own. A key names one bound, so it is an id or a name -- hash it yourself if it has to be longer.",
+      "what": "A job declares a concurrency limit henri cannot read."
     },
     {
       "area": "job",
@@ -1262,6 +1285,17 @@
       "code": "HENRI_JOB_INVALID_SCHEDULE",
       "fix": "A schedule is `{ job, cron | every, args?, queue? }` and its `job` is the name of a file in app/jobs. The message names the entry that is wrong.",
       "what": "A recurring job of the configuration is not shaped like a schedule."
+    },
+    {
+      "area": "job",
+      "causes": [
+        "a queue installed by a henri older than 1.3, whose table has no `concurrency_key` column",
+        "`jobs.install: false` with no `henri jobs:install` since the upgrade",
+        "a database user that may not ALTER the table"
+      ],
+      "code": "HENRI_JOB_LIMIT_UNINSTALLED",
+      "fix": "Run `henri jobs:install` once with a user that may alter the table. The queue works without the column -- a job that declares a limit does not, and is refused rather than run unbounded.",
+      "what": "A job declares a concurrency limit and the queue's table cannot hold it."
     },
     {
       "area": "job",

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -4844,6 +4844,12 @@ declare namespace start {
       runner: string | null;
     }>;
     uniqueKey: string | null;
+    /**
+     * The concurrency bucket the job counts against, `null` when its job
+     * declares no limit. It is the `concurrency.group` (the job's own name
+     * by default), plus `:<key>` when the job names one.
+     */
+    concurrencyKey: string | null;
   }
 
   /** The options of an enqueue. */
@@ -4879,6 +4885,28 @@ declare namespace start {
     signal: AbortSignal;
   }
 
+  /**
+   * How many of a job may run at once, across every runner.
+   *
+   * `henri jobs --concurrency` bounds one runner; this bounds the job. It
+   * belongs to the job and never to a call, so no caller can step outside a
+   * bound the job declared.
+   */
+  interface JobConcurrency {
+    /** How many at once. A whole number above zero. */
+    limit: number;
+    /**
+     * What partitions the bound: the name of an argument, or a function of
+     * them. Without one the whole job shares one bound.
+     */
+    key?: string | ((args: any) => unknown);
+    /**
+     * The bound's name, so several jobs may share one. The job's own name
+     * by default; two jobs of one group must agree on the limit.
+     */
+    group?: string;
+  }
+
   /** A file of `app/jobs`. */
   interface JobDefinition {
     perform(args: any, context: JobContext): unknown | Promise<unknown>;
@@ -4886,12 +4914,35 @@ declare namespace start {
     priority?: number;
     maxAttempts?: number;
     timeout?: number | string;
+    /** `3` is `{ limit: 3 }`; `false` (the default) is no bound at all. */
+    concurrency?: number | JobConcurrency | false | null;
     backoff?: {
       base?: number | string;
       factor?: number;
       max?: number | string;
       jitter?: number;
     };
+  }
+
+  /** The concurrency limits of an application, and the slots being held. */
+  interface JobLimits {
+    /** What the job files asked for. */
+    declared: Array<{
+      job: string;
+      group: string;
+      limit: number;
+      /** Whether the bound is partitioned by a key of the arguments. */
+      keyed: boolean;
+    }>;
+    /** What is holding a bound up right now. Never any job arguments. */
+    held: Array<{
+      key: string;
+      slot: number;
+      runner: string;
+      job: string | null;
+      takenAt: number;
+      heartbeatAt: number;
+    }>;
   }
 
   /** What the queue holds, by queue and state. */
@@ -4966,6 +5017,11 @@ declare namespace start {
     get(id: string): Promise<Job | null>;
     list(filter?: JobFilter): Promise<Job[]>;
     stats(): Promise<JobStats>;
+    /**
+     * The concurrency limits of the application and the slots being held --
+     * what a page of your own would show, since henri mounts none.
+     */
+    limits(): Promise<JobLimits>;
     /** The job names of the application. */
     names(): string[];
     /** The dead letter queue. */

--- a/packages/core/src/base/config-schema.js
+++ b/packages/core/src/base/config-schema.js
@@ -1509,7 +1509,7 @@ const SCHEMA = {
       table: text({
         default: 'henri_jobs',
         describe: 'a table name: letters, digits and underscores only',
-        hint: 'henri creates it, and the schedules live next to it in <table>_schedules',
+        hint: 'henri creates it; the schedules live in <table>_schedules and the concurrency slots in <table>_limits',
         pattern: /^[A-Za-z_][A-Za-z0-9_]*$/u,
       }),
       timeout: {

--- a/packages/drizzle/__tests__/retention.spec.js
+++ b/packages/drizzle/__tests__/retention.spec.js
@@ -161,6 +161,7 @@ describe(`the access trail on ${target.name}`, () => {
       'henri_calls',
       'henri_identities',
       'henri_jobs',
+      'henri_jobs_limits',
       'henri_jobs_schedules',
       'henri_trail',
       'henri_versions',

--- a/packages/drizzle/index.js
+++ b/packages/drizzle/index.js
@@ -1369,6 +1369,7 @@ class Drizzle {
     return new Set([
       queue,
       `${queue}_schedules`,
+      `${queue}_limits`,
       name(calls.table, 'henri_calls'),
       name(identities.table, 'henri_identities'),
       name(trail.table, 'henri_trail'),

--- a/packages/jobs/__tests__/__snapshots__/config.spec.js.snap
+++ b/packages/jobs/__tests__/__snapshots__/config.spec.js.snap
@@ -97,6 +97,7 @@ exports[`the schema > writes the DDL of mssql 1`] = `
   error_stack NVARCHAR(MAX) NULL,
   history NVARCHAR(MAX) NULL,
   unique_key VARCHAR(190) NULL,
+  concurrency_key VARCHAR(190) NULL,
   PRIMARY KEY (id)
 );
 IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'henri_jobs_claim' AND object_id = OBJECT_ID('henri_jobs')) CREATE INDEX [henri_jobs_claim] ON [henri_jobs] (state, queue, priority, run_at);
@@ -113,7 +114,19 @@ IF OBJECT_ID('henri_jobs_schedules', 'U') IS NULL CREATE TABLE [henri_jobs_sched
   created_at BIGINT NOT NULL,
   updated_at BIGINT NOT NULL,
   PRIMARY KEY (name)
-)"
+);
+IF OBJECT_ID('henri_jobs_limits', 'U') IS NULL CREATE TABLE [henri_jobs_limits] (
+  limit_key VARCHAR(190) NOT NULL,
+  slot INT NOT NULL,
+  job_id VARCHAR(36) NULL,
+  runner VARCHAR(120) NOT NULL,
+  taken_at BIGINT NOT NULL,
+  heartbeat_at BIGINT NOT NULL,
+  PRIMARY KEY (limit_key, slot)
+);
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'henri_jobs_limits_stale' AND object_id = OBJECT_ID('henri_jobs_limits')) CREATE INDEX [henri_jobs_limits_stale] ON [henri_jobs_limits] (heartbeat_at);
+IF COL_LENGTH('henri_jobs', 'concurrency_key') IS NULL ALTER TABLE [henri_jobs] ADD concurrency_key VARCHAR(190) NULL;
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'henri_jobs_limited' AND object_id = OBJECT_ID('henri_jobs')) CREATE INDEX [henri_jobs_limited] ON [henri_jobs] (state, concurrency_key, run_at)"
 `;
 
 exports[`the schema > writes the DDL of mysql 1`] = `
@@ -141,6 +154,7 @@ exports[`the schema > writes the DDL of mysql 1`] = `
   error_stack MEDIUMTEXT NULL,
   history MEDIUMTEXT NULL,
   unique_key VARCHAR(190) NULL,
+  concurrency_key VARCHAR(190) NULL,
   PRIMARY KEY (id),
   KEY \`henri_jobs_claim\` (state, queue, priority, run_at),
   KEY \`henri_jobs_token\` (claim_token),
@@ -157,7 +171,19 @@ CREATE TABLE IF NOT EXISTS \`henri_jobs_schedules\` (
   created_at BIGINT NOT NULL,
   updated_at BIGINT NOT NULL,
   PRIMARY KEY (name)
-)"
+);
+CREATE TABLE IF NOT EXISTS \`henri_jobs_limits\` (
+  limit_key VARCHAR(190) NOT NULL,
+  slot INT NOT NULL,
+  job_id VARCHAR(36) NULL,
+  runner VARCHAR(120) NOT NULL,
+  taken_at BIGINT NOT NULL,
+  heartbeat_at BIGINT NOT NULL,
+  PRIMARY KEY (limit_key, slot),
+  KEY \`henri_jobs_limits_stale\` (heartbeat_at)
+);
+ALTER TABLE \`henri_jobs\` ADD COLUMN concurrency_key VARCHAR(190) NULL;
+CREATE INDEX \`henri_jobs_limited\` ON \`henri_jobs\` (state, concurrency_key, run_at)"
 `;
 
 exports[`the schema > writes the DDL of postgres 1`] = `
@@ -185,6 +211,7 @@ exports[`the schema > writes the DDL of postgres 1`] = `
   error_stack TEXT NULL,
   history TEXT NULL,
   unique_key VARCHAR(190) NULL,
+  concurrency_key VARCHAR(190) NULL,
   PRIMARY KEY (id)
 );
 CREATE INDEX IF NOT EXISTS "henri_jobs_claim" ON "henri_jobs" (state, queue, priority, run_at);
@@ -201,7 +228,19 @@ CREATE TABLE IF NOT EXISTS "henri_jobs_schedules" (
   created_at BIGINT NOT NULL,
   updated_at BIGINT NOT NULL,
   PRIMARY KEY (name)
-)"
+);
+CREATE TABLE IF NOT EXISTS "henri_jobs_limits" (
+  limit_key VARCHAR(190) NOT NULL,
+  slot INTEGER NOT NULL,
+  job_id VARCHAR(36) NULL,
+  runner VARCHAR(120) NOT NULL,
+  taken_at BIGINT NOT NULL,
+  heartbeat_at BIGINT NOT NULL,
+  PRIMARY KEY (limit_key, slot)
+);
+CREATE INDEX IF NOT EXISTS "henri_jobs_limits_stale" ON "henri_jobs_limits" (heartbeat_at);
+ALTER TABLE "henri_jobs" ADD COLUMN IF NOT EXISTS concurrency_key VARCHAR(190) NULL;
+CREATE INDEX IF NOT EXISTS "henri_jobs_limited" ON "henri_jobs" (state, concurrency_key, run_at)"
 `;
 
 exports[`the schema > writes the DDL of sqlite 1`] = `
@@ -229,6 +268,7 @@ exports[`the schema > writes the DDL of sqlite 1`] = `
   error_stack TEXT NULL,
   history TEXT NULL,
   unique_key VARCHAR(190) NULL,
+  concurrency_key VARCHAR(190) NULL,
   PRIMARY KEY (id)
 );
 CREATE INDEX IF NOT EXISTS "henri_jobs_claim" ON "henri_jobs" (state, queue, priority, run_at);
@@ -245,5 +285,17 @@ CREATE TABLE IF NOT EXISTS "henri_jobs_schedules" (
   created_at BIGINT NOT NULL,
   updated_at BIGINT NOT NULL,
   PRIMARY KEY (name)
-)"
+);
+CREATE TABLE IF NOT EXISTS "henri_jobs_limits" (
+  limit_key VARCHAR(190) NOT NULL,
+  slot INTEGER NOT NULL,
+  job_id VARCHAR(36) NULL,
+  runner VARCHAR(120) NOT NULL,
+  taken_at BIGINT NOT NULL,
+  heartbeat_at BIGINT NOT NULL,
+  PRIMARY KEY (limit_key, slot)
+);
+CREATE INDEX IF NOT EXISTS "henri_jobs_limits_stale" ON "henri_jobs_limits" (heartbeat_at);
+ALTER TABLE "henri_jobs" ADD COLUMN concurrency_key VARCHAR(190) NULL;
+CREATE INDEX IF NOT EXISTS "henri_jobs_limited" ON "henri_jobs" (state, concurrency_key, run_at)"
 `;

--- a/packages/jobs/__tests__/concurrency.spec.js
+++ b/packages/jobs/__tests__/concurrency.spec.js
@@ -1,0 +1,504 @@
+const { randomUUID } = require('crypto');
+
+const live = require('./live');
+const { adapterFor, build, close, sharedKey, target } = require('./helpers');
+const { Runner } = require('../src/runner');
+
+/**
+ * A concurrency limit is a **negative** property: never more than N of a job
+ * at once, across every runner. A count taken afterwards cannot see it --
+ * two jobs that overlapped for a millisecond and two that never met leave
+ * the same rows behind -- so the jobs themselves record when they are
+ * inside (`./live.js`) and these suites assert the high-water mark.
+ *
+ * Like `claim.spec.js`, every queue here opens its own connection pool, so
+ * the runners race on the server rather than in one client. On sqlite that
+ * proves the logic; against the PostgreSQL and MySQL of `pnpm test:sql:live`
+ * it proves the guarantee.
+ */
+
+const RUNNERS = target.live ? 4 : 2;
+const JOBS = target.live ? 24 : 10;
+
+describe(`concurrency limits (${target.name}, ${RUNNERS} runners)`, () => {
+  const adapters = [];
+  const queues = [];
+
+  /**
+   * Empties the queue and every slot it holds
+   *
+   * @returns {Promise<void>} Resolves when it is empty
+   */
+  const clear = async () => {
+    for (const state of ['pending', 'running', 'done', 'dead']) {
+      await queues[0].store.remove({ state });
+    }
+
+    for (const held of await queues[0].store.slots()) {
+      await queues[0].store.releaseSlot(held.key, held.slot);
+    }
+
+    live.reset();
+  };
+
+  /**
+   * Runs every runner until the queue has nothing left to give
+   *
+   * @param {object} [options={}] `concurrency`
+   * @returns {Promise<Array<object>>} What each runner did
+   */
+  const drain = async (options = {}) => {
+    const runners = queues.map((queue) =>
+      new Runner(queue, {
+        concurrency: options.concurrency || 4,
+        recurring: false,
+      }).start()
+    );
+
+    for (let waited = 0; waited < 600; waited += 1) {
+      const pending = await queues[0].count({ state: 'pending' });
+      const running = await queues[0].count({ state: 'running' });
+
+      if (pending === 0 && running === 0) {
+        break;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+
+    return Promise.all(runners.map((runner) => runner.stop()));
+  };
+
+  beforeAll(async () => {
+    const key = sharedKey('concurrency');
+
+    for (let index = 0; index < RUNNERS; index += 1) {
+      const adapter = await adapterFor(key);
+      const built = await build({
+        adapter,
+        config: { pollInterval: 25, stuckAfter: '10s' },
+      });
+
+      adapters.push(adapter);
+      queues.push(built.jobs);
+    }
+  }, 60000);
+
+  afterAll(() => close(adapters));
+
+  beforeEach(clear);
+
+  test('the store can hold a concurrency key', async () => {
+    // Everything below rests on this: without the column the queue refuses
+    // to start with a limited job rather than running it unbounded
+    expect(await queues[0].store.concurrent()).toBe(true);
+    expect(queues[0].concurrent).toBe(true);
+  });
+
+  test('exactly as many slots are handed out as the limit allows', async () => {
+    const key = `slots:${randomUUID().slice(0, 8)}`;
+    const limit = Math.max(2, Math.floor(RUNNERS / 2));
+    const taken = await Promise.all(
+      queues.map((queue, index) =>
+        queue.store.takeSlot({
+          key,
+          limit,
+          now: Date.now(),
+          runner: `runner-${index}`,
+        })
+      )
+    );
+    const won = taken.filter((slot) => slot !== null);
+
+    // The primary key of the table is what refuses the others: one insert
+    // per slot succeeds, whatever the interleaving
+    expect(won).toHaveLength(Math.min(limit, RUNNERS));
+    expect(new Set(won).size).toBe(won.length);
+    expect(await queues[0].store.slots()).toHaveLength(won.length);
+
+    for (const slot of won) {
+      expect(slot).toBeLessThan(limit);
+    }
+  }, 30000);
+
+  test('a slot nobody freed is taken again once it is released', async () => {
+    const key = `once:${randomUUID().slice(0, 8)}`;
+    const first = await queues[0].store.takeSlot({
+      key,
+      limit: 1,
+      now: Date.now(),
+      runner: 'first',
+    });
+
+    expect(first).toBe(0);
+    expect(
+      await queues[1 % RUNNERS].store.takeSlot({
+        key,
+        limit: 1,
+        now: Date.now(),
+        runner: 'second',
+      })
+    ).toBeNull();
+
+    await queues[0].store.releaseSlot(key, first, 'first');
+
+    expect(
+      await queues[1 % RUNNERS].store.takeSlot({
+        key,
+        limit: 1,
+        now: Date.now(),
+        runner: 'second',
+      })
+    ).toBe(0);
+  });
+
+  test('never more than one exclusive job runs, whatever the runners do', async () => {
+    const tokens = [];
+
+    for (let index = 0; index < JOBS; index += 1) {
+      const token = `exclusive-${index}`;
+
+      tokens.push(token);
+      await queues[0].perform('exclusive', { token });
+    }
+
+    await drain();
+
+    // The property: not "one was performed at a time on average", but that
+    // two were never inside at once
+    expect(live.most('exclusive')).toBe(1);
+    expect([...live.performed()].sort()).toEqual([...tokens].sort());
+    expect(await queues[0].count({ state: 'done' })).toBe(JOBS);
+    expect(await queues[0].count({ state: 'pending' })).toBe(0);
+  }, 120000);
+
+  test('a keyed limit bounds each key and never the whole job', async () => {
+    const tenants = ['acme', 'globex', 'initech'];
+
+    for (const tenant of tenants) {
+      for (let index = 0; index < 4; index += 1) {
+        await queues[0].perform('tenanted', {
+          tenant,
+          token: `${tenant}-${index}`,
+        });
+      }
+    }
+
+    await drain();
+
+    for (const tenant of tenants) {
+      expect(live.most(`tenanted:${tenant}`)).toBeGreaterThan(0);
+      expect(live.most(`tenanted:${tenant}`)).toBeLessThanOrEqual(2);
+    }
+
+    // And the bound is on the key, not on the job: more than one tenant's
+    // worth ran at once, or the limit would be indistinguishable from a
+    // limit on `tenanted` itself
+    expect(live.most('*')).toBeGreaterThan(2);
+
+    expect(live.performed()).toHaveLength(tenants.length * 4);
+    expect(await queues[0].count({ state: 'done' })).toBe(tenants.length * 4);
+  }, 120000);
+
+  test('the key is stored with the job, prefixed by its group', async () => {
+    const bounded = await queues[0].perform('tenanted', {
+      tenant: 'acme',
+      token: 'k',
+    });
+    const exclusive = await queues[0].perform('exclusive', { token: 'k' });
+    const plain = await queues[0].perform('ok', null);
+
+    expect(bounded.concurrencyKey).toBe('tenanted:acme');
+    // No key of its own: the group is the bucket, and so is a row an older
+    // henri enqueued with no key at all
+    expect(exclusive.concurrencyKey).toBe('exclusive');
+    expect(plain.concurrencyKey).toBeNull();
+  });
+
+  test('a full key holds its own jobs back and nobody else', async () => {
+    await queues[0].perform('exclusive', { token: 'held' });
+    await queues[0].perform('ok', { token: 'free' });
+
+    // Somebody else is holding the only slot of `exclusive`
+    const held = await queues[0].store.takeSlot({
+      key: 'exclusive',
+      limit: 1,
+      now: Date.now(),
+      runner: 'somebody-else',
+    });
+
+    expect(held).toBe(0);
+
+    const runner = new Runner(queues[1 % RUNNERS], {
+      concurrency: 4,
+      recurring: false,
+    });
+
+    await runner.once();
+
+    expect(await queues[0].count({ state: 'pending' })).toBe(1);
+
+    const [waiting] = await queues[0].list({ state: 'pending' });
+
+    expect(waiting.name).toBe('exclusive');
+    // The unbounded job went through while the bounded one waited
+    expect(live.performed()).toEqual([]);
+
+    await queues[0].store.releaseSlot('exclusive', held, 'somebody-else');
+    await runner.once();
+
+    expect(live.performed()).toEqual(['held']);
+  }, 60000);
+
+  test('a job enqueued before the limit was declared is bounded too', async () => {
+    // What an upgrade leaves behind: rows written by a henri whose table had
+    // no `concurrency_key` at all
+    for (let index = 0; index < 4; index += 1) {
+      const job = await queues[0].perform('exclusive', {
+        token: `older-${index}`,
+      });
+
+      await queues[0].store.update(job.id, { concurrency_key: null });
+    }
+
+    expect(
+      (await queues[0].list({ state: 'pending' })).every(
+        (job) => job.concurrencyKey === null
+      )
+    ).toBe(true);
+
+    await drain();
+
+    expect(live.most('exclusive')).toBe(1);
+    expect(live.performed()).toHaveLength(4);
+  }, 120000);
+
+  test('every slot is given back when the jobs are done', async () => {
+    for (let index = 0; index < 3; index += 1) {
+      await queues[0].perform('exclusive', { token: `back-${index}` });
+    }
+
+    await drain();
+
+    expect(await queues[0].store.slots()).toEqual([]);
+  }, 120000);
+
+  test('a slot whose runner stopped answering is freed', async () => {
+    const key = `stale:${randomUUID().slice(0, 8)}`;
+    const now = Date.now();
+
+    await queues[0].store.takeSlot({
+      key,
+      limit: 1,
+      now: now - 60000,
+      runner: 'a-runner-that-died',
+    });
+
+    // Not yet: the heartbeat is younger than stuckAfter
+    expect(
+      await queues[0].store.sweepSlots({ now, stuckAfter: 300000 })
+    ).toEqual([]);
+
+    const freed = await queues[0].store.sweepSlots({ now, stuckAfter: 30000 });
+
+    expect(freed).toHaveLength(1);
+    expect(freed[0].key).toBe(key);
+    expect(freed[0].runner).toBe('a-runner-that-died');
+    expect(await queues[0].store.slots()).toEqual([]);
+  });
+
+  test('the unlimited claim never takes a job that declares a limit', async () => {
+    await queues[0].perform('exclusive', { token: 'bounded' });
+    await queues[0].perform('ok', null);
+
+    const claimed = await queues[0].store.claim({
+      except: queues[0].limited().names,
+      limit: 10,
+      now: Date.now(),
+      queues: [],
+      runner: 'unlimited-only',
+      token: randomUUID(),
+    });
+
+    expect(claimed).toHaveLength(1);
+    expect(claimed[0].name).toBe('ok');
+  });
+
+  test('two jobs that share a group and disagree on it are refused', () => {
+    const bounded = (name, limit) => ({
+      concurrency: { group: 'imports', key: null, limit },
+      name,
+    });
+
+    expect(() =>
+      queues[0].conflicts([bounded('a', 2), bounded('b', 2)])
+    ).not.toThrow();
+
+    let error = null;
+
+    try {
+      queues[0].conflicts([bounded('a', 2), bounded('b', 3)]);
+    } catch (thrown) {
+      error = thrown;
+    }
+
+    expect(error).not.toBeNull();
+    expect(error.code).toBe('HENRI_JOB_CONCURRENCY_CONFLICT');
+    expect(error.message).toContain('imports');
+  });
+
+  test('jobs of one group share one bound between them', async () => {
+    for (const [index, queue] of queues.entries()) {
+      for (const half of ['one', 'two']) {
+        queue.define(`grouped/${half}`, {
+          concurrency: { group: 'grouped', limit: 1 },
+
+          /**
+           * Counts itself inside the shared window
+           *
+           * @param {object} args What it was enqueued with
+           * @returns {Promise<string>} Its token
+           */
+          perform: (args) => live.inside('grouped', args.token, 25),
+        });
+      }
+
+      expect(queue.limited().groups.get('grouped').names.sort()).toEqual([
+        'grouped/one',
+        'grouped/two',
+      ]);
+      expect(index).toBeGreaterThanOrEqual(0);
+    }
+
+    for (let index = 0; index < 4; index += 1) {
+      await queues[0].perform(`grouped/${index % 2 ? 'one' : 'two'}`, {
+        token: `grouped-${index}`,
+      });
+    }
+
+    await drain();
+
+    // One bound across two job names: that is what a group is for
+    expect(live.most('grouped')).toBe(1);
+    expect(live.performed()).toHaveLength(4);
+  }, 120000);
+
+  test('the keys with work waiting come back, the most urgent first', async () => {
+    await queues[0].perform('tenanted', { tenant: 'b', token: '1' });
+    await queues[0].perform(
+      'tenanted',
+      { tenant: 'a', token: '2' },
+      { priority: -10 }
+    );
+    await queues[0].perform('ok', null);
+
+    const waiting = await queues[0].store.waiting({
+      names: queues[0].limited().names,
+      now: Date.now(),
+      queues: [],
+    });
+
+    expect(waiting.map((entry) => entry.key)).toEqual([
+      'tenanted:a',
+      'tenanted:b',
+    ]);
+    expect(waiting.every((entry) => entry.name === 'tenanted')).toBe(true);
+  });
+});
+
+describe(`upgrading a queue an older henri installed (${target.name})`, () => {
+  const adapters = [];
+  let jobs = null;
+  let store = null;
+
+  /**
+   * Takes the table back to what a henri without concurrency limits wrote
+   *
+   * @returns {Promise<void>} Resolves when the column is gone
+   */
+  const downgrade = async () => {
+    const { jobs: table } = jobs.config.tables;
+
+    await store.run(`DROP INDEX IF EXISTS ${table}_limited`).catch(() => null);
+    await store
+      .run(`ALTER TABLE ${table} DROP INDEX ${table}_limited`)
+      .catch(() => null);
+    await store.run(`ALTER TABLE ${table} DROP COLUMN concurrency_key`);
+    store.limits = null;
+    jobs.concurrent = await store.concurrent();
+  };
+
+  beforeAll(async () => {
+    const adapter = await adapterFor(sharedKey('upgrade'));
+    const built = await build({ adapter });
+
+    adapters.push(adapter);
+    jobs = built.jobs;
+    store = built.jobs.store;
+    await downgrade();
+  }, 60000);
+
+  afterAll(() => close(adapters));
+
+  test('the queue works exactly as it did without the column', async () => {
+    // Nothing about an application that declares no limit changes: the
+    // claim statement it sends is the one it always sent
+    expect(await store.concurrent()).toBe(false);
+
+    const job = await jobs.perform('ok', { still: 'working' });
+    const claimed = await store.claim({
+      except: [],
+      limit: 5,
+      now: Date.now(),
+      queues: [],
+      runner: 'upgrading',
+      token: randomUUID(),
+    });
+
+    expect(claimed.map((row) => row.id)).toContain(job.id);
+    await store.remove({ state: 'running' });
+  });
+
+  test('a job that declares a limit refuses to start rather than run unbounded', async () => {
+    const { Jobs } = require('../src/jobs');
+    const bounded = new Jobs(
+      { cwd: () => jobs.cwd, pen: null },
+      { adapter: store.adapter, config: { install: false }, cwd: jobs.cwd }
+    );
+    const error = await bounded.start().then(
+      () => null,
+      (thrown) => thrown
+    );
+
+    expect(error).not.toBeNull();
+    expect(error.code).toBe('HENRI_JOB_LIMIT_UNINSTALLED');
+    expect(error.message).toContain('exclusive');
+    expect(error.hint).toContain('henri jobs:install');
+  });
+
+  test('the install adds the column, and the limits work from then on', async () => {
+    const statements = await store.install();
+
+    expect(statements.join(';')).toContain('concurrency_key');
+    store.limits = null;
+    expect(await store.concurrent()).toBe(true);
+
+    // The same queue, started again, now has its bound
+    const { jobs: started } = await build({
+      adapter: store.adapter,
+      config: { install: false },
+    });
+
+    expect(started.concurrent).toBe(true);
+
+    const job = await started.perform('exclusive', { token: 'upgraded' });
+
+    expect(job.concurrencyKey).toBe('exclusive');
+    await started.store.remove({ state: 'pending' });
+  }, 60000);
+
+  test('the install may be run again and changes nothing', async () => {
+    await expect(store.install()).resolves.toBeInstanceOf(Array);
+    expect(await store.concurrent()).toBe(true);
+  }, 60000);
+});

--- a/packages/jobs/__tests__/config.spec.js
+++ b/packages/jobs/__tests__/config.spec.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
-const { install, uninstall } = require('../src/store/schema');
-const { load } = require('../src/definitions');
+const { install, uninstall, upgrade } = require('../src/store/schema');
+const { keyOf, load, validate } = require('../src/definitions');
 const { normalize } = require('../src/config');
 const { storeFor } = require('../src/store');
 
@@ -21,6 +21,7 @@ describe('configuration', () => {
     expect(config.install).toBe(true);
     expect(config.tables).toEqual({
       jobs: 'henri_jobs',
+      limits: 'henri_jobs_limits',
       schedules: 'henri_jobs_schedules',
     });
     expect(config.backoff).toEqual({
@@ -49,6 +50,7 @@ describe('configuration', () => {
     expect(config.timeout).toBe(120000);
     expect(config.tables).toEqual({
       jobs: 'queue',
+      limits: 'queue_limits',
       schedules: 'queue_schedules',
     });
   });
@@ -133,10 +135,12 @@ describe('definitions', () => {
     expect(Object.keys(definitions).sort()).toEqual([
       'boom',
       'counter',
+      'exclusive',
       'mailers',
       'nested/deep',
       'ok',
       'slow',
+      'tenanted',
     ]);
     expect(definitions['nested/deep'].queue).toBe('default');
     expect(definitions.slow.timeout).toBe(40);
@@ -145,6 +149,111 @@ describe('definitions', () => {
 
   test('is empty when there is no app/jobs', () => {
     expect(load(path.join(APP, 'nowhere'), normalize())).toEqual({});
+  });
+
+  describe('concurrency', () => {
+    /**
+     * A definition with a concurrency declaration
+     *
+     * @param {*} value What the file declared
+     * @returns {?object} The normalized limit
+     */
+    const declare = (value) =>
+      validate(
+        'import',
+        { concurrency: value, perform: () => null },
+        normalize()
+      ).concurrency;
+
+    test('a number is a limit on the job itself', () => {
+      expect(declare(1)).toMatchObject({
+        group: 'import',
+        key: null,
+        limit: 1,
+      });
+      expect(declare({ limit: 4 })).toMatchObject({
+        group: 'import',
+        limit: 4,
+      });
+    });
+
+    test('a job that declares none is unbounded', () => {
+      expect(declare(undefined)).toBeNull();
+      expect(declare(null)).toBeNull();
+      expect(declare(false)).toBeNull();
+    });
+
+    test('the key is the group, and a value under it', () => {
+      const named = declare({ key: 'tenantId', limit: 2 });
+      const own = declare({ group: 'tenant-work', key: 'tenantId', limit: 2 });
+
+      expect(
+        keyOf({ concurrency: named, name: 'import' }, { tenantId: 7 })
+      ).toBe('import:7');
+      expect(keyOf({ concurrency: own, name: 'import' }, { tenantId: 7 })).toBe(
+        'tenant-work:7'
+      );
+    });
+
+    test('a key that resolves to nothing is the group itself', () => {
+      const bound = declare({ key: 'tenantId', limit: 2 });
+      const definition = { concurrency: bound, name: 'import' };
+
+      // The bucket a job enqueued before the limit was declared falls into,
+      // so the two do not each get a bound of their own
+      expect(keyOf(definition, {})).toBe('import');
+      expect(keyOf(definition, { tenantId: null })).toBe('import');
+      expect(keyOf(definition, { tenantId: '' })).toBe('import');
+    });
+
+    test('a function reads whatever it likes of the arguments', () => {
+      const bound = declare({ key: (args) => args.account.id, limit: 3 });
+
+      expect(
+        keyOf({ concurrency: bound, name: 'import' }, { account: { id: 'a' } })
+      ).toBe('import:a');
+    });
+
+    test('refuses a limit it cannot honour', () => {
+      for (const value of [0, -1, 1.5, 'three', { limit: 0 }, { limit: 'x' }]) {
+        expect(() => declare(value)).toThrow(/concurrency limit/u);
+      }
+
+      expect(() => declare({ key: 12, limit: 1 })).toThrow(
+        /neither the name of an argument nor a function/u
+      );
+      expect(() => declare({ group: '', limit: 1 })).toThrow(
+        /group is not a name/u
+      );
+    });
+
+    test('refuses a key it cannot store', () => {
+      const definition = {
+        concurrency: declare({ key: 'id', limit: 1 }),
+        name: 'import',
+      };
+
+      expect(() => keyOf(definition, { id: 'x'.repeat(200) })).toThrow(
+        /over the 190 that are stored/u
+      );
+      expect(() => keyOf(definition, { id: { a: 1 } })).toThrow(
+        /has to be a value that names one bound/u
+      );
+      expect(() =>
+        keyOf(
+          {
+            concurrency: declare({
+              key: () => {
+                throw new Error('no such tenant');
+              },
+              limit: 1,
+            }),
+            name: 'import',
+          },
+          {}
+        )
+      ).toThrow(/no such tenant/u);
+    });
   });
 
   test('refuses a file that is not a job', () => {
@@ -199,7 +308,11 @@ describe('starting', () => {
 
 describe('the claim statement', () => {
   const { SqlStore } = require('../src/store/sql');
-  const tables = { jobs: 'henri_jobs', schedules: 'henri_jobs_schedules' };
+  const tables = {
+    jobs: 'henri_jobs',
+    limits: 'henri_jobs_limits',
+    schedules: 'henri_jobs_schedules',
+  };
 
   /**
    * The claim of a dialect, as it is sent to the database
@@ -247,6 +360,92 @@ describe('the claim statement', () => {
     }
   });
 
+  test('takes everything but the limited jobs on the unlimited pass', () => {
+    const store = new SqlStore(
+      { query: () => null },
+      { dialect: 'postgres', dollars: true, tables }
+    );
+    const built = store.claimStatement({
+      except: ['import', 'export'],
+      limit: 4,
+      now: 1,
+      queues: [],
+      runner: 'r',
+      token: 't',
+    });
+    const { params } = built;
+    const sql = store.prepare(built.sql);
+
+    expect(sql).toContain('name NOT IN ($8, $9)');
+    expect(sql).toContain('FOR UPDATE SKIP LOCKED');
+    expect(sql).not.toContain('concurrency_key');
+    expect(params).toContain('import');
+  });
+
+  test('takes one row of one key on the limited pass', () => {
+    const store = new SqlStore(
+      { query: () => null },
+      { dialect: 'postgres', dollars: true, tables }
+    );
+    const built = store.claimStatement({
+      key: { own: false, value: 'import:acme' },
+      limit: 1,
+      names: ['import'],
+      now: 1,
+      queues: [],
+      runner: 'r',
+      token: 't',
+    });
+    const { params } = built;
+    const sql = store.prepare(built.sql);
+
+    expect(sql).toContain('name IN ($8)');
+    expect(sql).toContain('concurrency_key = $9');
+    expect(sql).not.toContain('IS NULL');
+    expect(params).toContain('import:acme');
+  });
+
+  test('the group bucket also takes the rows enqueued before the limit', () => {
+    const store = new SqlStore(
+      { query: () => null },
+      { dialect: 'sqlite', tables }
+    );
+    const { sql } = store.claimStatement({
+      key: { own: true, value: 'import' },
+      limit: 1,
+      names: ['import'],
+      now: 1,
+      queues: [],
+      runner: 'r',
+      token: 't',
+    });
+
+    expect(sql).toContain('(concurrency_key = ? OR concurrency_key IS NULL)');
+  });
+
+  test('every dialect claims one row per slot on the limited pass', () => {
+    for (const dialect of ['sqlite', 'postgres', 'mysql', 'mssql']) {
+      const store = new SqlStore(
+        { query: () => null },
+        { dialect, dollars: dialect === 'postgres', tables }
+      );
+      const { sql } = store.claimStatement({
+        key: { own: false, value: 'import:acme' },
+        limit: 1,
+        names: ['import'],
+        now: 1,
+        queues: [],
+        runner: 'r',
+        token: 't',
+      });
+
+      // Still one statement, so still its own transaction
+      expect(store.prepare(sql).split(';')).toHaveLength(1);
+      expect(sql).toContain('concurrency_key');
+      expect(sql).toContain(`state = 'pending'`);
+    }
+  });
+
   test('leaves the queue filter out when no queue was named', () => {
     const store = new SqlStore(
       { query: () => null },
@@ -266,7 +465,11 @@ describe('the claim statement', () => {
 });
 
 describe('the schema', () => {
-  const tables = { jobs: 'henri_jobs', schedules: 'henri_jobs_schedules' };
+  const tables = {
+    jobs: 'henri_jobs',
+    limits: 'henri_jobs_limits',
+    schedules: 'henri_jobs_schedules',
+  };
 
   test.each(['sqlite', 'postgres', 'mysql', 'mssql'])(
     'writes the DDL of %s',
@@ -277,6 +480,7 @@ describe('the schema', () => {
 
   test('drops the tables newest first', () => {
     expect(uninstall('postgres', tables)).toEqual([
+      'DROP TABLE IF EXISTS "henri_jobs_limits"',
       'DROP TABLE IF EXISTS "henri_jobs_schedules"',
       'DROP TABLE IF EXISTS "henri_jobs"',
     ]);
@@ -286,12 +490,47 @@ describe('the schema', () => {
     expect(() => install('oracle', tables)).toThrow(
       'unsupported SQL dialect "oracle"'
     );
+
+    expect(() => upgrade('oracle', tables)).toThrow(
+      'unsupported SQL dialect "oracle"'
+    );
+  });
+
+  test('adds the concurrency column to a table an older henri wrote', () => {
+    for (const dialect of ['sqlite', 'postgres', 'mysql', 'mssql']) {
+      const statements = upgrade(dialect, tables);
+
+      // The column and the index it serves, and nothing else: an upgrade
+      // touches an existing table, so it says exactly what it changes
+      expect(statements).toHaveLength(2);
+      expect(statements[0]).toContain('concurrency_key');
+      expect(statements[0]).toMatch(/ALTER TABLE/u);
+      expect(statements[1]).toContain('henri_jobs_limited');
+
+      // Every one of them is part of the install, so a fresh database and an
+      // upgraded one end up with the same table
+      expect(install(dialect, tables)).toEqual(
+        expect.arrayContaining(statements)
+      );
+    }
+  });
+
+  test('the limited index is never inlined, so mysql upgrades too', () => {
+    // MySQL declares its indexes inside the guarded CREATE TABLE, which does
+    // nothing for a table that is already there
+    const statements = install('mysql', tables);
+
+    expect(statements.join('\n')).not.toContain('KEY `henri_jobs_limited`');
+    expect(statements).toContain(
+      'CREATE INDEX `henri_jobs_limited` ON `henri_jobs` (state, concurrency_key, run_at)'
+    );
   });
 
   test('refuses a table name that is not a plain identifier', () => {
     expect(() =>
       install('postgres', {
         jobs: 'jobs"; DROP TABLE users; --',
+        limits: 'l',
         schedules: 's',
       })
     ).toThrow('invalid table name');

--- a/packages/jobs/__tests__/fixtures/app/app/jobs/exclusive.js
+++ b/packages/jobs/__tests__/fixtures/app/app/jobs/exclusive.js
@@ -1,0 +1,12 @@
+// One at a time, across every runner. It records how many of it were
+// running when it started and when it ended, so the suite can assert the
+// bound was never exceeded rather than that it happened to hold
+module.exports = {
+  concurrency: 1,
+
+  perform: async (args) => {
+    const live = require('../../../../live');
+
+    return live.inside('exclusive', args.token, 25);
+  },
+};

--- a/packages/jobs/__tests__/fixtures/app/app/jobs/tenanted.js
+++ b/packages/jobs/__tests__/fixtures/app/app/jobs/tenanted.js
@@ -1,0 +1,11 @@
+// Two at a time per tenant, and no bound at all between tenants: the key
+// is what partitions it
+module.exports = {
+  concurrency: { key: 'tenant', limit: 2 },
+
+  perform: async (args) => {
+    const live = require('../../../../live');
+
+    return live.inside(`tenanted:${args.tenant}`, args.token, 25);
+  },
+};

--- a/packages/jobs/__tests__/live.js
+++ b/packages/jobs/__tests__/live.js
@@ -1,0 +1,89 @@
+/**
+ * How many jobs of a key were running at the same moment.
+ *
+ * A concurrency limit is a **negative** property -- never more than N at
+ * once -- and a count taken after the fact cannot see it: two jobs that
+ * overlapped for a millisecond and two that never met leave the same rows
+ * behind. So the jobs themselves say when they enter and when they leave,
+ * and this keeps the high-water mark per key.
+ *
+ * The state is on `global` rather than in this module's closure because the
+ * job fixtures are loaded by `require()` from each queue's own `app/jobs`,
+ * and every queue of a suite has to count into the same place.
+ */
+
+/**
+ * The counters of this process
+ *
+ * @returns {object} `{ live, max, order }` by key
+ */
+const state = () => {
+  global.__henriJobsLive = global.__henriJobsLive || {
+    live: {},
+    max: {},
+    order: [],
+  };
+
+  return global.__henriJobsLive;
+};
+
+/**
+ * Forgets everything counted so far
+ *
+ * @returns {void}
+ */
+const reset = () => {
+  global.__henriJobsLive = { live: {}, max: {}, order: [] };
+};
+
+/**
+ * Runs inside the counted window
+ *
+ * @param {string} key What the bound is on
+ * @param {string} token What identifies this run
+ * @param {number} [wait=25] How long to stay inside, so runs overlap
+ * @returns {Promise<string>} The token
+ */
+const inside = async (key, token, wait = 25) => {
+  const counters = state();
+  // `*` is every key at once, which is what says a keyed bound partitions
+  // rather than serializing: three keys of two may run six
+  const keys = [key, '*'];
+
+  for (const counted of keys) {
+    counters.live[counted] = (counters.live[counted] || 0) + 1;
+    counters.max[counted] = Math.max(
+      counters.max[counted] || 0,
+      counters.live[counted]
+    );
+  }
+
+  counters.order.push(token);
+
+  try {
+    await new Promise((resolve) => setTimeout(resolve, wait));
+  } finally {
+    for (const counted of keys) {
+      counters.live[counted] -= 1;
+    }
+  }
+
+  return token;
+};
+
+/**
+ * The most that ran at once under a key
+ *
+ * @param {string} key The key
+ * @returns {number} The high-water mark
+ */
+const most = (key) => state().max[key] || 0;
+
+/**
+ * Every token that was performed, in the order they started
+ *
+ * @returns {Array<string>} The tokens
+ */
+const performed = () => [...state().order];
+
+module.exports = { inside, most, performed, reset, state };

--- a/packages/jobs/__tests__/mongo.spec.js
+++ b/packages/jobs/__tests__/mongo.spec.js
@@ -4,6 +4,7 @@ const { randomUUID } = require('crypto');
 const Mongoose = require('@usehenri/mongoose');
 const { MongoMemoryServer } = require('mongodb-memory-server');
 
+const live = require('./live');
 const { fakeHenri } = require('./helpers');
 const { Jobs } = require('../src/jobs');
 const { Runner } = require('../src/runner');
@@ -52,7 +53,103 @@ describe('queue (mongodb)', () => {
       await jobs.store.remove({ state });
     }
 
+    for (const held of await jobs.store.slots()) {
+      await jobs.store.releaseSlot(held.key, held.slot);
+    }
+
     global.__henriJobsRuns = [];
+    live.reset();
+  });
+
+  describe('concurrency limits', () => {
+    test('a collection needs no upgrade to hold a key', async () => {
+      // The one thing the SQL backends need an ALTER for
+      expect(await jobs.store.concurrent()).toBe(true);
+      expect(jobs.concurrent).toBe(true);
+    });
+
+    test('exactly one runner wins a slot, the others are refused', async () => {
+      const key = `slots:${randomUUID().slice(0, 8)}`;
+      const taken = await Promise.all(
+        [0, 1, 2, 3].map((index) =>
+          jobs.store.takeSlot({
+            key,
+            limit: 1,
+            now: Date.now(),
+            runner: `runner-${index}`,
+          })
+        )
+      );
+
+      // 11000 is what refuses the others: the same answer a primary key
+      // gives the SQL backends
+      expect(taken.filter((slot) => slot === 0)).toHaveLength(1);
+      expect(taken.filter((slot) => slot === null)).toHaveLength(3);
+      expect(await jobs.store.slots()).toHaveLength(1);
+    });
+
+    test('never more than one exclusive job runs at a time', async () => {
+      for (let index = 0; index < 6; index += 1) {
+        await jobs.perform('exclusive', { token: `mongo-${index}` });
+      }
+
+      await new Runner(jobs, { concurrency: 4, recurring: false }).once();
+
+      expect(live.most('exclusive')).toBe(1);
+      expect(live.performed()).toHaveLength(6);
+      expect(await jobs.count({ state: 'done' })).toBe(6);
+    }, 60000);
+
+    test('a keyed limit bounds each key of its own', async () => {
+      for (const tenant of ['acme', 'globex']) {
+        for (let index = 0; index < 3; index += 1) {
+          await jobs.perform('tenanted', {
+            tenant,
+            token: `${tenant}-${index}`,
+          });
+        }
+      }
+
+      await new Runner(jobs, { concurrency: 6, recurring: false }).once();
+
+      expect(live.most('tenanted:acme')).toBeLessThanOrEqual(2);
+      expect(live.most('tenanted:globex')).toBeLessThanOrEqual(2);
+      expect(live.performed()).toHaveLength(6);
+      expect(await jobs.store.slots()).toEqual([]);
+    }, 60000);
+
+    test('a document with no key at all belongs to the group', async () => {
+      // What a document an older henri wrote looks like: the field is not
+      // there, and `$in: [value, null]` is what still matches it
+      const job = await jobs.perform('exclusive', { token: 'older' });
+
+      await jobs.store
+        .jobs()
+        .updateOne({ _id: job.id }, { $unset: { concurrency_key: '' } });
+
+      await new Runner(jobs, { concurrency: 4, recurring: false }).once();
+
+      expect(live.performed()).toEqual(['older']);
+      expect(await jobs.count({ state: 'done' })).toBe(1);
+    }, 60000);
+
+    test('a slot whose runner stopped answering is freed', async () => {
+      const key = `stale:${randomUUID().slice(0, 8)}`;
+      const now = Date.now();
+
+      await jobs.store.takeSlot({
+        key,
+        limit: 1,
+        now: now - 600000,
+        runner: 'gone',
+      });
+
+      const freed = await jobs.store.sweepSlots({ now, stuckAfter: 300000 });
+
+      expect(freed).toHaveLength(1);
+      expect(freed[0].runner).toBe('gone');
+      expect(await jobs.store.slots()).toEqual([]);
+    });
   });
 
   test('picks the MongoDB backend for a mongoose store', () => {

--- a/packages/jobs/__tests__/queue.spec.js
+++ b/packages/jobs/__tests__/queue.spec.js
@@ -31,12 +31,14 @@ describe(`queue (${target.name})`, () => {
       expect(jobs.names()).toEqual([
         'boom',
         'counter',
+        'exclusive',
         'henri/mail',
         'henri/retention',
         'mailers',
         'nested/deep',
         'ok',
         'slow',
+        'tenanted',
       ]);
     });
 

--- a/packages/jobs/src/config.js
+++ b/packages/jobs/src/config.js
@@ -175,6 +175,7 @@ const normalize = (config = {}) => {
     stuckAfter: duration(value.stuckAfter, duration(DEFAULTS.stuckAfter)),
     tables: {
       jobs: table(value.table || DEFAULTS.table),
+      limits: `${table(value.table || DEFAULTS.table)}_limits`,
       schedules: `${table(value.table || DEFAULTS.table)}_schedules`,
     },
     timeout: duration(value.timeout, DEFAULTS.timeout),

--- a/packages/jobs/src/definitions.js
+++ b/packages/jobs/src/definitions.js
@@ -11,6 +11,152 @@ const { JobError } = require('./errors');
  * is the job `mail/welcome`.
  */
 
+/** The widest a concurrency key may be: the column that holds it */
+const KEY_LENGTH = 190;
+
+/**
+ * Reads a job's `concurrency` declaration
+ *
+ * `1` is `{ limit: 1 }`; a `key` is a field of the arguments or a function
+ * of them, and a `group` is the name several jobs share a bound under. The
+ * default group is the job's own name, so a limit is that job's alone
+ * unless it says otherwise.
+ *
+ * The limit belongs to the **job**, never to the call: an option of
+ * `perform()` would let one caller step outside a bound the job declared,
+ * which is the one thing a bound is for.
+ *
+ * @param {string} name The job name
+ * @param {(number|object|null)} value What the file declared
+ * @returns {?object} `{ group, key, limit }`, or null
+ * @throws {JobError} HENRI_JOB_INVALID_CONCURRENCY on anything else
+ */
+const concurrency = (name, value) => {
+  if (value === null || typeof value === 'undefined' || value === false) {
+    return null;
+  }
+
+  const declared = typeof value === 'number' ? { limit: value } : value;
+  const refuse = (why) => {
+    throw new JobError(
+      'HENRI_JOB_INVALID_CONCURRENCY',
+      `The job "${name}" declares a concurrency limit that cannot be read: ${why}`,
+      {
+        hint: '`concurrency: 3`, or `concurrency: { limit: 3, key: "tenantId" }` to bound each key of its own',
+        job: name,
+      }
+    );
+  };
+
+  if (typeof declared !== 'object') {
+    refuse('it is neither a number nor an object');
+  }
+
+  const limit = Number(declared.limit);
+
+  if (!Number.isInteger(limit) || limit < 1) {
+    refuse(
+      `its limit is ${JSON.stringify(declared.limit)}, not a whole number above zero`
+    );
+  }
+
+  const group =
+    typeof declared.group === 'undefined' || declared.group === null
+      ? name
+      : declared.group;
+
+  if (typeof group !== 'string' || group === '') {
+    refuse('its group is not a name');
+  }
+
+  if (group.length > KEY_LENGTH) {
+    refuse(`its group is longer than ${KEY_LENGTH} characters`);
+  }
+
+  const { key } = declared;
+
+  if (
+    typeof key !== 'undefined' &&
+    key !== null &&
+    typeof key !== 'string' &&
+    typeof key !== 'function'
+  ) {
+    refuse('its key is neither the name of an argument nor a function of them');
+  }
+
+  return {
+    group,
+    key:
+      typeof key === 'string'
+        ? (args) => (args ? args[key] : null)
+        : key || null,
+    limit,
+  };
+};
+
+/**
+ * The concurrency key of one call, or null when the job is unbounded
+ *
+ * A key that resolves to nothing is the group's own bucket, which is also
+ * where a job enqueued before the limit was declared sits: the two mean the
+ * same thing, so they share a bound rather than each getting one.
+ *
+ * @param {object} definition A validated definition
+ * @param {*} args What perform() will receive
+ * @returns {?string} The key to store
+ * @throws {JobError} HENRI_JOB_INVALID_CONCURRENCY when the key cannot be read
+ */
+const keyOf = (definition, args) => {
+  const bound = definition && definition.concurrency;
+
+  if (!bound) {
+    return null;
+  }
+
+  if (!bound.key) {
+    return bound.group;
+  }
+
+  let value;
+
+  try {
+    value = bound.key(args);
+  } catch (error) {
+    throw new JobError(
+      'HENRI_JOB_INVALID_CONCURRENCY',
+      `The concurrency key of "${definition.name}" could not be read: ${error.message}`,
+      { cause: error, job: definition.name }
+    );
+  }
+
+  if (value === null || typeof value === 'undefined' || value === '') {
+    return bound.group;
+  }
+
+  if (typeof value === 'object') {
+    throw new JobError(
+      'HENRI_JOB_INVALID_CONCURRENCY',
+      `The concurrency key of "${definition.name}" is an object; it has to be a value that names one bound`,
+      { job: definition.name }
+    );
+  }
+
+  const key = `${bound.group}:${String(value)}`;
+
+  if (key.length > KEY_LENGTH) {
+    throw new JobError(
+      'HENRI_JOB_INVALID_CONCURRENCY',
+      `The concurrency key of "${definition.name}" is ${key.length} characters, over the ${KEY_LENGTH} that are stored`,
+      {
+        hint: 'A key names a bound, so it is an id or a tenant name; hash it yourself if it has to be longer',
+        job: definition.name,
+      }
+    );
+  }
+
+  return key;
+};
+
 /**
  * Reads and checks one definition
  *
@@ -41,6 +187,7 @@ const validate = (name, definition, defaults) => {
           : defaults.backoff.jitter,
       max: duration(backoff.max, defaults.backoff.max),
     },
+    concurrency: concurrency(name, definition.concurrency),
     maxAttempts: Math.max(
       1,
       Number(definition.maxAttempts) || defaults.maxAttempts
@@ -86,4 +233,4 @@ const load = (location, defaults) => {
   return definitions;
 };
 
-module.exports = { load, validate };
+module.exports = { KEY_LENGTH, concurrency, keyOf, load, validate };

--- a/packages/jobs/src/jobs.js
+++ b/packages/jobs/src/jobs.js
@@ -6,7 +6,7 @@ const { JobError, JobStoreError, JobTimeoutError } = require('./errors');
 const { deserialize, serialize } = require('./serialize');
 const { keep } = require('./keys');
 const { duration, runAt } = require('./duration');
-const { load, validate } = require('./definitions');
+const { keyOf, load, validate } = require('./definitions');
 const { normalize, recurring } = require('./config');
 const { storeFor } = require('./store');
 const { toNumber, HISTORY_LIMIT } = require('./store/sql');
@@ -65,6 +65,7 @@ const toJob = (row) => {
     attempts: toNumber(row.attempts) || 0,
     claimedAt: at(row.claimed_at),
     claimedBy: row.claimed_by || null,
+    concurrencyKey: row.concurrency_key || null,
     createdAt: at(row.created_at),
     duration: toNumber(row.duration_ms),
     error: message ? { message, stack: row.error_stack || null } : null,
@@ -118,6 +119,8 @@ class Jobs {
     this.definitions = {};
     this.started = false;
     this.runners = new Set();
+    /** Whether the store can hold a concurrency key; see start() */
+    this.concurrent = false;
 
     /**
      * The retry policy of a job whose file this runner does not have: the
@@ -195,6 +198,24 @@ class Jobs {
       }
     }
 
+    this.concurrent = await this.store.concurrent();
+
+    const bounded = Object.values(this.definitions).filter(
+      (definition) => definition.concurrency
+    );
+
+    this.conflicts(bounded);
+
+    if (bounded.length > 0 && !this.concurrent) {
+      throw new JobError(
+        'HENRI_JOB_LIMIT_UNINSTALLED',
+        `@usehenri/jobs: ${bounded.map((one) => one.name).join(', ')} declare a concurrency limit, and the "${this.config.store}" store has no ${this.config.tables.jobs}.concurrency_key column to hold it`,
+        {
+          hint: 'Run `henri jobs:install` once with a user that may alter the table; the queue itself keeps working without it, and the limit would not',
+        }
+      );
+    }
+
     this.started = true;
 
     const missing = this.config.recurring
@@ -255,6 +276,100 @@ class Jobs {
         },
         this.config
       ),
+    };
+  }
+
+  /**
+   * Refuses two jobs that share a group and disagree on its limit
+   *
+   * A group is a plain string declared in a file, so this is knowable at
+   * boot -- and it has to be answered there, because the two jobs would
+   * otherwise take slots of the same key counting to different numbers and
+   * the bound would be whichever of them asked last.
+   *
+   * @param {Array<object>} bounded The definitions that declare a limit
+   * @returns {void}
+   * @throws {JobError} HENRI_JOB_CONCURRENCY_CONFLICT when two disagree
+   * @memberof Jobs
+   */
+  conflicts(bounded) {
+    const limits = new Map();
+
+    for (const definition of bounded) {
+      const { group, limit } = definition.concurrency;
+      const first = limits.get(group);
+
+      if (first && first.limit !== limit) {
+        throw new JobError(
+          'HENRI_JOB_CONCURRENCY_CONFLICT',
+          `The jobs "${first.name}" and "${definition.name}" share the concurrency group "${group}" and ask for different limits (${first.limit} and ${limit})`,
+          {
+            hint: 'Jobs that share a group share one bound: give them the same limit, or a group each',
+            job: definition.name,
+          }
+        );
+      }
+
+      if (!first) {
+        limits.set(group, { limit, name: definition.name });
+      }
+    }
+  }
+
+  /**
+   * The jobs that declare a concurrency limit, by group
+   *
+   * The runner asks for this every tick: the names are what partitions the
+   * claim into its two passes, and the groups are what says how many slots
+   * a key has.
+   *
+   * @returns {object} `{ names, groups }`
+   * @memberof Jobs
+   */
+  limited() {
+    const groups = new Map();
+    const names = [];
+
+    for (const definition of Object.values(this.definitions)) {
+      if (!definition.concurrency) {
+        continue;
+      }
+
+      const { group, limit } = definition.concurrency;
+      const entry = groups.get(group) || { limit, names: [] };
+
+      entry.names.push(definition.name);
+      groups.set(group, entry);
+      names.push(definition.name);
+    }
+
+    return { groups, names: names.sort() };
+  }
+
+  /**
+   * What a key with work waiting needs to be claimed from
+   *
+   * @param {object} entry `{ key, name }`, as the store's `waiting()` gives
+   * @param {object} [bounded] What `limited()` answered, when the caller
+   *   already has it (the runner asks once per tick, not once per key)
+   * @returns {?object} `{ key, limit, names }`, or null when the job is gone
+   * @memberof Jobs
+   */
+  bucket(entry, bounded = this.limited()) {
+    const definition = this.definitions[entry.name];
+
+    if (!definition || !definition.concurrency) {
+      return null;
+    }
+
+    const { group, limit } = definition.concurrency;
+    const value = entry.key || group;
+    const held = bounded.groups.get(group);
+
+    return {
+      key: { own: value === group, value },
+      limit,
+      names: held ? held.names : [definition.name],
     };
   }
 
@@ -438,6 +553,21 @@ class Jobs {
    */
   async perform(name, args = null, options = {}) {
     const definition = this.definition(name);
+
+    // A job a package defined after the boot may declare a limit the store
+    // has no column for; the enqueue is where that is caught, because
+    // enqueuing it unbounded is the one answer that breaks the guarantee
+    if (definition.concurrency && !this.concurrent) {
+      throw new JobError(
+        'HENRI_JOB_LIMIT_UNINSTALLED',
+        `The job "${name}" declares a concurrency limit, and the "${this.config.store}" store has no ${this.config.tables.jobs}.concurrency_key column to hold it`,
+        {
+          hint: 'Run `henri jobs:install` once with a user that may alter the table',
+          job: name,
+        }
+      );
+    }
+
     const now = Date.now();
     const when = runAt(options, now);
     const row = {
@@ -446,6 +576,7 @@ class Jobs {
       claim_token: null,
       claimed_at: null,
       claimed_by: null,
+      concurrency_key: keyOf(definition, args),
       created_at: now,
       duration_ms: null,
       error_message: null,
@@ -678,6 +809,33 @@ class Jobs {
       ),
       totals,
     };
+  }
+
+  /**
+   * What the concurrency limits are, and which of their slots are held
+   *
+   * The pair an operator needs and no log line carries: what the
+   * application asked for, and what is holding it up right now. It carries
+   * job ids and runner names and no arguments -- what a job was given is
+   * the application's data, and `henri jobs:show <id>` is where it is read
+   * by somebody who may.
+   *
+   * @returns {Promise<object>} `{ declared, held }`
+   * @memberof Jobs
+   */
+  async limits() {
+    const declared = Object.values(this.definitions)
+      .filter((definition) => definition.concurrency)
+      .map((definition) => ({
+        group: definition.concurrency.group,
+        job: definition.name,
+        keyed: Boolean(definition.concurrency.key),
+        limit: definition.concurrency.limit,
+      }))
+      .sort((one, other) => one.job.localeCompare(other.job));
+    const held = this.concurrent ? await this.storeOrDie().slots() : [];
+
+    return { declared, held };
   }
 
   /**

--- a/packages/jobs/src/module.js
+++ b/packages/jobs/src/module.js
@@ -393,6 +393,16 @@ class JobsModule extends BaseModule {
   }
 
   /**
+   * The concurrency limits of the application, and the slots being held
+   *
+   * @returns {Promise<object>} `{ declared, held }`
+   * @memberof JobsModule
+   */
+  limits() {
+    return this.ready().limits();
+  }
+
+  /**
    * The job names of the application
    *
    * @returns {Array<string>} The names

--- a/packages/jobs/src/runner.js
+++ b/packages/jobs/src/runner.js
@@ -8,6 +8,19 @@ const { slot } = require('./keys');
 /** What a schedule waits before it looks again at an expression */
 const MINUTE = 60000;
 
+/**
+ * How many concurrency keys one tick looks at.
+ *
+ * A keyed limit (`key: 'tenantId'`) makes as many keys as there are tenants
+ * with work waiting, and a runner only ever has room for a handful of them:
+ * the store hands back the most urgent, which is the order the claim would
+ * have taken them in anyway.
+ */
+const KEYS_PER_TICK = 100;
+
+/** No job of this application declares a limit */
+const UNBOUNDED = { groups: new Map(), names: [] };
+
 /** The signals a runner stops on */
 const SIGNALS = ['SIGINT', 'SIGTERM', 'SIGQUIT'];
 
@@ -53,6 +66,8 @@ class Runner {
 
     /** The jobs in flight: id -> { promise, token } */
     this.running = new Map();
+    /** The concurrency slots this runner holds: job id -> { key, slot } */
+    this.slots = new Map();
     this.stopping = false;
     this.stopped = null;
     this.loop = null;
@@ -375,25 +390,182 @@ class Runner {
       return 1;
     }
 
+    // The two passes partition the queue by job name: the first takes
+    // everything that declares no limit, in one statement, exactly as it
+    // always did; the second takes one row per concurrency slot it holds
+    const bounded = this.jobs.concurrent ? this.jobs.limited() : UNBOUNDED;
     const token = uuid();
+    const now = Date.now();
     const started = process.hrtime.bigint();
     const rows = await this.jobs.storeOrDie().claim({
+      except: bounded.names,
       limit: room,
-      now: Date.now(),
+      now,
       queues: this.queues,
       runner: this.id,
       token,
-    });
-
-    this.claimed.record(Number(process.hrtime.bigint() - started) / 1e9, {
-      'henri.jobs.claimed': rows.length,
     });
 
     for (const row of rows) {
       this.running.set(row.id, { promise: this.hold(row), token });
     }
 
-    return rows.length;
+    const left = room - rows.length;
+    const held =
+      left > 0 && bounded.names.length > 0
+        ? await this.throttled(bounded, left, now)
+        : 0;
+
+    this.claimed.record(Number(process.hrtime.bigint() - started) / 1e9, {
+      'henri.jobs.claimed': rows.length + held,
+    });
+
+    return rows.length + held;
+  }
+
+  /**
+   * Claims the jobs whose concurrency limit leaves room for them
+   *
+   * The permit comes **first**: a slot is taken, and only then is one row of
+   * that key claimed. The other order -- claim, discover the key is full,
+   * put the row back -- would make a full key spin this loop, because the
+   * cycle only sleeps when a tick claimed nothing.
+   *
+   * @param {object} bounded `{ names, groups }` from the queue
+   * @param {number} room How many jobs this runner still has room for
+   * @param {number} now The current time
+   * @returns {Promise<number>} How many jobs were claimed
+   * @memberof Runner
+   */
+  async throttled(bounded, room, now) {
+    const store = this.jobs.storeOrDie();
+    const waiting = await store.waiting({
+      limit: KEYS_PER_TICK,
+      names: bounded.names,
+      now,
+      queues: this.queues,
+    });
+    const seen = new Set();
+    let taken = 0;
+
+    for (const entry of waiting) {
+      if (taken >= room) {
+        break;
+      }
+
+      const bucket = this.jobs.bucket(entry, bounded);
+
+      // Two jobs of one group may answer for the same key: it is one bound,
+      // so it is asked for once
+      if (!bucket || seen.has(bucket.key.value)) {
+        continue;
+      }
+
+      seen.add(bucket.key.value);
+
+      // A key with room for three and a runner with room for three takes
+      // three: the slots run out (`takeSlot` answers null) or the key does
+      // (`claimOne` gives the permit straight back)
+      while (taken < room) {
+        const slot = await store.takeSlot({
+          key: bucket.key.value,
+          limit: bucket.limit,
+          now: Date.now(),
+          runner: this.id,
+        });
+
+        if (slot === null || !(await this.claimOne(bucket, slot, now))) {
+          break;
+        }
+
+        taken += 1;
+      }
+    }
+
+    return taken;
+  }
+
+  /**
+   * Claims one row of a key this runner holds a slot of
+   *
+   * @param {object} bucket `{ key, limit, names }`
+   * @param {number} slot The slot this runner took
+   * @param {number} now The current time
+   * @returns {Promise<boolean>} Whether a job was claimed
+   * @memberof Runner
+   */
+  async claimOne(bucket, slot, now) {
+    const store = this.jobs.storeOrDie();
+    const key = bucket.key.value;
+    const token = uuid();
+    let rows;
+
+    try {
+      rows = await store.claim({
+        key: bucket.key,
+        limit: 1,
+        names: bucket.names,
+        now,
+        queues: this.queues,
+        runner: this.id,
+        token,
+      });
+    } catch (error) {
+      await store.releaseSlot(key, slot, this.id).catch(() => null);
+      throw error;
+    }
+
+    const [row] = rows;
+
+    if (!row) {
+      // Another runner took the last row of this key in between: the permit
+      // goes back at once rather than waiting for the sweep
+      await store.releaseSlot(key, slot, this.id);
+
+      return false;
+    }
+
+    this.slots.set(row.id, { key, slot });
+    // Says what the slot is being held for, for `henri jobs:status`; the
+    // bound does not rest on it, so a failure here is a debug line
+    await store
+      .holdSlot(key, slot, row.id, Date.now())
+      .catch((error) => debug('holdSlot: %s', error.message));
+    this.running.set(row.id, { promise: this.hold(row), token });
+
+    return true;
+  }
+
+  /**
+   * Gives back the concurrency slot a job was performed under
+   *
+   * A slot that cannot be given back is freed by the sweep once its
+   * heartbeat goes stale, like the job of a runner that died.
+   *
+   * @param {string} id The job id
+   * @returns {Promise<void>} Resolves when it is back
+   * @memberof Runner
+   */
+  async free(id) {
+    const held = this.slots.get(id);
+
+    if (!held) {
+      return;
+    }
+
+    this.slots.delete(id);
+
+    try {
+      await this.jobs.storeOrDie().releaseSlot(held.key, held.slot, this.id);
+    } catch (error) {
+      this.log(
+        'warn',
+        'runner',
+        this.id,
+        `could not free the concurrency slot ${held.key}#${held.slot}:`,
+        error.message
+      );
+    }
   }
 
   /**
@@ -420,6 +592,11 @@ class Runner {
       this.log('error', 'runner', this.id, row.name, error.message);
       debug('%O', error);
     } finally {
+      // The slot goes back before the job leaves `running`, and in that
+      // order: `shutdown()` waits on the promises of what is running, so a
+      // job removed first would let the runner stop with its permit still
+      // held, to be freed by a sweep five minutes later
+      await this.free(row.id);
       this.running.delete(row.id);
     }
   }
@@ -449,6 +626,15 @@ class Runner {
     try {
       for (const [token, ids] of batches) {
         await this.jobs.storeOrDie().heartbeat(ids, now, token);
+      }
+
+      // The concurrency slots are refreshed by the same beat, and the sweep
+      // that frees a stale one uses the same `stuckAfter`: a slot outlives
+      // a runner by exactly as long as its jobs do
+      if (this.slots.size > 0) {
+        await this.jobs
+          .storeOrDie()
+          .heartbeatSlots([...this.slots.values()], now, this.id);
       }
 
       this.beatFailed = false;
@@ -503,12 +689,28 @@ class Runner {
     // `stuckAfter` has gone by, and the pruning is housekeeping
     this.sweepAt = now + Math.max(5000, Math.floor(this.stuckAfter / 10));
 
-    const recovered = await this.jobs
-      .storeOrDie()
-      .recover({ now, stuckAfter: this.stuckAfter });
+    const store = this.jobs.storeOrDie();
+    const recovered = await store.recover({ now, stuckAfter: this.stuckAfter });
 
     for (const row of recovered) {
       this.log('warn', row.name, row.id, 'recovered from', row.claimed_by);
+    }
+
+    if (this.jobs.concurrent) {
+      const freed = await store.sweepSlots({
+        now,
+        stuckAfter: this.stuckAfter,
+      });
+
+      for (const held of freed) {
+        this.log(
+          'warn',
+          'concurrency',
+          `${held.key}#${held.slot}`,
+          'freed from',
+          held.runner
+        );
+      }
     }
 
     if (this.keepCompleted > 0) {
@@ -692,4 +894,4 @@ class Runner {
   }
 }
 
-module.exports = { Runner, SIGNALS };
+module.exports = { KEYS_PER_TICK, Runner, SIGNALS };

--- a/packages/jobs/src/store/mongo.js
+++ b/packages/jobs/src/store/mongo.js
@@ -23,6 +23,19 @@ const { keep } = require('../keys');
  *
  * Documents use the same field names as the SQL columns so the two backends
  * hand the queue the same rows.
+ *
+ * ## Concurrency limits
+ *
+ * The same as the SQL backend, for the same reason: a bound on how many of
+ * a job run at once cannot be counted inside the claim, so it is held by a
+ * collection whose `_id` is `<key>#<slot>`. An `insertOne` either writes it
+ * or answers 11000, which is exactly the primitive the SQL side gets from a
+ * primary key -- and the one thing MongoDB has no other way to give, having
+ * neither `SELECT ... FOR UPDATE` nor an advisory lock.
+ *
+ * A collection needs no upgrade: a document written by an older henri
+ * simply has no `concurrency_key`, which is what an unlimited job's row
+ * looks like anyway.
  */
 
 /** The collection is written with the SQL column names, on purpose */
@@ -38,7 +51,7 @@ class MongoStore {
    * Creates an instance of MongoStore.
    *
    * @param {object} adapter A henri mongoose (or disk) adapter
-   * @param {object} tables `{ jobs, schedules }` collection names
+   * @param {object} tables `{ jobs, schedules, limits }` collection names
    * @memberof MongoStore
    */
   constructor(adapter, tables) {
@@ -89,6 +102,29 @@ class MongoStore {
   }
 
   /**
+   * The concurrency slots collection
+   *
+   * @returns {object} A MongoDB collection
+   * @memberof MongoStore
+   */
+  limits() {
+    return this.database().collection(this.tables.limits);
+  }
+
+  /**
+   * Whether concurrency limits can be held here; they always can
+   *
+   * A collection has no columns to be missing, so there is nothing for an
+   * installation to upgrade and nothing to refuse.
+   *
+   * @returns {Promise<boolean>} true
+   * @memberof MongoStore
+   */
+  async concurrent() {
+    return true;
+  }
+
+  /**
    * A document, as the queue reads rows
    *
    * @param {?object} document A stored document
@@ -136,7 +172,12 @@ class MongoStore {
       }
     );
 
-    return [this.tables.jobs, this.tables.schedules];
+    await this.limits().createIndex(
+      { heartbeat_at: 1 },
+      { name: `${this.tables.limits}_stale` }
+    );
+
+    return [this.tables.jobs, this.tables.schedules, this.tables.limits];
   }
 
   /**
@@ -169,14 +210,18 @@ class MongoStore {
    * @memberof MongoStore
    */
   async uninstall() {
-    for (const name of [this.tables.jobs, this.tables.schedules]) {
+    for (const name of [
+      this.tables.jobs,
+      this.tables.schedules,
+      this.tables.limits,
+    ]) {
       await this.database()
         .collection(name)
         .drop()
         .catch(() => null);
     }
 
-    return [this.tables.schedules, this.tables.jobs];
+    return [this.tables.limits, this.tables.schedules, this.tables.jobs];
   }
 
   /**
@@ -209,6 +254,15 @@ class MongoStore {
     // partial unique index never sees it
     if (rest.unique_key === null || typeof rest.unique_key === 'undefined') {
       delete rest.unique_key;
+    }
+
+    // Likewise: an unlimited job has no `concurrency_key` field at all, and
+    // that is what a document an older henri wrote looks like
+    if (
+      rest.concurrency_key === null ||
+      typeof rest.concurrency_key === 'undefined'
+    ) {
+      delete rest.concurrency_key;
     }
 
     try {
@@ -265,10 +319,22 @@ class MongoStore {
    * @param {string} options.runner The runner id
    * @param {string} options.token A token unique to this claim
    * @param {number} options.now The current time
+   * @param {object} [options.key] The concurrency key a slot is held for
+   * @param {Array<string>} [options.names] Only these job names
+   * @param {Array<string>} [options.except] Every name but these
    * @returns {Promise<Array<object>>} The rows this runner owns
    * @memberof MongoStore
    */
-  async claim({ queues = [], limit = 1, runner, token, now }) {
+  async claim({
+    queues = [],
+    limit = 1,
+    runner,
+    token,
+    now,
+    key,
+    names,
+    except,
+  }) {
     // `includeResultMetadata: false` is the default of the v6+ driver and is
     // named here on purpose: under an older one findOneAndUpdate answers
     // `{ value }`, which would read as a win for every runner
@@ -278,6 +344,22 @@ class MongoStore {
 
     if (queues.length > 0) {
       filter.queue = { $in: queues };
+    }
+
+    // The two passes partition the pending documents by **name**, exactly as
+    // the SQL backend does
+    if (except && except.length > 0) {
+      filter.name = { $nin: except };
+    }
+
+    if (names && names.length > 0) {
+      filter.name = { $in: names };
+    }
+
+    if (key) {
+      // A document with no `concurrency_key` field matches `null`, which is
+      // what a job enqueued before the limit was declared looks like
+      filter.concurrency_key = key.own ? { $in: [key.value, null] } : key.value;
     }
 
     for (let taken = 0; taken < limit; taken += 1) {
@@ -314,6 +396,226 @@ class MongoStore {
     debug('claimed %d job(s) for %s', claimed.length, runner);
 
     return claimed;
+  }
+
+  /**
+   * The concurrency keys with work waiting, the most urgent first
+   *
+   * @param {object} options Options
+   * @param {number} options.now The current time
+   * @param {Array<string>} options.names The names of the limited jobs
+   * @param {Array<string>} [options.queues=[]] The queues to look at
+   * @param {number} [options.limit=100] How many keys at most
+   * @returns {Promise<Array<object>>} `{ key, name, total }` rows
+   * @memberof MongoStore
+   */
+  async waiting({ now, names, queues = [], limit = 100 }) {
+    if (!names || names.length === 0) {
+      return [];
+    }
+
+    const match = {
+      name: { $in: names },
+      run_at: { $lte: now },
+      state: 'pending',
+    };
+
+    if (queues.length > 0) {
+      match.queue = { $in: queues };
+    }
+
+    const rows = await this.jobs()
+      .aggregate([
+        { $match: match },
+        {
+          $group: {
+            _id: { key: '$concurrency_key', name: '$name' },
+            due: { $min: '$run_at' },
+            priority: { $min: '$priority' },
+            total: { $sum: 1 },
+          },
+        },
+        // Ordered, like an ORDER BY
+        // eslint-disable-next-line sort-keys
+        { $sort: { priority: 1, due: 1 } },
+        { $limit: Math.max(1, Number(limit) || 100) },
+      ])
+      .toArray();
+
+    return rows.map((row) => ({
+      key: row._id.key || null,
+      name: row._id.name,
+      total: row.total || 0,
+    }));
+  }
+
+  /**
+   * The `_id` of one slot
+   *
+   * The slot is an integer and it is always last, so the split on the final
+   * `#` gives the key back whatever the key holds.
+   *
+   * @param {string} key The concurrency key
+   * @param {number} slot The slot
+   * @returns {string} The document id
+   * @memberof MongoStore
+   */
+  slotId(key, slot) {
+    return `${key}#${slot}`;
+  }
+
+  /**
+   * Takes one of a key's slots, or answers null when they are all held
+   *
+   * **This is the bound.** An `insertOne` on a taken `_id` answers 11000 and
+   * writes nothing, which is the same refusal a primary key gives the SQL
+   * backend.
+   *
+   * @param {object} options Options
+   * @param {string} options.key The concurrency key
+   * @param {number} options.limit How many may run at once
+   * @param {string} options.runner The runner id
+   * @param {number} options.now The current time
+   * @returns {Promise<?number>} The slot this runner holds, or null
+   * @memberof MongoStore
+   */
+  async takeSlot({ key, limit, runner, now }) {
+    for (let slot = 0; slot < limit; slot += 1) {
+      try {
+        await this.limits().insertOne({
+          _id: this.slotId(key, slot),
+          heartbeat_at: now,
+          job_id: null,
+          limit_key: key,
+          runner,
+          slot,
+          taken_at: now,
+        });
+
+        return slot;
+      } catch (error) {
+        if (error.code !== 11000) {
+          throw error;
+        }
+
+        debug('slot %d of %s was taken first', slot, key);
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Says which job a slot is being held for
+   *
+   * @param {string} key The concurrency key
+   * @param {number} slot The slot
+   * @param {?string} id The job id
+   * @param {number} now The current time
+   * @returns {Promise<void>} Resolves when written
+   * @memberof MongoStore
+   */
+  async holdSlot(key, slot, id, now) {
+    await this.limits().updateOne(
+      { _id: this.slotId(key, slot) },
+      { $set: { heartbeat_at: now, job_id: id } }
+    );
+  }
+
+  /**
+   * Gives a slot back
+   *
+   * @param {string} key The concurrency key
+   * @param {number} slot The slot
+   * @param {string} [runner] Only when this runner still holds it
+   * @returns {Promise<void>} Resolves when written
+   * @memberof MongoStore
+   */
+  async releaseSlot(key, slot, runner) {
+    const filter = { _id: this.slotId(key, slot) };
+
+    if (runner) {
+      filter.runner = runner;
+    }
+
+    await this.limits().deleteOne(filter);
+  }
+
+  /**
+   * Tells the database this runner still holds these slots
+   *
+   * @param {Array<object>} slots `{ key, slot }` entries
+   * @param {number} now The current time
+   * @param {string} runner The runner id
+   * @returns {Promise<void>} Resolves when written
+   * @memberof MongoStore
+   */
+  async heartbeatSlots(slots, now, runner) {
+    if (slots.length === 0) {
+      return;
+    }
+
+    await this.limits().updateMany(
+      {
+        _id: { $in: slots.map((held) => this.slotId(held.key, held.slot)) },
+        runner,
+      },
+      { $set: { heartbeat_at: now } }
+    );
+  }
+
+  /**
+   * Frees the slots of runners that stopped answering
+   *
+   * @param {object} options `now`, `stuckAfter` and `limit`
+   * @returns {Promise<Array<object>>} The slots that were freed
+   * @memberof MongoStore
+   */
+  async sweepSlots({ now, stuckAfter, limit = 100 }) {
+    const documents = await this.limits()
+      .find({ heartbeat_at: { $lt: now - stuckAfter } })
+      .sort({ heartbeat_at: 1 })
+      .limit(limit)
+      .toArray();
+
+    for (const document of documents) {
+      await this.limits().deleteOne({
+        _id: document._id,
+        heartbeat_at: document.heartbeat_at,
+      });
+    }
+
+    return documents.map((document) => ({
+      job: document.job_id || null,
+      key: document.limit_key,
+      runner: document.runner,
+      slot: document.slot,
+      takenAt: document.taken_at,
+    }));
+  }
+
+  /**
+   * Every slot being held right now
+   *
+   * @param {number} [limit=200] How many at most
+   * @returns {Promise<Array<object>>} The held slots
+   * @memberof MongoStore
+   */
+  async slots(limit = 200) {
+    const documents = await this.limits()
+      .find({})
+      .sort({ limit_key: 1, slot: 1 })
+      .limit(limit)
+      .toArray();
+
+    return documents.map((document) => ({
+      heartbeatAt: document.heartbeat_at,
+      job: document.job_id || null,
+      key: document.limit_key,
+      runner: document.runner,
+      slot: document.slot,
+      takenAt: document.taken_at,
+    }));
   }
 
   /**
@@ -674,7 +976,7 @@ class MongoStore {
  * Builds the MongoDB store of an adapter
  *
  * @param {object} adapter A henri mongoose (or disk) adapter
- * @param {object} tables `{ jobs, schedules }` collection names
+ * @param {object} tables `{ jobs, schedules, limits }` collection names
  * @returns {MongoStore} The store
  */
 const create = (adapter, tables) => new MongoStore(adapter, tables);

--- a/packages/jobs/src/store/schema.js
+++ b/packages/jobs/src/store/schema.js
@@ -2,9 +2,25 @@
  * The tables `@usehenri/jobs` owns, and the DDL of every SQL dialect henri
  * can talk to.
  *
- * The queue never goes through a henri model: it owns two tables of its own
+ * The queue never goes through a henri model: it owns three tables of its own
  * so it cannot collide with the application's schema, and so a store that
  * has no models at all (a fresh application) still has a queue.
+ *
+ * ## The upgrade block
+ *
+ * These tables are `CREATE TABLE IF NOT EXISTS` and there is no migration
+ * chain behind them, so a table an older henri created is the table an
+ * installation still has. A **new table** is therefore free -- the guarded
+ * create makes it appear -- and a **new column** is not.
+ *
+ * `upgrade()` is the answer: the statements that bring an existing table up
+ * to what this version writes, every one of them idempotent, and every one
+ * of them **tolerated** by the store (see `SqlStore#install`). A database
+ * user who may not `ALTER` never fails a boot over a feature the
+ * application does not use; the feature itself asks whether its column is
+ * there (`SqlStore#concurrent`) and refuses with the install line when it is
+ * not. The same statements run on a fresh database, where they find their
+ * work already done.
  *
  * Every moment is stored as a BIGINT of milliseconds since the epoch rather
  * than a timestamp column: sqlite has no date type, MySQL, PostgreSQL and
@@ -22,6 +38,17 @@ const SAFE_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 const DIALECTS = {
   mssql: {
+    /**
+     * Adds a column, only when the table has none by that name
+     *
+     * @param {string} table The table name
+     * @param {string} column The column name
+     * @param {string} type The column type
+     * @returns {string} The statement
+     */
+    addColumn: (table, column, type) =>
+      `IF COL_LENGTH('${table}', '${column}') IS NULL ALTER TABLE [${table}] ADD ${column} ${type} NULL`,
+
     /**
      * Wraps a statement so it only runs when the index is missing
      *
@@ -44,6 +71,7 @@ const DIALECTS = {
       `IF OBJECT_ID('${table}', 'U') IS NULL ${statement}`,
 
     ifNotExists: '',
+    indexIfNotExists: '',
     inlineIndexes: false,
     int: 'INT',
     // MSSQL is the one dialect that treats NULLs as equal in a unique index
@@ -52,9 +80,16 @@ const DIALECTS = {
     text: 'NVARCHAR(MAX)',
   },
   mysql: {
+    // MySQL has no ADD COLUMN IF NOT EXISTS: a second run answers 1060,
+    // which the store tolerates like every other upgrade statement
+    addColumn: (table, column, type) =>
+      `ALTER TABLE \`${table}\` ADD COLUMN ${column} ${type} NULL`,
     ifNotExists: 'IF NOT EXISTS',
     // MySQL has no CREATE INDEX IF NOT EXISTS: the indexes are declared in
-    // the CREATE TABLE, which is guarded
+    // the CREATE TABLE, which is guarded. An index the create cannot carry
+    // (a `late` one, on a table that is already there) is written bare and
+    // tolerated when it answers 1061
+    indexIfNotExists: '',
     inlineIndexes: true,
     int: 'INT',
     partialUnique: false,
@@ -63,7 +98,10 @@ const DIALECTS = {
     text: 'MEDIUMTEXT',
   },
   postgres: {
+    addColumn: (table, column, type) =>
+      `ALTER TABLE "${table}" ADD COLUMN IF NOT EXISTS ${column} ${type} NULL`,
     ifNotExists: 'IF NOT EXISTS',
+    indexIfNotExists: 'IF NOT EXISTS',
     inlineIndexes: false,
     int: 'INTEGER',
     partialUnique: false,
@@ -71,7 +109,12 @@ const DIALECTS = {
     text: 'TEXT',
   },
   sqlite: {
+    // SQLite has no ADD COLUMN IF NOT EXISTS either: a second run answers
+    // "duplicate column name", which the store tolerates
+    addColumn: (table, column, type) =>
+      `ALTER TABLE "${table}" ADD COLUMN ${column} ${type} NULL`,
     ifNotExists: 'IF NOT EXISTS',
+    indexIfNotExists: 'IF NOT EXISTS',
     inlineIndexes: false,
     int: 'INTEGER',
     partialUnique: false,
@@ -79,6 +122,15 @@ const DIALECTS = {
     text: 'TEXT',
   },
 };
+
+/**
+ * The columns an older henri did not write, and the type they take.
+ *
+ * One entry per column added after a version that shipped: the create
+ * statement declares them and `upgrade()` adds them to a table that has
+ * them not.
+ */
+const ADDED = [{ column: 'concurrency_key', type: 'VARCHAR(190)' }];
 
 /**
  * The columns of the jobs table, in order
@@ -110,7 +162,38 @@ const jobColumns = (dialect) => [
   `error_stack ${dialect.text} NULL`,
   `history ${dialect.text} NULL`,
   'unique_key VARCHAR(190) NULL',
+  'concurrency_key VARCHAR(190) NULL',
   'PRIMARY KEY (id)',
+];
+
+/**
+ * The columns of the concurrency table, in order
+ *
+ * One row is one slot of one key: `(limit_key, slot)` is the primary key, so
+ * `slot` counts from zero to the job's limit and an INSERT is what takes it.
+ * That unique index is the whole bound -- see `SqlStore#takeSlot`.
+ *
+ * @param {object} dialect A dialect description
+ * @returns {Array<string>} The column definitions
+ */
+const limitColumns = (dialect) => [
+  'limit_key VARCHAR(190) NOT NULL',
+  `slot ${dialect.int} NOT NULL`,
+  'job_id VARCHAR(36) NULL',
+  'runner VARCHAR(120) NOT NULL',
+  'taken_at BIGINT NOT NULL',
+  'heartbeat_at BIGINT NOT NULL',
+  'PRIMARY KEY (limit_key, slot)',
+];
+
+/**
+ * The indexes of the concurrency table
+ *
+ * @param {string} table The table name
+ * @returns {Array<object>} `{ name, columns, unique }` entries
+ */
+const limitIndexes = (table) => [
+  { columns: ['heartbeat_at'], name: `${table}_stale`, unique: false },
 ];
 
 /**
@@ -150,21 +233,59 @@ const jobIndexes = (table) => [
     unique: false,
   },
   { columns: ['unique_key'], name: `${table}_unique`, unique: true },
+  // `late`: it arrived with a column an older table has not, so it belongs
+  // to the upgrade block on every dialect rather than to the create
+  {
+    columns: ['state', 'concurrency_key', 'run_at'],
+    late: true,
+    name: `${table}_limited`,
+    unique: false,
+  },
 ];
+
+/**
+ * The statement that creates one index
+ *
+ * @param {object} dialect A dialect description
+ * @param {string} table The table name
+ * @param {object} index An index description
+ * @returns {string} The statement
+ */
+const indexStatement = (dialect, table, index) => {
+  const filter =
+    index.unique && dialect.partialUnique
+      ? ` WHERE ${index.columns[0]} IS NOT NULL`
+      : '';
+  const statement = [
+    `CREATE ${index.unique ? 'UNIQUE ' : ''}INDEX`,
+    dialect.guardIndex ? '' : dialect.indexIfNotExists,
+    `${dialect.quote(index.name)} ON ${dialect.quote(table)} (${index.columns.join(', ')})${filter}`,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return dialect.guardIndex
+    ? dialect.guardIndex(table, index.name, statement)
+    : statement;
+};
 
 /**
  * The statements that create a table and its indexes, in order
  *
+ * An index marked `late` is left out: it names a column an older table does
+ * not have, so it is the upgrade block's, on every dialect at once.
+ *
  * @param {object} dialect A dialect description
  * @param {string} table The table name
  * @param {Array<string>} columns The column definitions
- * @param {Array<object>} indexes The indexes
+ * @param {Array<object>} all The indexes
  * @returns {Array<string>} The statements to run, in order
  */
-const statementsFor = (dialect, table, columns, indexes) => {
+const statementsFor = (dialect, table, columns, all) => {
   const quoted = dialect.quote(table);
   const definitions = [...columns];
   const statements = [];
+  const indexes = all.filter((index) => !index.late);
 
   if (dialect.inlineIndexes) {
     for (const index of indexes) {
@@ -191,26 +312,43 @@ const statementsFor = (dialect, table, columns, indexes) => {
   }
 
   for (const index of indexes) {
-    const filter =
-      index.unique && dialect.partialUnique
-        ? ` WHERE ${index.columns[0]} IS NOT NULL`
-        : '';
-    const statement = [
-      `CREATE ${index.unique ? 'UNIQUE ' : ''}INDEX`,
-      dialect.guardIndex ? '' : dialect.ifNotExists,
-      `${dialect.quote(index.name)} ON ${quoted} (${index.columns.join(', ')})${filter}`,
-    ]
-      .filter(Boolean)
-      .join(' ');
-
-    statements.push(
-      dialect.guardIndex
-        ? dialect.guardIndex(table, index.name, statement)
-        : statement
-    );
+    statements.push(indexStatement(dialect, table, index));
   }
 
   return statements;
+};
+
+/**
+ * The statements that bring a table an older henri created up to date
+ *
+ * Every one of them is idempotent and every one of them is tolerated by the
+ * store: a database user who may not `ALTER` never fails a boot over a
+ * feature the application does not use. What decides whether the feature
+ * works is asking the table, not whether these ran.
+ *
+ * @param {string} name The dialect (sqlite, postgres, mysql, mssql)
+ * @param {object} tables `{ jobs, schedules, limits }` table names
+ * @returns {Array<string>} The statements
+ * @throws {Error} When the dialect is unknown
+ */
+const upgrade = (name, tables) => {
+  const dialect = DIALECTS[name];
+
+  if (!dialect) {
+    throw coded(
+      'HENRI_JOB_UNSUPPORTED_STORE',
+      `@usehenri/jobs: unsupported SQL dialect "${name}"`
+    );
+  }
+
+  return [
+    ...ADDED.map((added) =>
+      dialect.addColumn(tables.jobs, added.column, added.type)
+    ),
+    ...jobIndexes(tables.jobs)
+      .filter((index) => index.late)
+      .map((index) => indexStatement(dialect, tables.jobs, index)),
+  ];
 };
 
 /**
@@ -220,7 +358,7 @@ const statementsFor = (dialect, table, columns, indexes) => {
  * database another runner already prepared, changes nothing.
  *
  * @param {string} name The dialect (sqlite, postgres, mysql, mssql)
- * @param {object} tables `{ jobs, schedules }` table names
+ * @param {object} tables `{ jobs, schedules, limits }` table names
  * @returns {Array<string>} The statements
  * @throws {Error} When the dialect or a table name is unknown
  */
@@ -251,6 +389,13 @@ const install = (name, tables) => {
       jobIndexes(tables.jobs)
     ),
     ...statementsFor(dialect, tables.schedules, scheduleColumns(dialect), []),
+    ...statementsFor(
+      dialect,
+      tables.limits,
+      limitColumns(dialect),
+      limitIndexes(tables.limits)
+    ),
+    ...upgrade(name, tables),
   ];
 };
 
@@ -258,7 +403,7 @@ const install = (name, tables) => {
  * The statements that drop the tables, newest first
  *
  * @param {string} name The dialect
- * @param {object} tables `{ jobs, schedules }` table names
+ * @param {object} tables `{ jobs, schedules, limits }` table names
  * @returns {Array<string>} The statements
  * @throws {Error} When the dialect is unknown
  */
@@ -272,9 +417,9 @@ const uninstall = (name, tables) => {
     );
   }
 
-  return [tables.schedules, tables.jobs].map(
+  return [tables.limits, tables.schedules, tables.jobs].map(
     (table) => `DROP TABLE IF EXISTS ${dialect.quote(table)}`
   );
 };
 
-module.exports = { DIALECTS, install, uninstall };
+module.exports = { ADDED, DIALECTS, install, uninstall, upgrade };

--- a/packages/jobs/src/store/sql.js
+++ b/packages/jobs/src/store/sql.js
@@ -1,7 +1,7 @@
 const debug = require('debug')('henri:jobs:sql');
 
 const { JobStoreError } = require('../errors');
-const { install, uninstall } = require('./schema');
+const { install, uninstall, upgrade } = require('./schema');
 const { keep } = require('../keys');
 
 /**
@@ -32,6 +32,33 @@ const { keep } = require('../keys');
  * The claim stamps a fresh `claim_token` on the rows it took, so the rows
  * are read back with an exact `WHERE claim_token = ?` rather than by
  * guessing which of the candidates were won.
+ *
+ * ## Concurrency limits
+ *
+ * A job may declare how many of it may run at once across every runner
+ * (`concurrency`). That bound is **not** in the claim statement, and it
+ * cannot be: a `SELECT COUNT(*) ... WHERE state = 'running'` inside the
+ * claim is read at the statement's own snapshot, so two runners racing both
+ * see the same free room, both take it and both commit. `FOR UPDATE SKIP
+ * LOCKED` does not help -- it locks the candidate *rows*, so the second
+ * runner steps over them and claims the next ones instead. Making the count
+ * exact needs a lock on something shared per key, and that is
+ * `pg_advisory_xact_lock` on PostgreSQL, `GET_LOCK` on MySQL,
+ * `sp_getapplock` on MSSQL and nothing at all on MongoDB: four mechanisms,
+ * one of them missing.
+ *
+ * So the bound lives in a table (`<jobs>_limits`), and the primitive is the
+ * one every backend agrees on: **a unique index refusing a duplicate**. One
+ * row is one slot, `(limit_key, slot)` is the primary key, and a runner
+ * takes a slot by inserting it -- exactly one insert per slot wins. A runner
+ * takes the permit *first* and claims one row of that key second, so a job
+ * is never claimed only to be put back, which would spin the runner's loop.
+ *
+ * The claim statement itself gains one predicate and keeps its shape:
+ * `name NOT IN (...)` for the pass that takes the unlimited work, and
+ * `name IN (...) AND concurrency_key = ?` for the pass that takes one
+ * limited row. With no limited job in the application the statement is what
+ * it always was, down to its parameters.
  */
 
 /** The columns of the jobs table, in insert order */
@@ -59,6 +86,7 @@ const COLUMNS = [
   'error_stack',
   'history',
   'unique_key',
+  'concurrency_key',
 ];
 
 /** How many attempts of a job are kept in its history */
@@ -74,7 +102,7 @@ const HISTORY_LIMIT = 10;
  * by intent, so that failure means it is done, not that it broke.
  */
 const ALREADY_THERE =
-  /already exists|duplicate key|duplicate table|there is already an object named/i;
+  /already exists|duplicate key|duplicate table|duplicate column|duplicate key name|there is already an object named/i;
 
 /**
  * Errors that mean a unique index refused the row.
@@ -166,7 +194,7 @@ class SqlStore {
    * @param {string} options.dialect sqlite, postgres, mysql or mssql
    * @param {boolean} [options.dollars=false] The driver numbers its
    *   placeholders (`$1`), as node-postgres does
-   * @param {object} options.tables `{ jobs, schedules }` table names
+   * @param {object} options.tables `{ jobs, schedules, limits }` table names
    * @memberof SqlStore
    */
   constructor(adapter, { dialect, dollars = false, tables }) {
@@ -175,6 +203,8 @@ class SqlStore {
     this.dollars = dollars;
     this.tables = tables;
     this.kind = 'sql';
+    /** Whether the table has `concurrency_key`; asked once, see concurrent() */
+    this.limits = null;
   }
 
   /**
@@ -270,16 +300,28 @@ class SqlStore {
   /**
    * Creates the tables and the indexes; idempotent
    *
+   * The upgrade block (`schema.upgrade()`) is tolerated whatever it answers:
+   * it touches a table an older henri created, and a user who may not
+   * `ALTER` must not fail the boot of an application that never asked for
+   * the column it adds. What the column is needed for asks for it by name
+   * (`concurrent()`), and says so with the install line.
+   *
    * @returns {Promise<Array<string>>} The statements that ran
    * @memberof SqlStore
    */
   async install() {
     const statements = install(this.dialect, this.tables);
+    const soft = new Set(upgrade(this.dialect, this.tables));
 
     for (const statement of statements) {
       try {
         await this.run(statement);
       } catch (error) {
+        if (soft.has(statement)) {
+          debug('upgrade statement did not apply: %s', error.message);
+          continue;
+        }
+
         if (!ALREADY_THERE.test(reasons(error))) {
           throw error;
         }
@@ -288,7 +330,39 @@ class SqlStore {
       }
     }
 
+    this.limits = null;
+
     return statements;
+  }
+
+  /**
+   * Whether the jobs table has the column concurrency limits need
+   *
+   * Asked once, of the table itself rather than of what the install
+   * answered: an installation that upgraded henri without running the
+   * install, or whose database user may not `ALTER`, has the table an older
+   * version wrote and the queue works exactly as it did.
+   *
+   * @returns {Promise<boolean>} true when `concurrency_key` is there
+   * @memberof SqlStore
+   */
+  async concurrent() {
+    if (typeof this.limits === 'boolean') {
+      return this.limits;
+    }
+
+    try {
+      // Reads nothing: the planner still has to resolve the column
+      await this.select(
+        `SELECT concurrency_key FROM ${this.tables.jobs} WHERE 1 = 0`
+      );
+      this.limits = true;
+    } catch (error) {
+      debug('no concurrency_key column: %s', error.message);
+      this.limits = false;
+    }
+
+    return this.limits;
   }
 
   /**
@@ -332,13 +406,19 @@ class SqlStore {
    * @memberof SqlStore
    */
   async insert(job) {
-    const values = COLUMNS.map((column) =>
+    // A table an older henri wrote has no `concurrency_key` at all, and an
+    // application with no limited job must not notice: the insert names the
+    // columns that are there, so the queue works exactly as it did
+    const columns = (await this.concurrent())
+      ? COLUMNS
+      : COLUMNS.filter((column) => column !== 'concurrency_key');
+    const values = columns.map((column) =>
       typeof job[column] === 'undefined' ? null : job[column]
     );
 
     try {
       await this.run(
-        `INSERT INTO ${this.tables.jobs} (${COLUMNS.join(', ')}) VALUES (${marks(COLUMNS)})`,
+        `INSERT INTO ${this.tables.jobs} (${columns.join(', ')}) VALUES (${marks(columns)})`,
         values
       );
     } catch (error) {
@@ -394,11 +474,20 @@ class SqlStore {
   /**
    * The claim statement of this dialect, and its parameters
    *
-   * @param {object} options `queues`, `limit`, `runner`, `token`, `now`
+   * @param {object} options Options
+   * @param {Array<string>} options.queues The queues to take from
+   * @param {number} options.limit How many rows at most
+   * @param {string} options.runner The runner id
+   * @param {string} options.token A token unique to this claim
+   * @param {number} options.now The current time
+   * @param {object} [options.key] `{ value, own }`, the concurrency key this
+   *   pass holds a slot for; `own` when it is the group's own bucket
+   * @param {Array<string>} [options.names] Only these job names
+   * @param {Array<string>} [options.except] Every name but these
    * @returns {{sql: string, params: Array}} The statement
    * @memberof SqlStore
    */
-  claimStatement({ queues, limit, runner, token, now }) {
+  claimStatement({ queues, limit, runner, token, now, key, names, except }) {
     const table = this.tables.jobs;
     const set = [
       `state = 'running'`,
@@ -417,6 +506,31 @@ class SqlStore {
     if (queues.length > 0) {
       filter.push(`queue IN (${marks(queues)})`);
       filterParams.push(...queues);
+    }
+
+    // The two passes partition the pending rows by **name**, so every row
+    // belongs to exactly one of them: a job that gained a limit is taken by
+    // the second pass from that moment on, and one that lost its limit goes
+    // back to the first even though its rows still carry a key
+    if (except && except.length > 0) {
+      filter.push(`name NOT IN (${marks(except)})`);
+      filterParams.push(...except);
+    }
+
+    if (names && names.length > 0) {
+      filter.push(`name IN (${marks(names)})`);
+      filterParams.push(...names);
+    }
+
+    if (key) {
+      // A row enqueued before the limit was declared carries no key at all;
+      // it belongs to the group's own bucket, which is what `key.own` says
+      filter.push(
+        key.own
+          ? '(concurrency_key = ? OR concurrency_key IS NULL)'
+          : 'concurrency_key = ?'
+      );
+      filterParams.push(key.value);
     }
 
     const where = filter.join(' AND ');
@@ -458,12 +572,27 @@ class SqlStore {
    * @param {string} options.runner The runner id
    * @param {string} options.token A token unique to this claim
    * @param {number} options.now The current time
+   * @param {object} [options.key] The concurrency key a slot is held for
+   * @param {Array<string>} [options.names] Only these job names
+   * @param {Array<string>} [options.except] Every name but these
    * @returns {Promise<Array<object>>} The rows this runner owns
    * @memberof SqlStore
    */
-  async claim({ queues = [], limit = 1, runner, token, now }) {
+  async claim({
+    queues = [],
+    limit = 1,
+    runner,
+    token,
+    now,
+    key,
+    names,
+    except,
+  }) {
     const { params, sql } = this.claimStatement({
+      except,
+      key,
       limit,
+      names,
       now,
       queues,
       runner,
@@ -476,6 +605,224 @@ class SqlStore {
       `SELECT * FROM ${this.tables.jobs} WHERE claim_token = ? AND state = 'running' ORDER BY priority ASC, run_at ASC, id ASC`,
       [token]
     );
+  }
+
+  /**
+   * The concurrency keys with work waiting, the most urgent first
+   *
+   * One row per `(concurrency_key, name)` pair, so the caller can map a row
+   * that carries no key -- enqueued before the limit was declared -- onto
+   * the group it belongs to, which only the definitions know.
+   *
+   * @param {object} options Options
+   * @param {number} options.now The current time
+   * @param {Array<string>} options.names The names of the limited jobs
+   * @param {Array<string>} [options.queues=[]] The queues to look at
+   * @param {number} [options.limit=100] How many keys at most
+   * @returns {Promise<Array<object>>} `{ key, name, total }` rows
+   * @memberof SqlStore
+   */
+  async waiting({ now, names, queues = [], limit = 100 }) {
+    if (!names || names.length === 0) {
+      return [];
+    }
+
+    const filter = [
+      `state = 'pending'`,
+      'run_at <= ?',
+      `name IN (${marks(names)})`,
+    ];
+    const params = [now, ...names];
+
+    if (queues.length > 0) {
+      filter.push(`queue IN (${marks(queues)})`);
+      params.push(...queues);
+    }
+
+    const page =
+      this.dialect === 'mssql'
+        ? 'OFFSET 0 ROWS FETCH NEXT ? ROWS ONLY'
+        : 'LIMIT ?';
+    const rows = await this.select(
+      `SELECT concurrency_key, name, COUNT(*) AS total FROM ${this.tables.jobs} WHERE ${filter.join(' AND ')} GROUP BY concurrency_key, name ORDER BY MIN(priority) ASC, MIN(run_at) ASC ${page}`,
+      [...params, Math.max(1, Number(limit) || 100)]
+    );
+
+    return rows.map((row) => ({
+      key: row.concurrency_key || null,
+      name: row.name,
+      total: toNumber(row.total) || 0,
+    }));
+  }
+
+  /**
+   * Takes one of a key's slots, or answers null when they are all held
+   *
+   * **This is the bound.** `(limit_key, slot)` is the primary key, so of
+   * every runner inserting the same slot exactly one succeeds and the others
+   * are refused by the index -- no transaction, no affected-row count, no
+   * dialect of its own. The slots are tried in order, so a key at its limit
+   * costs `limit` refused inserts and nothing else.
+   *
+   * @param {object} options Options
+   * @param {string} options.key The concurrency key
+   * @param {number} options.limit How many may run at once
+   * @param {string} options.runner The runner id
+   * @param {number} options.now The current time
+   * @returns {Promise<?number>} The slot this runner holds, or null
+   * @memberof SqlStore
+   */
+  async takeSlot({ key, limit, runner, now }) {
+    const held = await this.select(
+      `SELECT slot FROM ${this.tables.limits} WHERE limit_key = ?`,
+      [key]
+    );
+    const taken = new Set(held.map((row) => toNumber(row.slot)));
+
+    for (let slot = 0; slot < limit; slot += 1) {
+      if (taken.has(slot)) {
+        continue;
+      }
+
+      try {
+        await this.run(
+          `INSERT INTO ${this.tables.limits} (limit_key, slot, job_id, runner, taken_at, heartbeat_at) VALUES (?, ?, ?, ?, ?, ?)`,
+          [key, slot, null, runner, now, now]
+        );
+
+        return slot;
+      } catch (error) {
+        if (!DUPLICATE.test(reasons(error))) {
+          throw error;
+        }
+
+        debug('slot %d of %s was taken first', slot, key);
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Says which job a slot is being held for
+   *
+   * @param {string} key The concurrency key
+   * @param {number} slot The slot
+   * @param {?string} id The job id
+   * @param {number} now The current time
+   * @returns {Promise<void>} Resolves when written
+   * @memberof SqlStore
+   */
+  async holdSlot(key, slot, id, now) {
+    await this.run(
+      `UPDATE ${this.tables.limits} SET job_id = ?, heartbeat_at = ? WHERE limit_key = ? AND slot = ?`,
+      [id, now, key, slot]
+    );
+  }
+
+  /**
+   * Gives a slot back
+   *
+   * @param {string} key The concurrency key
+   * @param {number} slot The slot
+   * @param {string} [runner] Only when this runner still holds it
+   * @returns {Promise<void>} Resolves when written
+   * @memberof SqlStore
+   */
+  async releaseSlot(key, slot, runner) {
+    const own = runner ? ' AND runner = ?' : '';
+    const params = runner ? [key, slot, runner] : [key, slot];
+
+    await this.run(
+      `DELETE FROM ${this.tables.limits} WHERE limit_key = ? AND slot = ?${own}`,
+      params
+    );
+  }
+
+  /**
+   * Tells the database this runner still holds these slots
+   *
+   * @param {Array<object>} slots `{ key, slot }` entries
+   * @param {number} now The current time
+   * @param {string} runner The runner id
+   * @returns {Promise<void>} Resolves when written
+   * @memberof SqlStore
+   */
+  async heartbeatSlots(slots, now, runner) {
+    for (const held of slots) {
+      await this.run(
+        `UPDATE ${this.tables.limits} SET heartbeat_at = ? WHERE limit_key = ? AND slot = ? AND runner = ?`,
+        [now, held.key, held.slot, runner]
+      );
+    }
+  }
+
+  /**
+   * Frees the slots of runners that stopped answering
+   *
+   * The bound rests on this being slower than the heartbeat: a slot is
+   * refreshed four times per `stuckAfter`, and freeing one that is still
+   * held would let a second runner perform alongside the first. It is the
+   * same condition the recovery of a claimed job already rests on.
+   *
+   * @param {object} options Options
+   * @param {number} options.now The current time
+   * @param {number} options.stuckAfter How long without a heartbeat is dead
+   * @param {number} [options.limit=100] How many one sweep frees
+   * @returns {Promise<Array<object>>} The slots that were freed
+   * @memberof SqlStore
+   */
+  async sweepSlots({ now, stuckAfter, limit = 100 }) {
+    const page =
+      this.dialect === 'mssql'
+        ? 'ORDER BY heartbeat_at ASC OFFSET 0 ROWS FETCH NEXT ? ROWS ONLY'
+        : 'ORDER BY heartbeat_at ASC LIMIT ?';
+    const rows = await this.select(
+      `SELECT * FROM ${this.tables.limits} WHERE heartbeat_at < ? ${page}`,
+      [now - stuckAfter, limit]
+    );
+
+    for (const row of rows) {
+      await this.run(
+        `DELETE FROM ${this.tables.limits} WHERE limit_key = ? AND slot = ? AND heartbeat_at = ?`,
+        [row.limit_key, toNumber(row.slot), toNumber(row.heartbeat_at)]
+      );
+    }
+
+    return rows.map((row) => ({
+      job: row.job_id || null,
+      key: row.limit_key,
+      runner: row.runner,
+      slot: toNumber(row.slot),
+      takenAt: toNumber(row.taken_at),
+    }));
+  }
+
+  /**
+   * Every slot being held right now
+   *
+   * @param {number} [limit=200] How many at most
+   * @returns {Promise<Array<object>>} The held slots
+   * @memberof SqlStore
+   */
+  async slots(limit = 200) {
+    const page =
+      this.dialect === 'mssql'
+        ? 'OFFSET 0 ROWS FETCH NEXT ? ROWS ONLY'
+        : 'LIMIT ?';
+    const rows = await this.select(
+      `SELECT * FROM ${this.tables.limits} ORDER BY limit_key ASC, slot ASC ${page}`,
+      [limit]
+    );
+
+    return rows.map((row) => ({
+      heartbeatAt: toNumber(row.heartbeat_at),
+      job: row.job_id || null,
+      key: row.limit_key,
+      runner: row.runner,
+      slot: toNumber(row.slot),
+      takenAt: toNumber(row.taken_at),
+    }));
   }
 
   /**

--- a/types/core.test-d.ts
+++ b/types/core.test-d.ts
@@ -22,6 +22,7 @@ import type {
   IdentityResult,
   Job,
   JobDefinition,
+  JobLimits,
   JobStats,
   EncryptionFieldStatus,
   ErasureReceipt,
@@ -196,6 +197,7 @@ expectType<Promise<Job>>(jobs.performIn('5m', 'welcome', { userId: 1 }));
 expectType<Promise<Job>>(jobs.performAt(new Date(), 'welcome', null));
 expectType<Promise<Job[]>>(jobs.list({ state: 'pending' }));
 expectType<Promise<JobStats>>(jobs.stats());
+expectType<Promise<JobLimits>>(jobs.limits());
 expectType<Promise<Job | null>>(jobs.dead.retry('an-id'));
 expectType<Promise<number>>(jobs.dead.discardAll({ queue: 'mailers' }));
 
@@ -213,6 +215,33 @@ const welcome: JobDefinition = {
 };
 
 expectType<JobDefinition>(welcome);
+
+// A bound on the job itself, and one per key of its arguments
+const exclusive: JobDefinition = { concurrency: 1, perform: async () => null };
+const perTenant: JobDefinition = {
+  concurrency: { group: 'tenant-work', key: 'tenantId', limit: 3 },
+
+  perform: async () => null,
+};
+const computed: JobDefinition = {
+  concurrency: { key: (args) => args.account.id, limit: 2 },
+
+  perform: async () => null,
+};
+
+expectType<JobDefinition>(exclusive);
+expectType<JobDefinition>(perTenant);
+expectType<JobDefinition>(computed);
+expectType<string | null>((await jobs.perform('import')).concurrencyKey);
+
+const unbounded: JobDefinition = {
+  // @ts-expect-error a concurrency limit is a number or `{ limit }`
+  concurrency: { every: 3 },
+
+  perform: async () => null,
+};
+
+expectType<JobDefinition>(unbounded);
 
 // @ts-expect-error `pending` is a state, not a queue
 jobs.list({ state: 'sleeping' });

--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -788,24 +788,24 @@ Everything the [job queue](/guides/jobs/) reads, all of it optional. The queue i
 }
 ```
 
-| Key             | Default      | Description                                                                                                                                  |
-| --------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `store`         | `default`    | Which store of `stores` holds the queue.                                                                                                     |
-| `priority`      | `0`          | Priority of a job that names none; the higher, the sooner it is claimed.                                                                     |
-| `table`         | `henri_jobs` | Table (or collection) name; the schedules live in `<table>_schedules`. Letters, digits and underscores only.                                 |
-| `queue`         | `default`    | Queue of a job that names none.                                                                                                              |
-| `queues`        | all          | Queues a runner takes from when `henri jobs` is given no `--queue`.                                                                          |
-| `concurrency`   | `5`          | How many jobs one runner performs at once.                                                                                                   |
-| `maxAttempts`   | `5`          | Attempts before a job goes to the dead letter queue.                                                                                         |
-| `timeout`       | none         | How long one attempt may take, for jobs that set none.                                                                                       |
-| `backoff`       | see above    | Wait before the next attempt: `base × factor^(attempt − 1)`, capped at `max`, spread by `jitter` (0 to 1).                                   |
-| `pollInterval`  | `1s`         | How often a runner looks for work when the queue is empty (never under 50ms).                                                                |
-| `stuckAfter`    | `5m`         | Without a heartbeat for that long, a `running` job is taken to belong to a dead runner and put back. Keep it above the longest `timeout`.    |
-| `keepCompleted` | `1d`         | How long finished jobs are kept before a runner prunes them. `0` keeps them forever.                                                         |
-| `maxArgsBytes`  | `524288`     | Size limit of the serialized arguments of one job; over it the enqueue fails instead of storing a truncated payload.                         |
-| `mailQueue`     | `mailers`    | Queue of the messages [`deliverLater()`](/guides/mail/#delivering-later) hands over.                                                         |
-| `install`       | `true`       | Create the tables at boot. Set `false` in production and run `henri jobs:install` in the deploy.                                             |
-| `recurring`     | `{}`         | Schedules, by name: `job` (defaults to the name), `cron` **or** `every`, and optionally `args`, `queue` and `priority`. Cron is read in UTC. |
+| Key             | Default      | Description                                                                                                                                                |
+| --------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `store`         | `default`    | Which store of `stores` holds the queue.                                                                                                                   |
+| `priority`      | `0`          | Priority of a job that names none; the higher, the sooner it is claimed.                                                                                   |
+| `table`         | `henri_jobs` | Table (or collection) name; the schedules live in `<table>_schedules` and the concurrency slots in `<table>_limits`. Letters, digits and underscores only. |
+| `queue`         | `default`    | Queue of a job that names none.                                                                                                                            |
+| `queues`        | all          | Queues a runner takes from when `henri jobs` is given no `--queue`.                                                                                        |
+| `concurrency`   | `5`          | How many jobs one runner performs at once.                                                                                                                 |
+| `maxAttempts`   | `5`          | Attempts before a job goes to the dead letter queue.                                                                                                       |
+| `timeout`       | none         | How long one attempt may take, for jobs that set none.                                                                                                     |
+| `backoff`       | see above    | Wait before the next attempt: `base × factor^(attempt − 1)`, capped at `max`, spread by `jitter` (0 to 1).                                                 |
+| `pollInterval`  | `1s`         | How often a runner looks for work when the queue is empty (never under 50ms).                                                                              |
+| `stuckAfter`    | `5m`         | Without a heartbeat for that long, a `running` job is taken to belong to a dead runner and put back. Keep it above the longest `timeout`.                  |
+| `keepCompleted` | `1d`         | How long finished jobs are kept before a runner prunes them. `0` keeps them forever.                                                                       |
+| `maxArgsBytes`  | `524288`     | Size limit of the serialized arguments of one job; over it the enqueue fails instead of storing a truncated payload.                                       |
+| `mailQueue`     | `mailers`    | Queue of the messages [`deliverLater()`](/guides/mail/#delivering-later) hands over.                                                                       |
+| `install`       | `true`       | Create the tables at boot. Set `false` in production and run `henri jobs:install` in the deploy.                                                           |
+| `recurring`     | `{}`         | Schedules, by name: `job` (defaults to the name), `cron` **or** `every`, and optionally `args`, `queue` and `priority`. Cron is read in UTC.               |
 
 Every duration is a number of milliseconds or a string: `'250ms'`, `'30s'`, `'5m'`, `'2h'`, `'1d'`, `'1w'`.
 

--- a/website/src/content/docs/guides/jobs.md
+++ b/website/src/content/docs/guides/jobs.md
@@ -121,7 +121,7 @@ henri jobs --no-recurring                   # ignore the schedules
 
 The runner boots the application to the models (runlevel 4): no HTTP server, no views, no `app/workers`. It claims a batch of jobs, performs up to `concurrency` of them at a time, and polls every `jobs.pollInterval` (one second) when the queue is empty.
 
-**Several runners are meant to run at once against one database**, on one machine or on twenty. A job is never performed twice because two of them raced: claiming is a single statement on every dialect, so it is its own transaction, and the state is part of that statement's own `WHERE`. PostgreSQL takes `FOR UPDATE SKIP LOCKED`, MySQL an `UPDATE ... ORDER BY ... LIMIT`, MSSQL `UPDLOCK, READPAST`, sqlite a subquery (its writers are serialized anyway), and MongoDB one atomic `findOneAndUpdate` per document. The rows a claim took carry a token it reads them back by, so a runner only ever sees the jobs it actually won.
+**Several runners are meant to run at once against one database**, on one machine or on twenty. A job is never performed twice because two of them raced: claiming is a single statement on every dialect, so it is its own transaction, and the state is part of that statement's own `WHERE`. PostgreSQL takes `FOR UPDATE SKIP LOCKED`, MySQL an `UPDATE ... ORDER BY ... LIMIT`, MSSQL `UPDLOCK, READPAST`, sqlite a subquery (its writers are serialized anyway), and MongoDB one atomic `findOneAndUpdate` per document. The rows a claim took carry a token it reads them back by, so a runner only ever sees the jobs it actually won. A job that declares [how many of it may run at once](#how-many-at-once) is claimed by a second pass of the same statement, one row per permit the runner holds.
 
 On `SIGINT`, `SIGTERM` or `SIGQUIT` the runner stops claiming, finishes what it is holding, writes the outcomes and exits — the usual restart of a deployment loses nothing. A runner that is killed outright leaves its jobs `running`; another runner notices that nothing has refreshed their heartbeat for `jobs.stuckAfter` (five minutes) and puts them back.
 
@@ -134,6 +134,20 @@ The outcome of an attempt carries the token of the claim it belongs to, so a run
 Two runners never perform one job at the same time — that is the guarantee above — but the queue is **at least once**, not exactly once. A runner that is killed after `perform()` returned and before the outcome reached the database leaves the job `running`; five minutes later another runner takes it back and performs it again. There is no way around that without a transaction spanning your code and the database, which a job does not have.
 
 So write a job the way you would write a webhook handler: charge the card with an idempotency key, `find` before you `create`, update by id rather than incrementing blindly. `job.id` is stable across attempts of the same job and is the natural key to deduplicate on.
+
+### The queue is not in your transaction
+
+The queue reaches its own tables through the store adapter's raw `query()`, which does **not** join an open model transaction. So this enqueues a job that runs whatever happens next:
+
+```js
+await henri.model.stores.default.transaction(async () => {
+  await Invoice.create({ ... });
+  await henri.jobs.perform('invoice/send', { id });  // already written
+  throw new Error('rolled back');                    // the invoice is gone
+});
+```
+
+That is the trade every database-backed queue makes in one direction or the other, and henri makes it towards **the job always running**: a queue that joined your transaction would silently hold work back whenever a request failed late, and a job that runs for a record that no longer exists is a `findById` returning `null`, which a job should survive anyway. Enqueue after the commit when the order matters, and write jobs that check.
 
 ## Retries and the dead letter queue
 
@@ -199,6 +213,90 @@ module.exports = {
 The job lands in the dead letter queue like any other, so `henri jobs:dead`, `henri jobs:show <id>` and `henri jobs:retry <id>` still apply — it just gets there without the wait. [Outbound webhooks](/guides/webhooks/) use this for every failure a retry cannot fix.
 
 Jobs that succeed are kept for `jobs.keepCompleted` (a day) so their timings can be read, then pruned by the runner.
+
+## How many at once
+
+`henri jobs --concurrency` bounds a **runner**: how many jobs that process performs at a time. What an application usually wants is a bound on a **job** — never more than one `import` anywhere, at most three per tenant — and that is a different number, because it has to hold across every runner on every machine.
+
+A job declares it:
+
+```js
+// app/jobs/import.js
+module.exports = {
+  concurrency: 1, // one at a time, whatever is running it
+
+  perform: async ({ accountId }) => {
+    /* ... */
+  },
+};
+```
+
+```js
+// app/jobs/tenant/rebuild.js
+module.exports = {
+  // Three at a time per tenant, and no bound at all between tenants
+  concurrency: { limit: 3, key: 'tenantId' },
+
+  perform: async ({ tenantId }) => {
+    /* ... */
+  },
+};
+```
+
+`key` is the name of an argument, or a function of them (`key: (args) => args.account.id`). Without one the whole job shares one bound. `group` gives several jobs one bound between them:
+
+```js
+// app/jobs/tenant/import.js and app/jobs/tenant/export.js
+module.exports = {
+  concurrency: { limit: 2, group: 'tenant-io', key: 'tenantId' },
+  // ...
+};
+```
+
+Two jobs of one group must agree on the limit, or the boot says so (`HENRI_JOB_CONCURRENCY_CONFLICT`) — a group is one bound, and it cannot count to two numbers at once.
+
+**The limit belongs to the job and never to a call.** There is no `concurrency` option on `perform()`: an option would let one caller step outside the bound the job declared, which is the one thing a bound is for.
+
+### What it guarantees, and on what
+
+A runner takes a **permit** before it takes the work. The permits live in a table the queue owns (`henri_jobs_limits`), one row per slot, with `(limit_key, slot)` as its primary key: a runner takes a slot by inserting it, and of every runner inserting the same slot exactly one succeeds. That is the same primitive `unique` jobs already rest on, and it is the only one that means the same thing on PostgreSQL, MySQL, MSSQL, sqlite **and** MongoDB, where an `insertOne` answers 11000.
+
+It is deliberately not counted inside the claim. A `SELECT COUNT(*) ... WHERE state = 'running'` there is read at the statement's own snapshot, so two runners racing both see the same free room, both take it and both commit; `FOR UPDATE SKIP LOCKED` does not help, because it locks the candidate _rows_ and the second runner simply steps over them to the next ones. Making the count exact needs a lock on something shared per key — `pg_advisory_xact_lock`, `GET_LOCK`, `sp_getapplock`, and nothing at all on MongoDB. Four mechanisms, one of them missing.
+
+The claim statement itself keeps its shape and gains one predicate: `name NOT IN (...)` on the pass that takes the unlimited work, `name IN (...) AND concurrency_key = ?` with a limit of one on the pass that takes a row the runner holds a permit for. An application with no limited job sends the statement it always sent, parameter for parameter.
+
+The permit comes first and the work second, on purpose. The other order — claim a job, discover its key is full, put it back — makes a full key spin the runner's loop at full speed doing nothing, because the loop only sleeps when a tick claimed nothing.
+
+**What the bound rests on, said plainly:**
+
+- **The heartbeat.** A runner refreshes its permits four times per `jobs.stuckAfter`, and a permit nobody has refreshed for that long is freed — the same rule, and the same clock, that puts a dead runner's jobs back. A runner that goes quiet for five minutes and comes back still performing its job has lost its permit, exactly as it has lost its job. This is the same condition [at least once](#at-least-once) already rests on: keep `stuckAfter` above the longest a job may take.
+- **A deploy that lowers a limit** may overlap while the permits taken under the old one drain. Raising a limit takes effect at once.
+- **A rolling deploy that adds one.** A runner still on the old code does not know the job is bounded and claims it the way it always did, until it is replaced — the same window as a runner that does not have a new job's file at all. Restart the runners.
+- **`performNow()` is not the queue**, so it takes no permit and counts against nothing. Neither does a job you call yourself.
+
+`henri jobs:status` prints what was asked for and what is holding it up:
+
+```
+  Concurrency:
+    import -> 1 at a time
+    tenant/rebuild -> 3 at a time per key
+    held tenant/rebuild:acme#0 by web-3:41:2f8c for 4f0e...
+```
+
+```js
+const { declared, held } = await henri.jobs.limits();
+```
+
+### The column, and an upgrade
+
+The bound stores one thing on the job row: `concurrency_key`, the bucket it counts against. The queue's tables are created with `CREATE TABLE IF NOT EXISTS` and there is no migration chain behind them, so a **new table** appears on its own and a **new column** does not.
+
+`henri jobs:install` — which the boot already runs unless `jobs.install` is false — adds it, and the statement that adds it is idempotent and **tolerated**: a database user who may not `ALTER` fails no boot. What decides whether limits work is asking the table, not whether that statement ran:
+
+- An application that declares no limit **is not affected at all**. Its inserts name the columns that are there and its claim never mentions the new one.
+- An application that declares one and whose table has no column for it **fails the boot** with `HENRI_JOB_LIMIT_UNINSTALLED`, naming `henri jobs:install`. A limit that is silently not applied is worse than one that refuses to start.
+- A job already **in the queue** when the limit was declared carries no key. It is not left behind: a row with no key belongs to its job's own bucket, so adding a limit takes effect on the backlog — which is the moment you would be adding it.
+- On MongoDB there is nothing to upgrade: a document simply has no such field.
 
 ## A job a package ships
 
@@ -287,9 +385,38 @@ await henri.jobs.count({ state: 'dead' });
 
 Every moment a job carries (`runAt`, `createdAt`, `startedAt`, `finishedAt`, `claimedAt`, `updatedAt`) is an ISO string; `duration` is in milliseconds.
 
+## No dashboard, and what to build one from
+
+henri mounts no queue dashboard, in any environment, and will not. This is a decision rather than a gap, so here is the argument.
+
+The obvious counter is that `/_routes`, `/_openapi.json` and `/_mailers` are already pages henri mounts in development, behind loopback, and one more would cost nothing. But look at what those three show: an application's **routes**, its **API description**, its **mail templates**. Every one of them is a description of the application, written by the people reading it. A queue page is the first that would show the application's **data** — a job's arguments are the customer's email address, the invoice being rebuilt, the account being merged. henri spends a whole [privacy](/guides/privacy/) tranche making sure fields marked personal do not reach an answer it builds; printing them in a browser tab because a page is convenient would be that decision made twice, differently. And a queue page that hides the arguments cannot tell you why a job died, which is the only reason to open it.
+
+The second half is where a dashboard is actually wanted, which is production. There henri must not mount one at all: a route that exists in production has to be authenticated, authorized, rate limited, CSRF-defended and kept out of `henri audit`'s way, and every mounted admin runtime people have come to resent got there one reasonable feature at a time. A page henri ships is a page henri chooses the auth model of. A page **you** ship goes behind your `roles`, your [policy](/guides/policies/), your own decision about who may read an argument — and it shows up in `henri routes`, `henri audit` and your own tests like any other route.
+
+So the answer is a read-only page of your own, over an API that is already there:
+
+```js
+// app/controllers/admin/jobs.js
+module.exports = {
+  index: async (req, res) => {
+    await req.authorize('read', 'Jobs');
+
+    const [stats, dead, limits] = await Promise.all([
+      henri.jobs.stats(),
+      henri.jobs.dead.list({ limit: 50 }),
+      henri.jobs.limits(),
+    ]);
+
+    return { dead, limits, stats };
+  },
+};
+```
+
+`stats()`, `list()`, `get()`, `limits()` and the whole `dead.*` API are the same calls `henri jobs:*` makes, and every one of those commands takes `--json`, so a script, a Grafana exporter or a page all read the same numbers. What henri owns instead of a page is the [telemetry](/guides/telemetry/): the queue depth by queue and state, and how long claiming takes — the two numbers a screenshot cannot alert on.
+
 ## Storage
 
-The queue owns two tables of its own, `henri_jobs` and `henri_jobs_schedules`, and reaches them through the store adapter's own surface — `query()` on the SQL adapters, the collections on MongoDB. **No henri model is involved**, so the queue cannot collide with the application's schema, does not follow its model conventions and works on a store that has no models at all.
+The queue owns three tables of its own, `henri_jobs`, `henri_jobs_schedules` and `henri_jobs_limits`, and reaches them through the store adapter's own surface — `query()` on the SQL adapters, the collections on MongoDB. **No henri model is involved**, so the queue cannot collide with the application's schema, does not follow its model conventions and works on a store that has no models at all.
 
 Every moment is stored as a `BIGINT` of milliseconds since the epoch rather than a timestamp column: sqlite has no date type, the SQL servers disagree on the precision and the zone of a bare `TIMESTAMP`, and the claim compares `run_at` to the runner's clock — a comparison that has to mean the same thing everywhere.
 
@@ -300,6 +427,20 @@ henri jobs:install         # creates the tables and the indexes; idempotent
 The tables are also created when the application boots with a queue, so development needs nothing. In production, where the application may not be allowed to create tables, run `henri jobs:install` once as part of the deploy and set `"install": false` so the boot stops trying.
 
 Every adapter is supported: `drizzle` (sqlite, postgres, mysql), `postgresql`, `mysql`, `mariadb`, `mssql`, `mongoose` and `disk`. MongoDB claims one document at a time with `findOneAndUpdate`, which is atomic on a standalone `mongod` as much as on a replica set, so the guarantee holds there too — at the cost of one round trip per job instead of one per batch.
+
+## What is not here
+
+**Batching** — forty jobs and one that runs when they are all done — is not in henri yet. It is the next thing the queue wants, and the shape it will take is settled, so that an application does not build something today that has to be unbuilt:
+
+- A batch **finishes**, it does not **succeed**. The callback runs once every job of the batch has reached a terminal state, `dead` included, and is handed the counts. A batch whose last job fails is a finished batch with a failure in it, and pretending otherwise means a callback that never runs and nobody notices.
+- The callback runs **exactly once**, and that rests on where the counter is advanced: by the same token-guarded write that records an attempt's outcome, so a job recovered from a dead runner and performed again does not count twice.
+- A batch is **not a transaction**. A runner that dies mid-batch leaves its job `pending`, the batch's counter unmoved and the batch unfinished until that job reaches an outcome — which is the right answer, and the reason the counter cannot be advanced at claim time.
+- It is **not atomic with your database** either, for the reason above: [the queue is not in your transaction](#the-queue-is-not-in-your-transaction), so a batch enqueued inside one that rolls back is a batch that runs.
+- Adding a job to a batch that has finished is **refused**, not swallowed.
+
+What it needs that is not there yet is a second column on the job row and a table for the batches, which is the same upgrade question the concurrency key answered — so it is a tranche of its own rather than a paragraph of this one.
+
+Also deliberately absent: a mounted dashboard ([above](#no-dashboard-and-what-to-build-one-from)), priorities that change after an enqueue, and a way to cancel a job that a runner is already performing — JavaScript cannot stop a function that is running, which is why `timeout` aborts a signal and hopes.
 
 ## Jobs or workers?
 

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -408,16 +408,16 @@ Runs and drives the [job queue](/guides/jobs/) of `@usehenri/jobs`, in the same 
 
 Without a command, `henri jobs` runs a worker: it claims jobs, performs up to `--concurrency` of them at once (`jobs.concurrency`, five by default), honours the recurring schedules, puts back the jobs of runners that died and stops on `SIGINT`, `SIGTERM` or `SIGQUIT` after finishing what it had claimed. `--queue=mailers,reports` limits it to some queues; `--once` performs what is due and exits instead of looping, which is what a cron entry wants; `--no-recurring` leaves the schedules alone.
 
-| Command                 | What it does                                                                                                                    |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `install`               | Creates `henri_jobs` and `henri_jobs_schedules` and their indexes. Idempotent; run it in a deploy that sets `"install": false`. |
-| `status`                | Counts by queue and state, the timings of the finished jobs, how long the oldest due job has waited, the schedules.             |
-| `list`                  | The jobs, newest change first (`--state`, `--queue`, `--name`, `--limit`).                                                      |
-| `dead`                  | The dead letter queue.                                                                                                          |
-| `show <id>`             | One job with its arguments, its error, its stack and the history of every attempt.                                              |
-| `perform <name> [json]` | Enqueues a job by hand; `--in=<duration>` or `--at=<date>` for later, `--now` to run it inline instead.                         |
-| `retry <id>`            | Puts a dead job back in its queue, attempts reset. `--all` (with `--queue`/`--name`) for every matching one.                    |
-| `discard <id>`          | Deletes a dead job for good. `--all` (with `--queue`/`--name`) for every matching one.                                          |
+| Command                 | What it does                                                                                                                                                                                                    |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `install`               | Creates `henri_jobs`, `henri_jobs_schedules` and `henri_jobs_limits` and their indexes, and adds the columns a table an older henri wrote has not. Idempotent; run it in a deploy that sets `"install": false`. |
+| `status`                | Counts by queue and state, the timings of the finished jobs, how long the oldest due job has waited, the schedules, the concurrency limits and the slots being held.                                            |
+| `list`                  | The jobs, newest change first (`--state`, `--queue`, `--name`, `--limit`).                                                                                                                                      |
+| `dead`                  | The dead letter queue.                                                                                                                                                                                          |
+| `show <id>`             | One job with its arguments, its error, its stack and the history of every attempt.                                                                                                                              |
+| `perform <name> [json]` | Enqueues a job by hand; `--in=<duration>` or `--at=<date>` for later, `--now` to run it inline instead.                                                                                                         |
+| `retry <id>`            | Puts a dead job back in its queue, attempts reset. `--all` (with `--queue`/`--name`) for every matching one.                                                                                                    |
+| `discard <id>`          | Deletes a dead job for good. `--all` (with `--queue`/`--name`) for every matching one.                                                                                                                          |
 
 `--wait` is a global flag (it belongs to `--inspect`), which is why the delay of an enqueue is `--in`.
 

--- a/website/src/content/docs/reference/errors.md
+++ b/website/src/content/docs/reference/errors.md
@@ -1284,6 +1284,17 @@ Usually:
 
 The background job queue of @usehenri/jobs.
 
+### `HENRI_JOB_CONCURRENCY_CONFLICT`
+
+Two jobs share a concurrency group and disagree on how many may run.
+
+Usually:
+
+- two jobs of one `concurrency.group` asking for different limits
+- a group renamed in one file and not in the other
+
+**Fix.** Jobs that share a concurrency group share one bound, so they have to agree on it: give them the same `limit`, or a `group` each.
+
 ### `HENRI_JOB_INVALID_ARGUMENTS`
 
 The arguments of a job cannot be stored.
@@ -1294,6 +1305,20 @@ Usually:
 - a model instance passed whole instead of its id
 
 **Fix.** The arguments of a job are stored as JSON: pass ids and plain values, and look the records up inside `perform()`.
+
+### `HENRI_JOB_INVALID_CONCURRENCY`
+
+A job declares a concurrency limit henri cannot read.
+
+Usually:
+
+- a `concurrency` that is neither a number nor `{ limit }`
+- a limit that is not a whole number above zero
+- a `key` that is neither the name of an argument nor a function
+- a key function that threw, or answered an object
+- a key longer than the 190 characters the column holds
+
+**Fix.** `concurrency: 3` bounds the job itself; `concurrency: { limit: 3, key: 'tenantId' }` bounds each key of its own. A key names one bound, so it is an id or a name -- hash it yourself if it has to be longer.
 
 ### `HENRI_JOB_INVALID_CRON`
 
@@ -1342,6 +1367,18 @@ Usually:
 - a cron expression that can never come round (February 30th)
 
 **Fix.** A schedule is `{ job, cron | every, args?, queue? }` and its `job` is the name of a file in app/jobs. The message names the entry that is wrong.
+
+### `HENRI_JOB_LIMIT_UNINSTALLED`
+
+A job declares a concurrency limit and the queue's table cannot hold it.
+
+Usually:
+
+- a queue installed by a henri older than 1.3, whose table has no `concurrency_key` column
+- `jobs.install: false` with no `henri jobs:install` since the upgrade
+- a database user that may not ALTER the table
+
+**Fix.** Run `henri jobs:install` once with a user that may alter the table. The queue works without the column -- a job that declares a limit does not, and is refused rather than run unbounded.
 
 ### `HENRI_JOB_QUEUE_NOT_STARTED`
 


### PR DESCRIPTION
## What

`henri jobs --concurrency` bounds a *worker*. What an application needs is a bound on a *job*: never more than one `henri/import` at a time across every runner, or at most three per tenant. That is a claim-time question, and the claim is the most carefully written statement in the queue.

The claim keeps its shape and gains **one predicate**. Two passes partition pending rows by job name, so every row belongs to exactly one:

| dialect | unlimited pass | limited pass |
| --- | --- | --- |
| postgres | `UPDATE … WHERE id IN (SELECT … AND name NOT IN (…) LIMIT ? FOR UPDATE SKIP LOCKED)` | same + `AND concurrency_key = ?`, `LIMIT 1` |
| mysql | `UPDATE … AND name NOT IN (…) ORDER BY … LIMIT ?` | same + key, `LIMIT 1` |
| mssql | `SELECT TOP (?) … WITH (UPDLOCK, READPAST) … AND name NOT IN (…)` | same + key, `TOP (1)` |
| sqlite | `UPDATE … WHERE id IN (SELECT … AND name NOT IN (…) LIMIT ?)` | same + key, `LIMIT 1` |
| mongodb | `findOneAndUpdate` + `name: {$nin}` | + `concurrency_key` |

With no limited job the `NOT IN` is not emitted at all and the statement is byte-identical to what it was.

## Why the bound is not in the statement

This is the part worth reading. A `COUNT(*) … WHERE state='running'` inside the claim is read at the statement's own snapshot: two runners racing both see the same free room, both take it, both commit. `FOR UPDATE SKIP LOCKED` does not help — it locks the candidate *rows*, so the loser steps over them to the next ones. Exactness needs a lock per key: `pg_advisory_xact_lock`, `GET_LOCK`, `sp_getapplock`, and **nothing on MongoDB**. Four mechanisms, one missing.

So the bound is a table, `henri_jobs_limits`, one row per slot with `(limit_key, slot)` as the primary key. A runner takes a permit by inserting it and exactly one insert per slot wins — **a unique index refusing a duplicate is the only primitive that means the same thing on all five backends**, and it is what `unique` jobs already rest on. Permit first, work second: claim-then-put-back livelocks a runner whose loop only sleeps when a tick claimed nothing.

The holes are stated in the guide rather than left implicit: the heartbeat (the same clock and the same condition at-least-once already rests on), a deploy that *lowers* a limit, a rolling deploy that *adds* one, and `performNow()`.

## The negative property, proved

A count taken afterwards cannot tell two jobs that overlapped from two that did not, so the jobs record their own overlap — a high-water mark per key. 18 tests with a queue and its own connection pool per runner, the model `claim.spec.js` already set: `limit: 1` over 24 jobs and 4 runners gives `most === 1`; `limit: 2` keyed by tenant gives ≤ 2 per tenant **and > 2 overall**, which is what proves the key partitions rather than serializing; N runners racing one key yield exactly `limit` winners; a group shares one bound across two job names; slots are all returned; a stale slot is swept.

**Verified here on sqlite and live PostgreSQL — three consecutive runs, 18/18, no flakes**, which is the only way a concurrency test means anything. My local MySQL could not be used: `Access denied for user 'henri'@'192.168.65.1'` on database creation, and the *existing* `claim.spec.js` fails identically against it, so it is this machine's credentials rather than anything in this branch. CI's Live MySQL job covers it and is green on this PR.

## How an existing installation upgrades

One column, `concurrency_key`, added by a guarded idempotent `ALTER` inside the install the boot already runs, and **tolerated** — a user who may not `ALTER` fails no boot. What decides is asking the table, not whether the upgrade ran:

- **No limited job → unaffected.** `insert()` names the columns that are there and the claim never mentions the new one. (This was a real bug the teammate caught: the first version always inserted the column and would have broken every un-upgraded queue.)
- **A limited job with no column → the boot fails**, naming `henri jobs:install`. Silently unbounded is worse.
- A job already queued when the limit is declared falls into its own job's bucket, so the limit takes effect on the backlog — which is the moment you would add it.
- MongoDB has nothing to upgrade, and `henri_jobs_limits` is a new table, so `CREATE TABLE IF NOT EXISTS` is its own upgrade.

The upgrade is proven against a real server: the spec drops the column off a live table and reinstalls it.

## Batching, and the dashboard: decided, not built

**Batching** is a tranche of its own (another column plus a table, the same upgrade question), and its promises are written down now: a batch **finishes**, it does not succeed — the callback runs once every job reaches a terminal state, `dead` included, with the counts; exactly once, because the counter is advanced by the same token-guarded outcome write; a runner dying mid-batch leaves it unfinished, which is why the counter cannot move at claim time.

It also nailed down something true today that nobody had written: **the queue is not in your transaction** — `adapter.query()` uses the client, not the ambient transaction, so a job enqueued in a transaction that rolls back still runs.

**The dashboard is a no, with an argument.** `/_routes`, `/_openapi.json` and `/_mailers` are not precedents: each shows a *description of the application*, written by the people reading it. A queue page would be the first to show the application's **data** — job arguments are the customer's address, the invoice, the account — which is the thing the privacy work exists to keep out of answers henri builds. A page that hides arguments cannot tell you why a job died, which is the only reason to open it. And the place a dashboard is wanted is production, where henri must mount none: a production route needs auth, authz, rate limiting, CSRF and a line in `henri audit`, and every resented admin runtime got there one reasonable feature at a time.

So the guide ships the ~15-line controller instead, over an API that already existed plus `henri.jobs.limits()` — job ids and runner names, never arguments.

## Gates

`pnpm test` (4685), `pnpm test:types`, `pnpm lint --max-warnings 0`, `pnpm format:check`, `scripts/smoke.sh` end to end (`henri audit`: nothing found in 56 checks), the SQL suites against live PostgreSQL (902), and the showcase against live PostgreSQL (172).