### PR TITLE
A write the store refused puts back every attribute it set

### DIFF
--- a/.changeset/a-refused-write-puts-it-back.md
+++ b/.changeset/a-refused-write-puts-it-back.md
@@ -1,0 +1,32 @@
+---
+'@usehenri/cli': minor
+'@usehenri/core': minor
+'@usehenri/drizzle': minor
+'@usehenri/mongoose': minor
+'@usehenri/sequelize': minor
+---
+
+A write the store refused puts back every attribute it set.
+
+`record.update(attrs)` sets the attributes and saves them, and only the second half can fail. Until now the set had already happened, so the value the store refused stayed on the record in hand:
+
+```js
+try {
+  await post.update(req.permit('title', 'views'));
+} catch (error) {
+  // post.views was the value the database or the validator just refused
+  return res.boom.badData(error.message, { errors: henri.model.errors(error) });
+}
+```
+
+Anything that then rendered, logged or wrote from `post` was working from a value no store ever accepted. The measurement on the three adapters is what settled the fix: the next `update()` on that record was measured against the stale value on Drizzle and Mongoose, so a second write naming a different field entirely was refused for a field it never named — while on Sequelize the same second write **succeeded**, because Sequelize narrows the statement to the fields the call names, so the row kept the old value and the record went on saying the refused one with nothing to say otherwise.
+
+So the rule, and it is the same sentence on `drizzle`, `postgresql`, `mysql`, `mongoose`, `disk` and `mssql`: **a write the store refused leaves the record holding the values it had.** A rule of `validates`, the schema's own `required` or `enum`, and the unique index all put the attributes back — the database's refusal too, because a single-row `INSERT` or `UPDATE` is refused whole and there is no half-written row for the record to disagree with.
+
+What it is not:
+
+- **Not a reload.** Nothing is read back and a refusal costs no query.
+- **Not everything that can go wrong.** A refusal is what `henri.model.errors()` calls one. A hook of yours that throws is not, and that matters for an `afterUpdate` hook in particular: by then the row has moved, and the record keeps the values it now holds.
+- **Not `set()` + `save()`.** Those stay two steps and keep what was set, which is how a form keeps what a person typed.
+
+On a `mongoose` or `disk` store `record.update()` is new: Mongoose removed `Document.prototype.update` in version 7, so henri adds it back with the meaning it has on the other two adapters — the models guide already told applications to write `article.update({ ... })`, and now that call exists everywhere. `henri generate scaffold|crud` writes it into the Mongoose controller in place of `set()` then `save()`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -708,7 +708,22 @@ model }` or Mongoose's `ref` -- which `res.render()`, `res.resource()`,
   `HENRI_MODEL_VALIDATION_UNCHECKED_WRITE`. **henri does not claim
   `unique`**: a check before an insert is a race, so the index stays what
   holds and `model-errors.js` turns the duplicate into
-  `{ field: 'must be unique' }`. The guide is `guides/models.md`
+  `{ field: 'must be unique' }`. **A write the store refused puts back
+  every attribute it set**: `record.update(attrs)` is `set()` then
+  `save()`, so a refusal used to leave the refused value on the record and
+  the next `update()` was measured against it -- refused for a field it
+  never named on drizzle and mongoose, and silently _not_ refused on
+  sequelize, which narrows the statement to the fields the call names. The
+  rollback is per adapter (`packages/drizzle/model.js` `rollbackOf()`,
+  which carries the whole argument, `restoring()` in
+  `packages/sequelize/plugins.js`, `updating()` in
+  `packages/mongoose/plugins.js` -- which also _adds_ `doc.update()`,
+  removed by Mongoose 7, so the call the guide names exists on all three).
+  It fires for what `henri.model.errors()` calls a refusal and nothing
+  else, so an `afterUpdate` hook that throws leaves the record saying what
+  the row now says; `set()` + `save()` stays two steps and keeps what was
+  set, which is how a form keeps what a person typed. The guide is
+  `guides/models.md`
   (`#validations`), which is also where the boundary with `params` is
   argued: `params` checks what arrives, `validates` what is written, and a
   job, a seed or a console has no request.
@@ -2127,11 +2142,6 @@ false` columns of the user model), sqlite offline and the live PostgreSQL
   (`HENRI_MODEL_VALIDATION_UNCHECKED_WRITE`), and `Model.upsert()` on
   Sequelize is treated as a partial write, so a required column it does
   not name is left to the database's `NOT NULL`.
-- Separate from the above and **not fixed**: on the drizzle adapter
-  `instance.update(attrs)` is `set()` then `save()`, so a write refused by
-  a validation leaves the refused value on the in-memory instance and the
-  next `update()` on that same instance is measured against it. A record
-  read again is fine; only the object in hand is stale.
 - Enum predicates and scopes are new. What was **deliberately left**: the
   bang (argued above), a scope that answers records, an `or` between two
   values (`{ status: { $in: [...] } }` is not portable by hand -- that is

--- a/packages/cli/__tests__/adapters.spec.js
+++ b/packages/cli/__tests__/adapters.spec.js
@@ -340,7 +340,9 @@ describe('the scaffolded resource follows the adapter', () => {
     const controller = read(app, 'app/controllers/tasks.js');
 
     expect(controller).toContain('byId(Task.findById(req.params.id))');
-    expect(controller).toContain('req.task.set(req.permit(...FIELDS))');
+    // The one henri adds to a Mongoose document, because it is the call
+    // that puts the attributes back when the store refuses the write
+    expect(controller).toContain('req.task.update(req.permit(...FIELDS))');
     expect(controller).toContain('req.task.deleteOne()');
     expect(controller).toContain('CastError');
   });

--- a/packages/cli/scripts/generate/controllers.js
+++ b/packages/cli/scripts/generate/controllers.js
@@ -314,10 +314,13 @@ ${validationHelper(opts)}`,
       opts,
       `req.${opts.lower} = await byId(${opts.doc}.findById(req.params.id));`
     ),
