### PR TITLE
Job batching: forty jobs, then one when they are all done

### DIFF
--- a/.changeset/batched-jobs.md
+++ b/.changeset/batched-jobs.md
@@ -1,0 +1,32 @@
+---
+'@usehenri/jobs': minor
+'@usehenri/core': minor
+'@usehenri/drizzle': minor
+'@usehenri/cli': minor
+---
+
+Job batches: forty jobs, and one that runs when they are all done.
+`henri.jobs.batch({ callback, args, jobs })` enqueues them and seals the batch,
+or takes a function that adds them itself for a list too long to write out. The
+callback is an ordinary job of `app/jobs` and is handed the counts under
+`batch`.
+
+A batch **finishes**, it does not succeed: the callback runs once every job has
+reached a terminal state, `dead` included, so a batch that half failed still
+calls it and `failed` is a number to branch on. It runs **exactly once**, and
+never before the last job is terminal. `total` is written once, when the batch
+is sealed; `done` is advanced by a single `SET done = done + 1` guarded by the
+claim token of the attempt that wrote the outcome, so the counter is never read
+into the process to be written back and it moves for exactly one runner — the
+one whose outcome landed. The callback is then enqueued under a unique key of
+the batch's own, which makes settling idempotent, and the runner's sweep counts
+the rows of a batch nothing else could count (a runner killed between an
+outcome and its count, a job the recovery buried).
+
+An existing queue gains one column and one table, added by the same idempotent
+`henri jobs:install` the boot already runs and tolerated the same way: an
+application that makes no batch is unaffected, and `batch()` on a store that has
+neither is refused (`HENRI_JOB_BATCH_UNINSTALLED`) rather than counting nowhere.
+
+`henri jobs:batches`, `henri jobs:list --batch <id>`, `henri jobs:status` and
+`henri.jobs.batches.*` are how a batch is read back.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1237,13 +1237,42 @@ duration, rows, requestId, source, callsite }` -- and the N+1 detector is
   the table_ rather than trusting it ran: an application with no limit is
   unaffected either way, and one that declares a limit the table cannot hold
   fails the boot (`HENRI_JOB_LIMIT_UNINSTALLED`) rather than running it
-  unbounded. `henri.jobs.recur(name, entry)` is the seam a
+  unbounded. **A batch is a set of jobs and one that runs when they are all
+  done** (`henri.jobs.batch({ callback, args, jobs })`, or a function that
+  adds them, sealed when it resolves). A batch **finishes**, it does not
+  succeed: the callback runs once every job has reached a terminal state,
+  `dead` included, and is handed the counts under `batch`. Three writes
+  carry it. `total` is written once, when the batch is sealed, and never
+  moves. `done` is advanced by **one statement per terminal outcome** --
+  `SET done = done + 1 ... WHERE finished_at IS NULL AND EXISTS (the job row
+still holds this runner's claim token and is terminal)` -- so the counter
+  is never read into the process to be written back (four runners finishing
+  at once make four increments; sqlite serializes its writers and the
+  servers re-evaluate the row under their own lock) and it moves for
+  **exactly one** runner, the one whose token-guarded outcome write landed;
+  MongoDB is `$inc` plus that same check as a `findOne`, exact because a
+  terminal document holding this token can never be claimed again. The
+  callback is then enqueued under a unique key of the batch's own -- the
+  recurring occurrence's primitive, and a key `keys.js` keeps for the life
+  of the row -- and `finished_at` is stamped **after** it, so settling is
+  idempotent and a process dying in between is repaired by the sweep. That
+  sweep is the other half: it counts the rows of a batch that has not moved
+  for `stuckAfter`, which answers both a runner killed between the outcome
+  and the count and a job the recovery buried, and it only ever moves a
+  batch forward. A job put back gives its slot back
+  (`releaseBatch`), and a batch is built where it is created -- adding to a
+  sealed one is `HENRI_JOB_BATCH_CLOSED`, asked of the table. Its column
+  (`batch_id`) and its table (`henri_jobs_batches`) arrive through the same
+  tolerated `ALTER` inside the idempotent install, and `batch()` on a store
+  that has neither is `HENRI_JOB_BATCH_UNINSTALLED` rather than a counter
+  nothing can hold. `henri.jobs.recur(name, entry)` is the seam a
   framework module uses to ask for a schedule the configuration did not
   write (`henri.retention` is the one that does); an entry the application
   declared under the same name wins. `henri jobs` runs a worker (`--queue`,
-  `--concurrency`, `--once`), `henri jobs:install|status|list|dead|show|
-perform|retry|discard` drive it; `jobs:status` and `henri.jobs.limits()`
-  report the limits and the slots held. The module also registers
+  `--concurrency`, `--once`), `henri jobs:install|status|list|batches|dead|
+show|perform|retry|discard` drive it; `jobs:status` and
+  `henri.jobs.limits()` report the limits and the slots held, and
+  `henri.jobs.batches.*` the batches. The module also registers
   `henri.mailers.onDeliverLater()`, so `deliverLater()` enqueues the rendered
   message as the built-in `henri/mail` job.
 - Outbound webhooks live in `@usehenri/webhooks`, which peer-depends on core
@@ -1715,8 +1744,8 @@ the LICENSE and a README into every public package at publish time
   collations. On a drizzle store the answer carries `migrations` rather
   than `drift`, which is what `henri db:status` answers there.
 - The tables henri owns in a drizzle store (`henri_jobs`,
-  `henri_jobs_schedules`, `henri_jobs_limits`, `henri_trail`, `henri_calls`,
-  `henri_versions`)
+  `henri_jobs_schedules`, `henri_jobs_limits`, `henri_jobs_batches`,
+  `henri_trail`, `henri_calls`, `henri_versions`)
   are created through
   raw SQL, so drizzle-kit sees them as tables the schema no longer wants.
   `Drizzle#reservedTables()` is what keeps a push from dropping them, and
@@ -1843,19 +1872,26 @@ concurrency.spec.js` proves the negative property the way `claim.spec.js`
   not. It runs on sqlite offline and on the live PostgreSQL and MySQL, and
   the same file also downgrades a table (`ALTER TABLE ... DROP COLUMN`) to
   prove the upgrade path on a real server; MongoDB has its own in
-  `mongo.spec.js`, MSSQL only its DDL. What is **left**: **batching** (a set
-  of jobs plus one that runs when they are all done) -- the promises are
-  decided and written in `guides/jobs.md#what-is-not-here`, and what it needs
-  is another column plus a table, which is the same upgrade question and so
-  a tranche of its own. There is **no dashboard and there will not be one**;
+  `mongo.spec.js`, MSSQL only its DDL. **Batches** are proved the same way
+  (`packages/jobs/__tests__/batch.spec.js`, and a `batches` block in
+  `mongo.spec.js`): a queue and a pool per runner, and the callback itself
+  recording what it saw -- one entry per run, plus how many jobs of its
+  batch were still waiting or running at that moment, read from the
+  database, because neither "exactly once" nor "never early" can be seen by
+  counting rows afterwards. The suite covers a half-failed batch, a job
+  buried by the recovery, a zombie runner writing its outcome after the job
+  was performed again, and the crash between an outcome and its count. What
+  is **left** of a batch: no order between its jobs, no batch inside one, no
+  cancelling, and no adding to a batch from another process (which is the
+  race the seal exists to close). There is **no dashboard and there will not be one**;
   the argument is in the same guide (`#no-dashboard-and-what-to-build-one-from`)
   and it is that `/_routes`, `/_openapi.json` and `/_mailers` describe the
   _application_ while a queue page would display its _data_ -- job arguments,
   which the privacy tranche marks personal -- and that the place a dashboard
   is wanted is production, where henri must mount none. `henri.jobs.limits()`
-  next to `stats()`, `list()` and `dead.*`, plus `--json` on every command,
-  is what an application builds its own read-only page from, behind its own
-  policy.
+  and `henri.jobs.batches.*` next to `stats()`, `list()` and `dead.*`, plus
+  `--json` on every command, is what an application builds its own read-only
+  page from, behind its own policy.
 - The call log (`config.calls`) is new. Its table, its join, its bodies and
   its bounded delete are covered on sqlite offline and on the live
   PostgreSQL and MySQL of `pnpm test:sql:live`