+  // `update()` rather than `set()` then `save()`: henri adds it to a
+  // Mongoose document (Mongoose 7 removed its own), and it is the call
+  // that puts the attributes back when the store refuses the write, so
+  // the record this action still holds never carries a refused value
   update: (opts) => `
     try {
-      req.${opts.lower}.set(req.permit(...FIELDS));
-      await req.${opts.lower}.save();
+      await req.${opts.lower}.update(req.permit(...FIELDS));
     } catch (error) {
       ${invalidCall(opts, 'edit')}
     }

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -3218,6 +3218,13 @@ declare namespace start {
     save(...args: any[]): Promise<any>;
     get(...args: any[]): any;
     set(...args: any[]): any;
+    /**
+     * Sets the attributes and saves them. A write the store refuses puts
+     * them back, so the record is left holding the values it had -- see
+     * `guides/models.md` (`#what-a-record-holds-after-a-refused-write`).
+     * On Mongoose, where the ORM itself has no such method, henri adds it.
+     */
+    update(values: Record<string, any>, ...args: any[]): Promise<any>;
     toJSON(): Record<string, any>;
   }
 
@@ -3234,7 +3241,6 @@ declare namespace start {
 
   /** A record of an `mssql` store: a Sequelize instance. */
   interface SequelizeRecord extends RecordBase {
-    update(values: Record<string, any>, ...args: any[]): Promise<any>;
     destroy(...args: any[]): Promise<any>;
     reload(...args: any[]): Promise<any>;
     changed(...args: any[]): any;
@@ -3245,7 +3251,6 @@ declare namespace start {
 
   /** A record of a `drizzle`, `mysql`, `postgresql` or `mariadb` store. */
   interface DrizzleRecord extends RecordBase {
-    update(values: Record<string, any>, ...args: any[]): Promise<any>;
     destroy(...args: any[]): Promise<any>;
     reload(...args: any[]): Promise<any>;
     changed(): string[];

--- a/packages/drizzle/__tests__/validations.spec.js
+++ b/packages/drizzle/__tests__/validations.spec.js
@@ -22,6 +22,26 @@ const postModel = (validates) => ({
 });
 
 /**
+ * A model whose name is unique, so the database has a refusal of its own
+ *
+ * @param {object} [validates] The `validates` block
+ * @returns {object} The model file
+ */
+const noteModel = (validates) => ({
+  globalId: 'Note',
+  identity: 'note',
+  options: { timestamps: true },
+  schema: {
+    slug: { type: 'string', unique: true },
+    status: { enum: ['draft', 'live'], type: 'string' },
+    title: { required: true, type: 'string' },
+    views: { type: 'integer' },
+  },
+  store: 'default',
+  validates,
+});
+
+/**
  * The `{ field: message }` of a rejected write
  *
  * @param {Promise} promise The write
@@ -72,8 +92,8 @@ describe('validations on a drizzle store', () => {
     });
 
     test('on an instance update', async () => {
-      // One record per write: `instance.update()` is `set()` then
-      // `save()`, so a refused value is still on the instance afterwards
+      // One record per write, so the two refusals are independent of each
+      // other. What one of them leaves on the record is the block below
       expect(
         await errorsOf(
           (await Post.create({ title: 'one' })).update({ slug: 'no' })
@@ -253,6 +273,109 @@ describe('validations on a drizzle store', () => {
       expect(
         await errorsOf(Post.update({ title: 'here' }, { status: 'x' }))
       ).toEqual({ status: 'must be one of draft, live' });
+    });
+  });
+
+  describe('what the record holds after a write the store refused', () => {
+    // `update()` is `set()` then `save()`, so a refusal used to leave the
+    // value the store refused on the record and the next `update()` was
+    // measured against it (`packages/drizzle/model.js`, `rollbackOf()`)
+    let Note;
+    let adapter;
+
+    beforeAll(async () => {
+      ({ adapter } = build());
+      Note = adapter.addModel(
+        noteModel({ views: { max: 1000, min: 0 } }),
+        'user'
+      );
+      await adapter.start();
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('a rule of the validates block puts its value back', async () => {
+      const note = await Note.create({ title: 'a', views: 1 });
+
+      expect(await errorsOf(note.update({ views: 9000 }))).toEqual({
+        views: 'must be at most 1000',
+      });
+      expect(note.views).toBe(1);
+      expect(note.changed()).toEqual([]);
+    });
+
+    test('the schema’s own required and enum do too', async () => {
+      const note = await Note.create({ status: 'draft', title: 'b' });
+
+      expect(await errorsOf(note.update({ title: null }))).toEqual({
+        title: 'is required',
+      });
+      expect(note.title).toBe('b');
+      expect(await errorsOf(note.update({ status: 'gone' }))).toEqual({
+        status: 'must be one of draft, live',
+      });
+      expect(note.status).toBe('draft');
+      expect(note.changed()).toEqual([]);
+    });
+
+    test('and so does the unique index, the database refusing', async () => {
+      await Note.create({ slug: 'taken', title: 'c' });
+      const note = await Note.create({ slug: 'mine', title: 'd' });
+
+      expect(await errorsOf(note.update({ slug: 'taken' }))).toEqual({
+        slug: 'must be unique',
+      });
+      expect(note.slug).toBe('mine');
+      expect(note.changed()).toEqual([]);
+    });
+
+    test('so the next update is not measured against a refused value', async () => {
+      const note = await Note.create({ title: 'e', views: 1 });
+
+      await errorsOf(note.update({ views: 9000 }));
+      // The write that used to be refused for a field it never named
+      expect(await errorsOf(note.update({ title: 'renamed' }))).toBeNull();
+
+      const stored = await Note.findByKey(note.id);
+
+      expect([stored.title, stored.views]).toEqual(['renamed', 1]);
+    });
+
+    test('set() and save() are two steps and keep what was set', async () => {
+      const note = await Note.create({ title: 'f', views: 1 });
+
+      note.set({ views: 9000 });
+      expect(await errorsOf(note.save())).toEqual({
+        views: 'must be at most 1000',
+      });
+      // The one way to keep what a person typed after the store said no
+      expect(note.views).toBe(9000);
+    });
+
+    test('a failure that is not a refusal rolls nothing back', async () => {
+      const { adapter: other } = build();
+      const Broken = other.addModel(
+        {
+          ...noteModel(),
+          afterUpdate: () => {
+            throw new Error('the hook says no');
+          },
+        },
+        'user'
+      );
+
+      await other.start();
+
+      const note = await Broken.create({ title: 'g', views: 1 });
+
+      // The row moved before the hook ran, so the record keeps the value
+      // that is now stored rather than being put back over it
+      await expect(note.update({ views: 2 })).rejects.toThrow(
+        'the hook says no'
+      );
+      expect(note.views).toBe(2);
+      expect((await Broken.findByKey(note.id)).views).toBe(2);
+      await other.stop();
     });
   });
 

--- a/packages/drizzle/model.js
+++ b/packages/drizzle/model.js
@@ -194,6 +194,101 @@ const same = (left, right) => {
 };
 
 /**
+ * What a record holds after a write the store refused.
+ *
+ * `instance.update(attrs)` is `set()` then `save()`, and only the second
+ * half can fail -- a rule of the model's `validates` block, the `required`
+ * or `enum` of its schema, the unique index of the database. The set has
+ * already happened by then, so the value the store refused stays on the
+ * object in hand, and a controller that catches the failure and answers
+ * 422 goes on to render, log or write again from a record holding
+ * something no store ever accepted.
+ *
+ * The three adapters were measured before this was written and they
+ * agreed: drizzle here, mongoose (`set()` then `save()`) and sequelize
+ * (`instance.update()`, which is those same two steps) all kept the
+ * refused value on the record. Agreement is not a decision, though --
+ * what they agree on is what two other ORMs happen to do -- and what is
+ * underneath it is not agreement at all. A second `update()` on the same
+ * instance is measured against the stale value on drizzle and mongoose,
+ * so a write naming a different field entirely is refused for a field it
+ * never named; on sequelize that same second update **succeeds**, because
+ * Sequelize narrows the statement to the fields the call named, so the row
+ * keeps the old value while the object in hand keeps the refused one and
+ * nothing ever says so. One of those is a record that cannot be written
+ * to again and the other is a record that lies.
+ *
+ * So the rule, and it is the same sentence on all three: **a write the
+ * store refused puts back every attribute it set**. The record is left
+ * holding the values it had when the call started, and the next
+ * `update()` on it is measured against those.
+ *
+ * Three things it deliberately is not.
+ *
+ * It is **not a reload**. Nothing is read back: a refusal costs no query,
+ * and what goes back on the record is what the record held, not what the
+ * row holds now. A record another process moved in the meantime is as
+ * stale as it was before the call, which is the same thing every other
+ * read of a loaded record already promises.
+ *
+ * It is **not `set()` + `save()`**. Those are two steps because a caller
+ * wrote them as two, and the values live on the record between them on
+ * purpose -- it is the one way to keep what a person typed after the store
+ * refused it. `update()` is the one call that does both, so it is the one
+ * call that undoes both.
+ *
+ * It is **not every failure**, and the line is drawn where the framework
+ * already draws it: a refusal is what `henri.model.errors()` turns into
+ * `{ field: message }` -- here, this adapter's own `ValidationError`,
+ * which `translateError()` also builds out of a unique violation. A
+ * `beforeUpdate` hook that throws, a connection that drops, an
+ * `afterUpdate` hook that throws are not refusals and roll nothing back;
+ * the last one matters, because by then the row has moved and putting the
+ * record back would make it lie in the other direction. The hole that
+ * leaves is an `afterUpdate` hook whose own write is refused, which is a
+ * refusal raised after the row moved -- it is left, rather than closed
+ * with a per adapter "did the statement land" test, because a rule the
+ * three adapters cannot state the same way is not a rule.
+ *
+ * The database's own refusal -- the unique index, which henri does not
+ * pre-check on purpose (`./validations.js`) -- is rolled back the same
+ * way, and it can be: a single row `INSERT` or `UPDATE` is refused whole
+ * on every engine henri writes to, so there is no half-written row for
+ * the record to disagree with. What no rollback can give back is the
+ * value the caller asked for, and nothing tries: it is still in the
+ * `req.permit()` result they passed in.
+ *
+ * @param {Model} instance The instance a write is about to set on
+ * @param {*} attrs What the caller passed
+ * @returns {function} Puts those attributes back, called with nothing
+ */
+const rollbackOf = (instance, attrs) => {
+  // The fields `set()` is about to write, which is `Object.assign()`'s own
+  // answer: the own enumerable keys, and none at all for anything that is
+  // not an object
+  const kept =
+    attrs === null || typeof attrs !== 'object'
+      ? []
+      : Object.keys(attrs).map((field) => [
+          field,
+          Object.prototype.hasOwnProperty.call(instance, field),
+          instance[field],
+        ]);
+
+  return () => {
+    for (const [field, held, value] of kept) {
+      if (held) {
+        instance[field] = value;
+      } else {
+        // A field the record did not carry is taken off it again rather
+        // than left as an `undefined` the dirty tracking would report
+        delete instance[field];
+      }
+    }
+  };
+};
+
+/**
  * Splits `find(where, options)` and `find({ where, order, limit })`
  *
  * @param {function} Model The model
@@ -1890,17 +1985,31 @@ class Model {
   }
 
   /**
-   * Sets attributes and saves
+   * Sets attributes and saves. A write the store refuses puts them back:
+   * the record is left holding the values it had when the call started,
+   * so the next `update()` on it is not measured against a refused value
+   * (see `rollbackOf()` above for the whole argument).
    *
    * @param {object} attrs The attributes
    * @param {object} [options={}] Options
    * @returns {Promise<Model>} The instance
+   * @throws {ValidationError} When the attributes are invalid
    * @memberof Model
    */
   async update(attrs, options = {}) {
+    const rollback = rollbackOf(this, attrs);
+
     this.set(attrs);
 
-    return this.save(options);
+    try {
+      return await this.save(options);
+    } catch (error) {
+      if (error instanceof ValidationError) {
+        rollback();
+      }
+
+      throw error;
+    }
   }
 
   /**

--- a/packages/mongoose/__tests__/validations.spec.js
+++ b/packages/mongoose/__tests__/validations.spec.js
@@ -67,6 +67,45 @@ const boot = async (validates) => {
 };
 
 /**
+ * A model whose name is unique, so the database has a refusal of its own
+ *
+ * @param {object} [validates] The `validates` block
+ * @returns {object} The model file
+ */
+const noteModel = (validates) => ({
+  globalId: 'Note',
+  identity: 'note',
+  options: { timestamps: true },
+  schema: {
+    slug: { type: 'string', unique: true },
+    status: { enum: ['draft', 'live'], type: 'string' },
+    title: { required: true, type: 'string' },
+    views: { type: 'integer' },
+  },
+  store: 'default',
+  validates,
+});
+
+/**
+ * An adapter with the Note model on a database of its own
+ *
+ * @param {object} [validates] The `validates` block
+ * @returns {Promise<{adapter: object, Note: object}>} Both
+ */
+const bootNote = async (validates) => {
+  const adapter = new Mongoose(
+    'default',
+    { url: mongod.getUri(`validations${(sequence += 1)}`) },
+    fakeHenri()
+  );
+  const Note = adapter.addModel(noteModel(validates), 'user');
+
+  await adapter.start();
+
+  return { Note, adapter };
+};
+
+/**
  * The `{ field: message }` a controller would answer with
  *
  * @param {Promise} promise The write
@@ -286,6 +325,108 @@ describe('validations on a mongoose store', () => {
       await expect(
         Post.updateOne({ title: 'a' }, { $unset: { slug: '' } })
       ).resolves.toBeDefined();
+    });
+  });
+
+  describe('what the record holds after a write the store refused', () => {
+    // Mongoose 7 removed `Document.prototype.update`, so henri adds the
+    // one call the other two adapters have (`plugins.js`, `updating()`),
+    // and with it the rule they now share: a write the store refused puts
+    // back every attribute it set. The argument is written down once, in
+    // `@usehenri/drizzle`'s `model.js` above `rollbackOf()`
+    let Note;
+    let adapter;
+
+    beforeAll(async () => {
+      ({ Note, adapter } = await bootNote({ views: { max: 1000, min: 0 } }));
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('the document has update(), the way the other two do', async () => {
+      const note = await Note.create({ slug: 'has-one', title: 'a' });
+
+      expect(typeof note.update).toBe('function');
+      await note.update({ title: 'renamed' });
+      expect((await Note.findByKey(note.id)).title).toBe('renamed');
+    });
+
+    test('a rule of the validates block puts its value back', async () => {
+      const note = await Note.create({ slug: 'rule', title: 'b', views: 1 });
+
+      expect(await errorsOf(note.update({ views: 9000 }))).toEqual({
+        views: 'must be at most 1000',
+      });
+      expect(note.views).toBe(1);
+      expect(note.modifiedPaths()).toEqual([]);
+    });
+
+    test('the schema’s own required and enum do too', async () => {
+      const note = await Note.create({
+        slug: 'schema',
+        status: 'draft',
+        title: 'c',
+      });
+
+      expect(await errorsOf(note.update({ title: null }))).toEqual({
+        title: 'is required',
+      });
+      expect(note.title).toBe('c');
+      expect(await errorsOf(note.update({ status: 'gone' }))).toEqual({
+        status: 'must be one of draft, live',
+      });
+      expect(note.status).toBe('draft');
+      expect(note.modifiedPaths()).toEqual([]);
+    });
+
+    test('and so does the unique index, the database refusing', async () => {
+      await Note.create({ slug: 'taken', title: 'd' });
+      const note = await Note.create({ slug: 'mine', title: 'e' });
+
+      expect(await errorsOf(note.update({ slug: 'taken' }))).toEqual({
+        slug: 'must be unique',
+      });
+      expect(note.slug).toBe('mine');
+      // `updatedAt` is Mongoose's own stamp for a save that reached the
+      // driver before it was refused, not an attribute the call set; the
+      // next save writes the time again whatever this one left behind
+      expect(note.modifiedPaths()).not.toContain('slug');
+    });
+
+    test('so the next update is not measured against a refused value', async () => {
+      const note = await Note.create({ slug: 'next', title: 'f', views: 1 });
+
+      await errorsOf(note.update({ views: 9000 }));
+      expect(await errorsOf(note.update({ title: 'renamed' }))).toBeNull();
+
+      const stored = await Note.findByKey(note.id);
+
+      expect([stored.title, stored.views]).toEqual(['renamed', 1]);
+    });
+
+    test('set() and save() are two steps and keep what was set', async () => {
+      const note = await Note.create({ slug: 'two-steps', title: 'g' });
+
+      note.set({ views: 9000 });
+      expect(await errorsOf(note.save())).toEqual({
+        views: 'must be at most 1000',
+      });
+      // The one way to keep what a person typed after the store said no
+      expect(note.views).toBe(9000);
+    });
+
+    test('a failure that is not a refusal rolls nothing back', async () => {
+      const note = await Note.create({ slug: 'gone', title: 'h', views: 1 });
+
+      await Note.deleteOne({ _id: note.id });
+
+      // The document is not there any more, which Mongoose answers with a
+      // DocumentNotFoundError: a failure, but not the store refusing a
+      // value, so nothing is put back
+      await expect(note.update({ views: 2 })).rejects.toThrow(
+        /No document found/u
+      );
+      expect(note.views).toBe(2);
     });
   });
 

--- a/packages/mongoose/index.js
+++ b/packages/mongoose/index.js
@@ -7,6 +7,7 @@ const {
   paginate,
   paranoid,
   slugged,
+  updating,
   validations,
 } = require('./plugins');
 const { validationsOf } = require('./validations');
@@ -277,6 +278,9 @@ class Mongoose {
     owned(schema, this.henri);
     paginate(schema);
     lookups(schema);
+    // `doc.update(attrs)`, which Mongoose itself dropped in 7, and the
+    // rollback of a write the store refused (./plugins.js)
+    updating(schema);
 
     // Before every other hook, so what a rule measures is the value the
     // application wrote rather than an envelope. A declaration henri

--- a/packages/mongoose/plugins.js
+++ b/packages/mongoose/plugins.js
@@ -226,6 +226,87 @@ const toInt = (value, fallback) => {
   return Number.isFinite(number) && number > 0 ? number : fallback;
 };
 
+// The MongoDB duplicate key error, whatever the driver calls it. It is
+// the other half of what `henri.model.errors()` calls a refused write
+// (`base/model-errors.js`), and the only half Mongoose does not name.
+const DUPLICATE_KEY = 11000;
+
+/**
+ * Is this the store refusing the write, rather than something else going
+ * wrong? The same question `henri.model.errors()` answers on every
+ * adapter, asked here because an adapter reaches for no part of core.
+ *
+ * @param {*} error What the write threw
+ * @returns {boolean} true for a validation failure or a duplicate key
+ */
+const refused = (error) =>
+  Boolean(error) &&
+  (error.name === 'ValidationError' ||
+    error.code === DUPLICATE_KEY ||
+    Boolean(error.cause && error.cause.code === DUPLICATE_KEY));
+
+/**
+ * Adds `doc.update(attrs)`: set the attributes and save, and put them back
+ * when the store refuses the write.
+ *
+ * Mongoose 7 removed `Document.prototype.update`, so this document had
+ * nothing but `set()` then `save()` while the other two adapters had one
+ * call -- and the models guide tells an application to write
+ * `article.update({ ... })` in the two places it explains a mass write
+ * that henri refuses. This is that call, on this adapter, spelled the way
+ * it is on the other two.
+ *
+ * The rollback is henri's rule and it is the same sentence on all three;
+ * the whole argument is written down once, in `@usehenri/drizzle`'s
+ * `model.js` above `rollbackOf()`. What is put back is each attribute the
+ * call named and whether the document had it marked modified, and only
+ * when the store refused: a `post('save')` hook that throws is not a
+ * refusal, and by then the document is written.
+ *
+ * @param {object} schema The Mongoose schema
+ * @returns {object} The schema
+ */
+const updating = (schema) => {
+  /**
+   * Sets attributes and saves, putting them back when the store refuses
+   *
+   * @param {object} attrs The attributes
+   * @param {object} [options={}] `save()` options (`unsafe` for the roles)
+   * @returns {Promise<object>} The document
+   */
+  schema.methods.update = async function updateOrRollBack(attrs, options = {}) {
+    // The own enumerable keys, which is what `set()` writes as well
+    const kept =
+      attrs === null || typeof attrs !== 'object'
+        ? []
+        : Object.keys(attrs).map((field) => [
+            field,
+            this.get(field),
+            this.isModified(field),
+          ]);
+
+    this.set(attrs);
+
+    try {
+      return await this.save(options);
+    } catch (error) {
+      if (refused(error)) {
+        for (const [field, value, modified] of kept) {
+          this.set(field, value);
+
+          if (!modified) {
+            this.unmarkModified(field);
+          }
+        }
+      }
+
+      throw error;
+    }
+  };
+
+  return schema;
+};
+
 /**
  * Adds `Model.paginate()`: one call for a page of documents and the
  * counters `res.collection()` wants
@@ -837,5 +918,6 @@ module.exports = {
   paranoid,
   slugged,
   updateValues,
+  updating,
   validations,
 };

--- a/packages/sequelize/__tests__/validations.spec.js
+++ b/packages/sequelize/__tests__/validations.spec.js
@@ -28,6 +28,26 @@ const postModel = (validates) => ({
 });
 
 /**
+ * A model whose name is unique, so the database has a refusal of its own
+ *
+ * @param {object} [validates] The `validates` block
+ * @returns {object} The model file
+ */
+const noteModel = (validates) => ({
+  globalId: 'Note',
+  identity: 'note',
+  options: { timestamps: true },
+  schema: {
+    slug: { type: 'string', unique: true },
+    status: { enum: ['draft', 'live'], type: 'string' },
+    title: { required: true, type: 'string' },
+    views: { type: 'integer' },
+  },
+  store: 'default',
+  validates,
+});
+
+/**
  * The `{ field: message }` a controller would answer with
  *
  * @param {Promise} promise The write
@@ -228,6 +248,107 @@ describe('validations on a sequelize store', () => {
         Post.increment('rank', { by: 1, where: { id: post.id } })
       ).resolves.toBeDefined();
       await adapter.stop();
+    });
+  });
+
+  describe('what the record holds after a write the store refused', () => {
+    // Sequelize's `instance.update()` is `set()` then `save()` like the
+    // other two, so a refusal used to leave the value the store refused on
+    // the record. The rule and the argument are in `@usehenri/drizzle`'s
+    // `model.js`, above `rollbackOf()`
+    let Note;
+    let adapter;
+
+    beforeAll(async () => {
+      ({ adapter } = build());
+      Note = adapter.addModel(
+        noteModel({ views: { max: 1000, min: 0 } }),
+        'user'
+      );
+      await adapter.start();
+    });
+
+    afterAll(() => adapter.stop());
+
+    test('a rule of the validates block puts its value back', async () => {
+      const note = await Note.create({ title: 'a', views: 1 });
+
+      expect(await errorsOf(note.update({ views: 9000 }))).toEqual({
+        views: 'must be at most 1000',
+      });
+      expect(note.views).toBe(1);
+      expect(note.changed()).toBe(false);
+    });
+
+    test('the schema’s own required and enum do too', async () => {
+      const note = await Note.create({ status: 'draft', title: 'b' });
+
+      expect(await errorsOf(note.update({ title: null }))).toEqual({
+        title: 'is required',
+      });
+      expect(note.title).toBe('b');
+      expect(await errorsOf(note.update({ status: 'gone' }))).toEqual({
+        status: 'must be one of draft, live',
+      });
+      expect(note.status).toBe('draft');
+      expect(note.changed()).toBe(false);
+    });
+
+    test('and so does the unique index, the database refusing', async () => {
+      await Note.create({ slug: 'taken', title: 'c' });
+      const note = await Note.create({ slug: 'mine', title: 'd' });
+
+      expect(await errorsOf(note.update({ slug: 'taken' }))).toEqual({
+        slug: 'slug must be unique',
+      });
+      // The one the three adapters used to disagree about: Sequelize
+      // narrows the statement to the fields the call named, so the next
+      // update wrote the row while the record kept saying `taken`
+      expect(note.slug).toBe('mine');
+      expect(note.changed()).toBe(false);
+    });
+
+    test('so the next update is not measured against a refused value', async () => {
+      const note = await Note.create({ title: 'e', views: 1 });
+
+      await errorsOf(note.update({ views: 9000 }));
+      expect(await errorsOf(note.update({ title: 'renamed' }))).toBeNull();
+
+      const stored = await Note.findByPk(note.id);
+
+      expect([stored.title, stored.views]).toEqual(['renamed', 1]);
+    });
+
+    test('set() and save() are two steps and keep what was set', async () => {
+      const note = await Note.create({ title: 'f', views: 1 });
+
+      note.set({ views: 9000 });
+      expect(await errorsOf(note.save())).toEqual({
+        views: 'must be at most 1000',
+      });
+      // The one way to keep what a person typed after the store said no
+      expect(note.views).toBe(9000);
+    });
+
+    test('a failure that is not a refusal rolls nothing back', async () => {
+      const { adapter: other } = build();
+      const Broken = other.addModel(noteModel(), 'user');
+
+      Broken.addHook('afterUpdate', () => {
+        throw new Error('the hook says no');
+      });
+      await other.start();
+
+      const note = await Broken.create({ title: 'g', views: 1 });
+
+      // The row moved before the hook ran, so the record keeps the value
+      // that is now stored rather than being put back over it
+      await expect(note.update({ views: 2 })).rejects.toThrow(
+        'the hook says no'
+      );
+      expect(note.views).toBe(2);
+      expect((await Broken.findByPk(note.id)).views).toBe(2);
+      await other.stop();
     });
   });
 

--- a/packages/sequelize/index.js
+++ b/packages/sequelize/index.js
@@ -9,6 +9,7 @@ const {
   lookup,
   paginate,
   publicId,
+  restoring,
   slugged,
   validations,
 } = require('./plugins');
@@ -335,7 +336,9 @@ class Sql {
     this.nameUniqueConstraints(attributes, model);
 
     const instance = lookup(
-      paginate(connector.define(model.globalId, attributes, options)),
+      restoring(
+        paginate(connector.define(model.globalId, attributes, options))
+      ),
       external,
       this.henri,
       declaredSlug

--- a/packages/sequelize/plugins.js
+++ b/packages/sequelize/plugins.js
@@ -45,6 +45,75 @@ const toInt = (value, fallback) => {
 };
 
 /**
+ * `instance.update()` that puts back what it set when the store refuses
+ * the write.
+ *
+ * The rule is henri's and is the same sentence on all three adapters; the
+ * whole argument for it is written down once, in `@usehenri/drizzle`'s
+ * `model.js` above `rollbackOf()`. In short: `update()` is `set()` then
+ * `save()`, so a refused write used to leave the value the store refused
+ * sitting on the record, and a controller answering 422 rendered, logged
+ * or wrote again from it. A refusal is what `henri.model.errors()` turns
+ * into `{ field: message }`, which here is Sequelize's own
+ * `ValidationError` -- `SequelizeUniqueConstraintError` extends it, so the
+ * index's refusal is covered by the same test.
+ *
+ * Sequelize's own `update()` is those two steps too, and it is wrapped
+ * rather than rewritten: `options.fields`, the transaction it picks up and
+ * everything else the call decides stay Sequelize's. What is put back is
+ * `dataValues` and the dirty flag of each attribute the call named --
+ * `dataValues` rather than `get()`, so an encrypted column goes back as
+ * the envelope it was stored as rather than through its getter.
+ *
+ * @param {object} Model A Sequelize model
+ * @returns {object} The model
+ */
+const restoring = (Model) => {
+  const update = Model.prototype.update;
+
+  /**
+   * Sets attributes and saves, putting them back when the store refuses
+   *
+   * @param {object} values The attributes
+   * @param {object} [options] The options
+   * @returns {Promise<object>} The instance
+   */
+  Model.prototype.update = async function updateOrRollBack(values, options) {
+    // The own enumerable keys, which is what Sequelize's `update()` reads
+    // out of `values` as well
+    const kept =
+      values === null || typeof values !== 'object'
+        ? []
+        : Object.keys(values).map((field) => [
+            field,
+            Object.prototype.hasOwnProperty.call(this.dataValues, field),
+            this.dataValues[field],
+            this.changed(field),
+          ]);
+
+    try {
+      return await update.call(this, values, options);
+    } catch (error) {
+      if (error instanceof ValidationError) {
+        for (const [field, held, value, dirty] of kept) {
+          if (held) {
+            this.dataValues[field] = value;
+          } else {
+            delete this.dataValues[field];
+          }
+
+          this.changed(field, dirty);
+        }
+      }
+
+      throw error;
+    }
+  };
+
+  return Model;
+};
+
+/**
  * Adds `Model.paginate()`: one call for a page of rows and the counters
  * `res.collection()` wants
  *
@@ -570,4 +639,11 @@ const validations = (Model, rules) => {
   return Model;
 };
 
-module.exports = { lookup, paginate, publicId, slugged, validations };
+module.exports = {
+  lookup,
+  paginate,
+  publicId,
+  restoring,
+  slugged,
+  validations,
+};

--- a/website/src/content/docs/guides/models.md
+++ b/website/src/content/docs/guides/models.md
@@ -174,6 +174,42 @@ for (const post of await Post.find({ status: 'draft' })) {
 
 The refusal is measured against the fields the write actually names, so a mass update that does not touch the validated field goes through, and so does a soft delete. A rule that only reads its value takes one parameter and never refuses anything.
 
+### What a record holds after a refused write
+
+`record.update(attrs)` sets the attributes and saves them, and only the second half can fail. So the obvious question is what the record in your hand holds once it has:
+
+```js
+try {
+  await post.update(req.permit('title', 'views'));
+} catch (error) {
+  // post.views — the value the store just refused, or the one it holds?
+}
+```
+
+**It holds the values it had before the call.** A write the store refused puts back every attribute it set, on all three adapters, so the record a controller still has after a 422 is the record as it is stored — safe to render, to log, and to write to again.
+
+That last one is the reason. Before this rule, the refused value stayed on the record and the _next_ `update()` was measured against it, so a second write naming a different field entirely was refused for a field it never named — and on the Sequelize path it was not refused at all, because Sequelize narrows the statement to the fields the call named, so the row kept the old value while the record went on saying the refused one. A record that cannot be written to again and a record that lies, from the same line of code.
+
+A refusal here means what [`henri.model.errors()`](#validation-errors) means: a rule of `validates`, the schema's own `required` or `enum`, and the unique index — the database's refusal is put back the same way, because a single-row `INSERT` or `UPDATE` is refused whole and there is no half-written row for the record to disagree with. Anything else — a hook of yours that throws, a connection that drops — is not a refusal and puts nothing back; that matters for an `afterUpdate` hook in particular, because by then the row has moved and the record should say so.
+
+Three things this deliberately is not:
+
+- **It is not a reload.** Nothing is read back, a refusal costs no query, and what goes back on the record is what the record held. A row another process moved in the meantime is exactly as stale as it was before the call.
+- **It is not the value you asked for.** `post.views` after the refusal is what is stored. What the person typed is still in the `req.permit()` result you passed in, which is where a form repopulates from.
+- **It is not `set()` + `save()`.** Those are two steps because you wrote two, and the values stay on the record between them on purpose — it is the way to keep what a person typed on the record itself:
+
+  ```js
+  post.set(req.permit('title', 'views'));
+
+  try {
+    await post.save();
+  } catch (error) {
+    // post.views is what they typed, and the form can be built from it
+  }
+  ```
+
+On a `mongoose` or `disk` store, `record.update()` is henri's own: Mongoose removed `Document.prototype.update` in version 7, and `set()` then `save()` was the only spelling. It is back, it means the same thing it means on the other two, and it is what the generated controllers write.
+
 ### What henri does not check
 
 - **`unique` is not a validation, and henri does not pretend otherwise.** A `SELECT` before an `INSERT` answers a question about a moment that has already passed: two requests both find nothing and both write. The unique index is what actually holds, so the database refuses the second one and `henri.model.errors()` turns that refusal into `{ field: 'must be unique' }` — [the same shape](#validation-errors) as everything above. What you give up is the message arriving before the round trip; what you get is a guarantee rather than a near-miss.


### PR DESCRIPTION
## The gap

`CLAUDE.md` carried this under the validations tranche as **"Separate from the above and not fixed"**:

> on the drizzle adapter `instance.update(attrs)` is `set()` then `save()`, so a write refused by a validation leaves the refused value on the in-memory instance and the next `update()` on that same instance is measured against it.

A controller does `await record.update(req.permit(...))`, catches the failure, answers 422 — and the object it still holds now carries the value the database refused. Anything that then reads it, renders it, logs it, or writes it again is working from a value that was never accepted.

## What the measurement changed

The plan was to check all three adapters first, because if they already agreed the honest fix was to write the rule down rather than make one differ. They only *look* like they agree:

| | drizzle | sequelize | mongoose |
| --- | --- | --- | --- |
| `validates` refusal keeps the refused value | yes | yes | yes |
| `required` / `enum` refusal keeps it | yes | yes | yes |
| `unique` refusal (the database) keeps it | yes | yes | yes |
| second `update()` naming another field | refused | refused | refused |
| second `update()` after a `unique` refusal | refused | **succeeds** | refused |

On Sequelize the second write **succeeds**, because it narrows `options.fields` to the keys the call named: the row keeps the old value, the object keeps the refused one, and nothing ever says so. Drizzle and mongoose give you a stuck record; Sequelize gives you a lying one. That asymmetry is what ruled out "document it and move on".

The second finding is worse in its way: **`instance.update()` does not exist on mongoose at all.** Mongoose removed `Document.prototype.update`, and `guides/models.md` told applications to write `await post.update({ status: 'live' })` in two explicitly cross-adapter passages. The generated mongoose controller quietly worked around it with `set()` + `save()`.

## What this does

**A write the store refused puts back every attribute it set**, on all three adapters, with the argument in the header above `rollbackOf()` in `packages/drizzle/model.js`.

- "Validate before setting" was rejected: it cannot cover the `unique` refusal, which henri deliberately does not pre-check, so one `catch` would leave two different post-conditions.
- **The line for "refused" is `henri.model.errors()`** — the repository's existing cross-adapter definition of a refusal, asked in each adapter's own vocabulary. That is what keeps a failure *after* the row moved from rolling the record back over a stored change.
- **`set()` + `save()` stays two steps and keeps what you set.** It is the seam for holding on to what a person typed, and the guide says so.
- The `unique` case rolls back too, because a single-row write is refused whole on every engine henri writes to — there is no half-written row for the record to disagree with.
- `doc.update(attrs, options)` is **added to mongoose**, which is the call the guide already documented, and `henri generate scaffold|crud` writes it into the mongoose controller instead of `set()` + `save()`.

**One hole is left open deliberately and written into the header**: an `afterUpdate` hook whose own write is refused raises a refusal after the row moved, and the record is rolled back over it. Closing it needs a per-adapter "did the statement land" test that Sequelize cannot express publicly, and a rule the three cannot state the same way is not a rule.

## What I checked myself before merging

I wrote the invariant a different way than the tranche's own tests do — not "the attribute is back to what the test remembers", but **the record agrees with a fresh read of the row** — and ran it on sqlite and on live PostgreSQL:

```
✓ a validation refusal leaves the record agreeing with the row
✓ a unique refusal, which is the database and not henri
✓ a write that succeeded is not rolled back
✓ the second update after a refusal writes only what it names
```

The same four against **master's `model.js`**, to be sure they are not vacuous:

```
× expected { title: 'Moved', views: 5000 } to deeply equal { title: 'Kept', views: 10 }
× expected 'taken' to be 'mine'
× the second update after a refusal writes only what it names
✓ a write that succeeded is not rolled back
```

And the mongoose claim, on the installed driver:

```
mongoose 9.9.5
Document.prototype.update: undefined
Document.prototype.set: function
```

against `guides/models.md:171` on master — `await post.update({ status: 'live' })`, in a passage that says it holds on every adapter. It threw a `TypeError` there.

## Gates

`pnpm test` 228 files / 4823 passed · `pnpm test:types` ok · `pnpm lint --max-warnings 0` clean · `pnpm format:check` clean · `scripts/smoke.sh` exit 0, `henri audit` clean in 56 checks · drizzle + sequelize + jobs against live PostgreSQL 921 passed.