--- a/packages/cli/__tests__/jobs.spec.js
+++ b/packages/cli/__tests__/jobs.spec.js
@@ -118,6 +118,7 @@ describe('henri jobs', () => {
         ok: true,
         store: 'default',
         tables: {
+          batches: 'henri_jobs_batches',
           jobs: 'henri_jobs',
           limits: 'henri_jobs_limits',
           schedules: 'henri_jobs_schedules',
@@ -203,10 +204,30 @@ describe('henri jobs', () => {
         { group: 'import', job: 'import', keyed: true, limit: 1 },
       ]);
       expect(result.limits.held).toEqual([]);
+      expect(result.batches).toEqual([]);
       expect(result.recurring).toEqual([
         { job: 'ping', name: 'nightly', spec: 'cron:0 3 * * *' },
       ]);
       expect(result.timings[0].runs).toBe(1);
+    });
+
+    test('lists the batches, and the jobs of one', () => {
+      const listed = run(['jobs:batches']);
+
+      expect(listed.status).toBe(0);
+      expect(listed.result).toMatchObject({
+        batches: [],
+        command: 'batches',
+        ok: true,
+        total: 0,
+      });
+
+      // The filter is a filter, not a state: an unknown batch is an empty
+      // list rather than every job of the queue
+      const jobs = run(['jobs:list', '--batch=nope']);
+
+      expect(jobs.status).toBe(0);
+      expect(jobs.result.jobs).toEqual([]);
     });
 
     test('drives the dead letter queue', () => {

--- a/packages/cli/scripts/help.js
+++ b/packages/cli/scripts/help.js
@@ -1003,8 +1003,8 @@ const COMMANDS = [
       'puts back the jobs a runner died on. Several runners are meant to run',
       'at once against one database. It stops on SIGINT, SIGTERM and SIGQUIT,',
       'finishing the jobs it already claimed. Without a command it runs;',
-      'install, status, list, dead, show, perform, retry and discard drive',
-      'the queue from the outside.',
+      'install, status, list, batches, dead, show, perform, retry and discard',
+      'drive the queue from the outside.',
     ],
     examples: [
       {
@@ -1045,6 +1045,11 @@ const COMMANDS = [
         description: 'list/retry/discard: how many, and which job or state',
         flag: '--limit=<n> --name=<job> --state=<state>',
       },
+      {
+        description:
+          'list: only the jobs of one batch; batches: only the finished ones',
+        flag: '--batch=<id> --finished',
+      },
       { description: 'retry, discard: every matching job', flag: '--all' },
       {
         description: 'perform: enqueue it later instead of now',
@@ -1072,8 +1077,14 @@ const COMMANDS = [
         name: 'status',
       },
       {
-        description: 'the jobs of the queue (--state, --queue, --name)',
+        description:
+          'the jobs of the queue (--state, --queue, --name, --batch)',
         name: 'list',
+      },
+      {
+        description:
+          'the batches: what each is waiting for, and its callback (--finished)',
+        name: 'batches',
       },
       { description: 'the dead letter queue', name: 'dead' },
       {

--- a/packages/cli/scripts/jobs.js
+++ b/packages/cli/scripts/jobs.js
@@ -5,6 +5,7 @@ const { usage } = require('./help');
 const { validInstall } = require('./utils');
 
 const COMMANDS = [
+  'batches',
   'dead',
   'discard',
   'install',
@@ -180,15 +181,48 @@ const status = async (args) => {
   }));
   let stats;
   let limits;
+  let batches;
 
   try {
     stats = await jobs.stats();
     limits = await jobs.limits();
+    // What is still being waited for, which is the only half of a batch a
+    // status can be wrong about
+    batches = jobs.queue.batched
+      ? await jobs.batches.list({ finished: false, limit: 20 })
+      : [];
   } finally {
     await henri.stop();
   }
 
-  return { command: 'status', limits, ok: true, recurring, ...stats };
+  return { batches, command: 'status', limits, ok: true, recurring, ...stats };
+};
+
+/**
+ * Lists the batches
+ *
+ * @param {object} args CLI arguments
+ * @returns {Promise<object>} The result of the command
+ */
+const batches = async (args) => {
+  const henri = await boot();
+  const jobs = await queueOf(henri);
+
+  try {
+    const found = await jobs.batches.list({
+      finished: args.finished === true ? true : undefined,
+      limit: Number(args.limit) || 50,
+    });
+
+    return {
+      batches: found,
+      command: 'batches',
+      ok: true,
+      total: found.length,
+    };
+  } finally {
+    await henri.stop();
+  }
 };
 
 /**
@@ -204,6 +238,7 @@ const list = async (args, state) => {
 
   try {
     const found = await jobs.list({
+      batch: typeof args.batch === 'string' ? args.batch : undefined,
       limit: Number(args.limit) || 50,
       name: typeof args.name === 'string' ? args.name : undefined,
       queue: typeof args.queue === 'string' ? args.queue : undefined,
@@ -439,6 +474,40 @@ const printJobs = (jobs) => {
 };
 
 /**
+ * Prints a list of batches
+ *
+ * A batch says what it is waiting for: the counts, and whether the callback
+ * has been enqueued. No arguments -- what a job was given is the
+ * application's data, and `henri jobs:show <id>` is where it is read.
+ *
+ * @param {Array<object>} batches The batches
+ * @returns {void}
+ */
+const printBatches = (batches) => {
+  if (batches.length === 0) {
+    console.log('  No batch');
+
+    return;
+  }
+
+  for (const batch of batches) {
+    const state = batch.finished
+      ? 'finished'
+      : (batch.sealed && 'running') || 'open';
+
+    console.log(
+      `  ${batch.id}  ${state.padEnd(8)} ${batch.done}/${batch.total} done, ${batch.failed} dead${batch.name ? `  ${batch.name}` : ''}`
+    );
+
+    if (batch.callback) {
+      console.log(
+        `      -> ${batch.callback}${batch.callbackId ? ` ${batch.callbackId}` : ' (not enqueued yet)'}`
+      );
+    }
+  }
+};
+
+/**
  * Prints a result for humans
  *
  * @param {object} result What a command returned
@@ -503,6 +572,16 @@ const print = (result) => {
         )
       );
     }
+
+    if (result.batches && result.batches.length > 0) {
+      console.log('');
+      console.log('  Batches still running:');
+      printBatches(result.batches);
+    }
+  }
+
+  if (result.command === 'batches') {
+    printBatches(result.batches);
   }
 
   if (result.command === 'list' || result.command === 'dead') {
@@ -516,6 +595,11 @@ const print = (result) => {
     console.log(
       `  attempts ${job.attempts}/${job.maxAttempts}, run at ${job.runAt}`
     );
+
+    if (job.batchId) {
+      console.log(`  batch ${job.batchId}`);
+    }
+
     console.log(`  args ${JSON.stringify(job.args)}`);
 
     if (job.error) {
@@ -555,6 +639,7 @@ const print = (result) => {
 };
 
 const RUNNERS = {
+  batches,
   dead: (args) => list(args, 'dead'),
   discard,
   install,
@@ -567,8 +652,8 @@ const RUNNERS = {
 };
 
 /**
- * Runs `henri jobs [run|install|status|list|dead|show|perform|retry|discard]`
- * (`henri jobs:<command>` too). Without a command it runs a worker.
+ * Runs `henri jobs [run|install|status|list|batches|dead|show|perform|retry|
+ * discard]` (`henri jobs:<command>` too). Without a command it runs a worker.
  *
  * With --json the result is printed as one JSON object on stdout.
  *

--- a/packages/core/error-codes.json
+++ b/packages/core/error-codes.json
@@ -1212,6 +1212,28 @@
     {
       "area": "job",
       "causes": [
+        "a job added to a batch that was already sealed",
+        "a batch built from somewhere other than the call that made it",
+        "a batch id that names no batch, or one the sweep pruned"
+      ],
+      "code": "HENRI_JOB_BATCH_CLOSED",
+      "fix": "A batch is built where it is created: add every job before it is sealed (`jobs: [...]`, or the function `henri.jobs.batch()` takes), or make another batch. A batch that has finished has already called its callback and never counts anything again.",
+      "what": "A job was added to a batch that is closed."
+    },
+    {
+      "area": "job",
+      "causes": [
+        "a queue installed by a henri older than 1.3, whose table has no `batch_id` column and no batches table",
+        "`jobs.install: false` with no `henri jobs:install` since the upgrade",
+        "a database user that may not create a table, or alter one"
+      ],
+      "code": "HENRI_JOB_BATCH_UNINSTALLED",
+      "fix": "Run `henri jobs:install` once with a user that may create a table and alter one. The queue works without them -- a batch does not, and is refused rather than run with a counter nothing can hold.",
+      "what": "A batch was asked for and the queue has nowhere to count it."
+    },
+    {
+      "area": "job",
+      "causes": [
         "two jobs of one `concurrency.group` asking for different limits",
         "a group renamed in one file and not in the other"
       ],
@@ -1228,6 +1250,18 @@
       "code": "HENRI_JOB_INVALID_ARGUMENTS",
       "fix": "The arguments of a job are stored as JSON: pass ids and plain values, and look the records up inside `perform()`.",
       "what": "The arguments of a job cannot be stored."
+    },
+    {
+      "area": "job",
+      "causes": [
+        "a `jobs` list holding something that is not a name, a list or an object",
+        "a callback that is not the name of a job",
+        "callback arguments that are not a plain object",
+        "both a `jobs` list and a function to add them"
+      ],
+      "code": "HENRI_JOB_INVALID_BATCH",
+      "fix": "`henri.jobs.batch({ callback: 'report/compile', jobs: [['resize', { id }]] })`, or a function that calls `batch.add()` itself. The counts reach the callback under `batch`, which is why its own arguments have to be an object.",
+      "what": "A batch declaration cannot be read."
     },
     {
       "area": "job",

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -4850,6 +4850,8 @@ declare namespace start {
      * by default), plus `:<key>` when the job names one.
      */
     concurrencyKey: string | null;
+    /** The batch this job counts into, `null` when it is not in one. */
+    batchId: string | null;
   }
 
   /** The options of an enqueue. */
@@ -4865,6 +4867,12 @@ declare namespace start {
     timeout?: number | string;
     /** A key no other job of the queue may hold. */
     unique?: string;
+    /**
+     * The batch to count the job into. `henri.jobs.batch()` is what makes
+     * one, and a batch that has been sealed refuses
+     * (`HENRI_JOB_BATCH_CLOSED`).
+     */
+    batch?: string;
   }
 
   /** What a job's `perform(args, context)` receives as its context. */
@@ -4973,8 +4981,85 @@ declare namespace start {
     state?: 'pending' | 'running' | 'done' | 'dead';
     queue?: string;
     name?: string;
+    /** Only the jobs of one batch. */
+    batch?: string;
     limit?: number;
     offset?: number;
+  }
+
+  /**
+   * A batch: a set of jobs, and one job that runs when they are all done.
+   *
+   * A batch **finishes**, it does not succeed: the callback runs once every
+   * job has reached a terminal state, `dead` included, and is handed these
+   * counts under `batch`. It runs exactly once, and never before the last
+   * job of the batch is terminal.
+   */
+  interface JobBatch {
+    id: string;
+    /** The label the batch was given, if any. */
+    name: string | null;
+    /** The job that runs when it finishes, `null` when it has none. */
+    callback: string | null;
+    /** The id of the enqueued callback, once it has been. */
+    callbackId: string | null;
+    /** How many jobs it holds; written when it is sealed, and fixed. */
+    total: number;
+    /** How many of them are terminal. */
+    done: number;
+    /** How many of those died. */
+    failed: number;
+    /** `done - failed`. */
+    succeeded: number;
+    /** Whether it is closed to new jobs. */
+    sealed: boolean;
+    /** Whether every job of it is terminal and the callback was enqueued. */
+    finished: boolean;
+    /** Moments are ISO strings. */
+    createdAt: string | null;
+    updatedAt: string | null;
+    sealedAt: string | null;
+    finishedAt: string | null;
+  }
+
+  /** One job of a batch, however it is written. */
+  type JobBatchEntry =
+    | string
+    | [string, unknown?, JobOptions?]
+    | { name: string; args?: unknown; options?: JobOptions };
+
+  /** What `henri.jobs.batch()` takes. */
+  interface JobBatchOptions extends JobOptions {
+    /** A label, for `henri jobs:batches`. */
+    name?: string;
+    /** The job to run when the batch finishes. */
+    callback?: string;
+    /**
+     * The callback's own arguments. The counts are added to them under
+     * `batch`, so this has to be a plain object.
+     */
+    args?: Record<string, unknown> | null;
+    /** The jobs of the batch. */
+    jobs?: JobBatchEntry[];
+  }
+
+  /**
+   * A batch in hand: what adds jobs to it and closes it.
+   *
+   * Its counters are what the database said when it was last read, so
+   * `reload()` is how they are refreshed.
+   */
+  interface JobBatchHandle extends JobBatch {
+    /** The ids of the jobs this handle enqueued. */
+    jobs: string[];
+    /** Adds one job; refuses once the batch is sealed. */
+    add(name: string, args?: unknown, options?: JobOptions): Promise<Job>;
+    /** Adds several, in any of the shapes `batch({ jobs })` takes. */
+    addAll(list: JobBatchEntry[]): Promise<Job[]>;
+    /** Closes the batch, and settles it when nothing was left to wait for. */
+    seal(): Promise<JobBatchHandle>;
+    /** Reads the counters back. */
+    reload(): Promise<JobBatchHandle>;
   }
 
   /**
@@ -5014,6 +5099,29 @@ declare namespace start {
     ): Promise<Job>;
     /** Performs a job here and now, without the queue (tests, console). */
     performNow(name: string, args?: unknown): Promise<unknown>;
+    /**
+     * Makes a batch: these jobs, and one that runs when they are all done.
+     *
+     * With `jobs` (or a function that adds them) the batch comes back
+     * sealed; with neither, it is open and `seal()` closes it.
+     */
+    batch(
+      options?: JobBatchOptions,
+      build?: (batch: JobBatchHandle) => unknown | Promise<unknown>
+    ): Promise<JobBatchHandle>;
+    /** Reading the batches back; `batch()` is what makes one. */
+    batches: {
+      get(id: string): Promise<JobBatch | null>;
+      list(filter?: {
+        finished?: boolean;
+        limit?: number;
+        offset?: number;
+      }): Promise<JobBatch[]>;
+      /** The jobs of a batch. */
+      jobs(id: string, filter?: JobFilter): Promise<Job[]>;
+      /** Forgets a batch, leaving its jobs alone. */
+      discard(id: string): Promise<boolean>;
+    };
     get(id: string): Promise<Job | null>;
     list(filter?: JobFilter): Promise<Job[]>;
     stats(): Promise<JobStats>;

--- a/packages/drizzle/__tests__/retention.spec.js
+++ b/packages/drizzle/__tests__/retention.spec.js
@@ -161,6 +161,7 @@ describe(`the access trail on ${target.name}`, () => {
       'henri_calls',
       'henri_identities',
       'henri_jobs',
+      'henri_jobs_batches',
       'henri_jobs_limits',
       'henri_jobs_schedules',
       'henri_trail',

--- a/packages/drizzle/index.js
+++ b/packages/drizzle/index.js
@@ -1370,6 +1370,7 @@ class Drizzle {
       queue,
       `${queue}_schedules`,
       `${queue}_limits`,
+      `${queue}_batches`,
       name(calls.table, 'henri_calls'),
       name(identities.table, 'henri_identities'),
       name(trail.table, 'henri_trail'),

--- a/packages/jobs/__tests__/__snapshots__/config.spec.js.snap
+++ b/packages/jobs/__tests__/__snapshots__/config.spec.js.snap
@@ -98,6 +98,7 @@ exports[`the schema > writes the DDL of mssql 1`] = `
   history NVARCHAR(MAX) NULL,
   unique_key VARCHAR(190) NULL,
   concurrency_key VARCHAR(190) NULL,
+  batch_id VARCHAR(36) NULL,
   PRIMARY KEY (id)
 );
 IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'henri_jobs_claim' AND object_id = OBJECT_ID('henri_jobs')) CREATE INDEX [henri_jobs_claim] ON [henri_jobs] (state, queue, priority, run_at);
@@ -125,8 +126,27 @@ IF OBJECT_ID('henri_jobs_limits', 'U') IS NULL CREATE TABLE [henri_jobs_limits] 
   PRIMARY KEY (limit_key, slot)
 );
 IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'henri_jobs_limits_stale' AND object_id = OBJECT_ID('henri_jobs_limits')) CREATE INDEX [henri_jobs_limits_stale] ON [henri_jobs_limits] (heartbeat_at);
+IF OBJECT_ID('henri_jobs_batches', 'U') IS NULL CREATE TABLE [henri_jobs_batches] (
+  id VARCHAR(36) NOT NULL,
+  name VARCHAR(190) NULL,
+  callback VARCHAR(120) NULL,
+  callback_args NVARCHAR(MAX) NULL,
+  callback_options NVARCHAR(MAX) NULL,
+  callback_id VARCHAR(36) NULL,
+  total INT NOT NULL,
+  done INT NOT NULL,
+  failed INT NOT NULL,
+  created_at BIGINT NOT NULL,
+  updated_at BIGINT NOT NULL,
+  sealed_at BIGINT NULL,
+  finished_at BIGINT NULL,
+  PRIMARY KEY (id)
+);
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'henri_jobs_batches_open' AND object_id = OBJECT_ID('henri_jobs_batches')) CREATE INDEX [henri_jobs_batches_open] ON [henri_jobs_batches] (finished_at, updated_at);
 IF COL_LENGTH('henri_jobs', 'concurrency_key') IS NULL ALTER TABLE [henri_jobs] ADD concurrency_key VARCHAR(190) NULL;
-IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'henri_jobs_limited' AND object_id = OBJECT_ID('henri_jobs')) CREATE INDEX [henri_jobs_limited] ON [henri_jobs] (state, concurrency_key, run_at)"
+IF COL_LENGTH('henri_jobs', 'batch_id') IS NULL ALTER TABLE [henri_jobs] ADD batch_id VARCHAR(36) NULL;
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'henri_jobs_limited' AND object_id = OBJECT_ID('henri_jobs')) CREATE INDEX [henri_jobs_limited] ON [henri_jobs] (state, concurrency_key, run_at);
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'henri_jobs_batch' AND object_id = OBJECT_ID('henri_jobs')) CREATE INDEX [henri_jobs_batch] ON [henri_jobs] (batch_id)"
 `;
 
 exports[`the schema > writes the DDL of mysql 1`] = `
@@ -155,6 +175,7 @@ exports[`the schema > writes the DDL of mysql 1`] = `
   history MEDIUMTEXT NULL,
   unique_key VARCHAR(190) NULL,
   concurrency_key VARCHAR(190) NULL,
+  batch_id VARCHAR(36) NULL,
   PRIMARY KEY (id),
   KEY \`henri_jobs_claim\` (state, queue, priority, run_at),
   KEY \`henri_jobs_token\` (claim_token),
@@ -182,8 +203,27 @@ CREATE TABLE IF NOT EXISTS \`henri_jobs_limits\` (
   PRIMARY KEY (limit_key, slot),
   KEY \`henri_jobs_limits_stale\` (heartbeat_at)
 );
+CREATE TABLE IF NOT EXISTS \`henri_jobs_batches\` (
+  id VARCHAR(36) NOT NULL,
+  name VARCHAR(190) NULL,
+  callback VARCHAR(120) NULL,
+  callback_args MEDIUMTEXT NULL,
+  callback_options MEDIUMTEXT NULL,
+  callback_id VARCHAR(36) NULL,
+  total INT NOT NULL,
+  done INT NOT NULL,
+  failed INT NOT NULL,
+  created_at BIGINT NOT NULL,
+  updated_at BIGINT NOT NULL,
+  sealed_at BIGINT NULL,
+  finished_at BIGINT NULL,
+  PRIMARY KEY (id),
+  KEY \`henri_jobs_batches_open\` (finished_at, updated_at)
+);
 ALTER TABLE \`henri_jobs\` ADD COLUMN concurrency_key VARCHAR(190) NULL;
-CREATE INDEX \`henri_jobs_limited\` ON \`henri_jobs\` (state, concurrency_key, run_at)"
+ALTER TABLE \`henri_jobs\` ADD COLUMN batch_id VARCHAR(36) NULL;
+CREATE INDEX \`henri_jobs_limited\` ON \`henri_jobs\` (state, concurrency_key, run_at);
+CREATE INDEX \`henri_jobs_batch\` ON \`henri_jobs\` (batch_id)"
 `;
 
 exports[`the schema > writes the DDL of postgres 1`] = `
@@ -212,6 +252,7 @@ exports[`the schema > writes the DDL of postgres 1`] = `
   history TEXT NULL,
   unique_key VARCHAR(190) NULL,
   concurrency_key VARCHAR(190) NULL,
+  batch_id VARCHAR(36) NULL,
   PRIMARY KEY (id)
 );
 CREATE INDEX IF NOT EXISTS "henri_jobs_claim" ON "henri_jobs" (state, queue, priority, run_at);
@@ -239,8 +280,27 @@ CREATE TABLE IF NOT EXISTS "henri_jobs_limits" (
   PRIMARY KEY (limit_key, slot)
 );
 CREATE INDEX IF NOT EXISTS "henri_jobs_limits_stale" ON "henri_jobs_limits" (heartbeat_at);
+CREATE TABLE IF NOT EXISTS "henri_jobs_batches" (
+  id VARCHAR(36) NOT NULL,
+  name VARCHAR(190) NULL,
+  callback VARCHAR(120) NULL,
+  callback_args TEXT NULL,
+  callback_options TEXT NULL,
+  callback_id VARCHAR(36) NULL,
+  total INTEGER NOT NULL,
+  done INTEGER NOT NULL,
+  failed INTEGER NOT NULL,
+  created_at BIGINT NOT NULL,
+  updated_at BIGINT NOT NULL,
+  sealed_at BIGINT NULL,
+  finished_at BIGINT NULL,
+  PRIMARY KEY (id)
+);
+CREATE INDEX IF NOT EXISTS "henri_jobs_batches_open" ON "henri_jobs_batches" (finished_at, updated_at);
 ALTER TABLE "henri_jobs" ADD COLUMN IF NOT EXISTS concurrency_key VARCHAR(190) NULL;
-CREATE INDEX IF NOT EXISTS "henri_jobs_limited" ON "henri_jobs" (state, concurrency_key, run_at)"
+ALTER TABLE "henri_jobs" ADD COLUMN IF NOT EXISTS batch_id VARCHAR(36) NULL;
+CREATE INDEX IF NOT EXISTS "henri_jobs_limited" ON "henri_jobs" (state, concurrency_key, run_at);
+CREATE INDEX IF NOT EXISTS "henri_jobs_batch" ON "henri_jobs" (batch_id)"
 `;
 
 exports[`the schema > writes the DDL of sqlite 1`] = `
@@ -269,6 +329,7 @@ exports[`the schema > writes the DDL of sqlite 1`] = `
   history TEXT NULL,
   unique_key VARCHAR(190) NULL,
   concurrency_key VARCHAR(190) NULL,
+  batch_id VARCHAR(36) NULL,
   PRIMARY KEY (id)
 );
 CREATE INDEX IF NOT EXISTS "henri_jobs_claim" ON "henri_jobs" (state, queue, priority, run_at);
@@ -296,6 +357,25 @@ CREATE TABLE IF NOT EXISTS "henri_jobs_limits" (
   PRIMARY KEY (limit_key, slot)
 );
 CREATE INDEX IF NOT EXISTS "henri_jobs_limits_stale" ON "henri_jobs_limits" (heartbeat_at);
+CREATE TABLE IF NOT EXISTS "henri_jobs_batches" (
+  id VARCHAR(36) NOT NULL,
+  name VARCHAR(190) NULL,
+  callback VARCHAR(120) NULL,
+  callback_args TEXT NULL,
+  callback_options TEXT NULL,
+  callback_id VARCHAR(36) NULL,
+  total INTEGER NOT NULL,
+  done INTEGER NOT NULL,
+  failed INTEGER NOT NULL,
+  created_at BIGINT NOT NULL,
+  updated_at BIGINT NOT NULL,
+  sealed_at BIGINT NULL,
+  finished_at BIGINT NULL,
+  PRIMARY KEY (id)
+);
+CREATE INDEX IF NOT EXISTS "henri_jobs_batches_open" ON "henri_jobs_batches" (finished_at, updated_at);
 ALTER TABLE "henri_jobs" ADD COLUMN concurrency_key VARCHAR(190) NULL;
-CREATE INDEX IF NOT EXISTS "henri_jobs_limited" ON "henri_jobs" (state, concurrency_key, run_at)"
+ALTER TABLE "henri_jobs" ADD COLUMN batch_id VARCHAR(36) NULL;
+CREATE INDEX IF NOT EXISTS "henri_jobs_limited" ON "henri_jobs" (state, concurrency_key, run_at);
+CREATE INDEX IF NOT EXISTS "henri_jobs_batch" ON "henri_jobs" (batch_id)"
 `;

--- a/packages/jobs/__tests__/batch.spec.js
+++ b/packages/jobs/__tests__/batch.spec.js
@@ -1,0 +1,702 @@
+const { randomUUID } = require('crypto');
+
+const { adapterFor, build, close, sharedKey, target } = require('./helpers');
+const { Runner } = require('../src/runner');
+
+/**
+ * A batch has one negative property, and it is the whole feature: the
+ * callback runs **exactly once**, and never before the last job of the
+ * batch is terminal. Neither half can be seen by counting rows afterwards
+ * -- a callback that ran twice and one that ran once leave the same
+ * arguments behind, and a callback that ran too early leaves no trace at
+ * all once the last job finishes a millisecond later.
+ *
+ * So the callback itself records what it saw (`fixtures/app/app/jobs/
+ * batch/finished.js`): one entry per run, and the number of jobs of its
+ * batch that were still waiting or running at that moment, read from the
+ * database. `unfinished: 0` is the assertion.
+ *
+ * Like `claim.spec.js` and `concurrency.spec.js`, every queue here opens a
+ * connection pool of its own, so the runners race on the server rather than
+ * in one client. On sqlite that proves the logic; against the PostgreSQL and
+ * MySQL of `pnpm test:sql:live` it proves the guarantee.
+ */
+
+const RUNNERS = target.live ? 4 : 2;
+const JOBS = target.live ? 12 : 6;
+
+/**
+ * The callbacks that were performed in this process
+ *
+ * @returns {Array<object>} `{ at, batch, runner, unfinished }` entries
+ */
+const callbacks = () => global.__henriJobsCallbacks || [];
+
+describe(`batches (${target.name}, ${RUNNERS} runners)`, () => {
+  const adapters = [];
+  const queues = [];
+
+  /**
+   * Empties the queue and forgets every batch
+   *
+   * @returns {Promise<void>} Resolves when it is empty
+   */
+  const clear = async () => {
+    for (const state of ['pending', 'running', 'done', 'dead']) {
+      await queues[0].store.remove({ state });
+    }
+
+    for (const batch of await queues[0].store.listBatches({ limit: 200 })) {
+      await queues[0].store.removeBatch(batch.id);
+    }
+
+    global.__henriJobsCallbacks = [];
+    global.__henriJobsRuns = [];
+  };
+
+  /**
+   * Runs every runner until the queue has nothing left to give
+   *
+   * @param {object} [options={}] `concurrency`
+   * @returns {Promise<Array<object>>} What each runner did
+   */
+  const drain = async (options = {}) => {
+    const runners = queues.map((queue) =>
+      new Runner(queue, {
+        concurrency: options.concurrency || 4,
+        recurring: false,
+      }).start()
+    );
+
+    // A callback is enqueued *after* the outcome of the last job of its
+    // batch is written down, so an empty table is not the end of the work:
+    // a runner still holding that job is what says the batch has not been
+    // settled yet, and a drain that stopped in that gap would leave the
+    // callback in the queue with nobody to perform it
+    const busy = () => runners.some((runner) => runner.running.size > 0);
+    let empty = 0;
+
+    for (let waited = 0; waited < 800 && empty < 3; waited += 1) {
+      const pending = await queues[0].count({ state: 'pending' });
+      const running = await queues[0].count({ state: 'running' });
+
+      empty = pending === 0 && running === 0 && !busy() ? empty + 1 : 0;
+
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+
+    return Promise.all(runners.map((runner) => runner.stop()));
+  };
+
+  /**
+   * The jobs of a batch, written the way `batch({ jobs })` takes them
+   *
+   * @param {number} total How many
+   * @param {object} [options={}] `fail` (how many of them die), `wait`
+   * @returns {Array} The entries
+   */
+  const members = (total, options = {}) =>
+    Array.from({ length: total }, (ignored, index) => [
+      'batch/member',
+      {
+        fail: index < (options.fail || 0),
+        token: `${options.token || 'job'}-${index}`,
+        wait: options.wait || 5,
+      },
+    ]);
+
+  beforeAll(async () => {
+    const key = sharedKey('batch');
+
+    for (let index = 0; index < RUNNERS; index += 1) {
+      const adapter = await adapterFor(key);
+      const built = await build({
+        adapter,
+        config: { pollInterval: 25, stuckAfter: '10s' },
+      });
+
+      // The callback asks the queue what is left of its batch, so it needs
+      // one on the henri it is handed -- which is what an application has
+      built.henri.jobs = built.jobs;
+      adapters.push(adapter);
+      queues.push(built.jobs);
+    }
+  }, 60000);
+
+  afterAll(() => close(adapters));
+
+  beforeEach(clear);
+
+  test('the store can hold a batch', async () => {
+    // Everything below rests on this: without the column and the table the
+    // queue refuses a batch rather than running one that counts nothing
+    expect(await queues[0].store.batched()).toBe(true);
+    expect(queues[0].batched).toBe(true);
+  });
+
+  test('the callback runs once, when the last job is terminal', async () => {
+    const batch = await queues[0].batch({
+      callback: 'batch/finished',
+      jobs: members(JOBS, { token: 'once' }),
+      name: 'every job of it',
+    });
+
+    expect(batch.total).toBe(JOBS);
+    expect(batch.sealed).toBe(true);
+    expect(batch.finished).toBe(false);
+
+    await drain();
+
+    // One callback, whatever the interleaving of the runners
+    expect(callbacks()).toHaveLength(1);
+
+    const [call] = callbacks();
+
+    // ... and not one job of the batch was left when it ran
+    expect(call.unfinished).toBe(0);
+    expect(call.batch).toEqual({
+      done: JOBS,
+      failed: 0,
+      id: batch.id,
+      name: 'every job of it',
+      succeeded: JOBS,
+      total: JOBS,
+    });
+
+    // One row, too: the callback is enqueued under a unique key of the
+    // batch's own, so a second settle answers the same job
+    const enqueued = await queues[0].list({
+      limit: 100,
+      name: 'batch/finished',
+    });
+
+    expect(enqueued).toHaveLength(1);
+    expect(enqueued[0].state).toBe('done');
+
+    const stored = await queues[0].batches.get(batch.id);
+
+    expect(stored.finished).toBe(true);
+    expect(stored.callbackId).toBe(enqueued[0].id);
+    expect(stored.done).toBe(JOBS);
+  }, 120000);
+
+  test('a batch finishes, it does not succeed', async () => {
+    const dead = 2;
+    const batch = await queues[0].batch({
+      args: { report: 'nightly' },
+      callback: 'batch/finished',
+      jobs: members(JOBS, { fail: dead, token: 'half' }),
+    });
+
+    await drain();
+
+    expect(callbacks()).toHaveLength(1);
+
+    const [call] = callbacks();
+
+    expect(call.unfinished).toBe(0);
+    expect(call.batch.total).toBe(JOBS);
+    expect(call.batch.done).toBe(JOBS);
+    expect(call.batch.failed).toBe(dead);
+    expect(call.batch.succeeded).toBe(JOBS - dead);
+
+    // The declared arguments are the callback's own, and the counts are
+    // added to them
+    const [job] = await queues[0].list({ limit: 10, name: 'batch/finished' });
+
+    expect(job.args.report).toBe('nightly');
+    expect(await queues[0].count({ state: 'dead' })).toBe(dead);
+    expect((await queues[0].batches.get(batch.id)).failed).toBe(dead);
+  }, 120000);
+
+  test('nothing is called while one job of the batch is still to run', async () => {
+    let last = null;
+    const batch = await queues[0].batch(
+      { callback: 'batch/finished' },
+      async (open) => {
+        await open.add('batch/member', { token: 'now-1' });
+        await open.add('batch/member', { token: 'now-2' });
+        last = await open.add(
+          'batch/member',
+          { token: 'later' },
+          { wait: '1h' }
+        );
+      }
+    );
+
+    expect(batch.total).toBe(3);
+
+    // A drain performs what is due and leaves what is not, so this one
+    // takes two of the three
+    await drain();
+
+    expect(callbacks()).toHaveLength(0);
+    expect((await queues[0].batches.get(batch.id)).done).toBe(2);
+
+    // The third comes due; moved by hand rather than waited for
+    await queues[0].store.update(last.id, { run_at: Date.now() });
+    await drain();
+
+    expect(callbacks()).toHaveLength(1);
+    expect(callbacks()[0].unfinished).toBe(0);
+    expect(callbacks()[0].batch.done).toBe(3);
+  }, 120000);
+
+  test('several batches finishing at once each get their own callback', async () => {
+    const made = [];
+
+    for (let index = 0; index < 3; index += 1) {
+      made.push(
+        await queues[0].batch({
+          callback: 'batch/finished',
+          jobs: members(JOBS, { token: `many-${index}`, wait: 15 }),
+          name: `batch ${index}`,
+        })
+      );
+    }
+
+    await drain();
+
+    const seen = callbacks();
+
+    expect(seen).toHaveLength(3);
+    expect(seen.every((call) => call.unfinished === 0)).toBe(true);
+    expect(new Set(seen.map((call) => call.batch.id)).size).toBe(3);
+
+    for (const batch of made) {
+      const call = seen.find((entry) => entry.batch.id === batch.id);
+
+      expect(call.batch.done).toBe(JOBS);
+      expect((await queues[0].batches.get(batch.id)).finished).toBe(true);
+    }
+  }, 120000);
+
+  test('an empty batch has nothing to wait for', async () => {
+    const batch = await queues[0].batch({
+      callback: 'batch/finished',
+      jobs: [],
+    });
+
+    // Sealed with a total of zero, so it is finished the moment it is made
+    expect(batch.finished).toBe(true);
+    expect(batch.callbackId).not.toBeNull();
+
+    await drain();
+
+    expect(callbacks()).toHaveLength(1);
+    expect(callbacks()[0].batch.total).toBe(0);
+  }, 60000);
+
+  test('a batch may have no callback at all', async () => {
+    const batch = await queues[0].batch({
+      jobs: members(2, { token: 'bare' }),
+    });
+
+    await drain();
+
+    const stored = await queues[0].batches.get(batch.id);
+
+    expect(stored.finished).toBe(true);
+    expect(stored.callback).toBeNull();
+    expect(stored.callbackId).toBeNull();
+    expect(stored.done).toBe(2);
+    expect(callbacks()).toHaveLength(0);
+  }, 60000);
+
+  test('a sealed batch refuses a job, and says so', async () => {
+    const batch = await queues[0].batch({
+      callback: 'batch/finished',
+      jobs: members(1, { token: 'closed' }),
+    });
+
+    await expect(batch.add('batch/member', { token: 'late' })).rejects.toThrow(
+      /is closed/u
+    );
+
+    // And so does the enqueue itself: the promise is about the batch, not
+    // about the handle in this process's memory
+    const error = await queues[1 % RUNNERS]
+      .perform('batch/member', { token: 'late' }, { batch: batch.id })
+      .then(
+        () => null,
+        (thrown) => thrown
+      );
+
+    expect(error.code).toBe('HENRI_JOB_BATCH_CLOSED');
+    expect(error.hint).toContain('before it is sealed');
+    expect(await queues[0].count({ state: 'pending' })).toBe(1);
+  });
+
+  test('the jobs of a batch are its own', async () => {
+    const batch = await queues[0].batch({
+      jobs: members(3, { token: 'listed' }),
+      name: 'listed',
+    });
+    const other = await queues[0].perform('ok', { outside: true });
+    const held = await queues[0].batches.jobs(batch.id, { limit: 50 });
+
+    expect(held).toHaveLength(3);
+    expect(held.every((job) => job.batchId === batch.id)).toBe(true);
+    expect(held.map((job) => job.id)).not.toContain(other.id);
+    expect(other.batchId).toBeNull();
+
+    const listed = await queues[0].batches.list({ finished: false });
+
+    expect(listed.map((entry) => entry.id)).toContain(batch.id);
+
+    // The way out of a batch that can never finish: forget it, and its
+    // jobs count against nothing
+    expect(await queues[0].batches.discard(batch.id)).toBe(true);
+    expect(await queues[0].batches.get(batch.id)).toBeNull();
+    await drain();
+    expect(callbacks()).toHaveLength(0);
+  }, 60000);
+
+  test('a declaration henri cannot read is refused', async () => {
+    for (const options of [
+      { callback: 'batch/finished', jobs: [42] },
+      { callback: 12 },
+      { args: 'a string', callback: 'batch/finished' },
+      { name: 'x'.repeat(200) },
+    ]) {
+      const error = await queues[0].batch(options).then(
+        () => null,
+        (thrown) => thrown
+      );
+
+      expect(error && error.code).toBe('HENRI_JOB_INVALID_BATCH');
+    }
+
+    // A callback no file answers to is caught here rather than when the
+    // last job of the batch finishes, minutes later and elsewhere
+    const unknown = await queues[0].batch({ callback: 'batch/nowhere' }).then(
+      () => null,
+      (thrown) => thrown
+    );
+
+    expect(unknown.code).toBe('HENRI_JOB_UNKNOWN');
+
+    // And a builder is one way or the other, never both
+    const both = await queues[0]
+      .batch({ jobs: members(1) }, async () => null)
+      .then(
+        () => null,
+        (thrown) => thrown
+      );
+
+    expect(both.code).toBe('HENRI_JOB_INVALID_BATCH');
+  });
+
+  test('a job put back gives its slot back, so the callback still waits', async () => {
+    const batch = await queues[0].batch({
+      callback: 'batch/finished',
+      jobs: members(2, { fail: 1, token: 'retried' }),
+    });
+
+    await drain();
+
+    expect(callbacks()).toHaveLength(1);
+
+    const [dead] = await queues[0].list({ limit: 5, state: 'dead' });
+    const before = await queues[0].batches.get(batch.id);
+
+    // A finished batch never moves again: it has already called its
+    // callback, and counting a second outcome for the same job would make
+    // its counts a lie
+    await queues[0].retry(dead.id);
+
+    const after = await queues[0].batches.get(batch.id);
+
+    expect(before.finished).toBe(true);
+    expect(after.done).toBe(before.done);
+    expect(after.failed).toBe(before.failed);
+
+    await drain();
+
+    expect(callbacks()).toHaveLength(1);
+  }, 120000);
+
+  test('a batch still running gives the slot back and waits again', async () => {
+    const batch = await queues[0].batch(
+      { callback: 'batch/finished' },
+      async (open) => {
+        await open.add('batch/member', { fail: true, token: 'first' });
+        await open.add(
+          'batch/member',
+          { token: 'second' },
+          { at: Date.now() + 100000 }
+        );
+      }
+    );
+
+    await drain();
+
+    const [dead] = await queues[0].list({ limit: 5, state: 'dead' });
+
+    expect(callbacks()).toHaveLength(0);
+    expect((await queues[0].batches.get(batch.id)).done).toBe(1);
+
+    await queues[0].retry(dead.id, { wait: 100000 });
+
+    const after = await queues[0].batches.get(batch.id);
+
+    expect(after.done).toBe(0);
+    expect(after.failed).toBe(0);
+  }, 120000);
+});
+
+describe(`a batch and a runner that died (${target.name})`, () => {
+  const adapters = [];
+  let jobs = null;
+  let store = null;
+
+  beforeAll(async () => {
+    const adapter = await adapterFor(sharedKey('batch-recovery'));
+    const built = await build({
+      adapter,
+      config: { pollInterval: 25, stuckAfter: 200 },
+    });
+
+    built.henri.jobs = built.jobs;
+    adapters.push(adapter);
+    jobs = built.jobs;
+    store = built.jobs.store;
+  }, 60000);
+
+  afterAll(() => close(adapters));
+
+  beforeEach(async () => {
+    for (const state of ['pending', 'running', 'done', 'dead']) {
+      await store.remove({ state });
+    }
+
+    for (const batch of await store.listBatches({ limit: 200 })) {
+      await store.removeBatch(batch.id);
+    }
+
+    global.__henriJobsCallbacks = [];
+    global.__henriJobsRuns = [];
+  });
+
+  test('an outcome that was refused counts nothing, and the new one counts once', async () => {
+    const batch = await jobs.batch({
+      callback: 'batch/finished',
+      jobs: [['batch/member', { token: 'zombie' }, { maxAttempts: 2 }]],
+    });
+    const [ghost] = await store.claim({
+      limit: 1,
+      now: Date.now(),
+      queues: [],
+      runner: 'ghost',
+      token: randomUUID(),
+    });
+
+    // The runner that holds it goes quiet: its jobs are put back, and the
+    // batch has counted nothing, which is the whole reason the counter
+    // cannot move at claim time
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    await store.recover({ now: Date.now(), stuckAfter: 200 });
+
+    expect((await jobs.batches.get(batch.id)).done).toBe(0);
+
+    const runner = new Runner(jobs, { concurrency: 2, recurring: false });
+
+    await runner.once();
+
+    // Performed by somebody else, counted once, and the callback called
+    expect((await jobs.batches.get(batch.id)).done).toBe(1);
+    expect(callbacks()).toHaveLength(1);
+
+    // And now the runner everybody gave up on writes its outcome. The
+    // write is refused by the claim token, and so is the count: this is
+    // the interleaving that would otherwise take `done` past `total`
+    const outcome = await jobs.attempt(ghost, { runner: 'ghost' });
+    const settled = await jobs.batches.get(batch.id);
+
+    expect(outcome.state).toBe('done');
+    expect(settled.done).toBe(1);
+    expect(settled.total).toBe(1);
+    expect(callbacks()).toHaveLength(1);
+    expect(await jobs.list({ limit: 10, name: 'batch/finished' })).toHaveLength(
+      1
+    );
+  }, 60000);
+
+  test('a job buried by the recovery is counted by the sweep', async () => {
+    const batch = await jobs.batch({
+      callback: 'batch/finished',
+      jobs: [['batch/member', { token: 'buried' }, { maxAttempts: 1 }]],
+    });
+
+    await store.claim({
+      limit: 1,
+      now: Date.now(),
+      queues: [],
+      runner: 'ghost',
+      token: randomUUID(),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    // Out of attempts, so the recovery buries it rather than putting it
+    // back: an outcome no attempt of anybody's ever wrote
+    await store.recover({ now: Date.now(), stuckAfter: 200 });
+
+    expect(await jobs.count({ state: 'dead' })).toBe(1);
+    expect((await jobs.batches.get(batch.id)).done).toBe(0);
+    expect(callbacks()).toHaveLength(0);
+
+    const settled = await jobs.reconcile({ before: Date.now() + 1 });
+
+    expect(settled.map((entry) => entry.id)).toEqual([batch.id]);
+
+    const stored = await jobs.batches.get(batch.id);
+
+    expect(stored.finished).toBe(true);
+    expect(stored.done).toBe(1);
+    expect(stored.failed).toBe(1);
+
+    await new Runner(jobs, { recurring: false }).once();
+
+    expect(callbacks()).toHaveLength(1);
+    expect(callbacks()[0].batch.failed).toBe(1);
+  }, 60000);
+
+  test('a runner killed between the outcome and the count is repaired', async () => {
+    const batch = await jobs.batch({
+      callback: 'batch/finished',
+      jobs: [['batch/member', { token: 'killed' }]],
+    });
+    const advance = store.advanceBatch.bind(store);
+
+    // The narrow window the sweep exists for: the outcome is written and
+    // the process dies before it is counted
+    store.advanceBatch = async () => null;
+
+    try {
+      await new Runner(jobs, { recurring: false }).once();
+    } finally {
+      store.advanceBatch = advance;
+    }
+
+    expect(await jobs.count({ state: 'done' })).toBe(1);
+    expect((await jobs.batches.get(batch.id)).done).toBe(0);
+    expect(callbacks()).toHaveLength(0);
+
+    // Counting the rows is what answers, and it only ever moves forward
+    await jobs.reconcile({ before: Date.now() + 1 });
+
+    const stored = await jobs.batches.get(batch.id);
+
+    expect(stored.done).toBe(1);
+    expect(stored.finished).toBe(true);
+
+    // Settling is idempotent: a second sweep answers the callback that is
+    // already in the queue rather than enqueuing another
+    await jobs.reconcile({ before: Date.now() + 1 });
+    await jobs.settle(await store.findBatch(batch.id));
+
+    expect(await jobs.list({ limit: 10, name: 'batch/finished' })).toHaveLength(
+      1
+    );
+
+    await new Runner(jobs, { recurring: false }).once();
+
+    expect(callbacks()).toHaveLength(1);
+  }, 60000);
+});
+
+describe(`upgrading a queue that has no batches (${target.name})`, () => {
+  const adapters = [];
+  let jobs = null;
+  let store = null;
+
+  /**
+   * Takes the store back to what a henri without batches wrote
+   *
+   * @returns {Promise<void>} Resolves when the column and the table are gone
+   */
+  const downgrade = async () => {
+    const { batches, jobs: table } = jobs.config.tables;
+
+    await store.run(`DROP INDEX IF EXISTS ${table}_batch`).catch(() => null);
+    await store
+      .run(`ALTER TABLE ${table} DROP INDEX ${table}_batch`)
+      .catch(() => null);
+    await store.run(`ALTER TABLE ${table} DROP COLUMN batch_id`);
+    await store.run(`DROP TABLE IF EXISTS ${batches}`);
+    store.batches = null;
+    jobs.batched = await store.batched();
+  };
+
+  beforeAll(async () => {
+    const adapter = await adapterFor(sharedKey('batch-upgrade'));
+    const built = await build({ adapter });
+
+    adapters.push(adapter);
+    jobs = built.jobs;
+    store = built.jobs.store;
+    await downgrade();
+  }, 60000);
+
+  afterAll(() => close(adapters));
+
+  test('the queue works exactly as it did without them', async () => {
+    expect(await store.batched()).toBe(false);
+
+    // The insert names the columns that are there, so an application that
+    // never asked for a batch does not notice
+    const job = await jobs.perform('ok', { still: 'working' });
+    const claimed = await store.claim({
+      except: [],
+      limit: 5,
+      now: Date.now(),
+      queues: [],
+      runner: 'upgrading',
+      token: randomUUID(),
+    });
+
+    expect(claimed.map((row) => row.id)).toContain(job.id);
+    await store.remove({ state: 'running' });
+  });
+
+  test('a batch is refused rather than counted nowhere', async () => {
+    const error = await jobs.batch({ callback: 'ok' }).then(
+      () => null,
+      (thrown) => thrown
+    );
+
+    expect(error.code).toBe('HENRI_JOB_BATCH_UNINSTALLED');
+    expect(error.hint).toContain('henri jobs:install');
+    expect(error.message).toContain('henri_jobs_batches');
+  });
+
+  test('the install adds them, and batches work from then on', async () => {
+    const statements = await store.install();
+
+    expect(statements.join(';')).toContain('batch_id');
+    store.batches = null;
+    expect(await store.batched()).toBe(true);
+
+    const { jobs: started } = await build({
+      adapter: store.adapter,
+      config: { install: false },
+    });
+
+    expect(started.batched).toBe(true);
+
+    const batch = await started.batch({ jobs: [['ok', { upgraded: true }]] });
+
+    expect(batch.total).toBe(1);
+
+    const [job] = await started.batches.jobs(batch.id);
+
+    expect(job.batchId).toBe(batch.id);
+    await started.store.remove({ state: 'pending' });
+    await started.store.removeBatch(batch.id);
+  }, 60000);
+
+  test('the install may be run again and changes nothing', async () => {
+    await expect(store.install()).resolves.toBeInstanceOf(Array);
+    expect(await store.batched()).toBe(true);
+  }, 60000);
+});

--- a/packages/jobs/__tests__/config.spec.js
+++ b/packages/jobs/__tests__/config.spec.js
@@ -20,6 +20,7 @@ describe('configuration', () => {
     expect(config.keepCompleted).toBe(86400000);
     expect(config.install).toBe(true);
     expect(config.tables).toEqual({
+      batches: 'henri_jobs_batches',
       jobs: 'henri_jobs',
       limits: 'henri_jobs_limits',
       schedules: 'henri_jobs_schedules',
@@ -49,6 +50,7 @@ describe('configuration', () => {
     expect(config.stuckAfter).toBe(600000);
     expect(config.timeout).toBe(120000);
     expect(config.tables).toEqual({
+      batches: 'queue_batches',
       jobs: 'queue',
       limits: 'queue_limits',
       schedules: 'queue_schedules',
@@ -133,6 +135,8 @@ describe('definitions', () => {
     const definitions = load(path.join(APP, 'app', 'jobs'), normalize());
 
     expect(Object.keys(definitions).sort()).toEqual([
+      'batch/finished',
+      'batch/member',
       'boom',
       'counter',
       'exclusive',
@@ -309,6 +313,7 @@ describe('starting', () => {
 describe('the claim statement', () => {
   const { SqlStore } = require('../src/store/sql');
   const tables = {
+    batches: 'henri_jobs_batches',
     jobs: 'henri_jobs',
     limits: 'henri_jobs_limits',
     schedules: 'henri_jobs_schedules',
@@ -466,6 +471,7 @@ describe('the claim statement', () => {
 
 describe('the schema', () => {
   const tables = {
+    batches: 'henri_jobs_batches',
     jobs: 'henri_jobs',
     limits: 'henri_jobs_limits',
     schedules: 'henri_jobs_schedules',
@@ -480,6 +486,7 @@ describe('the schema', () => {
 
   test('drops the tables newest first', () => {
     expect(uninstall('postgres', tables)).toEqual([
+      'DROP TABLE IF EXISTS "henri_jobs_batches"',
       'DROP TABLE IF EXISTS "henri_jobs_limits"',
       'DROP TABLE IF EXISTS "henri_jobs_schedules"',
       'DROP TABLE IF EXISTS "henri_jobs"',
@@ -496,16 +503,21 @@ describe('the schema', () => {
     );
   });
 
-  test('adds the concurrency column to a table an older henri wrote', () => {
+  test('adds the columns an older henri did not write', () => {
     for (const dialect of ['sqlite', 'postgres', 'mysql', 'mssql']) {
       const statements = upgrade(dialect, tables);
 
-      // The column and the index it serves, and nothing else: an upgrade
-      // touches an existing table, so it says exactly what it changes
-      expect(statements).toHaveLength(2);
+      // The two columns and the indexes they serve, and nothing else: an
+      // upgrade touches an existing table, so it says exactly what it
+      // changes. The batches table itself is a *new* table, so the guarded
+      // CREATE of the install is all it needs
+      expect(statements).toHaveLength(4);
       expect(statements[0]).toContain('concurrency_key');
       expect(statements[0]).toMatch(/ALTER TABLE/u);
-      expect(statements[1]).toContain('henri_jobs_limited');
+      expect(statements[1]).toContain('batch_id');
+      expect(statements[1]).toMatch(/ALTER TABLE/u);
+      expect(statements[2]).toContain('henri_jobs_limited');
+      expect(statements[3]).toContain('henri_jobs_batch');
 
       // Every one of them is part of the install, so a fresh database and an
       // upgraded one end up with the same table
@@ -529,6 +541,7 @@ describe('the schema', () => {
   test('refuses a table name that is not a plain identifier', () => {
     expect(() =>
       install('postgres', {
+        batches: 'b',
         jobs: 'jobs"; DROP TABLE users; --',
         limits: 'l',
         schedules: 's',

--- a/packages/jobs/__tests__/fixtures/app/app/jobs/batch/finished.js
+++ b/packages/jobs/__tests__/fixtures/app/app/jobs/batch/finished.js
@@ -1,0 +1,39 @@
+// The callback of a batch. It records the counts it was handed and, at the
+// same moment, asks the queue how many jobs of that batch are still waiting
+// or running -- which is the negative property: the callback must never run
+// before the last job of its batch is terminal, and a count taken by the
+// suite afterwards could not tell.
+module.exports = {
+  maxAttempts: 1,
+
+  perform: async (args, context) => {
+    const queue = context.henri && context.henri.jobs;
+    const record = {
+      at: Date.now(),
+      batch: args.batch,
+      // The runner that performed it, so two callbacks would be two records
+      runner: context.job.runner,
+      unfinished: null,
+    };
+
+    if (queue) {
+      const waiting = await queue.list({
+        batch: args.batch.id,
+        limit: 500,
+        state: 'pending',
+      });
+      const running = await queue.list({
+        batch: args.batch.id,
+        limit: 500,
+        state: 'running',
+      });
+
+      record.unfinished = waiting.length + running.length;
+    }
+
+    global.__henriJobsCallbacks = global.__henriJobsCallbacks || [];
+    global.__henriJobsCallbacks.push(record);
+
+    return record;
+  },
+};

--- a/packages/jobs/__tests__/fixtures/app/app/jobs/batch/member.js
+++ b/packages/jobs/__tests__/fixtures/app/app/jobs/batch/member.js
@@ -1,0 +1,20 @@
+// One job of a batch. It stays inside for a moment so the jobs of a batch
+// finish at the same time on several runners, and fails on demand: a batch
+// finishes, it does not succeed, so a failure has to be part of the suite
+module.exports = {
+  backoff: { base: 25, factor: 1, jitter: 0, max: 25 },
+  maxAttempts: 1,
+
+  perform: async (args) => {
+    global.__henriJobsRuns = global.__henriJobsRuns || [];
+    global.__henriJobsRuns.push(args.token);
+
+    await new Promise((resolve) => setTimeout(resolve, args.wait || 5));
+
+    if (args.fail) {
+      throw new Error(`refused ${args.token}`);
+    }
+
+    return args.token;
+  },
+};

--- a/packages/jobs/__tests__/mongo.spec.js
+++ b/packages/jobs/__tests__/mongo.spec.js
@@ -36,6 +36,9 @@ describe('queue (mongodb)', () => {
     });
 
     await jobs.start();
+    // The callback of a batch asks the queue what is left of it, which is
+    // what an application's own henri has
+    henri.jobs = jobs;
   }, 120000);
 
   afterAll(async () => {
@@ -57,8 +60,120 @@ describe('queue (mongodb)', () => {
       await jobs.store.releaseSlot(held.key, held.slot);
     }
 
+    for (const batch of await jobs.store.listBatches({ limit: 200 })) {
+      await jobs.store.removeBatch(batch.id);
+    }
+
     global.__henriJobsRuns = [];
+    global.__henriJobsCallbacks = [];
     live.reset();
+  });
+
+  describe('batches', () => {
+    /**
+     * The callbacks performed in this process
+     *
+     * @returns {Array<object>} What each of them saw
+     */
+    const callbacks = () => global.__henriJobsCallbacks || [];
+
+    test('a collection needs no upgrade to hold a batch', async () => {
+      // The SQL backends need a column and a table; a document simply has a
+      // field, and a collection appears when something is written into it
+      expect(await jobs.store.batched()).toBe(true);
+      expect(jobs.batched).toBe(true);
+    });
+
+    test('the callback runs once, with the counts, dead jobs included', async () => {
+      const batch = await jobs.batch({
+        callback: 'batch/finished',
+        jobs: [
+          ['batch/member', { token: 'mongo-1' }],
+          ['batch/member', { token: 'mongo-2' }],
+          ['batch/member', { fail: true, token: 'mongo-3' }],
+        ],
+        name: 'on mongodb',
+      });
+
+      await Promise.all(
+        [0, 1, 2].map(() =>
+          new Runner(jobs, { concurrency: 3, recurring: false }).once()
+        )
+      );
+      // The callback is enqueued once the last job is written down, so it
+      // is claimed by the pass that follows
+      await new Runner(jobs, { recurring: false }).once();
+
+      expect(callbacks()).toHaveLength(1);
+      expect(callbacks()[0].unfinished).toBe(0);
+      expect(callbacks()[0].batch).toEqual({
+        done: 3,
+        failed: 1,
+        id: batch.id,
+        name: 'on mongodb',
+        succeeded: 2,
+        total: 3,
+      });
+
+      const stored = await jobs.batches.get(batch.id);
+
+      expect(stored.finished).toBe(true);
+      expect(stored.callbackId).not.toBeNull();
+      expect(await jobs.list({ name: 'batch/finished' })).toHaveLength(1);
+    }, 60000);
+
+    test('an outcome the document refused counts nothing', async () => {
+      const batch = await jobs.batch({
+        jobs: [['batch/member', { token: 'mongo-zombie' }, { maxAttempts: 2 }]],
+      });
+      const [claimed] = await jobs.store.claim({
+        limit: 1,
+        now: Date.now(),
+        queues: [],
+        runner: 'zombie',
+        token: 'zombie-token',
+      });
+
+      await jobs.store.update(claimed.id, { heartbeat_at: 0 });
+      await jobs.store.recover({ now: Date.now(), stuckAfter: 1000 });
+      await new Runner(jobs, { recurring: false }).once();
+
+      expect((await jobs.batches.get(batch.id)).done).toBe(1);
+
+      // And now the runner everybody gave up on writes its outcome: the
+      // document no longer holds its token, so neither the outcome nor the
+      // count lands
+      await jobs.run(claimed, { runner: 'zombie' });
+
+      expect((await jobs.batches.get(batch.id)).done).toBe(1);
+    }, 60000);
+
+    test('the sweep settles a batch nothing else counted', async () => {
+      const batch = await jobs.batch({
+        callback: 'batch/finished',
+        jobs: [['batch/member', { token: 'mongo-swept' }]],
+      });
+      const advance = jobs.store.advanceBatch.bind(jobs.store);
+
+      jobs.store.advanceBatch = async () => null;
+
+      try {
+        await new Runner(jobs, { recurring: false }).once();
+      } finally {
+        jobs.store.advanceBatch = advance;
+      }
+
+      expect((await jobs.batches.get(batch.id)).done).toBe(0);
+
+      await jobs.reconcile({ before: Date.now() + 1 });
+      await jobs.reconcile({ before: Date.now() + 1 });
+
+      const stored = await jobs.batches.get(batch.id);
+
+      expect(stored.done).toBe(1);
+      expect(stored.finished).toBe(true);
+      expect(await jobs.list({ name: 'batch/finished' })).toHaveLength(1);
+    }, 60000);
   });
 
   describe('concurrency limits', () => {

--- a/packages/jobs/__tests__/queue.spec.js
+++ b/packages/jobs/__tests__/queue.spec.js
@@ -29,6 +29,8 @@ describe(`queue (${target.name})`, () => {
       // `henri/mail` and `henri/retention` are the jobs the package ships,
       // for the mailers and for `henri.retention`
       expect(jobs.names()).toEqual([
+        'batch/finished',
+        'batch/member',
         'boom',
         'counter',
         'exclusive',

--- a/packages/jobs/index.js
+++ b/packages/jobs/index.js
@@ -8,6 +8,7 @@ const store = require('./src/store');
 const JobsModule = require('./src/module');
 
 const { Jobs, MAIL_JOB, STATES, toJob } = require('./src/jobs');
+const { Batch, toBatch } = require('./src/batch');
 const { Runner } = require('./src/runner');
 const { duration } = require('./src/duration');
 
@@ -26,6 +27,7 @@ const { duration } = require('./src/duration');
 const create = (henri, options = {}) => new Jobs(henri, options);
 
 module.exports = create;
+module.exports.Batch = Batch;
 module.exports.Jobs = Jobs;
 module.exports.JobsModule = JobsModule;
 module.exports.MAIL_JOB = MAIL_JOB;
@@ -39,4 +41,5 @@ module.exports.duration = duration;
 module.exports.errors = errors;
 module.exports.serialize = serialize;
 module.exports.store = store;
+module.exports.toBatch = toBatch;
 module.exports.toJob = toJob;

--- a/packages/jobs/src/batch.js
+++ b/packages/jobs/src/batch.js
@@ -1,0 +1,371 @@
+const { JobError } = require('./errors');
+const { iso } = require('./duration');
+const { toNumber } = require('./store/sql');
+
+/**
+ * A batch: a set of jobs, and one job that runs when they are all done.
+ *
+ * ## A batch finishes, it does not succeed
+ *
+ * The callback runs once every job of the batch has reached a **terminal**
+ * state -- `dead` included -- and it is handed the counts. A batch whose
+ * last job failed is a finished batch with a failure in it, and what that
+ * means is the application's to decide: pretending otherwise would mean a
+ * callback that never runs and nobody noticing.
+ *
+ * ## The counter, and why it is exactly once
+ *
+ * `total` is written **once**, when the batch is sealed, and never moves
+ * again; `done` is advanced by one statement per terminal outcome, guarded
+ * by the claim token of the attempt that wrote it (`SqlStore#advanceBatch`,
+ * `MongoStore#advanceBatch`). So `done` reaches `total` exactly once, after
+ * the last job of the batch is terminal, whatever the interleaving of the
+ * runners -- and a job performed twice because its first runner went quiet
+ * counts once, for the attempt whose outcome actually landed.
+ *
+ * The callback is then enqueued under a unique key of the batch's own,
+ * which is what makes settling idempotent: the sweep settles an unfinished
+ * batch again after a runner is killed between writing an outcome and
+ * counting it, and the second settle answers the callback that is already
+ * in the queue rather than enqueuing a second one.
+ *
+ * ## What a batch is not
+ *
+ * It is not a transaction, and it is not atomic with the application's
+ * database: the queue reaches its own tables through the store adapter's
+ * raw `query()`, which does not join an open model transaction, so a batch
+ * enqueued inside one that rolls back is a batch that runs. That is true of
+ * every enqueue and the guide says so twice.
+ *
+ * A batch is also built where it is created: `add()` is a call on the
+ * handle, and once the handle has sealed the batch it refuses -- there is
+ * no adding a job from another process, which is the race that would let a
+ * callback run with work still on its way in.
+ */
+
+/** The widest a batch name may be: the column that holds it */
+const NAME_LENGTH = 190;
+
+/** The options of the callback that are passed to `perform()` */
+const CALLBACK_OPTIONS = [
+  'at',
+  'maxAttempts',
+  'priority',
+  'queue',
+  'timeout',
+  'wait',
+];
+
+/**
+ * A stored batch, as the API hands it out
+ *
+ * @param {?object} row A row of the batches table
+ * @returns {?object} The batch
+ */
+const toBatch = (row) => {
+  if (!row) {
+    return null;
+  }
+
+  const total = toNumber(row.total) || 0;
+  const done = toNumber(row.done) || 0;
+  const failed = toNumber(row.failed) || 0;
+
+  return {
+    callback: row.callback || null,
+    callbackId: row.callback_id || null,
+    createdAt: iso(row.created_at),
+    done,
+    failed,
+    finished: Boolean(row.finished_at),
+    finishedAt: iso(row.finished_at),
+    id: row.id,
+    name: row.name || null,
+    sealed: Boolean(row.sealed_at),
+    sealedAt: iso(row.sealed_at),
+    succeeded: Math.max(0, done - failed),
+    total,
+    updatedAt: iso(row.updated_at),
+  };
+};
+
+/**
+ * Refuses a batch declaration henri cannot read
+ *
+ * @param {string} why What is wrong with it
+ * @returns {void}
+ * @throws {JobError} HENRI_JOB_INVALID_BATCH, always
+ */
+const refuse = (why) => {
+  throw new JobError(
+    'HENRI_JOB_INVALID_BATCH',
+    `The batch cannot be read: ${why}`,
+    {
+      hint: "henri.jobs.batch({ callback: 'report/compile', jobs: [['resize', { id }]] }), or a function that adds them",
+    }
+  );
+};
+
+/**
+ * One job of a batch, however it was written
+ *
+ * `'resize'`, `['resize', args]`, `['resize', args, options]` and
+ * `{ name, args, options }` are the same thing.
+ *
+ * @param {*} entry What the application wrote
+ * @returns {object} `{ name, args, options }`
+ * @throws {JobError} HENRI_JOB_INVALID_BATCH on anything else
+ */
+const entry = (value) => {
+  if (typeof value === 'string') {
+    return { args: null, name: value, options: {} };
+  }
+
+  if (Array.isArray(value)) {
+    const [name, args = null, options = {}] = value;
+
+    if (typeof name !== 'string' || name === '') {
+      refuse('a job of the list does not begin with a name');
+    }
+
+    return { args, name, options: options || {} };
+  }
+
+  if (!value || typeof value !== 'object' || typeof value.name !== 'string') {
+    refuse(`${JSON.stringify(value)} is not a job name, a list or an object`);
+  }
+
+  return {
+    args: typeof value.args === 'undefined' ? null : value.args,
+    name: value.name,
+    options: value.options || {},
+  };
+};
+
+/**
+ * Reads what an application asked a batch for
+ *
+ * @param {object} [options={}] What `henri.jobs.batch()` was given
+ * @returns {object} `{ name, callback, args, options, jobs }`
+ * @throws {JobError} HENRI_JOB_INVALID_BATCH when it cannot be read
+ */
+const declaration = (options = {}) => {
+  const value = options || {};
+
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    refuse('it is not an object');
+  }
+
+  const name = typeof value.name === 'undefined' ? null : value.name;
+
+  if (
+    name !== null &&
+    (typeof name !== 'string' || name.length > NAME_LENGTH)
+  ) {
+    refuse(`its name is not a string of at most ${NAME_LENGTH} characters`);
+  }
+
+  const callback =
+    typeof value.callback === 'undefined' || value.callback === null
+      ? null
+      : value.callback;
+
+  if (callback !== null && (typeof callback !== 'string' || callback === '')) {
+    refuse('its callback is not the name of a job');
+  }
+
+  const args = typeof value.args === 'undefined' ? null : value.args;
+
+  if (
+    args !== null &&
+    (typeof args !== 'object' || Array.isArray(args) || args instanceof Date)
+  ) {
+    // The counts are handed over under `batch`, so there has to be somewhere
+    // to put them
+    refuse('the arguments of its callback are not a plain object');
+  }
+
+  // `null` is "no list at all", which leaves the batch open for the caller
+  // to add to and seal; `[]` is a batch of nothing, which is finished the
+  // moment it is made
+  const jobs = typeof value.jobs === 'undefined' ? null : value.jobs;
+
+  if (jobs !== null && !Array.isArray(jobs)) {
+    refuse('its jobs are not a list');
+  }
+
+  const passed = {};
+
+  for (const key of CALLBACK_OPTIONS) {
+    if (typeof value[key] !== 'undefined') {
+      passed[key] = value[key];
+    }
+  }
+
+  return {
+    args,
+    callback,
+    jobs: jobs && jobs.map(entry),
+    name,
+    options: passed,
+  };
+};
+
+/**
+ * A batch in hand: what adds jobs to it and closes it.
+ *
+ * `henri.jobs.batch()` answers one of these. Its counters are what the
+ * database said when it was last read, so `reload()` is how they are
+ * refreshed; everything else about a batch is read back with
+ * `henri.jobs.batches.get(id)`.
+ *
+ * @class Batch
+ */
+class Batch {
+  /**
+   * Creates an instance of Batch.
+   *
+   * @param {object} queue The queue that owns it
+   * @param {object} row The stored row
+   * @memberof Batch
+   */
+  constructor(queue, row) {
+    this.queue = queue;
+    /** The ids of the jobs this handle enqueued */
+    this.jobs = [];
+    this.sync(row);
+  }
+
+  /**
+   * Reads a row onto this handle
+   *
+   * @param {object} row The stored row
+   * @returns {Batch} This batch
+   * @memberof Batch
+   */
+  sync(row) {
+    Object.assign(this, toBatch(row));
+
+    return this;
+  }
+
+  /**
+   * Adds one job to the batch
+   *
+   * @param {string} name The job name
+   * @param {*} [args=null] What perform() receives
+   * @param {object} [options={}] The options of perform()
+   * @returns {Promise<object>} The enqueued job
+   * @throws {JobError} HENRI_JOB_BATCH_CLOSED once the batch is sealed
+   * @memberof Batch
+   */
+  async add(name, args = null, options = {}) {
+    if (this.sealed) {
+      throw new JobError(
+        'HENRI_JOB_BATCH_CLOSED',
+        `The batch ${this.id} is closed: it holds ${this.total} job(s) and was sealed at ${this.sealedAt}`,
+        {
+          batch: this.id,
+          hint: 'A batch is built where it is created: add every job before it is sealed, or make another batch',
+        }
+      );
+    }
+
+    const job = await this.queue.perform(name, args, {
+      ...options,
+      batch: this.id,
+    });
+
+    this.jobs.push(job.id);
+
+    return job;
+  }
+
+  /**
+   * Adds several jobs to the batch
+   *
+   * @param {Array} list The jobs, in any of the shapes `batch({ jobs })`
+   *   takes
+   * @returns {Promise<Array<object>>} The enqueued jobs
+   * @memberof Batch
+   */
+  async addAll(list) {
+    const enqueued = [];
+
+    for (const one of list) {
+      const { args, name, options } = entry(one);
+
+      enqueued.push(await this.add(name, args, options));
+    }
+
+    return enqueued;
+  }
+
+  /**
+   * Closes the batch, and settles it when there was nothing left to wait for
+   *
+   * @returns {Promise<Batch>} This batch
+   * @memberof Batch
+   */
+  async seal() {
+    if (this.sealed) {
+      return this;
+    }
+
+    const row = await this.queue
+      .storeOrDie()
+      .sealBatch({ id: this.id, now: Date.now(), total: this.jobs.length });
+
+    this.sync(row || (await this.queue.storeOrDie().findBatch(this.id)));
+
+    // Every job of the batch may already be terminal -- an empty batch
+    // certainly is -- and nothing else will look at it until the sweep does
+    await this.queue.settle(await this.queue.storeOrDie().findBatch(this.id));
+
+    return this.reload();
+  }
+
+  /**
+   * Reads the batch back
+   *
+   * @returns {Promise<Batch>} This batch
+   * @memberof Batch
+   */
+  async reload() {
+    return this.sync(await this.queue.storeOrDie().findBatch(this.id));
+  }
+
+  /**
+   * The batch as a plain object
+   *
+   * @returns {object} What `henri.jobs.batches.get()` answers
+   * @memberof Batch
+   */
+  toJSON() {
+    return {
+      callback: this.callback,
+      callbackId: this.callbackId,
+      createdAt: this.createdAt,
+      done: this.done,
+      failed: this.failed,
+      finished: this.finished,
+      finishedAt: this.finishedAt,
+      id: this.id,
+      name: this.name,
+      sealed: this.sealed,
+      sealedAt: this.sealedAt,
+      succeeded: this.succeeded,
+      total: this.total,
+      updatedAt: this.updatedAt,
+    };
+  }
+}
+
+module.exports = {
+  Batch,
+  CALLBACK_OPTIONS,
+  NAME_LENGTH,
+  declaration,
+  entry,
+  toBatch,
+};

--- a/packages/jobs/src/config.js
+++ b/packages/jobs/src/config.js
@@ -174,6 +174,7 @@ const normalize = (config = {}) => {
     store: value.store || DEFAULTS.store,
     stuckAfter: duration(value.stuckAfter, duration(DEFAULTS.stuckAfter)),
     tables: {
+      batches: `${table(value.table || DEFAULTS.table)}_batches`,
       jobs: table(value.table || DEFAULTS.table),
       limits: `${table(value.table || DEFAULTS.table)}_limits`,
       schedules: `${table(value.table || DEFAULTS.table)}_schedules`,

--- a/packages/jobs/src/duration.js
+++ b/packages/jobs/src/duration.js
@@ -89,4 +89,24 @@ const runAt = (options = {}, now = Date.now()) => {
   return now + (duration(wait, 0) || 0);
 };
 
-module.exports = { duration, runAt };
+/**
+ * A stored moment, as the API hands it out
+ *
+ * Every moment the queue stores is a BIGINT of milliseconds, and every
+ * moment it answers with is an ISO string. Some drivers read a BIGINT back
+ * as a string, so the number is taken first.
+ *
+ * @param {*} value A timestamp in milliseconds
+ * @returns {?string} An ISO string, or null
+ */
+const iso = (value) => {
+  if (value === null || typeof value === 'undefined' || value === '') {
+    return null;
+  }
+
+  const number = Number(value);
+
+  return Number.isNaN(number) ? null : new Date(number).toISOString();
+};
+
+module.exports = { duration, iso, runAt };

--- a/packages/jobs/src/jobs.js
+++ b/packages/jobs/src/jobs.js
@@ -4,12 +4,13 @@ const debug = require('debug')('henri:jobs');
 
 const { JobError, JobStoreError, JobTimeoutError } = require('./errors');
 const { deserialize, serialize } = require('./serialize');
-const { keep } = require('./keys');
-const { duration, runAt } = require('./duration');
+const { callback: callbackKey, keep } = require('./keys');
+const { duration, iso, runAt } = require('./duration');
 const { keyOf, load, validate } = require('./definitions');
 const { normalize, recurring } = require('./config');
 const { storeFor } = require('./store');
 const { toNumber, HISTORY_LIMIT } = require('./store/sql');
+const { Batch, declaration, toBatch } = require('./batch');
 
 /** The states a job goes through */
 const STATES = ['pending', 'running', 'done', 'dead'];
@@ -35,17 +36,8 @@ const MAIL_JOB = 'henri/mail';
  */
 const RETENTION_JOB = 'henri/retention';
 
-/**
- * A moment, as the API hands it out
- *
- * @param {*} value A timestamp in milliseconds
- * @returns {?string} An ISO string, or null
- */
-const at = (value) => {
-  const number = toNumber(value);
-
-  return number === null ? null : new Date(number).toISOString();
-};
+/** A moment, as the API hands it out */
+const at = iso;
 
 /**
  * A stored row, as the API hands it out
@@ -63,6 +55,7 @@ const toJob = (row) => {
   return {
     args: deserialize(row.args),
     attempts: toNumber(row.attempts) || 0,
+    batchId: row.batch_id || null,
     claimedAt: at(row.claimed_at),
     claimedBy: row.claimed_by || null,
     concurrencyKey: row.concurrency_key || null,
@@ -121,6 +114,8 @@ class Jobs {
     this.runners = new Set();
     /** Whether the store can hold a concurrency key; see start() */
     this.concurrent = false;
+    /** Whether the store can hold a batch; see start() */
+    this.batched = false;
 
     /**
      * The retry policy of a job whose file this runner does not have: the
@@ -136,6 +131,14 @@ class Jobs {
       list: (filter) => this.list({ ...filter, state: 'dead' }),
       retry: (id, opts) => this.retry(id, opts),
       retryAll: (filter, opts) => this.retryAll(filter, opts),
+    };
+
+    /** Reading the batches back; `batch()` is what makes one */
+    this.batches = {
+      discard: (id) => this.discardBatch(id),
+      get: (id) => this.getBatch(id),
+      jobs: (id, filter) => this.list({ ...(filter || {}), batch: id }),
+      list: (filter) => this.listBatches(filter),
     };
   }
 
@@ -199,6 +202,7 @@ class Jobs {
     }
 
     this.concurrent = await this.store.concurrent();
+    this.batched = await this.store.batched();
 
     const bounded = Object.values(this.definitions).filter(
       (definition) => definition.concurrency
@@ -546,6 +550,8 @@ class Jobs {
    * @param {string} [options.id] The id to give the job, so a caller racing
    *   another on the same `unique` key can tell whether it is the one that
    *   enqueued it (the recurring schedules use it)
+   * @param {string} [options.batch] The batch to count it into; `batch()`
+   *   is what makes one, and a batch that is sealed refuses
    * @returns {Promise<object>} The enqueued job
    * @throws {JobError} HENRI_JOB_UNKNOWN, or HENRI_JOB_INVALID_ARGUMENTS
    *   cannot be stored
@@ -553,6 +559,10 @@ class Jobs {
    */
   async perform(name, args = null, options = {}) {
     const definition = this.definition(name);
+
+    if (options.batch) {
+      await this.openBatch(options.batch);
+    }
 
     // A job a package defined after the boot may declare a limit the store
     // has no column for; the enqueue is where that is caught, because
@@ -573,6 +583,7 @@ class Jobs {
     const row = {
       args: serialize(args, { maxBytes: this.config.maxArgsBytes }),
       attempts: 0,
+      batch_id: options.batch || null,
       claim_token: null,
       claimed_at: null,
       claimed_by: null,
@@ -839,6 +850,340 @@ class Jobs {
   }
 
   /**
+   * Refuses to store a batch this store has nowhere to put it
+   *
+   * The concurrency limit's refusal, for the same reason and with the same
+   * shape: the tables of the queue have no migration chain behind them, so
+   * a new column and a new table arrive through the tolerated upgrade block
+   * of the install -- and what decides at runtime is asking the table.
+   * Running a batch that counts nothing would be worse than refusing it.
+   *
+   * @returns {object} The store
+   * @throws {JobError} HENRI_JOB_BATCH_UNINSTALLED
+   * @memberof Jobs
+   */
+  batchable() {
+    if (!this.batched) {
+      throw new JobError(
+        'HENRI_JOB_BATCH_UNINSTALLED',
+        `The "${this.config.store}" store has no ${this.config.tables.batches} table (or no ${this.config.tables.jobs}.batch_id column) to hold a batch`,
+        {
+          hint: 'Run `henri jobs:install` once with a user that may create a table and alter one; the queue itself keeps working without it, and a batch would not',
+        }
+      );
+    }
+
+    return this.storeOrDie();
+  }
+
+  /**
+   * The batch a job may still be added to
+   *
+   * Asked of the table rather than of the handle: "adding a job to a batch
+   * that has finished is refused" is a promise about the batch, not about
+   * the object in this process's memory.
+   *
+   * @param {string} id The batch id
+   * @returns {Promise<object>} The stored row
+   * @throws {JobError} HENRI_JOB_BATCH_CLOSED when it is sealed or gone
+   * @memberof Jobs
+   */
+  async openBatch(id) {
+    const store = this.batchable();
+    const row = await store.findBatch(id);
+
+    if (!row || row.sealed_at) {
+      throw new JobError(
+        'HENRI_JOB_BATCH_CLOSED',
+        row
+          ? `The batch ${id} is closed: it holds ${toNumber(row.total)} job(s) and was sealed at ${at(row.sealed_at)}`
+          : `There is no batch ${id}`,
+        {
+          batch: id,
+          hint: 'A batch is built where it is created: add every job before it is sealed, or make another batch',
+        }
+      );
+    }
+
+    return row;
+  }
+
+  /**
+   * Makes a batch: these jobs, and one that runs when they are all done
+   *
+   * The callback runs once every job of the batch has reached a terminal
+   * state, `dead` included, and it is handed the counts under `batch` --
+   * see `./batch.js` for the whole of the argument.
+   *
+   * @param {object} [options={}] Options
+   * @param {string} [options.callback] The job to run when it finishes
+   * @param {object} [options.args] The callback's own arguments; the counts
+   *   are added to them under `batch`
+   * @param {string} [options.name] A label, for `henri jobs:batches`
+   * @param {Array} [options.jobs] The jobs, as `'name'`, `['name', args]`,
+   *   `['name', args, options]` or `{ name, args, options }`
+   * @param {string} [options.queue] The callback's queue; `priority`,
+   *   `maxAttempts`, `timeout`, `wait` and `at` are read the same way
+   * @param {function} [build] Adds the jobs itself, when there are too many
+   *   to write out: it is given the batch and the batch is sealed when it
+   *   resolves
+   * @returns {Promise<Batch>} The batch, sealed unless it was given neither
+   *   `jobs` nor a function
+   * @throws {JobError} HENRI_JOB_BATCH_UNINSTALLED, HENRI_JOB_INVALID_BATCH
+   *   or HENRI_JOB_UNKNOWN when the callback is not a job
+   * @memberof Jobs
+   */
+  async batch(options = {}, build) {
+    const store = this.batchable();
+    const declared = declaration(options);
+
+    if (declared.jobs && typeof build === 'function') {
+      throw new JobError(
+        'HENRI_JOB_INVALID_BATCH',
+        'The batch was given both a list of jobs and a function to add them',
+        { hint: 'Pass `jobs`, or a function, and not both' }
+      );
+    }
+
+    // A callback nothing answers to is refused here rather than when the
+    // last job of the batch finishes, which is minutes later and elsewhere
+    if (declared.callback) {
+      this.definition(declared.callback);
+    }
+
+    const now = Date.now();
+    const row = await store.createBatch({
+      callback: declared.callback,
+      callback_args: serialize(declared.args, {
+        maxBytes: this.config.maxArgsBytes,
+      }),
+      callback_id: null,
+      callback_options: JSON.stringify(declared.options),
+      created_at: now,
+      done: 0,
+      failed: 0,
+      finished_at: null,
+      id: randomUUID(),
+      name: declared.name,
+      sealed_at: null,
+      total: 0,
+      updated_at: now,
+    });
+    const batch = new Batch(this, row);
+
+    debug('batch %s -> %s', batch.id, declared.callback || 'no callback');
+
+    // A list, even an empty one, is a batch that says what it holds: it is
+    // sealed here and now. No list at all leaves it open for the caller
+    if (declared.jobs) {
+      await batch.addAll(declared.jobs);
+
+      return batch.seal();
+    }
+
+    if (typeof build === 'function') {
+      // A builder that throws leaves the batch unsealed on purpose: its
+      // jobs run, its callback never does, and `henri jobs:batches` shows
+      // it. Sealing what an application abandoned half way through would
+      // call the callback for a batch that was never a batch
+      await build(batch);
+
+      return batch.seal();
+    }
+
+    return batch;
+  }
+
+  /**
+   * One batch
+   *
+   * @param {string} id The batch id
+   * @returns {Promise<?object>} The batch, or null
+   * @memberof Jobs
+   */
+  async getBatch(id) {
+    return toBatch(await this.batchable().findBatch(id));
+  }
+
+  /**
+   * The batches of the queue, the newest first
+   *
+   * @param {object} [filter={}] `finished`, `limit`, `offset`
+   * @returns {Promise<Array<object>>} The batches
+   * @memberof Jobs
+   */
+  async listBatches(filter = {}) {
+    const rows = await this.batchable().listBatches(filter);
+
+    return rows.map(toBatch);
+  }
+
+  /**
+   * Forgets a batch, leaving its jobs alone
+   *
+   * The way out of a batch that can never finish because one of its jobs
+   * was discarded: what is left of it counts against nothing.
+   *
+   * @param {string} id The batch id
+   * @returns {Promise<boolean>} Whether there was one to forget
+   * @memberof Jobs
+   */
+  async discardBatch(id) {
+    return this.batchable().removeBatch(id);
+  }
+
+  /**
+   * Counts one terminal outcome into the batch of a job, and settles it
+   *
+   * @param {object} row The row whose outcome was just written
+   * @param {object} [options={}] `failed`, whether it died
+   * @returns {Promise<?object>} The batch, when this outcome finished it
+   * @memberof Jobs
+   */
+  async advance(row, options = {}) {
+    if (!row.batch_id || !this.batched) {
+      return null;
+    }
+
+    try {
+      const batch = await this.storeOrDie().advanceBatch({
+        failed: Boolean(options.failed),
+        id: row.batch_id,
+        job: row.id,
+        now: Date.now(),
+        token: row.claim_token,
+      });
+
+      return await this.settle(batch);
+    } catch (error) {
+      // Never fail an attempt whose outcome is already written over the
+      // bookkeeping of its batch: the sweep settles what this missed
+      this.log(
+        'warn',
+        row.name,
+        row.id,
+        `could not count into the batch ${row.batch_id}:`,
+        error.message
+      );
+      debug('%O', error);
+
+      return null;
+    }
+  }
+
+  /**
+   * Enqueues the callback of a batch whose jobs are all terminal
+   *
+   * Idempotent, and that is the point: the callback is enqueued under a
+   * unique key of the batch's own (`./keys.js`), so a second settle -- from
+   * another runner, or from the sweep after a runner was killed between
+   * writing an outcome and counting it -- answers the job that is already
+   * in the queue instead of enqueuing a second one. The batch is stamped
+   * finished **after** the enqueue, so that gap is what the sweep repairs.
+   *
+   * @param {?object} row A batch row
+   * @returns {Promise<?object>} The batch, when this call finished it
+   * @memberof Jobs
+   */
+  async settle(row) {
+    if (!row || !row.sealed_at || row.finished_at) {
+      return null;
+    }
+
+    const store = this.storeOrDie();
+    const total = toNumber(row.total) || 0;
+    const done = toNumber(row.done) || 0;
+
+    if (done < total) {
+      return null;
+    }
+
+    const failed = toNumber(row.failed) || 0;
+    const counts = {
+      done,
+      failed,
+      id: row.id,
+      name: row.name || null,
+      succeeded: Math.max(0, done - failed),
+      total,
+    };
+    let job = null;
+
+    if (row.callback) {
+      const options = deserialize(row.callback_options) || {};
+
+      // The unique key is the arbiter and the id is not: two runners
+      // settling at once send the same insert, and the one the index
+      // refuses is answered with the job the other one enqueued -- which
+      // `insert()` only does for a row it did not write itself
+      job = await this.perform(
+        row.callback,
+        { ...(deserialize(row.callback_args) || {}), batch: counts },
+        { ...options, unique: callbackKey(row.id) }
+      );
+    }
+
+    await store.finishBatch({
+      callback: job && job.id,
+      id: row.id,
+      now: Date.now(),
+    });
+
+    this.log(
+      'info',
+      'batch',
+      row.id,
+      `finished: ${counts.succeeded} done, ${counts.failed} dead`,
+      job ? `-> ${row.callback} ${job.id}` : '(no callback)'
+    );
+
+    return toBatch(await store.findBatch(row.id));
+  }
+
+  /**
+   * Settles the batches nothing else will
+   *
+   * Two things leave a batch short of its total with every job of it
+   * terminal, and one sweep answers both: a runner killed between writing
+   * an outcome and counting it, and a job buried by the recovery of a dead
+   * runner, whose outcome no attempt of anybody's ever wrote. Counting the
+   * rows is what decides -- and it only ever moves a batch forward, so a
+   * finished job pruned out of the table cannot undo one.
+   *
+   * @param {object} options Options
+   * @param {number} options.before Only batches untouched since that moment
+   * @param {number} [options.limit=50] How many one sweep looks at
+   * @returns {Promise<Array<object>>} The batches this sweep finished
+   * @memberof Jobs
+   */
+  async reconcile({ before, limit = 50 }) {
+    if (!this.batched) {
+      return [];
+    }
+
+    const store = this.storeOrDie();
+    const open = await store.openBatches({ before, limit });
+    const finished = [];
+
+    for (const row of open) {
+      const counted = await store.countBatch(row.id);
+      const batch = await store.syncBatch({
+        done: counted.done,
+        failed: counted.failed,
+        id: row.id,
+        now: Date.now(),
+      });
+      const settled = await this.settle(batch);
+
+      if (settled) {
+        finished.push(settled);
+      }
+    }
+
+    return finished;
+  }
+
+  /**
    * Puts a job back in its queue
    *
    * Its attempt count starts over, so the retry policy applies again. Works
@@ -875,6 +1220,18 @@ class Jobs {
     }
 
     const now = Date.now();
+
+    // A job that was counted into a batch and is put back will reach a
+    // terminal state a second time, so it gives its slot back first: a
+    // batch that has already finished never moves again, which is what the
+    // guard of releaseBatch() says
+    if (row.batch_id && this.batched && row.state !== 'pending') {
+      await store.releaseBatch({
+        failed: row.state === 'dead',
+        id: row.batch_id,
+        now,
+      });
+    }
 
     await store.update(id, {
       attempts: 0,
@@ -1092,7 +1449,11 @@ class Jobs {
     await store.update(
       row.id,
       {
-        claim_token: null,
+        // A job of a batch keeps the token of the claim that wrote this,
+        // and that is what makes the counting exactly once: the batch is
+        // advanced by the runner whose token is on the row, which is the
+        // one whose outcome landed (see SqlStore#advanceBatch)
+        claim_token: row.batch_id ? row.claim_token : null,
         duration_ms: finished - started,
         error_message: null,
         error_stack: null,
@@ -1109,6 +1470,9 @@ class Jobs {
     const job = toJob(await store.find(row.id));
 
     this.lost(row, job);
+    // The counter of a batch is advanced by the write above and by nothing
+    // else: an outcome that was refused counts nothing (see advanceBatch)
+    await this.advance(row, { failed: false });
 
     return { job, state: 'done' };
   }
@@ -1194,7 +1558,10 @@ class Jobs {
     await store.update(
       row.id,
       {
-        claim_token: null,
+        // Kept on a terminal row of a batch, for the reason attempt()
+        // gives; a failure that goes back to its queue is claimed again
+        // and gets a token of its own
+        claim_token: dead && row.batch_id ? row.claim_token : null,
         duration_ms: took,
         error_message: message,
         error_stack: (error && error.stack) || null,
@@ -1222,6 +1589,12 @@ class Jobs {
     const job = toJob(await store.find(row.id));
 
     this.lost(row, job);
+
+    // A batch counts what is terminal: an attempt going back to its queue
+    // with a backoff is not an outcome, and the batch waits for it
+    if (dead) {
+      await this.advance(row, { failed: true });
+    }
 
     return { error, job, state: dead ? 'dead' : 'pending' };
   }

--- a/packages/jobs/src/keys.js
+++ b/packages/jobs/src/keys.js
@@ -6,9 +6,9 @@
  * the same work may be enqueued again. That is what people expect of a
  * unique job, and it is what the guide says.
  *
- * The keys the recurring scheduler writes are the exception, and they have
- * to be. A slot is enqueued *before* its schedule moves on, so that an
- * enqueue that fails leaves the schedule due and the next tick tries again;
+ * The keys the queue writes for itself are the exception, and they have
+ * to be. A recurring slot is enqueued *before* its schedule moves on, so that
+ * an enqueue that fails leaves the schedule due and the next tick tries again;
  * the row already in the queue is what stops a second runner enqueueing the
  * same slot. If that key were freed the moment the job finished, a slot
  * whose job ran to completion in the gap between the enqueue and the
@@ -16,10 +16,22 @@
  * shape is kept for the life of the row, and the row is pruned like any
  * other -- by which time that slot, a specific millisecond, can never be due
  * again.
+ *
+ * A batch's callback is the same argument, word for word. It is enqueued
+ * *before* the batch is stamped finished, so that a process dying in between
+ * leaves the batch unfinished and the next sweep settles it again; the row
+ * already in the queue is what makes that second settle answer the same job
+ * instead of calling the callback twice. A key freed on completion would let
+ * a callback that ran quickly be enqueued a second time by that sweep -- so
+ * the key belongs to the row for its life, and the batch is finished long
+ * before either is pruned.
  */
 
 /** What the recurring scheduler prefixes its slots with */
 const RECURRING = 'recurring:';
+
+/** What a batch's callback is enqueued under */
+const BATCH = 'batch:';
 
 /**
  * The unique key a finished job should keep, if any
@@ -28,7 +40,10 @@ const RECURRING = 'recurring:';
  * @returns {?string} The key to keep, or null to free it
  */
 const keep = (key) =>
-  typeof key === 'string' && key.startsWith(RECURRING) ? key : null;
+  typeof key === 'string' &&
+  (key.startsWith(RECURRING) || key.startsWith(BATCH))
+    ? key
+    : null;
 
 /**
  * The unique key of one occurrence of a recurring schedule
@@ -39,4 +54,12 @@ const keep = (key) =>
  */
 const slot = (name, due) => `${RECURRING}${name}:${due}`;
 
-module.exports = { RECURRING, keep, slot };
+/**
+ * The unique key of a batch's callback
+ *
+ * @param {string} id The batch id
+ * @returns {string} The key
+ */
+const callback = (id) => `${BATCH}${id}`;
+
+module.exports = { BATCH, RECURRING, callback, keep, slot };

--- a/packages/jobs/src/module.js
+++ b/packages/jobs/src/module.js
@@ -59,6 +59,14 @@ class JobsModule extends BaseModule {
         this.ready().dead.retryAll(filter, options),
     };
 
+    /** Reading the batches back, see @usehenri/jobs */
+    this.batches = {
+      discard: (id) => this.ready().batches.discard(id),
+      get: (id) => this.ready().batches.get(id),
+      jobs: (id, filter) => this.ready().batches.jobs(id, filter),
+      list: (filter) => this.ready().batches.list(filter),
+    };
+
     this.init = this.init.bind(this);
     this.stop = this.stop.bind(this);
     this.reload = this.reload.bind(this);
@@ -358,6 +366,24 @@ class JobsModule extends BaseModule {
    */
   performNow(name, args) {
     return this.ready().performNow(name, args);
+  }
+
+  /**
+   * Makes a batch: these jobs, and one that runs when they are all done
+   *
+   * The callback runs once every job has reached a terminal state, `dead`
+   * included, and is handed the counts under `batch`.
+   *
+   * @param {object} [options] `callback`, `args`, `name`, `jobs`, plus the
+   *   callback's own `queue`, `priority`, `maxAttempts`, `timeout`, `wait`
+   *   and `at`
+   * @param {function} [build] Adds the jobs itself; the batch is sealed
+   *   when it resolves
+   * @returns {Promise<object>} The batch
+   * @memberof JobsModule
+   */
+  batch(options, build) {
+    return this.ready().batch(options, build);
   }
 
   /**

--- a/packages/jobs/src/runner.js
+++ b/packages/jobs/src/runner.js
@@ -608,23 +608,23 @@ class Runner {
    * @memberof Runner
    */
   async beat() {
-    const batches = new Map();
+    const claims = new Map();
 
     for (const [id, entry] of this.running) {
-      const ids = batches.get(entry.token) || [];
+      const ids = claims.get(entry.token) || [];
 
       ids.push(id);
-      batches.set(entry.token, ids);
+      claims.set(entry.token, ids);
     }
 
-    if (batches.size === 0) {
+    if (claims.size === 0) {
       return;
     }
 
     const now = Date.now();
 
     try {
-      for (const [token, ids] of batches) {
+      for (const [token, ids] of claims) {
         await this.jobs.storeOrDie().heartbeat(ids, now, token);
       }
 
@@ -713,8 +713,29 @@ class Runner {
       }
     }
 
+    // The batches nothing else will settle: one killed between the outcome
+    // of its last job and the counting of it, and one whose last job was
+    // buried by the recovery above, which wrote an outcome no attempt owns.
+    // The window is the same clock, for the same reason
+    if (this.jobs.batched) {
+      const settled = await this.jobs.reconcile({
+        before: now - this.stuckAfter,
+      });
+
+      for (const batch of settled) {
+        this.log('warn', 'batch', batch.id, 'settled by the sweep');
+      }
+    }
+
     if (this.keepCompleted > 0) {
       await this.jobs.storeOrDie().prune(now - this.keepCompleted);
+
+      if (this.jobs.batched) {
+        await this.jobs
+          .storeOrDie()
+          .pruneBatches(now - this.keepCompleted)
+          .catch((error) => debug('pruneBatches: %s', error.message));
+      }
     }
   }
 

--- a/packages/jobs/src/store/mongo.js
+++ b/packages/jobs/src/store/mongo.js
@@ -36,6 +36,17 @@ const { keep } = require('../keys');
  * A collection needs no upgrade: a document written by an older henri
  * simply has no `concurrency_key`, which is what an unlimited job's row
  * looks like anyway.
+ *
+ * ## Batches
+ *
+ * `$inc` is atomic on one document, so the counter of a batch is advanced
+ * the way the SQL backend advances its own: never read into this process to
+ * be written back. What the SQL backend puts in the same statement -- the
+ * `EXISTS` saying the job row still holds this runner's claim token -- is
+ * two operations here, and it is exact all the same: a job document whose
+ * outcome was written under this token is **terminal**, and a terminal
+ * document is never recovered, never re-claimed and never written by anyone
+ * else. So once the check passes, it stays true.
  */
 
 /** The collection is written with the SQL column names, on purpose */
@@ -51,7 +62,7 @@ class MongoStore {
    * Creates an instance of MongoStore.
    *
    * @param {object} adapter A henri mongoose (or disk) adapter
-   * @param {object} tables `{ jobs, schedules, limits }` collection names
+   * @param {object} tables `{ jobs, schedules, limits, batches }` collection names
    * @memberof MongoStore
    */
   constructor(adapter, tables) {
@@ -112,6 +123,16 @@ class MongoStore {
   }
 
   /**
+   * The batches collection
+   *
+   * @returns {object} A MongoDB collection
+   * @memberof MongoStore
+   */
+  batches() {
+    return this.database().collection(this.tables.batches);
+  }
+
+  /**
    * Whether concurrency limits can be held here; they always can
    *
    * A collection has no columns to be missing, so there is nothing for an
@@ -121,6 +142,19 @@ class MongoStore {
    * @memberof MongoStore
    */
   async concurrent() {
+    return true;
+  }
+
+  /**
+   * Whether a batch can be held here; it always can
+   *
+   * A collection appears when something is written into it, so there is
+   * nothing to upgrade and nothing to refuse -- see `concurrent()`.
+   *
+   * @returns {Promise<boolean>} true
+   * @memberof MongoStore
+   */
+  async batched() {
     return true;
   }
 
@@ -172,12 +206,24 @@ class MongoStore {
       }
     );
 
+    await this.index({ batch_id: 1 }, { name: `${this.tables.jobs}_batch` });
+
     await this.limits().createIndex(
       { heartbeat_at: 1 },
       { name: `${this.tables.limits}_stale` }
     );
 
-    return [this.tables.jobs, this.tables.schedules, this.tables.limits];
+    await this.batches().createIndex(
+      { finished_at: 1, updated_at: 1 },
+      { name: `${this.tables.batches}_open` }
+    );
+
+    return [
+      this.tables.jobs,
+      this.tables.schedules,
+      this.tables.limits,
+      this.tables.batches,
+    ];
   }
 
   /**
@@ -214,6 +260,7 @@ class MongoStore {
       this.tables.jobs,
       this.tables.schedules,
       this.tables.limits,
+      this.tables.batches,
     ]) {
       await this.database()
         .collection(name)
@@ -221,7 +268,12 @@ class MongoStore {
         .catch(() => null);
     }
 
-    return [this.tables.limits, this.tables.schedules, this.tables.jobs];
+    return [
+      this.tables.batches,
+      this.tables.limits,
+      this.tables.schedules,
+      this.tables.jobs,
+    ];
   }
 
   /**
@@ -263,6 +315,11 @@ class MongoStore {
       typeof rest.concurrency_key === 'undefined'
     ) {
       delete rest.concurrency_key;
+    }
+
+    // And a job that belongs to no batch has no `batch_id`
+    if (rest.batch_id === null || typeof rest.batch_id === 'undefined') {
+      delete rest.batch_id;
     }
 
     try {
@@ -740,11 +797,12 @@ class MongoStore {
   /**
    * Lists jobs
    *
-   * @param {object} [options={}] `state`, `queue`, `name`, `limit`, `offset`
+   * @param {object} [options={}] `state`, `queue`, `name`, `batch`, `limit`,
+   *   `offset`
    * @returns {Promise<Array<object>>} The rows
    * @memberof MongoStore
    */
-  async list({ state, queue, name, limit = 50, offset = 0 } = {}) {
+  async list({ state, queue, name, batch, limit = 50, offset = 0 } = {}) {
     const filter = {};
 
     if (state) {
@@ -757,6 +815,10 @@ class MongoStore {
 
     if (name) {
       filter.name = name;
+    }
+
+    if (batch) {
+      filter.batch_id = batch;
     }
 
     const documents = await this.jobs()
@@ -970,13 +1032,256 @@ class MongoStore {
   async pruneSchedules(names) {
     await this.schedules().deleteMany({ _id: { $nin: names } });
   }
+
+  /**
+   * Records a batch
+   *
+   * @param {object} batch A batch row
+   * @returns {Promise<object>} The batch, read back
+   * @memberof MongoStore
+   */
+  async createBatch(batch) {
+    const { id, ...rest } = batch;
+
+    await this.batches().insertOne({ _id: id, ...rest });
+
+    return this.findBatch(id);
+  }
+
+  /**
+   * One batch by id
+   *
+   * @param {string} id The batch id
+   * @returns {Promise<?object>} The row, or null
+   * @memberof MongoStore
+   */
+  async findBatch(id) {
+    return this.row(await this.batches().findOne({ _id: id }));
+  }
+
+  /**
+   * Closes a batch to new jobs and writes down how many it holds
+   *
+   * @param {object} options `id`, `total` and `now`
+   * @returns {Promise<?object>} The batch, or null when it was sealed
+   *   already
+   * @memberof MongoStore
+   */
+  async sealBatch({ id, total, now }) {
+    const document = await this.batches().findOneAndUpdate(
+      { _id: id, sealed_at: null },
+      { $set: { sealed_at: now, total, updated_at: now } },
+      { includeResultMetadata: false, returnDocument: 'after' }
+    );
+
+    return this.row(document);
+  }
+
+  /**
+   * Counts one terminal outcome into its batch
+   *
+   * The check and the `$inc` are two operations and the pair is still
+   * exact: a job document that is terminal **and** still holds this
+   * runner's claim token was written by this runner and can never be
+   * claimed, recovered or written again, so nothing can make the check stale
+   * between here and the increment. `$inc` itself is atomic on the document.
+   *
+   * @param {object} options `id`, `job`, `token`, `failed` and `now`
+   * @returns {Promise<?object>} The batch as it is now, or null
+   * @memberof MongoStore
+   */
+  async advanceBatch({ id, job, token, failed, now }) {
+    const owned = await this.jobs().findOne({
+      _id: job,
+      batch_id: id,
+      claim_token: token,
+      state: { $in: ['done', 'dead'] },
+    });
+
+    if (!owned) {
+      return this.findBatch(id);
+    }
+
+    const document = await this.batches().findOneAndUpdate(
+      { _id: id, finished_at: null },
+      {
+        $inc: { done: 1, failed: failed ? 1 : 0 },
+        $set: { updated_at: now },
+      },
+      { includeResultMetadata: false, returnDocument: 'after' }
+    );
+
+    return this.row(document) || this.findBatch(id);
+  }
+
+  /**
+   * Gives a batch its slot back, when a job of it is put back in the queue
+   *
+   * @param {object} options `id`, `failed` and `now`
+   * @returns {Promise<void>} Resolves when written
+   * @memberof MongoStore
+   */
+  async releaseBatch({ id, failed, now }) {
+    await this.batches().updateOne(
+      { _id: id, done: { $gt: 0 }, finished_at: null },
+      { $inc: { done: -1, failed: failed ? -1 : 0 }, $set: { updated_at: now } }
+    );
+  }
+
+  /**
+   * Says a batch has finished, and what enqueued its callback
+   *
+   * @param {object} options `id`, `callback` and `now`
+   * @returns {Promise<void>} Resolves when written
+   * @memberof MongoStore
+   */
+  async finishBatch({ id, callback, now }) {
+    await this.batches().updateOne(
+      { _id: id, finished_at: null },
+      {
+        $set: {
+          callback_id: callback || null,
+          finished_at: now,
+          updated_at: now,
+        },
+      }
+    );
+  }
+
+  /**
+   * What a batch's jobs actually say, read from the queue itself
+   *
+   * @param {string} id The batch id
+   * @returns {Promise<object>} `{ done, failed }`
+   * @memberof MongoStore
+   */
+  async countBatch(id) {
+    const rows = await this.jobs()
+      .aggregate([
+        { $match: { batch_id: id, state: { $in: ['done', 'dead'] } } },
+        { $group: { _id: '$state', total: { $sum: 1 } } },
+      ])
+      .toArray();
+    const counted = { done: 0, failed: 0 };
+
+    for (const row of rows) {
+      counted.done += row.total;
+
+      if (row._id === 'dead') {
+        counted.failed += row.total;
+      }
+    }
+
+    return counted;
+  }
+
+  /**
+   * Moves a batch's counters up to what its jobs say, never backwards
+   *
+   * @param {object} options `id`, `done`, `failed` and `now`
+   * @returns {Promise<?object>} The batch as it is now
+   * @memberof MongoStore
+   */
+  async syncBatch({ id, done, failed, now }) {
+    await this.batches().updateOne(
+      { _id: id, done: { $lt: done }, finished_at: null },
+      { $set: { done, failed, updated_at: now } }
+    );
+
+    return this.findBatch(id);
+  }
+
+  /**
+   * The batches that were sealed and have not finished
+   *
+   * @param {object} options `before` and `limit`
+   * @returns {Promise<Array<object>>} The rows
+   * @memberof MongoStore
+   */
+  async openBatches({ before, limit = 50 }) {
+    const documents = await this.batches()
+      .find({
+        finished_at: null,
+        sealed_at: { $ne: null },
+        updated_at: { $lt: before },
+      })
+      .sort({ updated_at: 1 })
+      .limit(Math.max(1, Number(limit) || 50))
+      .toArray();
+
+    return documents.map((document) => this.row(document));
+  }
+
+  /**
+   * Lists batches, the newest first
+   *
+   * @param {object} [options={}] `finished`, `limit`, `offset`
+   * @returns {Promise<Array<object>>} The rows
+   * @memberof MongoStore
+   */
+  async listBatches({ finished, limit = 50, offset = 0 } = {}) {
+    const filter =
+      typeof finished === 'boolean'
+        ? { finished_at: finished ? { $ne: null } : null }
+        : {};
+    const documents = await this.batches()
+      .find(filter)
+      // eslint-disable-next-line sort-keys
+      .sort({ created_at: -1, _id: 1 })
+      .skip(offset)
+      .limit(limit)
+      .toArray();
+
+    return documents.map((document) => this.row(document));
+  }
+
+  /**
+   * Forgets a batch
+   *
+   * @param {string} id The batch id
+   * @returns {Promise<boolean>} Whether there was one
+   * @memberof MongoStore
+   */
+  async removeBatch(id) {
+    const result = await this.batches().deleteOne({ _id: id });
+
+    return (result.deletedCount || 0) > 0;
+  }
+
+  /**
+   * Deletes the batches that finished before a moment
+   *
+   * @param {number} before A timestamp
+   * @param {number} [limit=1000] How many one pass deletes
+   * @returns {Promise<number>} How many were deleted
+   * @memberof MongoStore
+   */
+  async pruneBatches(before, limit = 1000) {
+    const documents = await this.batches()
+      .find({ finished_at: { $lt: before, $ne: null } })
+      .sort({ finished_at: 1 })
+      .limit(limit)
+      .project({ _id: 1 })
+      .toArray();
+
+    if (documents.length === 0) {
+      return 0;
+    }
+
+    const ids = documents.map((document) => document._id);
+
+    await this.batches().deleteMany({ _id: { $in: ids } });
+
+    return ids.length;
+  }
 }
 
 /**
  * Builds the MongoDB store of an adapter
  *
  * @param {object} adapter A henri mongoose (or disk) adapter
- * @param {object} tables `{ jobs, schedules, limits }` collection names
+ * @param {object} tables `{ jobs, schedules, limits, batches }` collection
+ *   names
  * @returns {MongoStore} The store
  */
 const create = (adapter, tables) => new MongoStore(adapter, tables);

--- a/packages/jobs/src/store/schema.js
+++ b/packages/jobs/src/store/schema.js
@@ -2,7 +2,7 @@
  * The tables `@usehenri/jobs` owns, and the DDL of every SQL dialect henri
  * can talk to.
  *
- * The queue never goes through a henri model: it owns three tables of its own
+ * The queue never goes through a henri model: it owns four tables of its own
  * so it cannot collide with the application's schema, and so a store that
  * has no models at all (a fresh application) still has a queue.
  *
@@ -130,7 +130,10 @@ const DIALECTS = {
  * statement declares them and `upgrade()` adds them to a table that has
  * them not.
  */
-const ADDED = [{ column: 'concurrency_key', type: 'VARCHAR(190)' }];
+const ADDED = [
+  { column: 'concurrency_key', type: 'VARCHAR(190)' },
+  { column: 'batch_id', type: 'VARCHAR(36)' },
+];
 
 /**
  * The columns of the jobs table, in order
@@ -163,6 +166,7 @@ const jobColumns = (dialect) => [
   `history ${dialect.text} NULL`,
   'unique_key VARCHAR(190) NULL',
   'concurrency_key VARCHAR(190) NULL',
+  'batch_id VARCHAR(36) NULL',
   'PRIMARY KEY (id)',
 ];
 
@@ -194,6 +198,50 @@ const limitColumns = (dialect) => [
  */
 const limitIndexes = (table) => [
   { columns: ['heartbeat_at'], name: `${table}_stale`, unique: false },
+];
+
+/**
+ * The columns of the batches table, in order
+ *
+ * A batch counts: `total` is what was enqueued under it and is written once,
+ * when the batch is sealed; `done` and `failed` are advanced by the same
+ * token-guarded write that records an attempt's outcome, one statement per
+ * job. `finished_at` is stamped after the callback has been enqueued, so a
+ * crash in between leaves the batch unfinished and the sweep settles it
+ * again -- the enqueue is idempotent (see `../keys.js`).
+ *
+ * @param {object} dialect A dialect description
+ * @returns {Array<string>} The column definitions
+ */
+const batchColumns = (dialect) => [
+  'id VARCHAR(36) NOT NULL',
+  'name VARCHAR(190) NULL',
+  'callback VARCHAR(120) NULL',
+  `callback_args ${dialect.text} NULL`,
+  `callback_options ${dialect.text} NULL`,
+  'callback_id VARCHAR(36) NULL',
+  `total ${dialect.int} NOT NULL`,
+  `done ${dialect.int} NOT NULL`,
+  `failed ${dialect.int} NOT NULL`,
+  'created_at BIGINT NOT NULL',
+  'updated_at BIGINT NOT NULL',
+  'sealed_at BIGINT NULL',
+  'finished_at BIGINT NULL',
+  'PRIMARY KEY (id)',
+];
+
+/**
+ * The indexes of the batches table
+ *
+ * @param {string} table The table name
+ * @returns {Array<object>} `{ name, columns, unique }` entries
+ */
+const batchIndexes = (table) => [
+  {
+    columns: ['finished_at', 'updated_at'],
+    name: `${table}_open`,
+    unique: false,
+  },
 ];
 
 /**
@@ -239,6 +287,12 @@ const jobIndexes = (table) => [
     columns: ['state', 'concurrency_key', 'run_at'],
     late: true,
     name: `${table}_limited`,
+    unique: false,
+  },
+  {
+    columns: ['batch_id'],
+    late: true,
+    name: `${table}_batch`,
     unique: false,
   },
 ];
@@ -327,7 +381,7 @@ const statementsFor = (dialect, table, columns, all) => {
  * works is asking the table, not whether these ran.
  *
  * @param {string} name The dialect (sqlite, postgres, mysql, mssql)
- * @param {object} tables `{ jobs, schedules, limits }` table names
+ * @param {object} tables `{ jobs, schedules, limits, batches }` table names
  * @returns {Array<string>} The statements
  * @throws {Error} When the dialect is unknown
  */
@@ -358,7 +412,7 @@ const upgrade = (name, tables) => {
  * database another runner already prepared, changes nothing.
  *
  * @param {string} name The dialect (sqlite, postgres, mysql, mssql)
- * @param {object} tables `{ jobs, schedules, limits }` table names
+ * @param {object} tables `{ jobs, schedules, limits, batches }` table names
  * @returns {Array<string>} The statements
  * @throws {Error} When the dialect or a table name is unknown
  */
@@ -395,6 +449,12 @@ const install = (name, tables) => {
       limitColumns(dialect),
       limitIndexes(tables.limits)
     ),
+    ...statementsFor(
+      dialect,
+      tables.batches,
+      batchColumns(dialect),
+      batchIndexes(tables.batches)
+    ),
     ...upgrade(name, tables),
   ];
 };
@@ -403,7 +463,7 @@ const install = (name, tables) => {
  * The statements that drop the tables, newest first
  *
  * @param {string} name The dialect
- * @param {object} tables `{ jobs, schedules, limits }` table names
+ * @param {object} tables `{ jobs, schedules, limits, batches }` table names
  * @returns {Array<string>} The statements
  * @throws {Error} When the dialect is unknown
  */
@@ -417,7 +477,7 @@ const uninstall = (name, tables) => {
     );
   }
 
-  return [tables.limits, tables.schedules, tables.jobs].map(
+  return [tables.batches, tables.limits, tables.schedules, tables.jobs].map(
     (table) => `DROP TABLE IF EXISTS ${dialect.quote(table)}`
   );
 };

--- a/packages/jobs/src/store/sql.js
+++ b/packages/jobs/src/store/sql.js
@@ -59,6 +59,23 @@ const { keep } = require('../keys');
  * `name IN (...) AND concurrency_key = ?` for the pass that takes one
  * limited row. With no limited job in the application the statement is what
  * it always was, down to its parameters.
+ *
+ * ## Batches
+ *
+ * A batch counts its jobs, and a counter read, added to and written back is
+ * the lost update every textbook opens with -- two runners finishing at the
+ * same instant would both read 39 and both write 40. So the counter is
+ * **never read to be written**: `advanceBatch()` is one statement,
+ * `SET done = done + 1`, which every engine evaluates under a row lock of
+ * its own (sqlite serializes its writers outright), so the increments of
+ * four runners are four increments.
+ *
+ * What makes it exactly once is the `EXISTS` in that same statement: the
+ * counter only moves while the job row still holds **this runner's claim
+ * token** and is already terminal -- which is true of exactly one runner,
+ * the one whose token-guarded outcome write landed. A runner whose write
+ * was refused because it had been recovered from counts nothing, and the
+ * runner that took the job over counts once when it finishes.
  */
 
 /** The columns of the jobs table, in insert order */
@@ -87,6 +104,24 @@ const COLUMNS = [
   'history',
   'unique_key',
   'concurrency_key',
+  'batch_id',
+];
+
+/** The columns of the batches table, in insert order */
+const BATCH_COLUMNS = [
+  'id',
+  'name',
+  'callback',
+  'callback_args',
+  'callback_options',
+  'callback_id',
+  'total',
+  'done',
+  'failed',
+  'created_at',
+  'updated_at',
+  'sealed_at',
+  'finished_at',
 ];
 
 /** How many attempts of a job are kept in its history */
@@ -194,7 +229,7 @@ class SqlStore {
    * @param {string} options.dialect sqlite, postgres, mysql or mssql
    * @param {boolean} [options.dollars=false] The driver numbers its
    *   placeholders (`$1`), as node-postgres does
-   * @param {object} options.tables `{ jobs, schedules, limits }` table names
+   * @param {object} options.tables `{ jobs, schedules, limits, batches }` table names
    * @memberof SqlStore
    */
   constructor(adapter, { dialect, dollars = false, tables }) {
@@ -205,6 +240,8 @@ class SqlStore {
     this.kind = 'sql';
     /** Whether the table has `concurrency_key`; asked once, see concurrent() */
     this.limits = null;
+    /** Whether the store can hold a batch; asked once, see batched() */
+    this.batches = null;
   }
 
   /**
@@ -331,6 +368,7 @@ class SqlStore {
     }
 
     this.limits = null;
+    this.batches = null;
 
     return statements;
   }
@@ -363,6 +401,64 @@ class SqlStore {
     }
 
     return this.limits;
+  }
+
+  /**
+   * Whether this store can hold a batch
+   *
+   * Asked once, of the database rather than of what the install answered,
+   * for the reason `concurrent()` gives: an installation that upgraded
+   * henri without running the install, or whose database user may not
+   * `ALTER`, has the tables an older version wrote and the queue works
+   * exactly as it did. Both halves are asked, because a batch needs the
+   * column that ties a job to it *and* the table that counts.
+   *
+   * @returns {Promise<boolean>} true when a batch can be stored
+   * @memberof SqlStore
+   */
+  async batched() {
+    if (typeof this.batches === 'boolean') {
+      return this.batches;
+    }
+
+    try {
+      // Reads nothing: the planner still has to resolve both
+      await this.select(`SELECT batch_id FROM ${this.tables.jobs} WHERE 1 = 0`);
+      await this.select(`SELECT id FROM ${this.tables.batches} WHERE 1 = 0`);
+      this.batches = true;
+    } catch (error) {
+      debug('no batches here: %s', error.message);
+      this.batches = false;
+    }
+
+    return this.batches;
+  }
+
+  /**
+   * The columns of the jobs table an insert may name
+   *
+   * A table an older henri wrote has neither `concurrency_key` nor
+   * `batch_id`, and an application that uses neither must not notice: the
+   * insert names the columns that are there, so the queue works exactly as
+   * it did.
+   *
+   * @returns {Promise<Array<string>>} The column names
+   * @memberof SqlStore
+   */
+  async columns() {
+    const missing = [];
+
+    if (!(await this.concurrent())) {
+      missing.push('concurrency_key');
+    }
+
+    if (!(await this.batched())) {
+      missing.push('batch_id');
+    }
+
+    return missing.length === 0
+      ? COLUMNS
+      : COLUMNS.filter((column) => !missing.includes(column));
   }
 
   /**
@@ -406,12 +502,7 @@ class SqlStore {
    * @memberof SqlStore
    */
   async insert(job) {
-    // A table an older henri wrote has no `concurrency_key` at all, and an
-    // application with no limited job must not notice: the insert names the
-    // columns that are there, so the queue works exactly as it did
-    const columns = (await this.concurrent())
-      ? COLUMNS
-      : COLUMNS.filter((column) => column !== 'concurrency_key');
+    const columns = await this.columns();
     const values = columns.map((column) =>
       typeof job[column] === 'undefined' ? null : job[column]
     );
@@ -975,11 +1066,12 @@ class SqlStore {
   /**
    * Lists jobs
    *
-   * @param {object} [options={}] `state`, `queue`, `name`, `limit`, `offset`
+   * @param {object} [options={}] `state`, `queue`, `name`, `batch`, `limit`,
+   *   `offset`
    * @returns {Promise<Array<object>>} The rows
    * @memberof SqlStore
    */
-  async list({ state, queue, name, limit = 50, offset = 0 } = {}) {
+  async list({ state, queue, name, batch, limit = 50, offset = 0 } = {}) {
     const filter = [];
     const params = [];
     // The driver binds what it is given: `LIMIT '25'` is text where sqlite
@@ -1000,6 +1092,11 @@ class SqlStore {
     if (name) {
       filter.push('name = ?');
       params.push(name);
+    }
+
+    if (batch) {
+      filter.push('batch_id = ?');
+      params.push(batch);
     }
 
     const where = filter.length > 0 ? `WHERE ${filter.join(' AND ')}` : '';
@@ -1223,6 +1320,299 @@ class SqlStore {
       names
     );
   }
+
+  /**
+   * Records a batch
+   *
+   * @param {object} batch A batch row, in database shape
+   * @returns {Promise<object>} The batch, read back
+   * @memberof SqlStore
+   */
+  async createBatch(batch) {
+    const values = BATCH_COLUMNS.map((column) =>
+      typeof batch[column] === 'undefined' ? null : batch[column]
+    );
+
+    await this.run(
+      `INSERT INTO ${this.tables.batches} (${BATCH_COLUMNS.join(', ')}) VALUES (${marks(BATCH_COLUMNS)})`,
+      values
+    );
+
+    return this.findBatch(batch.id);
+  }
+
+  /**
+   * One batch by id
+   *
+   * @param {string} id The batch id
+   * @returns {Promise<?object>} The row, or null
+   * @memberof SqlStore
+   */
+  async findBatch(id) {
+    const [row] = await this.select(
+      `SELECT * FROM ${this.tables.batches} WHERE id = ?`,
+      [id]
+    );
+
+    return row || null;
+  }
+
+  /**
+   * Closes a batch to new jobs and writes down how many it holds
+   *
+   * `total` is written once and never moves again, which is what makes
+   * "the counter reached the total" mean "every job of the batch is
+   * terminal". Nothing settles before this: the guard of `settleBatch()`
+   * asks for `sealed_at`, so a batch whose first job finished while the
+   * fortieth was still being enqueued does not call its callback early.
+   *
+   * @param {object} options Options
+   * @param {string} options.id The batch id
+   * @param {number} options.total How many jobs it holds
+   * @param {number} options.now The current time
+   * @returns {Promise<?object>} The batch, or null when it was sealed
+   *   already (or is gone)
+   * @memberof SqlStore
+   */
+  async sealBatch({ id, total, now }) {
+    await this.run(
+      `UPDATE ${this.tables.batches} SET total = ?, sealed_at = ?, updated_at = ? WHERE id = ? AND sealed_at IS NULL`,
+      [total, now, now, id]
+    );
+
+    const row = await this.findBatch(id);
+
+    return row && toNumber(row.sealed_at) === now ? row : null;
+  }
+
+  /**
+   * Counts one terminal outcome into its batch
+   *
+   * One statement, and it is the whole of the exactly-once claim:
+   *
+   * - `done = done + 1` is evaluated by the engine under its own row lock,
+   *   so two runners finishing at the same instant make two increments and
+   *   not one. It is never read into this process to be written back.
+   * - the `EXISTS` is the guard: the job row has to still hold **this
+   *   runner's claim token** and be terminal, which is true only of the
+   *   runner whose token-guarded outcome write landed. A runner that was
+   *   recovered from wrote nothing and counts nothing.
+   * - `finished_at IS NULL` stops a batch that has already called its
+   *   callback from counting anything more.
+   *
+   * @param {object} options Options
+   * @param {string} options.id The batch id
+   * @param {string} options.job The job that reached a terminal state
+   * @param {string} options.token The claim token its outcome was written
+   *   under
+   * @param {boolean} options.failed Whether it died rather than finished
+   * @param {number} options.now The current time
+   * @returns {Promise<?object>} The batch as it is now, or null
+   * @memberof SqlStore
+   */
+  async advanceBatch({ id, job, token, failed, now }) {
+    await this.run(
+      `UPDATE ${this.tables.batches} SET done = done + 1, failed = failed + ?, updated_at = ? WHERE id = ? AND finished_at IS NULL AND EXISTS (SELECT 1 FROM ${this.tables.jobs} WHERE id = ? AND batch_id = ? AND claim_token = ? AND state IN ('done', 'dead'))`,
+      [failed ? 1 : 0, now, id, job, id, token]
+    );
+
+    return this.findBatch(id);
+  }
+
+  /**
+   * Gives a batch its slot back, when a job of it is put back in the queue
+   *
+   * A dead job that is retried will reach a terminal state a second time
+   * and count a second time, which would take `done` past what the batch
+   * holds. A finished batch never moves again, which is what the guard
+   * says.
+   *
+   * @param {object} options Options
+   * @param {string} options.id The batch id
+   * @param {boolean} options.failed Whether the job was in the dead letter
+   *   queue
+   * @param {number} options.now The current time
+   * @returns {Promise<void>} Resolves when written
+   * @memberof SqlStore
+   */
+  async releaseBatch({ id, failed, now }) {
+    await this.run(
+      `UPDATE ${this.tables.batches} SET done = done - 1, failed = ${failed ? 'failed - 1' : 'failed'}, updated_at = ? WHERE id = ? AND finished_at IS NULL AND done > 0`,
+      [now, id]
+    );
+  }
+
+  /**
+   * Says a batch has finished, and what enqueued its callback
+   *
+   * The callback is enqueued *before* this is written, so a process that
+   * dies in between leaves the batch unfinished and the next sweep settles
+   * it again -- the enqueue is idempotent (`../keys.js`).
+   *
+   * @param {object} options Options
+   * @param {string} options.id The batch id
+   * @param {?string} options.callback The id of the callback job
+   * @param {number} options.now The current time
+   * @returns {Promise<void>} Resolves when written
+   * @memberof SqlStore
+   */
+  async finishBatch({ id, callback, now }) {
+    await this.run(
+      `UPDATE ${this.tables.batches} SET finished_at = ?, callback_id = ?, updated_at = ? WHERE id = ? AND finished_at IS NULL`,
+      [now, callback || null, now, id]
+    );
+  }
+
+  /**
+   * What a batch's jobs actually say, read from the queue itself
+   *
+   * The repair the sweep uses: a runner killed between writing an
+   * outcome and counting it leaves a batch one short forever, and a job
+   * buried by the recovery of a dead runner was never counted by anybody.
+   * Counting the rows answers both.
+   *
+   * @param {string} id The batch id
+   * @returns {Promise<object>} `{ done, failed }`
+   * @memberof SqlStore
+   */
+  async countBatch(id) {
+    const rows = await this.select(
+      `SELECT state, COUNT(*) AS total FROM ${this.tables.jobs} WHERE batch_id = ? AND state IN ('done', 'dead') GROUP BY state`,
+      [id]
+    );
+    const counted = { done: 0, failed: 0 };
+
+    for (const row of rows) {
+      const total = toNumber(row.total) || 0;
+
+      counted.done += total;
+
+      if (row.state === 'dead') {
+        counted.failed += total;
+      }
+    }
+
+    return counted;
+  }
+
+  /**
+   * Moves a batch's counters up to what its jobs say
+   *
+   * Only ever **forward**: a job pruned after it finished is a row that is
+   * no longer counted, and a batch must not walk backwards over one.
+   *
+   * @param {object} options Options
+   * @param {string} options.id The batch id
+   * @param {number} options.done How many jobs are terminal
+   * @param {number} options.failed How many of them died
+   * @param {number} options.now The current time
+   * @returns {Promise<?object>} The batch as it is now
+   * @memberof SqlStore
+   */
+  async syncBatch({ id, done, failed, now }) {
+    await this.run(
+      `UPDATE ${this.tables.batches} SET done = ?, failed = ?, updated_at = ? WHERE id = ? AND finished_at IS NULL AND done < ?`,
+      [done, failed, now, id, done]
+    );
+
+    return this.findBatch(id);
+  }
+
+  /**
+   * The batches that were sealed and have not finished
+   *
+   * @param {object} options Options
+   * @param {number} options.before Only those untouched since that moment
+   * @param {number} [options.limit=50] How many at most
+   * @returns {Promise<Array<object>>} The rows
+   * @memberof SqlStore
+   */
+  async openBatches({ before, limit = 50 }) {
+    const page =
+      this.dialect === 'mssql'
+        ? 'ORDER BY updated_at ASC OFFSET 0 ROWS FETCH NEXT ? ROWS ONLY'
+        : 'ORDER BY updated_at ASC LIMIT ?';
+
+    return this.select(
+      `SELECT * FROM ${this.tables.batches} WHERE finished_at IS NULL AND sealed_at IS NOT NULL AND updated_at < ? ${page}`,
+      [before, Math.max(1, Number(limit) || 50)]
+    );
+  }
+
+  /**
+   * Lists batches, the ones still running first
+   *
+   * @param {object} [options={}] `finished`, `limit`, `offset`
+   * @returns {Promise<Array<object>>} The rows
+   * @memberof SqlStore
+   */
+  async listBatches({ finished, limit = 50, offset = 0 } = {}) {
+    const rows = Math.max(1, Number(limit) || 50);
+    const from = Math.max(0, Number(offset) || 0);
+    const filter =
+      typeof finished === 'boolean'
+        ? `WHERE finished_at IS ${finished ? 'NOT NULL' : 'NULL'}`
+        : '';
+    const page =
+      this.dialect === 'mssql'
+        ? 'OFFSET ? ROWS FETCH NEXT ? ROWS ONLY'
+        : 'LIMIT ? OFFSET ?';
+    const paging = this.dialect === 'mssql' ? [from, rows] : [rows, from];
+
+    return this.select(
+      `SELECT * FROM ${this.tables.batches} ${filter} ORDER BY created_at DESC, id ASC ${page}`,
+      paging
+    );
+  }
+
+  /**
+   * Forgets a batch
+   *
+   * @param {string} id The batch id
+   * @returns {Promise<boolean>} Whether there was one
+   * @memberof SqlStore
+   */
+  async removeBatch(id) {
+    if (!(await this.findBatch(id))) {
+      return false;
+    }
+
+    await this.run(`DELETE FROM ${this.tables.batches} WHERE id = ?`, [id]);
+
+    return true;
+  }
+
+  /**
+   * Deletes the batches that finished before a moment
+   *
+   * @param {number} before A timestamp
+   * @param {number} [limit=1000] How many one pass deletes
+   * @returns {Promise<number>} How many were deleted
+   * @memberof SqlStore
+   */
+  async pruneBatches(before, limit = 1000) {
+    const page =
+      this.dialect === 'mssql'
+        ? 'ORDER BY finished_at ASC OFFSET 0 ROWS FETCH NEXT ? ROWS ONLY'
+        : 'ORDER BY finished_at ASC LIMIT ?';
+    const rows = await this.select(
+      `SELECT id FROM ${this.tables.batches} WHERE finished_at IS NOT NULL AND finished_at < ? ${page}`,
+      [before, limit]
+    );
+
+    if (rows.length === 0) {
+      return 0;
+    }
+
+    const ids = rows.map((row) => row.id);
+
+    await this.run(
+      `DELETE FROM ${this.tables.batches} WHERE id IN (${marks(ids)})`,
+      ids
+    );
+
+    return ids.length;
+  }
 }
 
 /**
@@ -1278,6 +1668,7 @@ const create = (adapter, tables) => {
 };
 
 module.exports = {
+  BATCH_COLUMNS,
   COLUMNS,
   DUPLICATE,
   HISTORY_LIMIT,

--- a/types/core.test-d.ts
+++ b/types/core.test-d.ts
@@ -21,6 +21,8 @@ import type {
   IdentityProvider,
   IdentityResult,
   Job,
+  JobBatch,
+  JobBatchHandle,
   JobDefinition,
   JobLimits,
   JobStats,
@@ -233,6 +235,43 @@ expectType<JobDefinition>(exclusive);
 expectType<JobDefinition>(perTenant);
 expectType<JobDefinition>(computed);
 expectType<string | null>((await jobs.perform('import')).concurrencyKey);
+
+// A batch: these jobs, and one that runs when they are all done
+const batch = await jobs.batch({
+  args: { accountId: 'acc_1' },
+  callback: 'import/finished',
+  jobs: [
+    'import/row',
+    ['import/row', { row: 2 }],
+    ['import/row', { row: 3 }, { priority: -5 }],
+    { args: { row: 4 }, name: 'import/row', options: { queue: 'imports' } },
+  ],
+  name: 'acme import',
+  queue: 'imports',
+});
+
+expectType<JobBatchHandle>(batch);
+expectType<number>(batch.total);
+expectType<boolean>(batch.finished);
+expectType<string[]>(batch.jobs);
+expectType<Promise<JobBatchHandle>>(batch.reload());
+expectType<Promise<JobBatch | null>>(jobs.batches.get(batch.id));
+expectType<Promise<JobBatch[]>>(jobs.batches.list({ finished: false }));
+expectType<Promise<Job[]>>(jobs.batches.jobs(batch.id, { state: 'dead' }));
+expectType<Promise<boolean>>(jobs.batches.discard(batch.id));
+expectType<string | null>((await jobs.perform('import')).batchId);
+
+// The other half: a batch built by a function, sealed when it resolves
+expectType<Promise<JobBatchHandle>>(
+  jobs.batch({ callback: 'import/finished' }, async (open) => {
+    await open.add('import/row', { row: 1 });
+    await open.addAll([['import/row', { row: 2 }]]);
+  })
+);
+
+// @ts-expect-error the counts reach the callback under `batch`, so its own
+// arguments have to be an object
+jobs.batch({ args: 'acc_1', callback: 'import/finished' });
 
 const unbounded: JobDefinition = {
   // @ts-expect-error a concurrency limit is a number or `{ limit }`

--- a/website/src/content/docs/configuration.md
+++ b/website/src/content/docs/configuration.md
@@ -788,24 +788,24 @@ Everything the [job queue](/guides/jobs/) reads, all of it optional. The queue i
 }
 ```
 
-| Key             | Default      | Description                                                                                                                                                |
-| --------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `store`         | `default`    | Which store of `stores` holds the queue.                                                                                                                   |
-| `priority`      | `0`          | Priority of a job that names none; the higher, the sooner it is claimed.                                                                                   |
-| `table`         | `henri_jobs` | Table (or collection) name; the schedules live in `<table>_schedules` and the concurrency slots in `<table>_limits`. Letters, digits and underscores only. |
-| `queue`         | `default`    | Queue of a job that names none.                                                                                                                            |
-| `queues`        | all          | Queues a runner takes from when `henri jobs` is given no `--queue`.                                                                                        |
-| `concurrency`   | `5`          | How many jobs one runner performs at once.                                                                                                                 |
-| `maxAttempts`   | `5`          | Attempts before a job goes to the dead letter queue.                                                                                                       |
-| `timeout`       | none         | How long one attempt may take, for jobs that set none.                                                                                                     |
-| `backoff`       | see above    | Wait before the next attempt: `base × factor^(attempt − 1)`, capped at `max`, spread by `jitter` (0 to 1).                                                 |
-| `pollInterval`  | `1s`         | How often a runner looks for work when the queue is empty (never under 50ms).                                                                              |
-| `stuckAfter`    | `5m`         | Without a heartbeat for that long, a `running` job is taken to belong to a dead runner and put back. Keep it above the longest `timeout`.                  |
-| `keepCompleted` | `1d`         | How long finished jobs are kept before a runner prunes them. `0` keeps them forever.                                                                       |
-| `maxArgsBytes`  | `524288`     | Size limit of the serialized arguments of one job; over it the enqueue fails instead of storing a truncated payload.                                       |
-| `mailQueue`     | `mailers`    | Queue of the messages [`deliverLater()`](/guides/mail/#delivering-later) hands over.                                                                       |
-| `install`       | `true`       | Create the tables at boot. Set `false` in production and run `henri jobs:install` in the deploy.                                                           |
-| `recurring`     | `{}`         | Schedules, by name: `job` (defaults to the name), `cron` **or** `every`, and optionally `args`, `queue` and `priority`. Cron is read in UTC.               |
+| Key             | Default      | Description                                                                                                                                                                                  |
+| --------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `store`         | `default`    | Which store of `stores` holds the queue.                                                                                                                                                     |
+| `priority`      | `0`          | Priority of a job that names none; the higher, the sooner it is claimed.                                                                                                                     |
+| `table`         | `henri_jobs` | Table (or collection) name; the schedules live in `<table>_schedules`, the concurrency slots in `<table>_limits` and the batches in `<table>_batches`. Letters, digits and underscores only. |
+| `queue`         | `default`    | Queue of a job that names none.                                                                                                                                                              |
+| `queues`        | all          | Queues a runner takes from when `henri jobs` is given no `--queue`.                                                                                                                          |
+| `concurrency`   | `5`          | How many jobs one runner performs at once.                                                                                                                                                   |
+| `maxAttempts`   | `5`          | Attempts before a job goes to the dead letter queue.                                                                                                                                         |
+| `timeout`       | none         | How long one attempt may take, for jobs that set none.                                                                                                                                       |
+| `backoff`       | see above    | Wait before the next attempt: `base × factor^(attempt − 1)`, capped at `max`, spread by `jitter` (0 to 1).                                                                                   |
+| `pollInterval`  | `1s`         | How often a runner looks for work when the queue is empty (never under 50ms).                                                                                                                |
+| `stuckAfter`    | `5m`         | Without a heartbeat for that long, a `running` job is taken to belong to a dead runner and put back. Keep it above the longest `timeout`.                                                    |
+| `keepCompleted` | `1d`         | How long finished jobs are kept before a runner prunes them. `0` keeps them forever.                                                                                                         |
+| `maxArgsBytes`  | `524288`     | Size limit of the serialized arguments of one job; over it the enqueue fails instead of storing a truncated payload.                                                                         |
+| `mailQueue`     | `mailers`    | Queue of the messages [`deliverLater()`](/guides/mail/#delivering-later) hands over.                                                                                                         |
+| `install`       | `true`       | Create the tables at boot. Set `false` in production and run `henri jobs:install` in the deploy.                                                                                             |
+| `recurring`     | `{}`         | Schedules, by name: `job` (defaults to the name), `cron` **or** `every`, and optionally `args`, `queue` and `priority`. Cron is read in UTC.                                                 |
 
 Every duration is a number of milliseconds or a string: `'250ms'`, `'30s'`, `'5m'`, `'2h'`, `'1d'`, `'1w'`.
 

--- a/website/src/content/docs/guides/jobs.md
+++ b/website/src/content/docs/guides/jobs.md
@@ -298,6 +298,133 @@ The bound stores one thing on the job row: `concurrency_key`, the bucket it coun
 - A job already **in the queue** when the limit was declared carries no key. It is not left behind: a row with no key belongs to its job's own bucket, so adding a limit takes effect on the backlog — which is the moment you would be adding it.
 - On MongoDB there is nothing to upgrade: a document simply has no such field.
 
+## Batches
+
+Forty jobs, and one that runs when they are all done: an import that resizes every image and then sends the mail, a nightly report compiled from a page of work per account.
+
+```js
+const batch = await henri.jobs.batch({
+  name: `import ${account.id}`, // a label, for henri jobs:batches
+  callback: 'import/finished', // the job that runs when they are done
+  args: { accountId: account.id }, // its own arguments
+  queue: 'imports', // and its queue, priority, maxAttempts, timeout, wait, at
+
+  jobs: rows.map((row) => ['import/row', { id: row.id }]),
+});
+
+batch.id; // the batch
+batch.total; // 40
+batch.jobs; // the ids of the jobs it enqueued
+```
+
+A job of the list is `'name'`, `['name', args]`, `['name', args, options]` or `{ name, args, options }` — the options being `perform()`'s own, so one job of a batch can have its own queue or priority.
+
+The callback is an ordinary job of `app/jobs`, and it is handed the counts under `batch`:
+
+```js
+// app/jobs/import/finished.js
+module.exports = {
+  perform: async ({ accountId, batch }) => {
+    // batch: { id, name, total, done, failed, succeeded }
+    const account = await Account.findById(accountId);
+
+    await henri.mailers.imports.done(account, batch).deliverLater();
+  },
+};
+```
+
+The `batch` key is henri's, so an `args` of your own that carries one is overwritten; and because the counts go in there, `args` has to be a plain object.
+
+When there are too many jobs to write out — a cursor over a table, a stream — the second argument builds the batch instead, and the batch is sealed when it resolves:
+
+```js
+const batch = await henri.jobs.batch(
+  { callback: 'import/finished' },
+  async (open) => {
+    for await (const row of rows) {
+      await open.add('import/row', { id: row.id });
+    }
+  }
+);
+```
+
+A **batch is built where it is created**. `add()` is a call on the handle that `batch()` answered, and once the batch is sealed it refuses (`HENRI_JOB_BATCH_CLOSED`) — there is no adding a job to a batch from another process later, because that is exactly the race that would let a callback run with work still on its way in. A builder that throws leaves the batch unsealed on purpose: the jobs it added still run, the callback never does, and `henri jobs:batches` shows it. Without either a list or a function the batch comes back open, and `batch.seal()` closes it when you are ready.
+
+### A batch finishes, it does not succeed
+
+The callback runs once **every job of the batch has reached a terminal state** — `dead` included — and it is handed the counts. A batch whose last job failed is a finished batch with a failure in it, and what that means is the application's to decide: a callback that only ran when everything succeeded would be a callback that never runs and nobody notices.
+
+So `failed` is a number the callback reads, `henri jobs:dead` has the rows, and `henri.jobs.batches.jobs(id, { state: 'dead' })` is the list of what went wrong in this batch.
+
+An **empty** batch (`jobs: []`) has nothing to wait for and finishes the moment it is made. A batch with no `callback` at all is a counter you can look at.
+
+### Exactly once, and never early
+
+Two promises, and they rest on the same three writes.
+
+`total` is written **once**, when the batch is sealed, and never moves again. `done` is advanced by **one statement per terminal outcome**, and that statement is the whole of it:
+
+```sql
+UPDATE henri_jobs_batches
+   SET done = done + 1, failed = failed + ?, updated_at = ?
+ WHERE id = ? AND finished_at IS NULL
+   AND EXISTS (SELECT 1 FROM henri_jobs
+                WHERE id = ? AND batch_id = ? AND claim_token = ?
+                  AND state IN ('done', 'dead'))
+```
+
+- The counter is **never read into the process to be written back**. `done = done + 1` is evaluated by the engine under a row lock of its own — PostgreSQL and MySQL re-evaluate the row after waiting for the writer in front, MSSQL takes an update lock, sqlite serializes its writers outright — so four runners finishing at the same instant make four increments and not one. MongoDB's `$inc` is the same guarantee on a document.
+- The `EXISTS` is what makes it exactly once: the counter only moves while the job row still holds **the claim token of the attempt that wrote its outcome**, and that is true of exactly one runner. A runner whose heartbeat went stale had its job taken away and its outcome refused — it counts nothing, and the runner that took the job over counts it once when it finishes. (On MongoDB the check is a `findOne` before the `$inc`, and it is exact for the same reason: a document that is terminal and holds this token can never be claimed, recovered or written again.)
+- `finished_at IS NULL` stops a batch that has already called its callback from ever counting again.
+
+So `done` reaches `total` after the last job of the batch is terminal, and not before — which is what the callback's own test asserts, by asking the database what is left of its batch at the moment it runs.
+
+The callback is then enqueued under a **unique key of the batch's own**, the way a [recurring](#recurring-jobs) occurrence is: two runners that both saw the last outcome send the same insert, the index refuses one of them, and it is answered with the job the other one enqueued. The batch is stamped finished _after_ that, so a process dying in between leaves it unfinished and the next sweep settles it again — settling is idempotent, which is the point.
+
+### What a batch is not
+
+- **It is not a transaction.** A runner that dies mid-batch leaves its job to be recovered, the counter unmoved and the batch unfinished until that job reaches an outcome — which is the right answer, and the reason the counter cannot be advanced at claim time.
+- **It is not atomic with your database** either: [the queue is not in your transaction](#the-queue-is-not-in-your-transaction), so a batch enqueued inside one that rolls back is a batch that runs, callback and all. Enqueue after the commit when the order matters.
+- **A job cannot be added to a batch that is sealed**, and that refusal is asked of the table rather than of the handle in your process's memory.
+- **A batch is not a pipeline.** There is no order between its jobs, no batch inside a batch, and no cancelling one.
+
+Two things leave a batch short of its total with every job of it terminal: a runner killed between writing an outcome and counting it, and a job buried by the recovery of a dead runner, whose outcome no attempt of anybody's ever wrote. The runner's sweep answers both — it counts the rows of a batch that has not moved for `jobs.stuckAfter` and settles it — so the callback is late by a sweep rather than never. That count only ever moves a batch **forward**, so a finished job pruned out of the table can never undo one.
+
+A job of a batch that is [put back](#retries-and-the-dead-letter-queue) gives its slot back first, so it is counted once when it finishes rather than twice; a job of a batch that is **discarded** leaves that batch unfinished for good, and `henri.jobs.batches.discard(id)` is the way to forget it.
+
+### What a batch looks like from the outside
+
+```bash
+henri jobs:batches                 # what is running, and what it is waiting for
+henri jobs:batches --finished
+henri jobs:list --batch <id>       # the jobs of one batch
+henri jobs:status                  # says which batches are still running
+```
+
+```
+  4f0e8f2c-...  running   38/40 done, 1 dead  import acme
+      -> import/finished (not enqueued yet)
+```
+
+```js
+await henri.jobs.batches.get(id); // one batch and its counts
+await henri.jobs.batches.list({ finished: false });
+await henri.jobs.batches.jobs(id, { state: 'dead' });
+await henri.jobs.batches.discard(id);
+```
+
+A finished batch is kept for `jobs.keepCompleted`, like a finished job, and pruned by the same sweep.
+
+### The table, and an upgrade
+
+A batch stores one column on the job row (`batch_id`) and one table of its own (`henri_jobs_batches`). The queue's tables are created with `CREATE TABLE IF NOT EXISTS` and there is no migration chain behind them, so — exactly as for the [concurrency key](#the-column-and-an-upgrade) — a **new table** appears on its own and a **new column** does not.
+
+`henri jobs:install`, which the boot already runs unless `jobs.install` is false, adds both, and the `ALTER` is idempotent and **tolerated**: a database user who may not alter the table fails no boot. What decides whether batches work is asking the database, not whether that statement ran:
+
+- An application that makes no batch **is not affected at all**. Its inserts name the columns that are there.
+- `henri.jobs.batch()` on a store that has neither **is refused** with `HENRI_JOB_BATCH_UNINSTALLED`, naming `henri jobs:install`. A batch is refused rather than run with a counter nothing can hold — there is nothing declared in a file to fail a boot over, so the refusal is at the call.
+- On MongoDB there is nothing to upgrade: a document has no such field, and a collection appears when something is written into it.
+
 ## A job a package ships
 
 A package that does work of its own registers its job on the queue rather than asking every application to write a file that would only forward the call:
@@ -401,22 +528,23 @@ module.exports = {
   index: async (req, res) => {
     await req.authorize('read', 'Jobs');
 
-    const [stats, dead, limits] = await Promise.all([
+    const [stats, dead, limits, batches] = await Promise.all([
       henri.jobs.stats(),
       henri.jobs.dead.list({ limit: 50 }),
       henri.jobs.limits(),
+      henri.jobs.batches.list({ finished: false }),
     ]);
 
-    return { dead, limits, stats };
+    return { batches, dead, limits, stats };
   },
 };
 ```
 
-`stats()`, `list()`, `get()`, `limits()` and the whole `dead.*` API are the same calls `henri jobs:*` makes, and every one of those commands takes `--json`, so a script, a Grafana exporter or a page all read the same numbers. What henri owns instead of a page is the [telemetry](/guides/telemetry/): the queue depth by queue and state, and how long claiming takes — the two numbers a screenshot cannot alert on.
+`stats()`, `list()`, `get()`, `limits()`, `batches.*` and the whole `dead.*` API are the same calls `henri jobs:*` makes, and every one of those commands takes `--json`, so a script, a Grafana exporter or a page all read the same numbers. What henri owns instead of a page is the [telemetry](/guides/telemetry/): the queue depth by queue and state, and how long claiming takes — the two numbers a screenshot cannot alert on.
 
 ## Storage
 
-The queue owns three tables of its own, `henri_jobs`, `henri_jobs_schedules` and `henri_jobs_limits`, and reaches them through the store adapter's own surface — `query()` on the SQL adapters, the collections on MongoDB. **No henri model is involved**, so the queue cannot collide with the application's schema, does not follow its model conventions and works on a store that has no models at all.
+The queue owns four tables of its own, `henri_jobs`, `henri_jobs_schedules`, `henri_jobs_limits` and `henri_jobs_batches`, and reaches them through the store adapter's own surface — `query()` on the SQL adapters, the collections on MongoDB. **No henri model is involved**, so the queue cannot collide with the application's schema, does not follow its model conventions and works on a store that has no models at all.
 
 Every moment is stored as a `BIGINT` of milliseconds since the epoch rather than a timestamp column: sqlite has no date type, the SQL servers disagree on the precision and the zone of a bare `TIMESTAMP`, and the claim compares `run_at` to the runner's clock — a comparison that has to mean the same thing everywhere.
 
@@ -430,17 +558,7 @@ Every adapter is supported: `drizzle` (sqlite, postgres, mysql), `postgresql`, `
 
 ## What is not here
 
-**Batching** — forty jobs and one that runs when they are all done — is not in henri yet. It is the next thing the queue wants, and the shape it will take is settled, so that an application does not build something today that has to be unbuilt:
-
-- A batch **finishes**, it does not **succeed**. The callback runs once every job of the batch has reached a terminal state, `dead` included, and is handed the counts. A batch whose last job fails is a finished batch with a failure in it, and pretending otherwise means a callback that never runs and nobody notices.
-- The callback runs **exactly once**, and that rests on where the counter is advanced: by the same token-guarded write that records an attempt's outcome, so a job recovered from a dead runner and performed again does not count twice.
-- A batch is **not a transaction**. A runner that dies mid-batch leaves its job `pending`, the batch's counter unmoved and the batch unfinished until that job reaches an outcome — which is the right answer, and the reason the counter cannot be advanced at claim time.
-- It is **not atomic with your database** either, for the reason above: [the queue is not in your transaction](#the-queue-is-not-in-your-transaction), so a batch enqueued inside one that rolls back is a batch that runs.
-- Adding a job to a batch that has finished is **refused**, not swallowed.
-
-What it needs that is not there yet is a second column on the job row and a table for the batches, which is the same upgrade question the concurrency key answered — so it is a tranche of its own rather than a paragraph of this one.
-
-Also deliberately absent: a mounted dashboard ([above](#no-dashboard-and-what-to-build-one-from)), priorities that change after an enqueue, and a way to cancel a job that a runner is already performing — JavaScript cannot stop a function that is running, which is why `timeout` aborts a signal and hopes.
+Deliberately absent: a mounted dashboard ([above](#no-dashboard-and-what-to-build-one-from)), priorities that change after an enqueue, an order between the jobs of a [batch](#batches) or a batch inside one, and a way to cancel a job that a runner is already performing — JavaScript cannot stop a function that is running, which is why `timeout` aborts a signal and hopes.
 
 ## Jobs or workers?
 

--- a/website/src/content/docs/reference/cli.md
+++ b/website/src/content/docs/reference/cli.md
@@ -399,7 +399,7 @@ All three exit with `1` when the key is missing or wrong, naming the file and `H
 
 ```bash
 henri jobs [--queue=<a,b>] [--concurrency=<n>] [--once] [--no-recurring]
-henri jobs:install | jobs:status | jobs:list | jobs:dead | jobs:show <id>
+henri jobs:install | jobs:status | jobs:list | jobs:batches | jobs:dead | jobs:show <id>
 henri jobs:perform <name> [json] [--in=<duration>] [--at=<date>] [--queue=<name>] [--now]
 henri jobs:retry <id> | --all      |  henri jobs:discard <id> | --all      [--json]
 ```
@@ -408,16 +408,17 @@ Runs and drives the [job queue](/guides/jobs/) of `@usehenri/jobs`, in the same 
 
 Without a command, `henri jobs` runs a worker: it claims jobs, performs up to `--concurrency` of them at once (`jobs.concurrency`, five by default), honours the recurring schedules, puts back the jobs of runners that died and stops on `SIGINT`, `SIGTERM` or `SIGQUIT` after finishing what it had claimed. `--queue=mailers,reports` limits it to some queues; `--once` performs what is due and exits instead of looping, which is what a cron entry wants; `--no-recurring` leaves the schedules alone.
 
-| Command                 | What it does                                                                                                                                                                                                    |
-| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `install`               | Creates `henri_jobs`, `henri_jobs_schedules` and `henri_jobs_limits` and their indexes, and adds the columns a table an older henri wrote has not. Idempotent; run it in a deploy that sets `"install": false`. |
-| `status`                | Counts by queue and state, the timings of the finished jobs, how long the oldest due job has waited, the schedules, the concurrency limits and the slots being held.                                            |
-| `list`                  | The jobs, newest change first (`--state`, `--queue`, `--name`, `--limit`).                                                                                                                                      |
-| `dead`                  | The dead letter queue.                                                                                                                                                                                          |
-| `show <id>`             | One job with its arguments, its error, its stack and the history of every attempt.                                                                                                                              |
-| `perform <name> [json]` | Enqueues a job by hand; `--in=<duration>` or `--at=<date>` for later, `--now` to run it inline instead.                                                                                                         |
-| `retry <id>`            | Puts a dead job back in its queue, attempts reset. `--all` (with `--queue`/`--name`) for every matching one.                                                                                                    |
-| `discard <id>`          | Deletes a dead job for good. `--all` (with `--queue`/`--name`) for every matching one.                                                                                                                          |
+| Command                 | What it does                                                                                                                                                                                                                          |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `install`               | Creates `henri_jobs`, `henri_jobs_schedules`, `henri_jobs_limits` and `henri_jobs_batches` and their indexes, and adds the columns a table an older henri wrote has not. Idempotent; run it in a deploy that sets `"install": false`. |
+| `status`                | Counts by queue and state, the timings of the finished jobs, how long the oldest due job has waited, the schedules, the concurrency limits and the slots being held, and the batches still running.                                   |
+| `list`                  | The jobs, newest change first (`--state`, `--queue`, `--name`, `--batch`, `--limit`).                                                                                                                                                 |
+| `batches`               | The [batches](/guides/jobs/#batches): what each is waiting for, and the callback it enqueued. `--finished` for the ones that are done.                                                                                                |
+| `dead`                  | The dead letter queue.                                                                                                                                                                                                                |
+| `show <id>`             | One job with its arguments, its error, its stack and the history of every attempt.                                                                                                                                                    |
+| `perform <name> [json]` | Enqueues a job by hand; `--in=<duration>` or `--at=<date>` for later, `--now` to run it inline instead.                                                                                                                               |
+| `retry <id>`            | Puts a dead job back in its queue, attempts reset. `--all` (with `--queue`/`--name`) for every matching one.                                                                                                                          |
+| `discard <id>`          | Deletes a dead job for good. `--all` (with `--queue`/`--name`) for every matching one.                                                                                                                                                |
 
 `--wait` is a global flag (it belongs to `--inspect`), which is why the delay of an enqueue is `--in`.
 

--- a/website/src/content/docs/reference/errors.md
+++ b/website/src/content/docs/reference/errors.md
@@ -1284,6 +1284,30 @@ Usually:
 
 The background job queue of @usehenri/jobs.
 
+### `HENRI_JOB_BATCH_CLOSED`
+
+A job was added to a batch that is closed.
+
+Usually:
+
+- a job added to a batch that was already sealed
+- a batch built from somewhere other than the call that made it
+- a batch id that names no batch, or one the sweep pruned
+
+**Fix.** A batch is built where it is created: add every job before it is sealed (`jobs: [...]`, or the function `henri.jobs.batch()` takes), or make another batch. A batch that has finished has already called its callback and never counts anything again.
+
+### `HENRI_JOB_BATCH_UNINSTALLED`
+
+A batch was asked for and the queue has nowhere to count it.
+
+Usually:
+
+- a queue installed by a henri older than 1.3, whose table has no `batch_id` column and no batches table
+- `jobs.install: false` with no `henri jobs:install` since the upgrade
+- a database user that may not create a table, or alter one
+
+**Fix.** Run `henri jobs:install` once with a user that may create a table and alter one. The queue works without them -- a batch does not, and is refused rather than run with a counter nothing can hold.
+
 ### `HENRI_JOB_CONCURRENCY_CONFLICT`
 
 Two jobs share a concurrency group and disagree on how many may run.
@@ -1305,6 +1329,19 @@ Usually:
 - a model instance passed whole instead of its id
 
 **Fix.** The arguments of a job are stored as JSON: pass ids and plain values, and look the records up inside `perform()`.
+
+### `HENRI_JOB_INVALID_BATCH`
+
+A batch declaration cannot be read.
+
+Usually:
+
+- a `jobs` list holding something that is not a name, a list or an object
+- a callback that is not the name of a job
+- callback arguments that are not a plain object
+- both a `jobs` list and a function to add them
+
+**Fix.** `henri.jobs.batch({ callback: 'report/compile', jobs: [['resize', { id }]] })`, or a function that calls `batch.add()` itself. The counts reach the callback under `batch`, which is why its own arguments have to be an object.
 
 ### `HENRI_JOB_INVALID_CONCURRENCY`
 


### PR DESCRIPTION
## What

The last of the three things the comparison said Solid Queue has and `@usehenri/jobs` does not. Concurrency limits landed as #434, the dashboard was argued down there with a reason, and this is the rest.

`henri.jobs.batch({ callback, jobs, … })` returns a handle. A `jobs` list — even `[]` — seals it; a builder function seals when it resolves; neither leaves it open for the caller to remember. The callback is an ordinary `app/jobs` file handed `args.batch = { id, name, total, done, failed, succeeded }`. Read back with `henri.jobs.batches.*`, `henri jobs:batches`, `jobs:list --batch <id>`, and a block in `jobs:status`.

**The promises were decided in #434 and written into the guide before any of this existed**, so this implements a contract rather than reopening one: a batch **finishes**, it does not succeed — the callback runs once every job is terminal, `dead` included, with the counts.

## The counter, and why it is safe

One statement per terminal outcome, byte-identical on sqlite, PostgreSQL, MySQL and MSSQL:

```sql
UPDATE <jobs>_batches SET done = done + 1, failed = failed + ?, updated_at = ?
 WHERE id = ? AND finished_at IS NULL
   AND EXISTS (SELECT 1 FROM <jobs>
                WHERE id = ? AND batch_id = ? AND claim_token = ?
                  AND state IN ('done','dead'))
```

Two halves. **No lost update**: the counter is never read into the process to be written back — `done = done + 1` is evaluated by the engine under its own row lock, so four runners finishing at once make four increments (MongoDB's `$inc` is the same guarantee). **Exactly one increment per job**: the `EXISTS` requires the job row to be terminal *and* still hold **this runner's** claim token, so a runner whose heartbeat went stale counts nothing and the runner that took the job over counts once. To make that expressible the terminal write of a batched job keeps its `claim_token` instead of nulling it — only for batched rows, so nothing else changes.

Settling is arbitrated by the queue's **own unique index** rather than a token read-back: the callback is enqueued with `unique: batch:<id>` and `finished_at` is stamped after, so a crash in between leaves the batch unfinished and the sweep settles it again idempotently. A real bug found on live PostgreSQL along the way: giving the callback the batch's own id made `insert()`'s `existing.id !== job.id` guard rethrow for the losing racer, so the id is random and the unique key is the sole arbiter.

## Exactly-once, proved

A count taken afterwards cannot see either property, so **the callback records what it saw** — one entry per run, plus how many of its batch's jobs were still `pending`/`running` at that instant, read from the database. Four runners with a queue and a connection pool each: `callbacks().length === 1`, `unfinished === 0`, and exactly one `batch/finished` row.

Covered: 12 jobs finishing simultaneously; three batches at once (three callbacks, one each); a dead-lettered job; a job still to run (two drains, no callback after the first); a zombie runner writing its outcome after the job was performed again; a job buried by recovery; a runner killed between the outcome and the count; a double settle producing one row.

**I ran the batch spec four consecutive times on live PostgreSQL — 19/19 each time**, which after this week's flake is the bar for anything asserting concurrency.

## A half-failed batch, and the way out

It finishes, with `failed`/`succeeded`; the dead rows stay in the dead letter queue and are listable. Retrying a dead job of an **unfinished** batch gives its slot back first, so it counts once and not twice; a finished batch never moves again. A *discarded* job leaves its batch unfinished for good, and `batches.discard(id)` is the documented way out rather than something papered over.

## Upgrading, and one deviation worth naming

#434's pattern exactly: `batch_id` joins the tolerated idempotent `ALTER` inside the install the boot already runs, `henri_jobs_batches` is a new table under the guarded `CREATE`, and what decides at runtime is **asking the database** rather than whether the statement ran. An application that makes no batch is untouched — the inserts and the claim are what they were.

The deviation from my brief, and the teammate is right: the refusal for a store with neither is at the **call**, not at the boot, because nothing about a batch is declared in a file the way a `concurrency` limit is, so there is nothing for a boot to check. The guide says so in those words.

## Gates

`pnpm test` (4721), `pnpm test:types`, `pnpm lint --max-warnings 0`, `pnpm format:check`, `scripts/smoke.sh` end to end (`henri audit`: nothing found in 56 checks), the SQL suites against live PostgreSQL (926), and the showcase against live PostgreSQL (172).

## Left

No adding to a batch from another process — that is the race the seal exists to close, stated rather than half-supported. A builder that throws leaves the batch unsealed: its jobs run, its callback does not, and `jobs:batches` shows it. No order between a batch's jobs, no nesting, no cancelling. MSSQL has only its generated DDL covered, like the rest of that adapter.