### PR TITLE
A tenant on the queue row and on the version, and the runner enters it

### DIFF
--- a/.changeset/tenanted-jobs-and-versions.md
+++ b/.changeset/tenanted-jobs-and-versions.md
@@ -1,0 +1,46 @@
+---
+'@usehenri/core': minor
+'@usehenri/jobs': minor
+'@usehenri/cli': minor
+---
+
+The queue and the version table know which tenant a row belongs to.
+
+`henri_jobs` gains a `tenant` column. `henri.jobs.perform()` stamps the tenant
+of the request or job it was called from, the way `henri.webhooks.emit()`
+already defaults its `owner`, and **the runner enters that tenant before it
+calls `perform()`** — so a job that touches a tenanted model no longer needs a
+first line putting the tenant back, and forgetting it is no longer a job that
+dies in the dead letter queue. A row with no tenant enters no scope, because
+null is not every tenant: a recurring occurrence, a job enqueued from a script,
+one enqueued with `tenant: null` and every row that predates the column all
+behave exactly as they did. Naming a different tenant while one is in scope is
+`HENRI_TENANT_CROSS_WRITE`. `henri jobs:list --tenant`, `jobs:dead`,
+`jobs:retry --all`, `jobs:discard --all` and `jobs:perform` take it, `jobs:show`
+prints it and every `--json` job carries it. A batch carries the tenant it was
+made in, so its callback is performed there too.
+
+`henri_versions` gains one as well, read off the record's own tenant column
+rather than off the scope, so a sweep running across every customer still names
+the right one. `henri.versions.list()`, `count()`, `of()` and `get()` are
+narrowed to the tenant in scope and **refused** (`HENRI_TENANT_REQUIRED`) when
+there is none — a table of everybody's old values is read the way a tenanted
+model is. `restore()` on a record that is _gone_ creates it, and a create is
+stamped with the tenant in scope, so restoring another tenant's version (or one
+written before the column existed) is `HENRI_VERSION_CROSS_TENANT` rather than
+that record quietly appearing here. `henri versions`, `versions:show` and
+`versions:restore` run across every tenant like the operator commands they are,
+take `--tenant`, and reify as the tenant the row names.
+
+`henri privacy:export`, `henri privacy:erase` and `henri retention:sweep` now
+walk the models inside `henri.tenancy.unscoped()`. They were unusable on a
+tenanted model before this: from a command line there is no tenant in scope, so
+the first model call raised `HENRI_TENANT_REQUIRED`.
+
+**An application with no `config.tenancy` is unaffected**: no column is asked
+for, nothing is stamped, nothing is narrowed and there is no boot line. Both
+columns arrive through the tolerated `ALTER` of the idempotent install, and both
+stores ask the table rather than trusting it ran — so an application that turned
+tenancy on and whose table cannot hold the column fails the boot naming it
+(`HENRI_JOB_TENANT_UNINSTALLED`, `HENRI_VERSION_TENANT_UNINSTALLED`) instead of
+writing rows nothing can scope. For most people the upgrade is the next deploy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -928,7 +928,20 @@ model }` or Mongoose's `ref` -- which `res.render()`, `res.resource()`,
   user model **cannot** be marked. Around it: the idempotency keys are
   scoped by tenant, `henri.webhooks.emit()` defaults its `owner` to the
   tenant in scope, and `henri audit` gained `tenancy.header-from-any` and
-  `tenancy.unmarked-model`. The guide is `guides/multi-tenancy.md`.
+  `tenancy.unmarked-model`. **`henri_jobs` and `henri_versions` carry a
+  `tenant` column**: `henri.jobs.perform()` stamps the tenant in scope and
+  the runner enters it around `perform()` (a null tenant enters none --
+  null is not every tenant), and a version names the tenant of the
+  **record** it is about, read off the record so a sweep running
+  `unscoped()` still names the right one. `henri.versions` reads are
+  narrowed and refused the way a tenanted model's are; `restore()` of a
+  record that is gone _creates_ one, so across the boundary it is
+  `HENRI_VERSION_CROSS_TENANT`. henri's own sweeps say `unscoped()` out
+  loud (`Privacy#everywhere`, `Retention#everywhere`) -- an erasure is
+  about a person and a retention rule is about a table, and both were
+  raising `HENRI_TENANT_REQUIRED` from a command line before that.
+  `Tenancy#columnFor(name)` is the accessor a caller that is not an adapter
+  asks. The guide is `guides/multi-tenancy.md`.
 - Personal data lives in `3.privacy.js` (`henri.privacy`), `base/privacy.js`
   and `base/erasure.js`. A model marks a field in the schema
   (`name: { personal: true, type: 'string' }`, or
@@ -1118,9 +1131,27 @@ duration, rows, requestId, source, callsite }` -- and the N+1 detector is
   without instances, so recording nothing for a hundred rows would make the
   history lie; the refusal names the loop, `{ versions: false }` is the way
   through, and henri's own sweeps use it. Each adapter has a `versions.js`
-  (the wiring) the way each has an `encryption.js`. `henri versions`,
-  `versions:show` and `versions:restore` read it back, and the guide is
-  `guides/versions.md`.
+  (the wiring) the way each has an `encryption.js`. **A row carries the
+  `tenant` of the record it is about** when `config.tenancy` is on, read
+  off the record's own column (`Versions#tenantOf`) and not off the scope,
+  so a sweep running `unscoped()` names the right one and a shared model
+  names none. `list`/`count`/`of` are narrowed to the tenant in scope and
+  **refused** without one (`Versions#scope`, `HENRI_TENANT_REQUIRED`), a
+  scoped read taking the null rows with it because that is what a shared
+  model's history and every pre-upgrade row look like; `get()` answers
+  `null` for another tenant's row (`findById()`'s non-oracle); and
+  `restore()` of a record that is **gone** is a create, so it refuses
+  across the boundary (`Versions#restorable`,
+  `HENRI_VERSION_CROSS_TENANT`) while an update never needs to. The column
+  arrives through an upgrade block this file did not have before (`ADDED`,
+  `upgrade()`, tolerated by `SqlVersions#install`, probed by `tenanted()`),
+  and a multi-tenant application whose table cannot hold it fails the boot
+  (`HENRI_VERSION_TENANT_UNINSTALLED`). `henri versions`,
+  `versions:show` and `versions:restore` read it back -- across every
+  tenant (`unscoped()`, an operator holds the database), `--tenant`
+  narrowing them, and the last two reifying **as the tenant the row
+  names**, which is what makes a restore work at all on a tenanted model.
+  The guide is `guides/versions.md`.
 - Encrypted attributes live in `1.encryption.js` (`henri.encryption`,
   runlevel 1, so a model that declares one finds a keyring already built),
   `base/encryption.js` (the envelope) and `base/rewrap.js` (the rotation
@@ -1348,12 +1379,28 @@ still holds this runner's claim token and is terminal)` -- so the counter
   (`batch_id`) and its table (`henri_jobs_batches`) arrive through the same
   tolerated `ALTER` inside the idempotent install, and `batch()` on a store
   that has neither is `HENRI_JOB_BATCH_UNINSTALLED` rather than a counter
-  nothing can hold. `henri.jobs.recur(name, entry)` is the seam a
+  nothing can hold. **A job carries the tenant it was enqueued in**
+  (`tenant`, the third column to arrive through that same tolerated
+  `ALTER`, and `SqlStore#tenanted()` asks the table for it): `perform()`
+  stamps `henri.tenancy.current()` the way `emit()` defaults its `owner`,
+  an explicit `tenant` wins (a _different_ one while a tenant is in scope
+  is `HENRI_TENANT_CROSS_WRITE`), and **the runner enters that tenant
+  before it calls `perform()`** (`Jobs#scoped`, inside `invoke()` so it
+  covers the one call that touches the models). A row with no tenant enters
+  none, deliberately: a recurring occurrence, a script, `tenant: null` and
+  every pre-upgrade row keep the refusal they had. A batch's tenant rides
+  in `callback_options`, which is already stored and already handed to
+  `perform()`, so no second table needs the column. The claim is **not**
+  narrowed by tenant -- a runner per customer is a scheduling feature --
+  and an application with `config.tenancy` on whose table has no column
+  fails the boot (`HENRI_JOB_TENANT_UNINSTALLED`).
+  `henri.jobs.recur(name, entry)` is the seam a
   framework module uses to ask for a schedule the configuration did not
   write (`henri.retention` is the one that does); an entry the application
   declared under the same name wins. `henri jobs` runs a worker (`--queue`,
   `--concurrency`, `--once`), `henri jobs:install|status|list|batches|dead|
-show|perform|retry|discard` drive it; `jobs:status` and
+show|perform|retry|discard` drive it (`--tenant` on the last five, and
+  every `--json` job carries one); `jobs:status` and
   `henri.jobs.limits()` report the limits and the slots held, and
   `henri.jobs.batches.*` the batches. The module also registers
   `henri.mailers.onDeliverLater()`, so `deliverLater()` enqueues the rendered
@@ -2258,15 +2305,33 @@ model` gained `status:string:enum=draft,live` in the CLI tranche below,
   real request -- the middleware mounted after passport, the mismatch 404
   and the refused sign-in -- is
   `packages/core/src/__tests__/tenancy-http.spec.js`, which boots the demo
-  application with `HENRI_CONFIG_JSON__tenancy`. MSSQL rides the
-  Sequelize wiring and has **no coverage of its own**: the rest of that
-  adapter runs against a real SQL Server now
+  application with `HENRI_CONFIG_JSON__tenancy`. The **model** wiring on
+  MSSQL rides the Sequelize adapter and has **no coverage of its own**:
+  the rest of that adapter runs against a real SQL Server now
   (`pnpm test:sql:mssql`), but there is no Sequelize tenancy suite for it
-  to point at. What was **deliberately left**: `henri_jobs` carries no `tenant`
-  column, so a job's tenant travels in its arguments and
-  `henri jobs:list --tenant` does not exist -- the queue's tables are
-  `CREATE TABLE IF NOT EXISTS` with no migration path, so adding a column
-  would break an upgrade; `henri_versions` is shared for the same reason;
+  to point at -- the queue's tenant column is covered there, and the models
+  are not. The **queue and the version table were the two known gaps
+  and are closed**: both carry a `tenant` column, proved by
+  `packages/jobs/__tests__/tenancy.spec.js` (sqlite offline plus the live
+  PostgreSQL and MySQL: the stamp, the cross-write refusal, the listing,
+  `retryAll`/`discardAll`, the scope the runner enters, two tenants
+  overlapping in one process, the batch callback, and a downgraded table
+  for the upgrade) -- **and on SQL Server**, since that file is in the
+  `jobs` project `pnpm test:sql:mssql` runs, which makes the queue the one
+  tenancy surface that adapter covers -- and by a `tenants` block in
+  `packages/jobs/__tests__/mongo.spec.js`, and by
+  `packages/drizzle/__tests__/versions-tenancy.spec.js` (the same targets:
+  the write, the scoped read, the refusal without a tenant, `get()`
+  answering null, the restore refusals, the boot refusal with the probe
+  forced false, and the pre-upgrade rows). What is **still deliberately
+  left**: no runner per tenant (the claim is not narrowed -- one customer's
+  backlog getting a runner of its own is scheduling, with a fairness
+  question attached); no per-tenant retention period or prune, since
+  `versions.keep`, `jobs.keepCompleted`, `calls.keep` and `trail.keep` are
+  one number for the application and the sweeps run across every tenant;
+  no backfill of the rows either upgrade left behind, because a job's
+  tenant is not recoverable at all and a version's is an `UPDATE` from the
+  records it names that only the application can write (the guide has it);
   the trail and the call log are shared **on purpose** (operator records,
   one hash chain, and an admin page built over them is the application's own
   cross-tenant view to scope); the flag store is shared and a per-tenant

--- a/packages/cli/__tests__/jobs.spec.js
+++ b/packages/cli/__tests__/jobs.spec.js
@@ -230,6 +230,43 @@ describe('henri jobs', () => {
       expect(jobs.result.jobs).toEqual([]);
     });
 
+    test('carries a tenant through the enqueue, the listing and the show', () => {
+      // This application is not multi-tenant, so nothing is stamped on its
+      // own -- what is proved here is the plumbing: the flag reaches the
+      // column, the column reaches the filter, and the filter is a filter
+      const enqueued = run([
+        'jobs',
+        'perform',
+        'ping',
+        '{"of":"acme"}',
+        '--tenant',
+        'acme',
+      ]);
+
+      expect(enqueued.status).toBe(0);
+      expect(enqueued.result.job.tenant).toBe('acme');
+
+      const mine = run(['jobs:list', '--tenant', 'acme']);
+
+      expect(mine.status).toBe(0);
+      expect(mine.result.jobs.map((job) => job.id)).toEqual([
+        enqueued.result.job.id,
+      ]);
+
+      // Another tenant's listing does not carry it, and neither does a
+      // tenant nothing was enqueued for
+      expect(run(['jobs:list', '--tenant', 'globex']).result.jobs).toEqual([]);
+
+      const shown = run(['jobs', 'show', enqueued.result.job.id]);
+
+      expect(shown.result.job.tenant).toBe('acme');
+
+      expect(
+        run(['jobs:discard', '--all', '--state=pending', '--tenant=acme'])
+          .status
+      ).toBe(0);
+    });
+
     test('drives the dead letter queue', () => {
       expect(run(['jobs', 'perform', 'boom']).status).toBe(0);
       expect(run(['jobs', '--once']).status).toBe(0);

--- a/packages/cli/__tests__/versions.spec.js
+++ b/packages/cli/__tests__/versions.spec.js
@@ -115,6 +115,38 @@ describe('henri versions', () => {
       expect(stdout).toContain('Nothing is versioned matching that');
     });
 
+    test('reads every tenant, because an operator holds the database', () => {
+      // With tenancy on there is no tenant at a shell prompt, and
+      // `henri.versions` refuses a read without one. These three commands
+      // say `henri.tenancy.unscoped()` out loud, so they keep working --
+      // without it this is HENRI_TENANT_REQUIRED
+      const tenanted = {
+        ...env,
+        HENRI_CONFIG_JSON__tenancy: '{"from":{"user":"tenantId"}}',
+      };
+      const listed = henri(['versions', 'Task', '--json'], {
+        cwd: fixture,
+        env: tenanted,
+        timeout: 120000,
+      });
+
+      expect(listed.status).toBe(0);
+
+      const [version] = JSON.parse(listed.stdout).versions;
+
+      // `Task` is not a tenanted model, so its versions name no tenant
+      expect(version.tenant).toBeNull();
+
+      const shown = henri(['versions:show', version.id, '--json'], {
+        cwd: fixture,
+        env: tenanted,
+        timeout: 120000,
+      });
+
+      expect(shown.status).toBe(0);
+      expect(JSON.parse(shown.stdout).attributes.name).toBe('Seeded');
+    }, 180000);
+
     test('a lowercase word is a command, and an unknown one says so', () => {
       const { status, stderr } = run(['versions:nope']);
 

--- a/packages/cli/scripts/help.js
+++ b/packages/cli/scripts/help.js
@@ -1020,6 +1020,10 @@ const COMMANDS = [
         description: 'The dead letter queue, as JSON',
       },
       {
+        command: 'henri jobs:list --tenant acme',
+        description: "One customer's jobs, in a multi-tenant application",
+      },
+      {
         command: 'henri jobs:retry --all',
         description: 'Put every dead job back in its queue',
       },
@@ -1050,6 +1054,11 @@ const COMMANDS = [
           'list: only the jobs of one batch; batches: only the finished ones',
         flag: '--batch=<id> --finished',
       },
+      {
+        description:
+          'list, dead, retry, discard: one tenant only; perform: the tenant to stamp',
+        flag: '--tenant=<id>',
+      },
       { description: 'retry, discard: every matching job', flag: '--all' },
       {
         description: 'perform: enqueue it later instead of now',
@@ -1078,7 +1087,7 @@ const COMMANDS = [
       },
       {
         description:
-          'the jobs of the queue (--state, --queue, --name, --batch)',
+          'the jobs of the queue (--state, --queue, --name, --batch, --tenant)',
         name: 'list',
       },
       {
@@ -1521,6 +1530,11 @@ const COMMANDS = [
       },
       { description: 'how many versions to print (25)', flag: '--limit=<n>' },
       {
+        description:
+          'one tenant only; without it these commands read every tenant, and show/restore run as the tenant the row names',
+        flag: '--tenant=<id>',
+      },
+      {
         description: 'restore an inexact reconstruction anyway',
         flag: '--force',
       },
@@ -1543,9 +1557,9 @@ const COMMANDS = [
       },
     ],
     usage: [
-      'henri versions [<Model> [<record>]] [--event=<name>] [--limit=<n>] [--json]',
-      'henri versions:show <id> [--json]',
-      'henri versions:restore <id> [--force] [--json]',
+      'henri versions [<Model> [<record>]] [--event=<name>] [--limit=<n>] [--tenant=<id>] [--json]',
+      'henri versions:show <id> [--tenant=<id>] [--json]',
+      'henri versions:restore <id> [--force] [--tenant=<id>] [--json]',
     ],
   },
   {

--- a/packages/cli/scripts/jobs.js
+++ b/packages/cli/scripts/jobs.js
@@ -88,6 +88,20 @@ const queues = (args) =>
     .filter(Boolean);
 
 /**
+ * The tenant named by --tenant
+ *
+ * A listing that names a tenant a table cannot hold is refused by the queue
+ * itself (`HENRI_JOB_TENANT_UNINSTALLED`), so nothing is checked here.
+ *
+ * @param {object} args CLI arguments
+ * @returns {(string|undefined)} The tenant, or nothing
+ */
+const tenant = (args) =>
+  typeof args.tenant === 'string' && args.tenant !== ''
+    ? args.tenant
+    : undefined;
+
+/**
  * Runs a worker process until a signal stops it
  *
  * @param {object} args CLI arguments
@@ -243,6 +257,7 @@ const list = async (args, state) => {
       name: typeof args.name === 'string' ? args.name : undefined,
       queue: typeof args.queue === 'string' ? args.queue : undefined,
       state: state || (typeof args.state === 'string' ? args.state : undefined),
+      tenant: tenant(args),
     });
 
     return {
@@ -328,7 +343,12 @@ const perform = async (args) => {
 
   try {
     if (args.now === true) {
-      const result = await jobs.performNow(name, payload);
+      // Inline, so there is no row to carry a tenant: --tenant is the
+      // scope the job is performed in, which is what the row would have
+      // decided (`Jobs#scoped`)
+      const result = await jobs.queue.scoped(tenant(args), () =>
+        jobs.performNow(name, payload)
+      );
 
       return {
         command: 'perform',
@@ -343,6 +363,7 @@ const perform = async (args) => {
     const job = await jobs.perform(name, payload, {
       at: typeof args.at === 'string' ? args.at : undefined,
       queue: typeof args.queue === 'string' ? args.queue : undefined,
+      ...(typeof args.tenant === 'string' ? { tenant: args.tenant } : {}),
       wait: typeof args.in === 'string' ? args.in : undefined,
     });
 
@@ -387,6 +408,7 @@ const retry = async (args) => {
     const requeued = await jobs.dead.retryAll({
       name: typeof args.name === 'string' ? args.name : undefined,
       queue: typeof args.queue === 'string' ? args.queue : undefined,
+      tenant: tenant(args),
     });
 
     return { command: 'retry', ok: true, requeued };
@@ -432,6 +454,7 @@ const discard = async (args) => {
     const discarded = await jobs.dead.discardAll({
       name: typeof args.name === 'string' ? args.name : undefined,
       queue: typeof args.queue === 'string' ? args.queue : undefined,
+      tenant: tenant(args),
     });
 
     return { command: 'discard', discarded, ok: true };
@@ -464,7 +487,9 @@ const printJobs = (jobs) => {
 
   for (const job of jobs) {
     console.log(
-      `  ${job.id}  ${job.state.padEnd(7)} ${job.queue}/${job.name}  ${job.attempts}/${job.maxAttempts}  ${job.runAt}`
+      `  ${job.id}  ${job.state.padEnd(7)} ${job.queue}/${job.name}  ${job.attempts}/${job.maxAttempts}  ${job.runAt}${
+        job.tenant ? `  @${job.tenant}` : ''
+      }`
     );
 
     if (job.error) {
@@ -595,6 +620,10 @@ const print = (result) => {
     console.log(
       `  attempts ${job.attempts}/${job.maxAttempts}, run at ${job.runAt}`
     );
+
+    if (job.tenant) {
+      console.log(`  tenant ${job.tenant}`);
+    }
 
     if (job.batchId) {
       console.log(`  batch ${job.batchId}`);

--- a/packages/cli/scripts/versions.js
+++ b/packages/cli/scripts/versions.js
@@ -14,6 +14,20 @@ const { boot, validInstall } = require('./utils');
  *
  * All three boot to runlevel 4: no port is bound and no route is
  * registered. The work is `henri.versions` (`core/src/4.versions.js`).
+ *
+ * ## Tenants
+ *
+ * A command line has no request, so it has no tenant, and
+ * `henri.versions` refuses a read with tenancy on and nothing in scope.
+ * That refusal is for an application's own code; an operator at a shell
+ * holds the database and means every customer, so these three commands say
+ * `henri.tenancy.unscoped()` out loud. `--tenant` narrows them to one.
+ *
+ * `show` and `restore` do one thing more: they read the version first and
+ * then run the reconstruction **as the tenant the row names**, because
+ * both of them touch the record itself through the model layer, which is
+ * scoped. Without that, `henri versions:restore` could not work at all on
+ * a tenanted model.
  */
 
 const COMMANDS = ['list', 'restore', 'show'];
@@ -22,19 +36,77 @@ const COMMANDS = ['list', 'restore', 'show'];
 const LIMIT = 25;
 
 /**
- * Runs one operation against a booted application and stops it again
+ * `henri.tenancy`, when the application turned it on
  *
+ * @param {object} henri A booted instance
+ * @returns {?object} The tenancy module, or null
+ */
+const tenancyOf = (henri) =>
+  henri.tenancy && henri.tenancy.enabled ? henri.tenancy : null;
+
+/**
+ * The tenant `--tenant` named, or null
+ *
+ * @param {object} args CLI arguments
+ * @returns {?string} The tenant
+ */
+const named = (args) =>
+  typeof args.tenant === 'string' && args.tenant !== '' ? args.tenant : null;
+
+/**
+ * Runs one operation against a booted application and stops it again.
+ *
+ * Every tenant unless `--tenant` says otherwise: an operator at a shell is
+ * not a request, and the refusal `henri.versions` makes without a tenant
+ * is aimed at an application's own code.
+ *
+ * @param {object} args CLI arguments
  * @param {function} work `(henri) => result`
  * @returns {Promise<*>} What the work resolved with
  */
-const withHenri = async (work) => {
+const withHenri = async (args, work) => {
   const henri = await boot({ runlevel: 4 });
 
   try {
-    return await work(henri);
+    const tenancy = tenancyOf(henri);
+
+    if (!tenancy) {
+      return await work(henri);
+    }
+
+    const only = named(args);
+
+    return only
+      ? await tenancy.run(only, () => work(henri))
+      : await tenancy.unscoped(() => work(henri));
   } finally {
     await henri.stop();
   }
+};
+
+/**
+ * Runs something as the tenant a version row names.
+ *
+ * `reify()` and `restore()` read (and write) the record itself, which is
+ * scoped -- so the tenant of the row is what has to be in scope for them,
+ * and the row is the only thing that knows it. `--tenant` wins when it was
+ * given, and a row that names no tenant enters none, which is what a
+ * shared model and a pre-upgrade row both are.
+ *
+ * @param {object} henri A booted instance
+ * @param {object} args CLI arguments
+ * @param {?object} version The version that was read
+ * @param {function} work What to run
+ * @returns {*} Whatever the work answered
+ */
+const asRecorded = (henri, args, version, work) => {
+  const tenancy = tenancyOf(henri);
+
+  if (!tenancy || named(args) || !version || !version.tenant) {
+    return work();
+  }
+
+  return tenancy.run(version.tenant, work);
 };
 
 /**
@@ -70,7 +142,9 @@ const filterOf = (args) => {
  */
 const list = async (args) => {
   const filter = filterOf(args);
-  const versions = await withHenri((henri) => henri.versions.list(filter));
+  const versions = await withHenri(args, (henri) =>
+    henri.versions.list(filter)
+  );
 
   return { command: 'list', filter, ok: true, versions };
 };
@@ -105,7 +179,13 @@ const idOf = (args, command) => {
  */
 const show = async (args) => {
   const id = idOf(args, 'show');
-  const reified = await withHenri((henri) => henri.versions.reify(id));
+  const reified = await withHenri(args, async (henri) => {
+    const version = await henri.versions.get(id);
+
+    return asRecorded(henri, args, version, () =>
+      henri.versions.reify(version || id)
+    );
+  });
 
   return { command: 'show', ok: true, ...reified };
 };
@@ -118,9 +198,13 @@ const show = async (args) => {
  */
 const restore = async (args) => {
   const id = idOf(args, 'restore');
-  const done = await withHenri((henri) =>
-    henri.versions.restore(id, { force: args.force === true })
-  );
+  const done = await withHenri(args, async (henri) => {
+    const version = await henri.versions.get(id);
+
+    return asRecorded(henri, args, version, () =>
+      henri.versions.restore(version || id, { force: args.force === true })
+    );
+  });
 
   return {
     command: 'restore',
@@ -129,6 +213,7 @@ const restore = async (args) => {
     model: done.version.model,
     ok: true,
     record: done.version.record,
+    tenant: done.version.tenant || null,
   };
 };
 
@@ -173,6 +258,7 @@ const printList = ({ versions }) => {
 
     const notes = [
       version.actor ? `actor ${version.actor}` : `source ${version.source}`,
+      version.tenant ? `tenant ${version.tenant}` : null,
       version.requestId ? `request ${version.requestId}` : null,
       version.erasedAt ? 'erased' : null,
     ].filter(Boolean);
@@ -236,10 +322,12 @@ const printShow = ({ attributes, complete, existed, missing, version }) => {
  * @param {object} result What restore() answered
  * @returns {void}
  */
-const printRestore = ({ created, missing, model, record }) => {
+const printRestore = ({ created, missing, model, record, tenant }) => {
   console.log('');
   console.log(
-    `  ${model} ${record} was ${created ? 'created again' : 'written back'}.`
+    `  ${model} ${record} was ${created ? 'created again' : 'written back'}${
+      tenant ? ` in ${tenant}` : ''
+    }.`
   );
 
   if (missing.length > 0) {

--- a/packages/core/error-codes.json
+++ b/packages/core/error-codes.json
@@ -1389,6 +1389,17 @@
     },
     {
       "area": "job",
+      "causes": [
+        "a queue installed by a henri older than 1.4, whose table has no `tenant` column",
+        "`jobs.install: false` with no `henri jobs:install` since `config.tenancy` was turned on",
+        "a database user that may not alter a table"
+      ],
+      "code": "HENRI_JOB_TENANT_UNINSTALLED",
+      "fix": "Run `henri jobs:install` once with a user that may alter the table. The queue works without the column, and a multi-tenant application does not: every job would be enqueued with no tenant and performed outside every one of them, which is not the same as being performed across all of them. The rows already in the table keep their null tenant and are performed exactly as they were.",
+      "what": "This application is multi-tenant and the queue has nowhere to write a job's tenant."
+    },
+    {
+      "area": "job",
       "causes": ["a job whose `perform()` never returned in time"],
       "code": "HENRI_JOB_TIMEOUT",
       "fix": "Raise the job\u2019s `timeout`, or split the work: the attempt is failed and retried like any other failure.",
@@ -2483,6 +2494,16 @@
     {
       "area": "version",
       "causes": [
+        "a `henri versions:restore` of a record that no longer exists, made as a tenant other than the one the version names",
+        "a restore of a version written before `henri_versions` had its `tenant` column, so henri cannot tell whose record it was"
+      ],
+      "code": "HENRI_VERSION_CROSS_TENANT",
+      "fix": "Restore it as the tenant it belongs to (`henri versions:restore --tenant <id>`, or `henri.tenancy.run()`), or say `henri.tenancy.unscoped()` when moving a record between tenants is what you mean. Restoring a record that is *gone* creates it again, and a create is stamped with the tenant in scope -- so henri refuses rather than materializing somebody else's record here. Updating a record that still exists is never refused: the model layer only ever found this tenant's row.",
+      "what": "A version of another tenant's record was about to be written back as a new record here."
+    },
+    {
+      "area": "version",
+      "causes": [
         "no model of the application says `options: { versioned: true }`",
         "the versions were read back before the boot reached runlevel 4"
       ],
@@ -2531,6 +2552,16 @@
       "code": "HENRI_VERSION_NO_IDENTIFIER",
       "fix": "A version names the record it is about by its `externalId`, because that is the identifier that already leaves the server (see the models guide). Take `externalId: false` off the model, or stop versioning it.",
       "what": "A version could not name the record it is about, which has no public identifier."
+    },
+    {
+      "area": "version",
+      "causes": [
+        "a version table created by a henri older than 1.4, whose `ALTER TABLE ... ADD COLUMN tenant` has not run",
+        "a database user that may not alter a table"
+      ],
+      "code": "HENRI_VERSION_TENANT_UNINSTALLED",
+      "fix": "Boot once with a database user that may `ALTER`, or run `ALTER TABLE henri_versions ADD COLUMN tenant VARCHAR(190) NULL` by hand. henri refuses rather than writing a history it cannot scope: with every row null, a read narrowed to a tenant is every tenant's rows. The rows written before the column exists stay null and are visible in every tenant's listing until they are backfilled -- see the upgrade note of the versions guide.",
+      "what": "This application is multi-tenant and the version table has no `tenant` column."
     },
     {
       "area": "version",

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -4708,6 +4708,14 @@ declare namespace start {
     meta: Record<string, unknown> | null;
     /** When an erasure emptied the values of this row. */
     erasedAt: Date | null;
+    /**
+     * Whose record this version is about, read off the record's own tenant
+     * column. `null` on a shared model, on an application that is not
+     * multi-tenant, and on every row written before the column existed --
+     * and a scoped listing takes the nulls with it, because a shared
+     * model's history belongs to everybody.
+     */
+    tenant: string | null;
   }
 
   /** What a version filter accepts. */
@@ -4774,7 +4782,15 @@ declare namespace start {
       record: object | { model: string; record: string },
       filter?: VersionFilter
     ): Promise<Version[]>;
-    /** The versions matching a filter, newest first. */
+    /**
+     * The versions matching a filter, newest first.
+     *
+     * Narrowed to the tenant in scope when the application is multi-tenant,
+     * and **refused** (`HENRI_TENANT_REQUIRED`) when there is none: a table
+     * holding every tenant's old values is read the way a tenanted model
+     * is. `henri.tenancy.unscoped()` is the one way past, and is what the
+     * `henri versions` commands say.
+     */
     list(filter?: VersionFilter): Promise<Version[]>;
     count(filter?: VersionFilter): Promise<number>;
     get(id: string): Promise<Version | null>;
@@ -4787,6 +4803,13 @@ declare namespace start {
      * Writes a reified record back: an update on one that still exists, an
      * insert under the same `externalId` on one that was destroyed. A
      * write: it refuses an inexact reconstruction unless `force`.
+     */
+    /**
+     * Restoring a record that no longer exists **creates** it, and a create
+     * is stamped with the tenant in scope -- so a version of another
+     * tenant's record, or one written before `henri_versions` had its
+     * `tenant` column, is refused here (`HENRI_VERSION_CROSS_TENANT`).
+     * Updating a record that still exists is never refused.
      */
     restore(
       version: string | Version,
@@ -5274,6 +5297,14 @@ declare namespace start {
     concurrencyKey: string | null;
     /** The batch this job counts into, `null` when it is not in one. */
     batchId: string | null;
+    /**
+     * The tenant this job belongs to, stamped from the request or job it
+     * was enqueued from (`henri.tenancy`). `null` when the application is
+     * not multi-tenant, when the enqueue named `tenant: null`, and on every
+     * row written before the column existed -- and a runner enters no
+     * tenant for any of the three, because null is not every tenant.
+     */
+    tenant: string | null;
   }
 
   /** The options of an enqueue. */
@@ -5295,6 +5326,13 @@ declare namespace start {
      * (`HENRI_JOB_BATCH_CLOSED`).
      */
     batch?: string;
+    /**
+     * The tenant this job belongs to. Defaults to the tenant of the request
+     * or job it is enqueued from when the application is multi-tenant;
+     * `null` is a job of no tenant, and naming a **different** tenant while
+     * one is in scope is refused (`HENRI_TENANT_CROSS_WRITE`).
+     */
+    tenant?: string | null;
   }
 
   /** What a job's `perform(args, context)` receives as its context. */
@@ -5310,6 +5348,12 @@ declare namespace start {
       enqueuedAt: string | null;
       runner: string | null;
       inline?: boolean;
+      /**
+       * The tenant of the row. The runner has already entered it, so
+       * `henri.tenancy.current()` answers the same thing inside `perform()`
+       * and a tenanted model needs nothing said.
+       */
+      tenant?: string | null;
     };
     /** Aborted when the attempt runs past its timeout. */
     signal: AbortSignal;
@@ -5405,6 +5449,12 @@ declare namespace start {
     name?: string;
     /** Only the jobs of one batch. */
     batch?: string;
+    /**
+     * Only the jobs of one tenant. Refused with
+     * `HENRI_JOB_TENANT_UNINSTALLED` when the table has no `tenant` column,
+     * rather than answered with every tenant's rows.
+     */
+    tenant?: string;
     limit?: number;
     offset?: number;
   }
@@ -5463,6 +5513,12 @@ declare namespace start {
     args?: Record<string, unknown> | null;
     /** The jobs of the batch. */
     jobs?: JobBatchEntry[];
+    /**
+     * The tenant of the callback. Defaults to the tenant the batch was made
+     * in: the callback is enqueued by a runner long after that request is
+     * gone, so it has to travel with the batch.
+     */
+    tenant?: string | null;
   }
 
   /**
@@ -6051,6 +6107,13 @@ declare namespace start {
     require(why?: string): string;
     /** The models that carry a mark, and the column each one uses. */
     map(): Record<string, string>;
+    /**
+     * The column a model's tenant lives in, by model name; `null` when
+     * tenancy is off and when the model is shared. What a caller that is
+     * not an adapter asks -- the version store uses it to decide whose
+     * record a version is about.
+     */
+    columnFor(model: string): string | null;
     /** The sources a request's tenant may come from, in order. */
     sources(): string[];
   }

--- a/packages/core/src/0.tenancy.js
+++ b/packages/core/src/0.tenancy.js
@@ -109,6 +109,7 @@ class Tenancy extends BaseModule {
     this.unscoped = this.unscoped.bind(this);
     this.require = this.require.bind(this);
     this.markFor = this.markFor.bind(this);
+    this.columnFor = this.columnFor.bind(this);
     this.conditionFor = this.conditionFor.bind(this);
     this.checkWrite = this.checkWrite.bind(this);
     this.resolve = this.resolve.bind(this);
@@ -348,6 +349,33 @@ class Tenancy extends BaseModule {
     }
 
     return mark;
+  }
+
+  /**
+   * The column a model's tenant lives in, by model name.
+   *
+   * `null` when tenancy is off and when the model is shared, which is the
+   * question a caller that is not an adapter actually has: the version
+   * store asks it to decide whose record a version is about, and answering
+   * `null` for a `Country` is what keeps a shared model's history shared.
+   *
+   * It reads the marks the adapters filled in while they built, so a model
+   * this module has never been asked about answers `null` -- the same
+   * `null` an unmarked model answers, and safe for the same reason: it is
+   * only ever used to *add* a tenant to a row, never to skip a condition.
+   *
+   * @param {string} model the model name (`Invoice`)
+   * @returns {?string} the column, or null
+   * @memberof Tenancy
+   */
+  columnFor(model) {
+    if (!this.enabled) {
+      return null;
+    }
+
+    const mark = this.marks.get(model);
+
+    return mark ? mark.column : null;
   }
 
   /**

--- a/packages/core/src/3.privacy.js
+++ b/packages/core/src/3.privacy.js
@@ -453,12 +453,18 @@ class Privacy extends BaseModule {
    */
   async tolerantly(work) {
     const { encryption } = this.henri;
+    // Across every tenant, and this is the one place it is said: an
+    // erasure and an export are about a *person*, and the records held
+    // about them are whatever holds them. A walk narrowed to the tenant
+    // that happened to be in scope would quietly miss rows -- and from a
+    // command line, where there is no tenant at all, it would not run
+    const walk = () => this.everywhere(work);
 
     if (!encryption || typeof encryption.tolerate !== 'function') {
-      return { ...(await work()), unreadable: [] };
+      return { ...(await walk()), unreadable: [] };
     }
 
-    const { failures, value } = await encryption.tolerate(work);
+    const { failures, value } = await encryption.tolerate(walk);
 
     if (failures.length > 0) {
       this.henri.pen.warn(
@@ -469,6 +475,37 @@ class Privacy extends BaseModule {
     }
 
     return { ...value, unreadable: failures };
+  }
+
+  /**
+   * Runs a walk over the models across every tenant, deliberately.
+   *
+   * henri's own sweeps are the caller `henri.tenancy.unscoped()` was
+   * written for, and saying so here rather than at each call site is the
+   * point: an erasure and an export are about a person,
+   * and the records held about that person are wherever they are. A walk
+   * narrowed to whatever tenant happened to be in scope would answer a
+   * person's request with part of their data and write a receipt saying
+   * it was all of it.
+   *
+   * It is a no-op in an application that is not multi-tenant, and it is
+   * **not** a hole. `unscoped()` only ever means "do not narrow"; what a
+   * person may do is still the policies' question, and nothing here is
+   * reachable from a request that did not already pass one.
+   *
+   * @async
+   * @param {function} work What to run
+   * @returns {Promise<*>} Whatever the work answered
+   * @memberof Privacy
+   */
+  async everywhere(work) {
+    const { tenancy } = this.henri;
+
+    if (!tenancy || !tenancy.enabled) {
+      return work();
+    }
+
+    return tenancy.unscoped(work);
   }
 
   /**

--- a/packages/core/src/4.retention.js
+++ b/packages/core/src/4.retention.js
@@ -220,7 +220,38 @@ class Retention extends BaseModule {
     check('henri.retention.plan', [options]);
     this.only(options, 'henri.retention.plan');
 
-    return planOf(this.context(), options);
+    return this.everywhere(() => planOf(this.context(), options));
+  }
+
+  /**
+   * Runs a sweep over the models across every tenant, deliberately.
+   *
+   * A retention rule is the application's policy about a *table*, not
+   * about a customer: `after: '90d'` on `Ticket` means every ticket, and a
+   * sweep narrowed to whatever tenant happened to be in scope would delete
+   * one customer's records and write a receipt saying the rule ran. There
+   * is no tenant in scope on a cron line anyway, so the alternative is not
+   * a narrower sweep -- it is `HENRI_TENANT_REQUIRED` on the first rule.
+   *
+   * A per-tenant retention period is a different feature, and it is the
+   * application's: a rule with a `where` of its own, or a job that calls
+   * `sweep({ only })` inside `henri.tenancy.run()`.
+   *
+   * It is a no-op in an application that is not multi-tenant.
+   *
+   * @async
+   * @param {function} work What to run
+   * @returns {Promise<*>} Whatever the work answered
+   * @memberof Retention
+   */
+  async everywhere(work) {
+    const { tenancy } = this.henri;
+
+    if (!tenancy || !tenancy.enabled) {
+      return work();
+    }
+
+    return tenancy.unscoped(work);
   }
 
   /**
@@ -272,7 +303,9 @@ class Retention extends BaseModule {
     check('henri.retention.sweep', [options]);
     this.only(options, 'henri.retention.sweep');
 
-    const receipt = await sweepOf(this.context(), options);
+    const receipt = await this.everywhere(() =>
+      sweepOf(this.context(), options)
+    );
 
     receipt.id = randomUUID();
     receipt.file = options.dryRun ? null : this.write(receipt);

--- a/packages/core/src/4.versions.js
+++ b/packages/core/src/4.versions.js
@@ -150,7 +150,22 @@ class Versions extends BaseModule {
 
     this.enabled = true;
 
-    await this.ready();
+    const store = await this.ready();
+
+    // The upgrade has to be honest. An application that turned tenancy on
+    // and whose table cannot hold the column would write a history nothing
+    // can scope, and a scoped read of a table where every row is null is
+    // every tenant's rows, which is the one answer this must never give.
+    // The `_UNINSTALLED` precedent of `@usehenri/jobs`: fail the boot and
+    // name what is missing
+    if (this.tenancy() && !(await store.tenanted())) {
+      throw refuse(
+        'HENRI_VERSION_TENANT_UNINSTALLED',
+        `config.tenancy is on and ${this.settings.table} has no tenant column, so a version could not say whose record it is about`,
+        `henri adds the column itself on a boot whose database user may ALTER; otherwise run ALTER TABLE ${this.settings.table} ADD COLUMN tenant VARCHAR(190) NULL by hand, and see the upgrade note of guides/versions.md for the rows that are already there`
+      );
+    }
+
     this.mount(this.henri.server);
 
     pen.info(
@@ -306,6 +321,91 @@ class Versions extends BaseModule {
   }
 
   /**
+   * `henri.tenancy`, when the application turned it on
+   *
+   * @returns {?object} the tenancy module, or null
+   * @memberof Versions
+   */
+  tenancy() {
+    const tenancy = this.henri && this.henri.tenancy;
+
+    return tenancy && tenancy.enabled ? tenancy : null;
+  }
+
+  /**
+   * Whose record this version is about.
+   *
+   * **The record's own column, and only then the tenant in scope.** A
+   * version describes a record, and whose record it is is written on the
+   * record: a sweep running `unscoped()` over every customer still writes
+   * rows that name the right one. The scope is the fallback for the
+   * adapter that hands over a partial `before` on a create.
+   *
+   * `null` on a shared model, on an application that is not multi-tenant,
+   * and on a record whose column is empty -- three different things that
+   * are the same thing to read back, which is why a scoped listing takes
+   * the nulls with it.
+   *
+   * @param {string} model the model name
+   * @param {object} event what `record()` was given
+   * @returns {?string} the tenant, or null
+   * @memberof Versions
+   */
+  tenantOf(model, event) {
+    const tenancy = this.tenancy();
+
+    if (!tenancy) {
+      return null;
+    }
+
+    const column = tenancy.columnFor(model);
+
+    if (!column) {
+      return null;
+    }
+
+    for (const values of [event.after, event.before]) {
+      const value = isPlainObject(values) ? values[column] : null;
+
+      if (value !== null && typeof value !== 'undefined' && value !== '') {
+        return String(value);
+      }
+    }
+
+    return tenancy.current();
+  }
+
+  /**
+   * The tenant a read of the history is narrowed to, or nothing.
+   *
+   * The version table holds the old values of records that belong to
+   * tenants, so reading it is scoped exactly the way reading those records
+   * is -- **including the refusal**. With tenancy on, no tenant in scope
+   * and no `unscoped()`, `henri.versions.list()` raises
+   * `HENRI_TENANT_REQUIRED` rather than answering with every customer's
+   * changes, which is `conditionFor()`'s instinct applied to a table core
+   * owns rather than to one an adapter built.
+   *
+   * henri's own callers say `unscoped()` because they mean every tenant:
+   * the retention prune, the erasure, the export, and the three
+   * `henri versions` commands.
+   *
+   * @param {string} [why='reading the version history'] for the message
+   * @returns {?string} the tenant, or null when nothing should be narrowed
+   * @throws HENRI_TENANT_REQUIRED with tenancy on and no tenant in scope
+   * @memberof Versions
+   */
+  scope(why = 'reading the version history') {
+    const tenancy = this.tenancy();
+
+    if (!tenancy || tenancy.isUnscoped()) {
+      return null;
+    }
+
+    return tenancy.require(why);
+  }
+
+  /**
    * Who is acting, and where the change came from.
    *
    * `acting()` wins, then the request the change is being made inside,
@@ -426,6 +526,7 @@ class Versions extends BaseModule {
       request_id: who.requestId,
       snapshot: snapshot ? JSON.stringify(snapshot) : null,
       source: who.source,
+      tenant: this.tenantOf(model, event),
     };
 
     await (await this.ready()).append(row);
@@ -522,7 +623,34 @@ class Versions extends BaseModule {
   async get(id) {
     check('henri.versions.get', [id]);
 
-    return toVersion(await (await this.ready()).get(id));
+    const row = await (await this.ready()).get(id);
+
+    return this.visible(row) ? toVersion(row) : null;
+  }
+
+  /**
+   * May the tenant in scope see this row?
+   *
+   * `null` rather than a refusal, which is `Model.findById()`'s own
+   * answer: a version another tenant wrote is not there, and a message
+   * saying "it is there but not yours" is the oracle the 404 exists to
+   * close. A row of **no** tenant is visible to everybody, for
+   * `conditions()`'s reason: it is what a shared model's history and every
+   * row written before the column look like.
+   *
+   * @param {?object} row a stored row
+   * @returns {boolean} yes or no
+   * @throws HENRI_TENANT_REQUIRED with tenancy on and no tenant in scope
+   * @memberof Versions
+   */
+  visible(row) {
+    if (!row) {
+      return false;
+    }
+
+    const tenant = this.scope();
+
+    return !tenant || !row.tenant || row.tenant === tenant;
   }
 
   /**
@@ -541,6 +669,10 @@ class Versions extends BaseModule {
     return {
       ...filter,
       since: moment(filter.since),
+      // The caller does not get to widen it: a `tenant` in the filter is
+      // overwritten by the scope, the way `req.filters()` intersects a
+      // client's condition with the policy's rather than replacing it
+      tenant: this.scope() || undefined,
       until: moment(filter.until),
     };
   }
@@ -709,6 +841,8 @@ class Versions extends BaseModule {
       return { created: false, missing, record: updated, version: target };
     }
 
+    this.restorable(target);
+
     // The public identifier goes back with it: every url, every link and
     // every foreign key that named this record still names it
     const created = await this.createRecord(Model, {
@@ -717,6 +851,53 @@ class Versions extends BaseModule {
     });
 
     return { created: true, missing, record: created, version: target };
+  }
+
+  /**
+   * May this version be written back as a **new** record here?
+   *
+   * This is the sharp edge of a shared version table, and it is a write
+   * rather than a read: a restore of a record that no longer exists
+   * *creates* one, and a create is stamped with the tenant in scope. So a
+   * version of somebody else's record would materialize their old values
+   * as this tenant's row, under their external id: the leak no later
+   * request notices, which is `HENRI_TENANT_CROSS_WRITE`'s whole argument.
+   *
+   * An **update** needs no check. `liveRecord()` reads through the model
+   * layer, which only ever finds this tenant's row.
+   *
+   * A version with no tenant on a tenanted model is refused here too, and
+   * that is the honest answer rather than a harsh one: the row predates
+   * the column, henri cannot tell whose record it was, and guessing "this
+   * one" is exactly the guess this column exists to stop making.
+   *
+   * @param {object} target the version being restored
+   * @returns {void}
+   * @throws HENRI_TENANT_REQUIRED, HENRI_VERSION_CROSS_TENANT
+   * @memberof Versions
+   */
+  restorable(target) {
+    const tenancy = this.tenancy();
+
+    if (!tenancy || tenancy.isUnscoped() || !tenancy.columnFor(target.model)) {
+      return;
+    }
+
+    const tenant = tenancy.require(
+      `restoring a ${target.model} that no longer exists`
+    );
+
+    if (target.tenant === tenant) {
+      return;
+    }
+
+    throw refuse(
+      'HENRI_VERSION_CROSS_TENANT',
+      target.tenant
+        ? `version ${target.id} is about a ${target.model} of the tenant '${target.tenant}' and the tenant in scope is '${tenant}', so restoring it would create that record here`
+        : `version ${target.id} is about a ${target.model} and names no tenant, having been written before ${this.settings.table} had the column, so restoring it would create the record in '${tenant}' on a guess`,
+      'Restore it as the tenant it belongs to, which is what the tenant flag of henri versions:restore does, or say henri.tenancy.unscoped() when moving a record between tenants is what you mean. A row with no tenant is one an upgrade left behind, and the backfill in guides/versions.md is what fills it in'
+    );
   }
 
   /**

--- a/packages/core/src/__tests__/tenancy.spec.js
+++ b/packages/core/src/__tests__/tenancy.spec.js
@@ -1,3 +1,5 @@
+const Privacy = require('../3.privacy');
+const Retention = require('../4.retention');
 const Tenancy = require('../0.tenancy');
 const {
   MAX_TENANT,
@@ -532,6 +534,78 @@ describe('henri.tenancy', () => {
       expect(() =>
         module.markFor({ globalId: 'Account', options: { tenant: true } })
       ).toThrow(/is the user model/u);
+    });
+  });
+
+  describe('the column of a model, by name', () => {
+    test('answers what the mark said, and null for a shared model', async () => {
+      const module = await build({ tenancy: {} });
+
+      module.markFor({ globalId: 'Invoice', options: { tenant: true } });
+      module.markFor({
+        globalId: 'Ticket',
+        options: { tenant: 'accountId' },
+        schema: { accountId: { type: 'string' } },
+      });
+      module.markFor({ globalId: 'Plan', options: {} });
+
+      expect(module.columnFor('Invoice')).toBe('tenantId');
+      expect(module.columnFor('Ticket')).toBe('accountId');
+      expect(module.columnFor('Plan')).toBeNull();
+      // A model nobody asked about answers the same null a shared one does,
+      // and it is safe for the same reason: it only ever adds a tenant to a
+      // row, never skips a condition
+      expect(module.columnFor('Nothing')).toBeNull();
+    });
+
+    test('answers null with tenancy off, whatever a model said', async () => {
+      const module = await build({});
+
+      expect(module.columnFor('Invoice')).toBeNull();
+    });
+  });
+
+  describe("henri's own sweeps run across every tenant", () => {
+    /**
+     * A module of core's carrying a tenancy module
+     *
+     * @param {function} Module the class
+     * @param {object} tenancy the tenancy module
+     * @returns {object} the module
+     */
+    const sweeper = (Module, tenancy) => {
+      const module = new Module();
+
+      module.henri = { tenancy };
+
+      return module;
+    };
+
+    test.each([
+      ['privacy', Privacy],
+      ['retention', Retention],
+    ])(
+      '%s walks the models inside unscoped(), so a command line works',
+      async (name, Module) => {
+        const tenancy = await build({ tenancy: {} });
+        const module = sweeper(Module, tenancy);
+
+        // Without this the first model call of a sweep raises
+        // HENRI_TENANT_REQUIRED: there is no tenant at a cron line, and a
+        // sweep narrowed to whatever happened to be in scope would delete
+        // one customer's rows and write a receipt saying the rule ran
+        expect(await module.everywhere(() => tenancy.isUnscoped())).toBe(true);
+        expect(tenancy.isUnscoped()).toBe(false);
+      }
+    );
+
+    test.each([
+      ['privacy', Privacy],
+      ['retention', Retention],
+    ])('%s costs nothing when there is no tenancy', async (name, Module) => {
+      const module = sweeper(Module, null);
+
+      expect(await module.everywhere(() => 'ran')).toBe('ran');
     });
   });
 });

--- a/packages/core/src/base/version-store.js
+++ b/packages/core/src/base/version-store.js
@@ -22,6 +22,18 @@
  * gives: sqlite has no date type and the other four dialects disagree about
  * the precision and the time zone of a bare `TIMESTAMP`.
  *
+ * ## The upgrade block
+ *
+ * This table is `CREATE TABLE IF NOT EXISTS` and there is no migration
+ * chain behind it, so a table an older henri created is the table an
+ * installation still has -- the queue's problem, and the queue's answer
+ * (`packages/jobs/src/store/schema.js`). `ADDED` names the columns a later
+ * henri writes, `upgrade()` turns them into idempotent statements, and
+ * `install()` **tolerates** every one of them: a database user who may not
+ * `ALTER` never fails a boot over a column the application does not need.
+ * What decides at runtime is asking the table (`tenanted()`), never
+ * whether the `ALTER` ran.
+ *
  * Ordering is by `id`, which is a uuid version 7: 48 bits of milliseconds
  * and then a counter, so it sorts by the moment it was made without a
  * sequence column and without the unique index the trail needs. Two
@@ -54,11 +66,32 @@ const COLUMNS = [
   'request_id',
   'meta',
   'erased_at',
+  'tenant',
 ];
 
 /** What each dialect calls the things this table needs */
+/**
+ * The columns an older henri did not write, and the type they take.
+ *
+ * One entry per column added after a version that shipped. 190 is the
+ * width `base/tenancy.js` gives a tenant: what MySQL indexes in a utf8mb4
+ * key, and never truncated to fit.
+ */
+const ADDED = [{ column: 'tenant', type: 'VARCHAR(190)' }];
+
 const DIALECTS = {
   mssql: {
+    /**
+     * Adds a column, only when the table has none by that name
+     *
+     * @param {string} table the table name
+     * @param {string} column the column name
+     * @param {string} type the column type
+     * @returns {string} the statement
+     */
+    addColumn: (table, column, type) =>
+      `IF COL_LENGTH('${table}', '${column}') IS NULL ALTER TABLE [${table}] ADD ${column} ${type} NULL`,
+
     /**
      * Wraps a statement so it only runs when the index is missing
      *
@@ -81,26 +114,42 @@ const DIALECTS = {
       `IF OBJECT_ID('${table}', 'U') IS NULL ${statement}`,
 
     ifNotExists: '',
+    indexIfNotExists: '',
     inlineIndexes: false,
     quote: (identifier) => `[${identifier}]`,
     text: 'NVARCHAR(MAX)',
   },
   mysql: {
+    // MySQL has no ADD COLUMN IF NOT EXISTS: a second run answers 1060,
+    // which the install tolerates like every other upgrade statement
+    addColumn: (table, column, type) =>
+      `ALTER TABLE \`${table}\` ADD COLUMN ${column} ${type} NULL`,
     ifNotExists: 'IF NOT EXISTS',
     // MySQL has no CREATE INDEX IF NOT EXISTS: the indexes go in the
-    // CREATE TABLE, which is guarded
+    // CREATE TABLE, which is guarded. An index the create cannot carry (a
+    // `late` one, on a table that is already there) is written bare and
+    // tolerated when it answers 1061
+    indexIfNotExists: '',
     inlineIndexes: true,
     quote: (identifier) => `\`${identifier}\``,
     text: 'MEDIUMTEXT',
   },
   postgres: {
+    addColumn: (table, column, type) =>
+      `ALTER TABLE "${table}" ADD COLUMN IF NOT EXISTS ${column} ${type} NULL`,
     ifNotExists: 'IF NOT EXISTS',
+    indexIfNotExists: 'IF NOT EXISTS',
     inlineIndexes: false,
     quote: (identifier) => `"${identifier}"`,
     text: 'TEXT',
   },
   sqlite: {
+    // SQLite has no ADD COLUMN IF NOT EXISTS either: a second run answers
+    // "duplicate column name", which the install tolerates
+    addColumn: (table, column, type) =>
+      `ALTER TABLE "${table}" ADD COLUMN ${column} ${type} NULL`,
     ifNotExists: 'IF NOT EXISTS',
+    indexIfNotExists: 'IF NOT EXISTS',
     inlineIndexes: false,
     quote: (identifier) => `"${identifier}"`,
     text: 'TEXT',
@@ -128,6 +177,11 @@ const columnsFor = (dialect) => [
   'request_id VARCHAR(64) NULL',
   `meta ${dialect.text} NULL`,
   'erased_at BIGINT NULL',
+  // Whose record this version is about, read off the record itself. Null
+  // on a shared model, on an application that is not multi-tenant, and on
+  // every row written before this column existed -- which is why a scoped
+  // read takes the nulls with it (see `conditions()`)
+  'tenant VARCHAR(190) NULL',
   'PRIMARY KEY (id)',
 ];
 
@@ -151,18 +205,48 @@ const indexesFor = (table) => [
   { columns: ['at'], name: `${table}_at`, unique: false },
   { columns: ['actor'], name: `${table}_actor`, unique: false },
   { columns: ['request_id'], name: `${table}_request`, unique: false },
+  // `late`: it names a column an older table has not, so it belongs to the
+  // upgrade block on every dialect rather than to the create
+  {
+    columns: ['tenant', 'at'],
+    late: true,
+    name: `${table}_tenant`,
+    unique: false,
+  },
 ];
 
 /**
- * Every statement that creates the table and its indexes, in order
+ * The statement that creates one index
+ *
+ * @param {object} dialect a dialect description
+ * @param {string} table the table name
+ * @param {object} index an index description
+ * @returns {string} the statement
+ */
+const indexStatement = (dialect, table, index) => {
+  const statement = [
+    `CREATE ${index.unique ? 'UNIQUE ' : ''}INDEX`,
+    dialect.guardIndex ? '' : dialect.indexIfNotExists,
+    `${dialect.quote(index.name)} ON ${dialect.quote(table)} (${index.columns.join(
+      ', '
+    )})`,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return dialect.guardIndex
+    ? dialect.guardIndex(table, index.name, statement)
+    : statement;
+};
+
+/**
+ * The dialect of a name, or a readable refusal
  *
  * @param {string} name the dialect (sqlite, postgres, mysql, mssql)
- * @param {string} table the table name
- * @returns {Array<string>} the statements, all of them idempotent
+ * @returns {object} the dialect description
  * @throws HENRI_VERSION_UNSUPPORTED_STORE on a dialect henri cannot talk to
- * @throws HENRI_CONFIG_INVALID on a table name that is not an identifier
  */
-const install = (name, table) => {
+const dialectOf = (name) => {
   const dialect = DIALECTS[name];
 
   if (!dialect) {
@@ -171,6 +255,47 @@ const install = (name, table) => {
       `versions cannot be kept in a ${name} store`
     );
   }
+
+  return dialect;
+};
+
+/**
+ * The statements that bring a table an older henri created up to date.
+ *
+ * Every one of them is idempotent and every one of them is **tolerated**
+ * by `SqlVersions#install()`: a database user who may not `ALTER` never
+ * fails a boot over a column the application does not need. What decides
+ * whether the column is usable is asking the table (`tenanted()`), not
+ * whether these ran.
+ *
+ * @param {string} name the dialect (sqlite, postgres, mysql, mssql)
+ * @param {string} table the table name
+ * @returns {Array<string>} the statements
+ * @throws HENRI_VERSION_UNSUPPORTED_STORE on an unknown dialect
+ */
+const upgrade = (name, table) => {
+  const dialect = dialectOf(name);
+
+  return [
+    ...ADDED.map((added) => dialect.addColumn(table, added.column, added.type)),
+    ...indexesFor(table)
+      .filter((index) => index.late)
+      .map((index) => indexStatement(dialect, table, index)),
+  ];
+};
+
+/**
+ * Every statement that creates the table, its indexes and the columns a
+ * table an older henri wrote has not, in order
+ *
+ * @param {string} name the dialect (sqlite, postgres, mysql, mssql)
+ * @param {string} table the table name
+ * @returns {Array<string>} the statements, all of them idempotent
+ * @throws HENRI_VERSION_UNSUPPORTED_STORE on a dialect henri cannot talk to
+ * @throws HENRI_CONFIG_INVALID on a table name that is not an identifier
+ */
+const install = (name, table) => {
+  const dialect = dialectOf(name);
 
   if (!SAFE_NAME.test(table)) {
     throw fail(
@@ -181,7 +306,9 @@ const install = (name, table) => {
 
   const quoted = dialect.quote(table);
   const definitions = [...columnsFor(dialect)];
-  const indexes = indexesFor(table);
+  // An index marked `late` names a column an older table does not have, so
+  // it is the upgrade block's, on every dialect at once
+  const indexes = indexesFor(table).filter((index) => !index.late);
   const statements = [];
 
   if (dialect.inlineIndexes) {
@@ -204,27 +331,13 @@ const install = (name, table) => {
     dialect.guardTable ? dialect.guardTable(table, create) : create
   );
 
-  if (dialect.inlineIndexes) {
-    return statements;
+  if (!dialect.inlineIndexes) {
+    for (const index of indexes) {
+      statements.push(indexStatement(dialect, table, index));
+    }
   }
 
-  for (const index of indexes) {
-    const statement = [
-      `CREATE ${index.unique ? 'UNIQUE ' : ''}INDEX`,
-      dialect.guardIndex ? '' : dialect.ifNotExists,
-      `${dialect.quote(index.name)} ON ${quoted} (${index.columns.join(', ')})`,
-    ]
-      .filter(Boolean)
-      .join(' ');
-
-    statements.push(
-      dialect.guardIndex
-        ? dialect.guardIndex(table, index.name, statement)
-        : statement
-    );
-  }
-
-  return statements;
+  return [...statements, ...upgrade(name, table)];
 };
 
 /** Errors that mean the object was created by another process first */
@@ -285,6 +398,8 @@ class SqlVersions {
     this.dollars = dollars;
     this.table = table;
     this.kind = 'sql';
+    /** Whether the table has `tenant`; asked once, see tenanted() */
+    this.tenants = null;
   }
 
   /**
@@ -346,11 +461,21 @@ class SqlVersions {
    */
   async install() {
     const statements = install(this.dialect, this.table);
+    // The upgrade block is tolerated whatever it answers: it touches a
+    // table an older henri created, and a user who may not `ALTER` must
+    // not fail the boot of an application that never asked for the column
+    // it adds. What needs the column asks for it by name (`tenanted()`)
+    const soft = new Set(upgrade(this.dialect, this.table));
 
     for (const statement of statements) {
       try {
         await this.run(statement);
       } catch (error) {
+        if (soft.has(statement)) {
+          debug('upgrade statement did not apply: %s', error.message);
+          continue;
+        }
+
         if (!ALREADY_THERE.test(reasons(error))) {
           throw error;
         }
@@ -359,7 +484,55 @@ class SqlVersions {
       }
     }
 
+    this.tenants = null;
+
     return statements;
+  }
+
+  /**
+   * Whether the table has the column a record's tenant is written in.
+   *
+   * Asked once, of the table itself rather than of what the install
+   * answered: an installation that upgraded henri without the `ALTER`
+   * having run has the table an older version wrote, and versioning works
+   * exactly as it did -- for an application that is not multi-tenant. One
+   * that *is* fails the boot instead of writing rows nothing can scope
+   * (`4.versions.js`).
+   *
+   * @returns {Promise<boolean>} true when `tenant` is there
+   * @memberof SqlVersions
+   */
+  async tenanted() {
+    if (typeof this.tenants === 'boolean') {
+      return this.tenants;
+    }
+
+    try {
+      // Reads nothing: the planner still has to resolve the column
+      await this.select(`SELECT tenant FROM ${this.table} WHERE 1 = 0`);
+      this.tenants = true;
+    } catch (error) {
+      debug('no tenant column: %s', error.message);
+      this.tenants = false;
+    }
+
+    return this.tenants;
+  }
+
+  /**
+   * The columns an insert may name
+   *
+   * A table an older henri wrote has no `tenant`, and an application that
+   * is not multi-tenant must not notice: the insert names the columns that
+   * are there.
+   *
+   * @returns {Promise<Array<string>>} the column names
+   * @memberof SqlVersions
+   */
+  async columns() {
+    return (await this.tenanted())
+      ? COLUMNS
+      : COLUMNS.filter((column) => column !== 'tenant');
   }
 
   /**
@@ -391,14 +564,15 @@ class SqlVersions {
    * @memberof SqlVersions
    */
   async append(row) {
-    const values = COLUMNS.map((column) =>
+    const columns = await this.columns();
+    const values = columns.map((column) =>
       typeof row[column] === 'undefined' ? null : row[column]
     );
 
     await this.run(
-      `INSERT INTO ${this.table} (${COLUMNS.join(', ')}) VALUES (${COLUMNS.map(
-        () => '?'
-      ).join(', ')})`,
+      `INSERT INTO ${this.table} (${columns.join(', ')}) VALUES (${columns
+        .map(() => '?')
+        .join(', ')})`,
       values
     );
 
@@ -514,6 +688,17 @@ class SqlVersions {
     if (Number.isFinite(filter.until)) {
       parts.push('at <= ?');
       params.push(filter.until);
+    }
+
+    // A tenant takes the rows of no tenant with it, and that is a decision
+    // rather than an oversight: `tenant IS NULL` is what a **shared**
+    // model's history looks like, and hiding a shared model's versions
+    // from every tenant would be worse than showing them to each. It is
+    // also what every row written before the column existed looks like,
+    // which the upgrade note in `guides/versions.md` says out loud
+    if (typeof filter.tenant === 'string' && filter.tenant !== '') {
+      parts.push('(tenant = ? OR tenant IS NULL)');
+      params.push(filter.tenant);
     }
 
     return {
@@ -679,8 +864,24 @@ class MongoVersions {
     await collection.createIndex({ at: -1 });
     await collection.createIndex({ actor: 1 });
     await collection.createIndex({ request_id: 1 });
+    // eslint-disable-next-line sort-keys
+    await collection.createIndex({ tenant: 1, at: -1 });
 
     return [`${this.table}.record`, `${this.table}.at`];
+  }
+
+  /**
+   * Whether a tenant can be written here; it always can
+   *
+   * A field appears when it is written, so there is nothing to upgrade and
+   * nothing to refuse. A document an older henri wrote simply has no
+   * `tenant`, which is what a shared model's version looks like anyway.
+   *
+   * @returns {Promise<boolean>} true
+   * @memberof MongoVersions
+   */
+  async tenanted() {
+    return true;
   }
 
   /**
@@ -741,6 +942,16 @@ class MongoVersions {
       if (Number.isFinite(filter.until)) {
         query.at.$lte = filter.until;
       }
+    }
+
+    // The SQL half's `(tenant = ? OR tenant IS NULL)`, and a document that
+    // never had the field is the third spelling of the same thing
+    if (typeof filter.tenant === 'string' && filter.tenant !== '') {
+      query.$or = [
+        { tenant: filter.tenant },
+        { tenant: null },
+        { tenant: { $exists: false } },
+      ];
     }
 
     return query;
@@ -931,6 +1142,7 @@ const storeFor = (adapter, table) => {
 };
 
 module.exports = {
+  ADDED,
   COLUMNS,
   DIALECTS,
   MongoVersions,
@@ -940,4 +1152,5 @@ module.exports = {
   reasons,
   storeFor,
   toNumber,
+  upgrade,
 };

--- a/packages/core/src/base/versions.js
+++ b/packages/core/src/base/versions.js
@@ -729,6 +729,10 @@ function toVersion(row) {
     requestId: row.request_id || null,
     snapshot: isPlainObject(snapshot) ? unpack(snapshot) : null,
     source: row.source,
+    // Whose record this is about. Null on a shared model, on an
+    // application that is not multi-tenant, and on a row written before
+    // the column existed
+    tenant: row.tenant || null,
   };
 }
 

--- a/packages/drizzle/__tests__/versions-tenancy.spec.js
+++ b/packages/drizzle/__tests__/versions-tenancy.spec.js
@@ -1,0 +1,495 @@
+// Model versioning across tenants, against a real store.
+//
+// `henri_versions` holds the old values of records that belong to tenants,
+// and one table holds all of them -- so the property to write down is the
+// same negative one the model suite proves: **tenant A cannot read one of
+// tenant B's versions, and cannot write one back.** The reading half is a
+// condition; the writing half is a refusal, because a restore of a record
+// that is gone *creates* it, and a create is stamped with the tenant in
+// scope.
+//
+// It runs on sqlite offline and on the live PostgreSQL or MySQL of
+// `pnpm test:sql:live`, which is what `./targets.js` decides.
+const Versions = require('@usehenri/core/src/4.versions');
+
+const { SqlVersions } = require('@usehenri/core/src/base/version-store');
+const { buildWith, fakeHenri, target } = require('./helpers');
+
+const invoiceModel = {
+  globalId: 'Invoice',
+  identity: 'invoice',
+  options: { paranoid: true, tenant: true, timestamps: true, versioned: true },
+  schema: {
+    amount: { default: 0, type: 'integer' },
+    reference: { required: true, type: 'string' },
+  },
+  store: 'default',
+};
+
+// Shared on purpose: a `Plan` belongs to nobody, and its history has to
+// stay readable from inside every tenant
+const planModel = {
+  globalId: 'Plan',
+  identity: 'plan',
+  options: { timestamps: true, versioned: true },
+  schema: { name: { type: 'string' } },
+  store: 'default',
+};
+
+/**
+ * A henri carrying both modules, on an adapter of its own
+ *
+ * @param {object} [settings={}] What the configuration says
+ * @returns {Promise<object>} `{ adapter, henri, models, versions }`
+ */
+const application = async (settings = {}) => {
+  const henri = fakeHenri({
+    tenancy: { from: { user: 'tenantId' } },
+    versions: { keep: '30d' },
+    ...settings,
+  });
+
+  await henri.encryption.init();
+
+  const { adapter } = buildWith(henri, {}, settings.key);
+
+  [invoiceModel, planModel].forEach((model) => adapter.addModel(model, 'user'));
+  await adapter.start();
+
+  henri.model = {
+    models: [invoiceModel, planModel],
+    stores: { default: adapter },
+  };
+  henri.privacy = { modelOf: (name) => adapter.getModels()[name] || null };
+
+  const versions = new Versions();
+
+  versions.henri = henri;
+  henri.versions = versions;
+  await versions.init();
+
+  return { adapter, henri, models: adapter.getModels(), versions };
+};
+
+describe(`versions across tenants (${target.name})`, () => {
+  let adapter = null;
+  let henri = null;
+  let versions = null;
+  let Invoice = null;
+  let Plan = null;
+
+  /**
+   * Runs something as a tenant
+   *
+   * @param {string} tenant The tenant
+   * @param {function} work What to run
+   * @returns {Promise<*>} Whatever the work answered
+   */
+  const as = (tenant, work) => henri.tenancy.run(tenant, work);
+
+  /**
+   * Runs something across every tenant
+   *
+   * @param {function} work What to run
+   * @returns {Promise<*>} Whatever the work answered
+   */
+  const all = (work) => henri.tenancy.unscoped(work);
+
+  beforeAll(async () => {
+    ({ adapter, henri, versions } = await application({ key: 'ver-tenancy' }));
+    ({ Invoice, Plan } = adapter.getModels());
+  }, 60000);
+
+  afterAll(async () => {
+    await adapter.stop();
+  });
+
+  beforeEach(async () => {
+    await all(async () => {
+      await Invoice.withDeleted()
+        .where({})
+        .destroy({ force: true, versions: false });
+      await Plan.where({}).destroy({ force: true, versions: false });
+    });
+    await adapter.query(`DELETE FROM ${versions.settings.table}`);
+  });
+
+  describe('the column', () => {
+    test('the table has it, and the store says so', async () => {
+      const store = await versions.ready();
+
+      expect(await store.tenanted()).toBe(true);
+    });
+
+    test('a version names the tenant of the record it is about', async () => {
+      const invoice = await as('acme', () =>
+        Invoice.create({ amount: 10, reference: 'A-1' })
+      );
+      const [version] = await as('acme', () => versions.of(invoice));
+
+      expect(version.tenant).toBe('acme');
+      expect(version.model).toBe('Invoice');
+    });
+
+    test('a shared model names none, and that is not a bug', async () => {
+      const plan = await Plan.create({ name: 'Pro' });
+      const [version] = await all(() => versions.of(plan));
+
+      expect(version.tenant).toBeNull();
+    });
+
+    test('the record decides, not the scope: a sweep still names it right', async () => {
+      const invoice = await as('acme', () =>
+        Invoice.create({ amount: 10, reference: 'A-2' })
+      );
+
+      // What `henri.retention` and `henri.privacy` do: walk every tenant
+      // and write. The version still says whose record it was
+      await all(() => invoice.update({ amount: 20 }));
+
+      const [latest] = await all(() =>
+        versions.of(invoice, { event: 'update' })
+      );
+
+      expect(latest.tenant).toBe('acme');
+    });
+  });
+
+  describe('reading it back', () => {
+    let mine = null;
+    let theirs = null;
+    let plan = null;
+
+    beforeEach(async () => {
+      mine = await as('acme', () =>
+        Invoice.create({ amount: 1, reference: 'ACME-1' })
+      );
+      theirs = await as('globex', () =>
+        Invoice.create({ amount: 2, reference: 'GLOBEX-1' })
+      );
+      plan = await Plan.create({ name: 'Pro' });
+    });
+
+    test('a listing inside a tenant never carries another tenant’s row', async () => {
+      const found = await as('acme', () => versions.list({ limit: 50 }));
+      const records = found.map((version) => version.record);
+
+      expect(records).toContain(mine.externalId);
+      expect(records).not.toContain(theirs.externalId);
+      // The shared model comes with it: its history belongs to everybody
+      expect(records).toContain(plan.externalId);
+    });
+
+    test('a count is narrowed the same way a list is', async () => {
+      expect(await as('acme', () => versions.count({ model: 'Invoice' }))).toBe(
+        1
+      );
+      expect(await all(() => versions.count({ model: 'Invoice' }))).toBe(2);
+    });
+
+    test('asking for another tenant’s record by id answers nothing', async () => {
+      const found = await as('acme', () =>
+        versions.of({ model: 'Invoice', record: theirs.externalId })
+      );
+
+      expect(found).toEqual([]);
+    });
+
+    test('one version of another tenant is null, not a refusal', async () => {
+      const [target_] = await all(() =>
+        versions.of({ model: 'Invoice', record: theirs.externalId })
+      );
+
+      expect(await as('globex', () => versions.get(target_.id))).not.toBeNull();
+      // `Model.findById()`'s own answer: not there. A message saying "it is
+      // there but not yours" is the oracle the 404 exists to close
+      expect(await as('acme', () => versions.get(target_.id))).toBeNull();
+    });
+
+    test('with tenancy on and no tenant in scope, a read is refused', async () => {
+      const error = await versions.list({ limit: 10 }).then(
+        () => null,
+        (thrown) => thrown
+      );
+
+      expect(error.code).toBe('HENRI_TENANT_REQUIRED');
+      expect(error.message).toContain('henri.tenancy.unscoped');
+    });
+
+    test('unscoped() is the way an operator reads every tenant', async () => {
+      const found = await all(() => versions.list({ limit: 50 }));
+
+      expect(found.length).toBeGreaterThanOrEqual(3);
+    });
+
+    test('a caller cannot widen it by asking for another tenant', async () => {
+      const found = await as('acme', () =>
+        versions.list({ limit: 50, tenant: 'globex' })
+      );
+
+      expect(found.map((version) => version.record)).not.toContain(
+        theirs.externalId
+      );
+    });
+  });
+
+  describe('reconstructing and writing back', () => {
+    test('a restore of one’s own record still works, and is a version too', async () => {
+      const invoice = await as('acme', () =>
+        Invoice.create({ amount: 5, reference: 'A-3' })
+      );
+
+      await as('acme', () => invoice.update({ amount: 500 }));
+
+      const [created] = await as('acme', () =>
+        versions.of(invoice, { event: 'create' })
+      );
+      const done = await as('acme', () => versions.restore(created.id));
+
+      expect(done.created).toBe(false);
+      expect(done.record.amount).toBe(5);
+    });
+
+    test('a destroyed record comes back in the tenant it belonged to', async () => {
+      const invoice = await as('globex', () =>
+        Invoice.create({ amount: 7, reference: 'G-1' })
+      );
+      const external = invoice.externalId;
+
+      await as('globex', () => invoice.destroy({ force: true }));
+
+      const [destroyed] = await all(() =>
+        versions.of(
+          { model: 'Invoice', record: external },
+          { event: 'destroy' }
+        )
+      );
+      const done = await as('globex', () => versions.restore(destroyed.id));
+
+      expect(done.created).toBe(true);
+
+      const back = await as('globex', () => Invoice.findById(external));
+
+      expect(back.reference).toBe('G-1');
+      expect(back.tenantId).toBe('globex');
+      // And it is not visible from the other tenant, which is the point
+      expect(await as('acme', () => Invoice.findById(external))).toBeNull();
+    });
+
+    test('another tenant cannot restore it here, even knowing the id', async () => {
+      const invoice = await as('globex', () =>
+        Invoice.create({ amount: 7, reference: 'G-2' })
+      );
+      const external = invoice.externalId;
+
+      await as('globex', () => invoice.destroy({ force: true }));
+
+      const [destroyed] = await all(() =>
+        versions.of(
+          { model: 'Invoice', record: external },
+          { event: 'destroy' }
+        )
+      );
+
+      // Reading it as acme answers nothing at all, so a restore by id gets
+      // the unknown-version refusal before it gets anywhere near a write
+      const byId = await as('acme', () => versions.restore(destroyed.id)).then(
+        () => null,
+        (thrown) => thrown
+      );
+
+      expect(byId.code).toBe('HENRI_VERSION_UNKNOWN');
+
+      // And with the row in hand -- which is what an operator script does
+      // after an `unscoped()` listing -- the write itself is what refuses
+      const withRow = await as('acme', () => versions.restore(destroyed)).then(
+        () => null,
+        (thrown) => thrown
+      );
+
+      expect(withRow.code).toBe('HENRI_VERSION_CROSS_TENANT');
+      expect(withRow.message).toContain('globex');
+      expect(await as('acme', () => Invoice.findById(external))).toBeNull();
+    });
+
+    test('a version that predates the column is refused rather than guessed', async () => {
+      const invoice = await as('acme', () =>
+        Invoice.create({ amount: 9, reference: 'A-4' })
+      );
+      const external = invoice.externalId;
+
+      await as('acme', () => invoice.destroy({ force: true }));
+
+      const [destroyed] = await all(() =>
+        versions.of(
+          { model: 'Invoice', record: external },
+          { event: 'destroy' }
+        )
+      );
+
+      // What an upgrade leaves behind: rows the column arrived after.
+      // No placeholder: `adapter.query()` is raw SQL and every dialect
+      // numbers its own, and an externalId is a uuid henri just made
+      await adapter.query(
+        `UPDATE ${versions.settings.table} SET tenant = NULL WHERE record = '${external}'`
+      );
+
+      const row = await all(() => versions.get(destroyed.id));
+
+      expect(row.tenant).toBeNull();
+
+      // It is still readable -- a null row is nobody's, and hiding it from
+      // everybody would be worse -- but it will not be written back on a
+      // guess about whose it was
+      expect(await as('acme', () => versions.get(destroyed.id))).not.toBeNull();
+
+      const error = await as('acme', () => versions.restore(row)).then(
+        () => null,
+        (thrown) => thrown
+      );
+
+      expect(error.code).toBe('HENRI_VERSION_CROSS_TENANT');
+      expect(error.message).toContain('names no tenant');
+    });
+
+    test('unscoped() is how a record is deliberately moved back', async () => {
+      const invoice = await as('globex', () =>
+        Invoice.create({ amount: 3, reference: 'G-3' })
+      );
+      const external = invoice.externalId;
+
+      await as('globex', () => invoice.destroy({ force: true }));
+
+      const [destroyed] = await all(() =>
+        versions.of(
+          { model: 'Invoice', record: external },
+          { event: 'destroy' }
+        )
+      );
+      const done = await all(() => versions.restore(destroyed.id));
+
+      expect(done.created).toBe(true);
+      expect(await all(() => Invoice.findById(external))).not.toBeNull();
+    });
+  });
+});
+
+describe(`upgrading a version table with no tenant column (${target.name})`, () => {
+  let adapter = null;
+  let henri = null;
+  let versions = null;
+  let table = null;
+
+  /**
+   * Whether the live table has the column right now
+   *
+   * @returns {Promise<boolean>} yes or no
+   */
+  const hasColumn = () =>
+    adapter.query(`SELECT tenant FROM ${table} WHERE 1 = 0`).then(
+      () => true,
+      () => false
+    );
+
+  /**
+   * Takes the table back to what a henri without the column wrote
+   *
+   * @returns {Promise<void>} Resolves when the column is gone
+   */
+  const downgrade = async () => {
+    await adapter
+      .query(`DROP INDEX IF EXISTS ${table}_tenant`)
+      .catch(() => null);
+    await adapter.query(`ALTER TABLE ${table} DROP COLUMN tenant`);
+  };
+
+  beforeAll(async () => {
+    ({ adapter, henri, versions } = await application({ key: 'ver-upgrade' }));
+    table = versions.settings.table;
+  }, 60000);
+
+  afterAll(async () => {
+    await adapter.stop();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('a boot whose user may ALTER adds the column itself', async () => {
+    await downgrade();
+    expect(await hasColumn()).toBe(false);
+
+    // `ready()` installs, and the install carries the tolerated upgrade
+    // block: for most people the upgrade is the next deploy and nothing
+    // else. The refusals below are for the installation where it is not
+    const fresh = new Versions();
+
+    fresh.henri = henri;
+    await fresh.init();
+
+    expect(await hasColumn()).toBe(true);
+    expect(await (await fresh.ready()).tenanted()).toBe(true);
+  }, 60000);
+
+  test('a table that cannot hold it fails the boot naming it', async () => {
+    // What decides is asking the table, never whether the `ALTER` ran --
+    // so a database user who may not alter one is exactly this: the
+    // statement was tolerated, and the column is still not there
+    vi.spyOn(SqlVersions.prototype, 'tenanted').mockResolvedValue(false);
+
+    const fresh = new Versions();
+
+    fresh.henri = henri;
+
+    const error = await fresh.init().then(
+      () => null,
+      (thrown) => thrown
+    );
+
+    expect(error.code).toBe('HENRI_VERSION_TENANT_UNINSTALLED');
+    expect(error.message).toContain('config.tenancy');
+    expect(error.hint).toContain('ADD COLUMN tenant');
+  }, 60000);
+
+  test('an application that is not multi-tenant notices nothing', async () => {
+    vi.spyOn(SqlVersions.prototype, 'tenanted').mockResolvedValue(false);
+
+    const plain = new Versions();
+
+    plain.henri = { ...henri, tenancy: { enabled: false } };
+    await plain.init();
+
+    expect(plain.enabled).toBe(true);
+
+    const { Plan } = adapter.getModels();
+    const plan = await henri.tenancy.unscoped(() =>
+      Plan.create({ name: 'Basic' })
+    );
+
+    // The insert names the columns that are there, so the history of an
+    // application that never asked for any of this is written as it was
+    const [version] = await plain.of(plan);
+
+    expect(version.model).toBe('Plan');
+    expect(version.tenant).toBeNull();
+  }, 60000);
+
+  test('the rows the upgrade left behind read from every tenant', async () => {
+    const { Invoice } = adapter.getModels();
+    const invoice = await henri.tenancy.run('acme', () =>
+      Invoice.create({ amount: 1, reference: 'UP-1' })
+    );
+
+    await adapter.query(`UPDATE ${table} SET tenant = NULL`);
+
+    // Null is not "acme" and it is not "globex": it is nobody's, which is
+    // what a shared model looks like too. Hiding those rows from everybody
+    // would lose a shared model's history, so a scoped read takes them
+    const seen = await henri.tenancy.run('globex', () =>
+      versions.list({ limit: 50 })
+    );
+
+    expect(seen.map((version) => version.record)).toContain(invoice.externalId);
+  }, 60000);
+});

--- a/packages/jobs/__tests__/__snapshots__/config.spec.js.snap
+++ b/packages/jobs/__tests__/__snapshots__/config.spec.js.snap
@@ -99,6 +99,7 @@ exports[`the schema > writes the DDL of mssql 1`] = `
   unique_key VARCHAR(190) NULL,
   concurrency_key VARCHAR(190) NULL,
   batch_id VARCHAR(36) NULL,
+  tenant VARCHAR(190) NULL,
   PRIMARY KEY (id)
 );
 IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'henri_jobs_claim' AND object_id = OBJECT_ID('henri_jobs')) CREATE INDEX [henri_jobs_claim] ON [henri_jobs] (state, queue, priority, run_at);
@@ -145,8 +146,10 @@ IF OBJECT_ID('henri_jobs_batches', 'U') IS NULL CREATE TABLE [henri_jobs_batches
 IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'henri_jobs_batches_open' AND object_id = OBJECT_ID('henri_jobs_batches')) CREATE INDEX [henri_jobs_batches_open] ON [henri_jobs_batches] (finished_at, updated_at);
 IF COL_LENGTH('henri_jobs', 'concurrency_key') IS NULL ALTER TABLE [henri_jobs] ADD concurrency_key VARCHAR(190) NULL;
 IF COL_LENGTH('henri_jobs', 'batch_id') IS NULL ALTER TABLE [henri_jobs] ADD batch_id VARCHAR(36) NULL;
+IF COL_LENGTH('henri_jobs', 'tenant') IS NULL ALTER TABLE [henri_jobs] ADD tenant VARCHAR(190) NULL;
 IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'henri_jobs_limited' AND object_id = OBJECT_ID('henri_jobs')) CREATE INDEX [henri_jobs_limited] ON [henri_jobs] (state, concurrency_key, run_at);
-IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'henri_jobs_batch' AND object_id = OBJECT_ID('henri_jobs')) CREATE INDEX [henri_jobs_batch] ON [henri_jobs] (batch_id)"
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'henri_jobs_batch' AND object_id = OBJECT_ID('henri_jobs')) CREATE INDEX [henri_jobs_batch] ON [henri_jobs] (batch_id);
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'henri_jobs_tenant' AND object_id = OBJECT_ID('henri_jobs')) CREATE INDEX [henri_jobs_tenant] ON [henri_jobs] (tenant, state, run_at)"
 `;
 
 exports[`the schema > writes the DDL of mysql 1`] = `
@@ -176,6 +179,7 @@ exports[`the schema > writes the DDL of mysql 1`] = `
   unique_key VARCHAR(190) NULL,
   concurrency_key VARCHAR(190) NULL,
   batch_id VARCHAR(36) NULL,
+  tenant VARCHAR(190) NULL,
   PRIMARY KEY (id),
   KEY \`henri_jobs_claim\` (state, queue, priority, run_at),
   KEY \`henri_jobs_token\` (claim_token),
@@ -222,8 +226,10 @@ CREATE TABLE IF NOT EXISTS \`henri_jobs_batches\` (
 );
 ALTER TABLE \`henri_jobs\` ADD COLUMN concurrency_key VARCHAR(190) NULL;
 ALTER TABLE \`henri_jobs\` ADD COLUMN batch_id VARCHAR(36) NULL;
+ALTER TABLE \`henri_jobs\` ADD COLUMN tenant VARCHAR(190) NULL;
 CREATE INDEX \`henri_jobs_limited\` ON \`henri_jobs\` (state, concurrency_key, run_at);
-CREATE INDEX \`henri_jobs_batch\` ON \`henri_jobs\` (batch_id)"
+CREATE INDEX \`henri_jobs_batch\` ON \`henri_jobs\` (batch_id);
+CREATE INDEX \`henri_jobs_tenant\` ON \`henri_jobs\` (tenant, state, run_at)"
 `;
 
 exports[`the schema > writes the DDL of postgres 1`] = `
@@ -253,6 +259,7 @@ exports[`the schema > writes the DDL of postgres 1`] = `
   unique_key VARCHAR(190) NULL,
   concurrency_key VARCHAR(190) NULL,
   batch_id VARCHAR(36) NULL,
+  tenant VARCHAR(190) NULL,
   PRIMARY KEY (id)
 );
 CREATE INDEX IF NOT EXISTS "henri_jobs_claim" ON "henri_jobs" (state, queue, priority, run_at);
@@ -299,8 +306,10 @@ CREATE TABLE IF NOT EXISTS "henri_jobs_batches" (
 CREATE INDEX IF NOT EXISTS "henri_jobs_batches_open" ON "henri_jobs_batches" (finished_at, updated_at);
 ALTER TABLE "henri_jobs" ADD COLUMN IF NOT EXISTS concurrency_key VARCHAR(190) NULL;
 ALTER TABLE "henri_jobs" ADD COLUMN IF NOT EXISTS batch_id VARCHAR(36) NULL;
+ALTER TABLE "henri_jobs" ADD COLUMN IF NOT EXISTS tenant VARCHAR(190) NULL;
 CREATE INDEX IF NOT EXISTS "henri_jobs_limited" ON "henri_jobs" (state, concurrency_key, run_at);
-CREATE INDEX IF NOT EXISTS "henri_jobs_batch" ON "henri_jobs" (batch_id)"
+CREATE INDEX IF NOT EXISTS "henri_jobs_batch" ON "henri_jobs" (batch_id);
+CREATE INDEX IF NOT EXISTS "henri_jobs_tenant" ON "henri_jobs" (tenant, state, run_at)"
 `;
 
 exports[`the schema > writes the DDL of sqlite 1`] = `
@@ -330,6 +339,7 @@ exports[`the schema > writes the DDL of sqlite 1`] = `
   unique_key VARCHAR(190) NULL,
   concurrency_key VARCHAR(190) NULL,
   batch_id VARCHAR(36) NULL,
+  tenant VARCHAR(190) NULL,
   PRIMARY KEY (id)
 );
 CREATE INDEX IF NOT EXISTS "henri_jobs_claim" ON "henri_jobs" (state, queue, priority, run_at);
@@ -376,6 +386,8 @@ CREATE TABLE IF NOT EXISTS "henri_jobs_batches" (
 CREATE INDEX IF NOT EXISTS "henri_jobs_batches_open" ON "henri_jobs_batches" (finished_at, updated_at);
 ALTER TABLE "henri_jobs" ADD COLUMN concurrency_key VARCHAR(190) NULL;
 ALTER TABLE "henri_jobs" ADD COLUMN batch_id VARCHAR(36) NULL;
+ALTER TABLE "henri_jobs" ADD COLUMN tenant VARCHAR(190) NULL;
 CREATE INDEX IF NOT EXISTS "henri_jobs_limited" ON "henri_jobs" (state, concurrency_key, run_at);
-CREATE INDEX IF NOT EXISTS "henri_jobs_batch" ON "henri_jobs" (batch_id)"
+CREATE INDEX IF NOT EXISTS "henri_jobs_batch" ON "henri_jobs" (batch_id);
+CREATE INDEX IF NOT EXISTS "henri_jobs_tenant" ON "henri_jobs" (tenant, state, run_at)"
 `;

--- a/packages/jobs/__tests__/config.spec.js
+++ b/packages/jobs/__tests__/config.spec.js
@@ -143,6 +143,7 @@ describe('definitions', () => {
       'mailers',
       'nested/deep',
       'ok',
+      'scope',
       'slow',
       'tenanted',
     ]);
@@ -507,17 +508,20 @@ describe('the schema', () => {
     for (const dialect of ['sqlite', 'postgres', 'mysql', 'mssql']) {
       const statements = upgrade(dialect, tables);
 
-      // The two columns and the indexes they serve, and nothing else: an
+      // The three columns and the indexes they serve, and nothing else: an
       // upgrade touches an existing table, so it says exactly what it
       // changes. The batches table itself is a *new* table, so the guarded
       // CREATE of the install is all it needs
-      expect(statements).toHaveLength(4);
+      expect(statements).toHaveLength(6);
       expect(statements[0]).toContain('concurrency_key');
       expect(statements[0]).toMatch(/ALTER TABLE/u);
       expect(statements[1]).toContain('batch_id');
       expect(statements[1]).toMatch(/ALTER TABLE/u);
-      expect(statements[2]).toContain('henri_jobs_limited');
-      expect(statements[3]).toContain('henri_jobs_batch');
+      expect(statements[2]).toContain('tenant');
+      expect(statements[2]).toMatch(/ALTER TABLE/u);
+      expect(statements[3]).toContain('henri_jobs_limited');
+      expect(statements[4]).toContain('henri_jobs_batch');
+      expect(statements[5]).toContain('henri_jobs_tenant');
 
       // Every one of them is part of the install, so a fresh database and an
       // upgraded one end up with the same table

--- a/packages/jobs/__tests__/fixtures/app/app/jobs/scope.js
+++ b/packages/jobs/__tests__/fixtures/app/app/jobs/scope.js
@@ -1,0 +1,30 @@
+// Says which tenant the runner entered before it called this.
+//
+// The whole point of the column is that a job's `perform()` runs where
+// there is no request, so this records what `henri.tenancy.current()`
+// answers *inside* the attempt -- which is the only place the question can
+// be asked honestly.
+module.exports = {
+  perform: async (args, context) => {
+    const tenancy = context.henri && context.henri.tenancy;
+    const scope = (tenancy && tenancy.current()) || null;
+
+    global.__henriJobScopes = global.__henriJobScopes || [];
+    global.__henriJobScopes.push({
+      row: context.job.tenant,
+      scope,
+      token: (args && args.token) || null,
+    });
+
+    // Long enough that two attempts of two tenants overlap, which is what
+    // makes the async context worth having rather than a field on `this`
+    await new Promise((resolve) =>
+      setTimeout(resolve, (args && args.wait) || 0)
+    );
+
+    return {
+      after: (tenancy && tenancy.current()) || null,
+      scope,
+    };
+  },
+};

--- a/packages/jobs/__tests__/helpers.js
+++ b/packages/jobs/__tests__/helpers.js
@@ -3,6 +3,11 @@ const path = require('path');
 const { randomUUID } = require('crypto');
 
 const Sql = require('@usehenri/sequelize');
+// The real module, not a stand-in: what a job's tenant is scoped by is
+// core's decision, and the queue is what has to ask. `enabled` is false
+// unless a suite passed a `tenancy` setting, so every other suite is
+// untouched -- the drizzle harness does exactly this
+const Tenancy = require('@usehenri/core/src/0.tenancy');
 // The target of the SQL suites: sqlite unless HENRI_TEST_POSTGRES_URL or
 // HENRI_TEST_MYSQL_URL points at a server, in which case these suites run
 // on that server too (`pnpm test:sql:live`)
@@ -17,12 +22,14 @@ if (typeof afterAll === 'function') {
 /**
  * A minimal henri stand-in
  *
- * @param {object} [options={}] `cwd`
+ * @param {object} [options={}] `cwd`, and `settings` for the configuration
+ *   the modules it carries read (`tenancy`)
  * @returns {object} A fake henri, with the pen calls in `calls`
  */
 const fakeHenri = (options = {}) => {
   const calls = [];
   const pen = {};
+  const settings = options.settings || {};
 
   ['error', 'info', 'warn'].forEach((level) => {
     pen[level] = (...args) => calls.push([level, ...args]);
@@ -35,11 +42,27 @@ const fakeHenri = (options = {}) => {
     return new Error(args.join(' '));
   };
 
-  return {
+  const henri = {
     calls,
+    config: {
+      get: (key) => settings[key],
+      has: (key) => typeof settings[key] !== 'undefined',
+      sourceOf: () => 'the test',
+    },
     cwd: () => options.cwd || path.join(__dirname, 'fixtures', 'app'),
     pen,
   };
+
+  const tenancy = new Tenancy();
+
+  tenancy.henri = henri;
+  tenancy.init();
+  henri.tenancy = tenancy;
+  // The module says at boot that it is on; that is core's line, not the
+  // queue's, and `calls` is what the suites read to see what the queue said
+  calls.length = 0;
+
+  return henri;
 };
 
 /**
@@ -80,10 +103,12 @@ const adapterFor = async (key) => {
  * @param {string} [options.cwd] The application directory (app/jobs)
  * @param {string} [options.key] The key of the database
  * @param {object} [options.adapter] An adapter to reuse
+ * @param {object} [options.henri] A henri stand-in to reuse, so a suite can
+ *   turn tenancy on for it
  * @returns {Promise<object>} `{ adapter, henri, jobs }`
  */
 const build = async (options = {}) => {
-  const henri = fakeHenri({ cwd: options.cwd });
+  const henri = options.henri || fakeHenri({ cwd: options.cwd });
   const adapter = options.adapter || (await adapterFor(options.key));
   const jobs = new Jobs(henri, {
     adapter,

--- a/packages/jobs/__tests__/mongo.spec.js
+++ b/packages/jobs/__tests__/mongo.spec.js
@@ -69,6 +69,118 @@ describe('queue (mongodb)', () => {
     live.reset();
   });
 
+  describe('tenants', () => {
+    /**
+     * The same property `./tenancy.spec.js` proves against SQL, on the
+     * backend that needs no upgrade to hold the field: **tenant A's runner
+     * never performs or lists tenant B's jobs.**
+     */
+    let multi = null;
+    let scoped = null;
+
+    /**
+     * Every scope a `scope` job recorded
+     *
+     * @returns {Array<object>} What each attempt saw
+     */
+    const scopes = () => global.__henriJobScopes || [];
+
+    beforeAll(async () => {
+      multi = fakeHenri({
+        cwd: path.join(__dirname, 'fixtures', 'app'),
+        settings: { tenancy: { from: { user: 'tenantId' } } },
+      });
+      scoped = new Jobs(multi, {
+        adapter,
+        config: { backoff: { jitter: 0 } },
+        cwd: multi.cwd(),
+      });
+
+      await scoped.start();
+      multi.jobs = scoped;
+    }, 60000);
+
+    beforeEach(() => {
+      global.__henriJobScopes = [];
+    });
+
+    test('a collection needs no upgrade to hold a tenant', async () => {
+      // A field appears when it is written, so there is nothing to alter
+      // and nothing to refuse -- and a document an older henri wrote is a
+      // job of no tenant, which is exactly what it was
+      expect(await scoped.store.tenanted()).toBe(true);
+      expect(scoped.tenanted).toBe(true);
+    });
+
+    test('an enqueue inside a tenant carries it, and one outside does not', async () => {
+      const mine = await multi.tenancy.run('acme', () =>
+        scoped.perform('ok', { of: 'acme' })
+      );
+      const nobody = await scoped.perform('ok', { of: 'nobody' });
+
+      expect(mine.tenant).toBe('acme');
+      expect(nobody.tenant).toBeNull();
+    });
+
+    test('a listing of one tenant is that tenant only', async () => {
+      await multi.tenancy.run('acme', () => scoped.perform('ok', { n: 1 }));
+      await multi.tenancy.run('globex', () => scoped.perform('ok', { n: 2 }));
+      await scoped.perform('ok', { n: 3 });
+
+      const acme = await scoped.list({ tenant: 'acme' });
+
+      expect(acme).toHaveLength(1);
+      expect(acme[0].args.n).toBe(1);
+      expect(await scoped.list({ limit: 50 })).toHaveLength(3);
+    });
+
+    test('naming another tenant while one is in scope is refused', async () => {
+      const error = await multi.tenancy
+        .run('acme', () => scoped.perform('ok', null, { tenant: 'globex' }))
+        .then(
+          () => null,
+          (thrown) => thrown
+        );
+
+      expect(error.code).toBe('HENRI_TENANT_CROSS_WRITE');
+      expect(await scoped.count()).toBe(0);
+    });
+
+    test('the runner enters the tenant the document names', async () => {
+      await multi.tenancy.run('acme', () =>
+        scoped.perform('scope', { token: 'a' })
+      );
+      await scoped.perform('scope', { token: 'none' });
+
+      await new Runner(scoped, { concurrency: 2, recurring: false }).once();
+
+      const seen = scopes().sort((left, right) =>
+        left.token < right.token ? -1 : 1
+      );
+
+      expect(seen).toEqual([
+        { row: 'acme', scope: 'acme', token: 'a' },
+        { row: null, scope: null, token: 'none' },
+      ]);
+    });
+
+    test('a discard of one tenant leaves the other in the collection', async () => {
+      const mine = await multi.tenancy.run('acme', () =>
+        scoped.perform('ok', null, { maxAttempts: 1 })
+      );
+      const theirs = await multi.tenancy.run('globex', () =>
+        scoped.perform('ok', null, { maxAttempts: 1 })
+      );
+
+      await scoped.store.update(mine.id, { state: 'dead' });
+      await scoped.store.update(theirs.id, { state: 'dead' });
+
+      expect(await scoped.dead.discardAll({ tenant: 'acme' })).toBe(1);
+      expect(await scoped.get(mine.id)).toBeNull();
+      expect(await scoped.get(theirs.id)).not.toBeNull();
+    });
+  });
+
   describe('batches', () => {
     /**
      * The callbacks performed in this process

--- a/packages/jobs/__tests__/queue.spec.js
+++ b/packages/jobs/__tests__/queue.spec.js
@@ -39,6 +39,7 @@ describe(`queue (${target.name})`, () => {
         'mailers',
         'nested/deep',
         'ok',
+        'scope',
         'slow',
         'tenanted',
       ]);

--- a/packages/jobs/__tests__/tenancy.spec.js
+++ b/packages/jobs/__tests__/tenancy.spec.js
@@ -1,0 +1,417 @@
+const { randomUUID } = require('crypto');
+
+const {
+  adapterFor,
+  build,
+  close,
+  dropIndex,
+  fakeHenri,
+  sharedKey,
+  target,
+} = require('./helpers');
+const { Runner } = require('../src/runner');
+
+/**
+ * The property this column exists for, written as a test: **tenant A's
+ * runner never performs, lists, retries or discards tenant B's jobs.**
+ *
+ * It is the queue's half of what
+ * `packages/drizzle/__tests__/tenancy.spec.js` proves for the models, and
+ * it is written the same way -- one list of the paths people forget rather
+ * than a happy path plus edge cases. The paths here are: the stamp on the
+ * enqueue, the listing, the dead letter queue's two bulk operations, the
+ * scope the runner enters before `perform()`, and the batch callback,
+ * which is the one row nobody is holding when it is written.
+ *
+ * It runs on sqlite offline and on the live PostgreSQL or MySQL of
+ * `pnpm test:sql:live`, which is what `./targets.js` decides. The MongoDB
+ * half is in `./mongo.spec.js`, where the rest of that backend lives.
+ */
+
+/** A henri whose tenancy module is on */
+const multitenant = () =>
+  fakeHenri({ settings: { tenancy: { from: { user: 'tenantId' } } } });
+
+/** Every scope a `scope` job recorded, in the order they were entered */
+const scopes = () => global.__henriJobScopes || [];
+
+describe(`a job carries its tenant (${target.name})`, () => {
+  const adapters = [];
+  let henri = null;
+  let jobs = null;
+  let store = null;
+
+  /**
+   * Runs something as a tenant
+   *
+   * @param {string} tenant The tenant
+   * @param {function} work What to run
+   * @returns {Promise<*>} Whatever the work answered
+   */
+  const as = (tenant, work) => henri.tenancy.run(tenant, work);
+
+  beforeAll(async () => {
+    const adapter = await adapterFor(sharedKey('tenancy'));
+
+    henri = multitenant();
+    ({ jobs } = await build({ adapter, henri }));
+    store = jobs.store;
+    henri.jobs = jobs;
+    adapters.push(adapter);
+  }, 60000);
+
+  afterAll(() => close(adapters));
+
+  beforeEach(async () => {
+    for (const state of ['pending', 'running', 'done', 'dead']) {
+      await store.remove({ state });
+    }
+
+    for (const batch of await store.listBatches({ limit: 200 })) {
+      await store.removeBatch(batch.id);
+    }
+
+    global.__henriJobScopes = [];
+    global.__henriJobsRuns = [];
+    global.__henriJobsCallbacks = [];
+  });
+
+  describe('the column', () => {
+    test('the table has it, and the queue says so', async () => {
+      expect(await store.tenanted()).toBe(true);
+      expect(jobs.tenanted).toBe(true);
+      expect(await store.columns()).toContain('tenant');
+    });
+
+    test('a queue with no tenancy stamps null and notices nothing', async () => {
+      const plain = await build({ adapter: store.adapter });
+
+      expect(plain.henri.tenancy.enabled).toBe(false);
+
+      const job = await plain.jobs.perform('ok', { plain: true });
+
+      expect(job.tenant).toBeNull();
+      await store.remove({ id: job.id });
+    });
+  });
+
+  describe('the stamp', () => {
+    test('an enqueue inside a tenant carries it, without being asked', async () => {
+      const job = await as('acme', () => jobs.perform('ok', { n: 1 }));
+
+      expect(job.tenant).toBe('acme');
+      expect((await jobs.get(job.id)).tenant).toBe('acme');
+    });
+
+    test('an enqueue outside every tenant carries none', async () => {
+      const job = await jobs.perform('ok', { n: 2 });
+
+      expect(job.tenant).toBeNull();
+    });
+
+    test('unscoped() is not a tenant either', async () => {
+      const job = await henri.tenancy.unscoped(() => jobs.perform('ok'));
+
+      expect(job.tenant).toBeNull();
+    });
+
+    test('naming a tenant wins, and naming null means no tenant', async () => {
+      const named = await jobs.perform('ok', null, { tenant: 'globex' });
+      const platform = await as('acme', () =>
+        jobs.perform('ok', null, { tenant: null })
+      );
+
+      expect(named.tenant).toBe('globex');
+      expect(platform.tenant).toBeNull();
+    });
+
+    test('naming another tenant while one is in scope is refused', async () => {
+      const error = await as('acme', () =>
+        jobs.perform('ok', null, { tenant: 'globex' })
+      ).then(
+        () => null,
+        (thrown) => thrown
+      );
+
+      expect(error.code).toBe('HENRI_TENANT_CROSS_WRITE');
+      expect(error.message).toContain('globex');
+      expect(error.message).toContain('acme');
+      // Nothing was written: the refusal is before the insert
+      expect(await jobs.count()).toBe(0);
+    });
+
+    test('unscoped() is how a fan-out enqueues for every tenant', async () => {
+      const made = await henri.tenancy.unscoped(async () => {
+        const out = [];
+
+        for (const tenant of ['acme', 'globex']) {
+          out.push(await jobs.perform('ok', { tenant }, { tenant }));
+        }
+
+        return out;
+      });
+
+      expect(made.map((job) => job.tenant)).toEqual(['acme', 'globex']);
+    });
+
+    test('a tenant too wide for the column is refused, never truncated', async () => {
+      const error = await jobs
+        .perform('ok', null, { tenant: 'a'.repeat(191) })
+        .then(
+          () => null,
+          (thrown) => thrown
+        );
+
+      expect(error.code).toBe('HENRI_TENANT_INVALID');
+      expect(error.message).toContain('191');
+    });
+  });
+
+  describe('reading it back', () => {
+    beforeEach(async () => {
+      await as('acme', () => jobs.perform('ok', { of: 'acme' }));
+      await as('acme', () => jobs.perform('boom', { of: 'acme' }));
+      await as('globex', () => jobs.perform('ok', { of: 'globex' }));
+      await jobs.perform('ok', { of: 'nobody' });
+    });
+
+    test('a listing of one tenant is that tenant only', async () => {
+      const acme = await jobs.list({ tenant: 'acme' });
+      const globex = await jobs.list({ tenant: 'globex' });
+
+      expect(acme).toHaveLength(2);
+      expect(acme.every((job) => job.tenant === 'acme')).toBe(true);
+      expect(globex).toHaveLength(1);
+      expect(globex[0].args.of).toBe('globex');
+    });
+
+    test('a job of no tenant is nobody’s, not everybody’s', async () => {
+      const acme = await jobs.list({ tenant: 'acme' });
+
+      expect(acme.map((job) => job.args.of)).not.toContain('nobody');
+      expect(await jobs.list({ limit: 50 })).toHaveLength(4);
+    });
+
+    test('a filter combines with the others rather than replacing them', async () => {
+      const found = await jobs.list({ name: 'ok', tenant: 'acme' });
+
+      expect(found).toHaveLength(1);
+      expect(found[0].name).toBe('ok');
+    });
+  });
+
+  describe('the dead letter queue', () => {
+    /**
+     * Buries one job of a tenant
+     *
+     * @param {string} tenant The tenant
+     * @returns {Promise<object>} The dead job
+     */
+    const bury = async (tenant) => {
+      const job = await henri.tenancy.run(tenant, () =>
+        jobs.perform('boom', { tenant }, { maxAttempts: 1 })
+      );
+
+      await new Runner(jobs, { recurring: false }).once();
+
+      return jobs.get(job.id);
+    };
+
+    test('a retry of one tenant leaves the other buried', async () => {
+      const acme = await bury('acme');
+      const globex = await bury('globex');
+
+      expect(acme.state).toBe('dead');
+      expect(globex.state).toBe('dead');
+
+      const requeued = await jobs.dead.retryAll({ tenant: 'acme' });
+
+      expect(requeued).toBe(1);
+      expect((await jobs.get(acme.id)).state).toBe('pending');
+      expect((await jobs.get(globex.id)).state).toBe('dead');
+    });
+
+    test('a discard of one tenant leaves the other in the table', async () => {
+      const acme = await bury('acme');
+      const globex = await bury('globex');
+      const discarded = await jobs.dead.discardAll({ tenant: 'acme' });
+
+      expect(discarded).toBe(1);
+      expect(await jobs.get(acme.id)).toBeNull();
+      expect(await jobs.get(globex.id)).not.toBeNull();
+    });
+  });
+
+  describe('what the runner does with it', () => {
+    test('it enters the tenant the row names before perform()', async () => {
+      await as('acme', () => jobs.perform('scope', { token: 'a' }));
+      await new Runner(jobs, { recurring: false }).once();
+
+      expect(scopes()).toEqual([{ row: 'acme', scope: 'acme', token: 'a' }]);
+    });
+
+    test('a row with no tenant enters none: null is not every tenant', async () => {
+      await jobs.perform('scope', { token: 'none' });
+      await new Runner(jobs, { recurring: false }).once();
+
+      expect(scopes()).toEqual([{ row: null, scope: null, token: 'none' }]);
+    });
+
+    test('two tenants performed at once never see each other', async () => {
+      // The attempts overlap on purpose: an async context is what makes
+      // this right, and a field on the runner would not be
+      await as('acme', () => jobs.perform('scope', { token: 'a', wait: 40 }));
+      await as('globex', () => jobs.perform('scope', { token: 'b', wait: 40 }));
+
+      await new Runner(jobs, { concurrency: 2, recurring: false }).once();
+
+      const seen = scopes().sort((left, right) =>
+        left.token < right.token ? -1 : 1
+      );
+
+      expect(seen).toEqual([
+        { row: 'acme', scope: 'acme', token: 'a' },
+        { row: 'globex', scope: 'globex', token: 'b' },
+      ]);
+    });
+
+    test('the scope is closed again by the time the next job runs', async () => {
+      await as('acme', () => jobs.perform('scope', { token: 'a' }));
+      await new Runner(jobs, { recurring: false }).once();
+
+      expect(henri.tenancy.current()).toBeNull();
+    });
+  });
+
+  describe('a batch', () => {
+    test('its callback is performed in the tenant that made it', async () => {
+      const batch = await as('acme', () =>
+        jobs.batch({
+          callback: 'scope',
+          jobs: [['ok', { of: 'acme' }]],
+        })
+      );
+
+      const [member] = await jobs.batches.jobs(batch.id);
+
+      expect(member.tenant).toBe('acme');
+
+      // The runner performs the member, settles the batch and enqueues the
+      // callback -- all of it outside every tenant, which is exactly the
+      // case the tenant on the batch exists for
+      await new Runner(jobs, { recurring: false }).once();
+
+      const [callback] = await jobs.list({ name: 'scope' });
+
+      expect(callback.tenant).toBe('acme');
+
+      await new Runner(jobs, { recurring: false }).once();
+
+      expect(scopes()).toEqual([{ row: 'acme', scope: 'acme', token: null }]);
+    }, 60000);
+  });
+});
+
+describe(`upgrading a queue that has no tenant column (${target.name})`, () => {
+  const adapters = [];
+  let henri = null;
+  let jobs = null;
+  let store = null;
+
+  /**
+   * Takes the store back to what a henri without the column wrote
+   *
+   * @returns {Promise<void>} Resolves when the column is gone
+   */
+  const downgrade = async () => {
+    const table = jobs.config.tables.jobs;
+
+    await dropIndex(store, table, `${table}_tenant`);
+    await store.run(`ALTER TABLE ${table} DROP COLUMN tenant`);
+    store.tenants = null;
+    jobs.tenanted = await store.tenanted();
+  };
+
+  beforeAll(async () => {
+    const adapter = await adapterFor(sharedKey('tenant-upgrade'));
+
+    henri = fakeHenri();
+    ({ jobs } = await build({ adapter, henri }));
+    store = jobs.store;
+    adapters.push(adapter);
+    await downgrade();
+  }, 60000);
+
+  afterAll(() => close(adapters));
+
+  test('the queue works exactly as it did without it', async () => {
+    expect(await store.tenanted()).toBe(false);
+
+    // The insert names the columns that are there, so an application that
+    // is not multi-tenant does not notice
+    const job = await jobs.perform('ok', { still: 'working' });
+    const claimed = await store.claim({
+      except: [],
+      limit: 5,
+      now: Date.now(),
+      queues: [],
+      runner: 'upgrading',
+      token: randomUUID(),
+    });
+
+    expect(claimed.map((row) => row.id)).toContain(job.id);
+    expect(job.tenant).toBeNull();
+    await store.remove({ state: 'running' });
+  });
+
+  test('a listing by tenant is refused rather than answered wrong', async () => {
+    const error = await jobs.list({ tenant: 'acme' }).then(
+      () => null,
+      (thrown) => thrown
+    );
+
+    expect(error.code).toBe('HENRI_JOB_TENANT_UNINSTALLED');
+    expect(error.hint).toContain('henri jobs:install');
+  });
+
+  test('a multi-tenant application fails the boot naming the column', async () => {
+    const error = await build({
+      adapter: store.adapter,
+      config: { install: false },
+      henri: fakeHenri({
+        settings: { tenancy: { from: { user: 'tenantId' } } },
+      }),
+    }).then(
+      () => null,
+      (thrown) => thrown
+    );
+
+    expect(error.code).toBe('HENRI_JOB_TENANT_UNINSTALLED');
+    expect(error.message).toContain('config.tenancy');
+    expect(error.message).toContain('tenant column');
+    expect(error.hint).toContain('henri jobs:install');
+  }, 60000);
+
+  test('the install adds it, and the tenant is carried from then on', async () => {
+    const statements = await store.install();
+
+    expect(statements.join(';')).toContain('tenant');
+    store.tenants = null;
+    expect(await store.tenanted()).toBe(true);
+
+    const upgraded = await build({
+      adapter: store.adapter,
+      config: { install: false },
+      henri: multitenant(),
+    });
+
+    expect(upgraded.jobs.tenanted).toBe(true);
+
+    const job = await upgraded.henri.tenancy.run('acme', () =>
+      upgraded.jobs.perform('ok', { upgraded: true })
+    );
+
+    expect(job.tenant).toBe('acme');
+    await store.remove({ state: 'pending' });
+  }, 60000);
+});

--- a/packages/jobs/src/batch.js
+++ b/packages/jobs/src/batch.js
@@ -46,12 +46,20 @@ const { toNumber } = require('./store/sql');
 /** The widest a batch name may be: the column that holds it */
 const NAME_LENGTH = 190;
 
-/** The options of the callback that are passed to `perform()` */
+/**
+ * The options of the callback that are passed to `perform()`.
+ *
+ * `tenant` is one of them and is the only one henri fills in by itself
+ * (`Jobs#batch`): the callback is enqueued by a runner long after the
+ * request that made the batch is gone, so the tenant has to travel with
+ * the batch or the callback would be performed outside every tenant.
+ */
 const CALLBACK_OPTIONS = [
   'at',
   'maxAttempts',
   'priority',
   'queue',
+  'tenant',
   'timeout',
   'wait',
 ];

--- a/packages/jobs/src/jobs.js
+++ b/packages/jobs/src/jobs.js
@@ -16,6 +16,16 @@ const { Batch, declaration, toBatch } = require('./batch');
 const STATES = ['pending', 'running', 'done', 'dead'];
 
 /**
+ * The widest a tenant may be: the column it is indexed in.
+ *
+ * The 190 of `base/tenancy.js` and of a webhook endpoint's `owner`, for
+ * the same reason -- it is what MySQL indexes in a utf8mb4 key. The number
+ * is repeated rather than imported because this package raises core's
+ * codes without importing core (see `./errors.js`).
+ */
+const MAX_TENANT = 190;
+
+/**
  * The name of the job that sends a mail `deliverLater()` handed over.
  *
  * `henri.mailers` renders the message before it hands it to the queue, so
@@ -72,6 +82,7 @@ const toJob = (row) => {
     runAt: at(row.run_at),
     startedAt: at(row.started_at),
     state: row.state,
+    tenant: row.tenant || null,
     timeout: toNumber(row.timeout_ms),
     uniqueKey: row.unique_key || null,
     updatedAt: at(row.updated_at),
@@ -116,6 +127,8 @@ class Jobs {
     this.concurrent = false;
     /** Whether the store can hold a batch; see start() */
     this.batched = false;
+    /** Whether the store can stamp a job's tenant; see start() */
+    this.tenanted = false;
 
     /**
      * The retry policy of a job whose file this runner does not have: the
@@ -203,6 +216,22 @@ class Jobs {
 
     this.concurrent = await this.store.concurrent();
     this.batched = await this.store.batched();
+    this.tenanted = await this.store.tenanted();
+
+    // The upgrade has to be honest. An application that turned tenancy on
+    // and whose table cannot hold the column would enqueue rows with no
+    // tenant, and a runner would then perform every one of them outside
+    // every tenant -- which is not "unscoped", it is "wrong, quietly". The
+    // `_UNINSTALLED` precedent: fail the boot and name what is missing
+    if (this.multitenant() && !this.tenanted) {
+      throw new JobError(
+        'HENRI_JOB_TENANT_UNINSTALLED',
+        `@usehenri/jobs: config.tenancy is on and the "${this.config.store}" store has no ${this.config.tables.jobs}.tenant column to stamp a job's tenant in`,
+        {
+          hint: 'Run `henri jobs:install` once with a user that may alter the table; the queue itself keeps working without the column, and a job would then carry no tenant at all',
+        }
+      );
+    }
 
     const bounded = Object.values(this.definitions).filter(
       (definition) => definition.concurrency
@@ -552,6 +581,10 @@ class Jobs {
    *   enqueued it (the recurring schedules use it)
    * @param {string} [options.batch] The batch to count it into; `batch()`
    *   is what makes one, and a batch that is sealed refuses
+   * @param {?string} [options.tenant] The tenant this job belongs to;
+   *   defaults to the tenant of the request or job it is enqueued from
+   *   when the application is multi-tenant (`henri.tenancy`). `null` is a
+   *   job of no tenant, and the runner enters none for it
    * @returns {Promise<object>} The enqueued job
    * @throws {JobError} HENRI_JOB_UNKNOWN, or HENRI_JOB_INVALID_ARGUMENTS
    *   cannot be stored
@@ -609,6 +642,7 @@ class Jobs {
       run_at: when,
       started_at: null,
       state: 'pending',
+      tenant: this.tenantOf(options),
       timeout_ms: duration(options.timeout, definition.timeout),
       unique_key: options.unique || null,
       updated_at: now,
@@ -695,6 +729,130 @@ class Jobs {
   }
 
   /**
+   * `henri.tenancy`, when the application has one and turned it on
+   *
+   * Core is a peer dependency and the queue runs against a henri stand-in
+   * in its own suites, so every reach for a module of core's is guarded the
+   * way the reach for `henri.pen` is.
+   *
+   * @returns {?object} The tenancy module, or null
+   * @memberof Jobs
+   */
+  tenancy() {
+    const tenancy = this.henri && this.henri.tenancy;
+
+    return tenancy && tenancy.enabled ? tenancy : null;
+  }
+
+  /**
+   * Is this application multi-tenant?
+   *
+   * @returns {boolean} yes or no
+   * @memberof Jobs
+   */
+  multitenant() {
+    return Boolean(this.tenancy());
+  }
+
+  /**
+   * The tenant a job is enqueued for: what the caller named, else the
+   * tenant in scope.
+   *
+   * `henri.webhooks.emit()`'s `owner` rule, one word changed, and for the
+   * same reason: an enqueue inside a request belongs to that request's
+   * tenant without the caller repeating it, and an application that is not
+   * multi-tenant is exactly where it was -- the column holds null.
+   *
+   * Naming a tenant still wins, including naming `null`, which is how a
+   * platform-wide job is enqueued from inside a customer's request: the
+   * runner then enters no tenant and the job says `unscoped()` itself.
+   * Naming a **different** tenant while one is in scope is refused, for
+   * `HENRI_TENANT_CROSS_WRITE`'s reason one layer up: a job stamped with
+   * somebody else's tenant is performed in somebody else's data, with
+   * arguments that came from this one.
+   *
+   * @param {object} [options={}] What `perform()` was given
+   * @returns {?string} The tenant to stamp
+   * @throws {JobError} HENRI_TENANT_CROSS_WRITE, HENRI_TENANT_INVALID
+   * @memberof Jobs
+   */
+  tenantOf(options = {}) {
+    const tenancy = this.tenancy();
+    const scope = (tenancy && tenancy.current()) || null;
+    const said = Object.prototype.hasOwnProperty.call(options, 'tenant');
+
+    if (!said) {
+      return scope;
+    }
+
+    const named =
+      options.tenant === null ||
+      typeof options.tenant === 'undefined' ||
+      options.tenant === ''
+        ? null
+        : String(options.tenant);
+
+    // The width and not the shape: `base/tenancy.js` owns what a tenant may
+    // look like and has already checked anything that came from a request.
+    // What the queue owns is its column, and a value truncated to fit it is
+    // two tenants sharing a prefix and therefore sharing their jobs
+    if (named && named.length > MAX_TENANT) {
+      throw new JobError(
+        'HENRI_TENANT_INVALID',
+        `a tenant is at most ${MAX_TENANT} characters and this one is ${named.length}`,
+        {
+          hint: 'An identifier is never truncated to fit: two tenants sharing a prefix would share their jobs',
+        }
+      );
+    }
+
+    if (scope && named && named !== scope) {
+      throw new JobError(
+        'HENRI_TENANT_CROSS_WRITE',
+        `a job was enqueued for the tenant '${named}' while the tenant in scope is '${scope}'`,
+        {
+          hint: `henri refuses rather than obeying: a runner enters the tenant the row names, so this job would read and write '${named}' data with arguments that came from '${scope}'. Enqueue it inside henri.tenancy.run('${named}', () => ...), or say tenant: null when it belongs to no tenant`,
+        }
+      );
+    }
+
+    return named;
+  }
+
+  /**
+   * Runs something as the tenant a job row names.
+   *
+   * **This is the half of the column that matters.** A job's `perform()`
+   * runs in another process, minutes later, with no request behind it --
+   * and a tenanted model touched with no tenant in scope raises
+   * `HENRI_TENANT_REQUIRED` rather than reading every tenant's rows. So
+   * the runner enters the tenant the *row* carries before it calls
+   * `perform()`, and a whole class of jobs stops needing a first line that
+   * says `henri.tenancy.run(args.tenant, ...)`.
+   *
+   * A row with **no** tenant enters nothing, deliberately: null is not
+   * "every tenant". That is what a job enqueued before the column existed
+   * looks like, what a recurring schedule looks like, and what
+   * `tenant: null` asked for -- and all three behave exactly as they did,
+   * which is to say the refusal fires on the first tenanted model call
+   * unless the job says `henri.tenancy.unscoped()` itself.
+   *
+   * @param {?string} tenant The tenant the row names
+   * @param {function} work What to run
+   * @returns {*} Whatever the work answered
+   * @memberof Jobs
+   */
+  scoped(tenant, work) {
+    const tenancy = this.tenancy();
+
+    if (!tenant || !tenancy || typeof tenancy.run !== 'function') {
+      return work();
+    }
+
+    return tenancy.run(tenant, work);
+  }
+
+  /**
    * The store, once the queue is started
    *
    * @returns {object} The store backend
@@ -729,9 +887,11 @@ class Jobs {
   /**
    * The jobs of the queue, newest change first
    *
-   * @param {object} [filter={}] `state`, `queue`, `name`, `limit`, `offset`
+   * @param {object} [filter={}] `state`, `queue`, `name`, `tenant`,
+   *   `limit`, `offset`
    * @returns {Promise<Array<object>>} The jobs
-   * @throws {JobError} HENRI_JOB_UNKNOWN_STATE for an unknown state
+   * @throws {JobError} HENRI_JOB_UNKNOWN_STATE for an unknown state, or
+   *   HENRI_JOB_TENANT_UNINSTALLED for a tenant the table cannot hold
    * @memberof Jobs
    */
   async list(filter = {}) {
@@ -745,9 +905,39 @@ class Jobs {
       );
     }
 
-    const rows = await this.storeOrDie().list(filter);
+    const store = this.storeOrDie();
+
+    this.filterable(filter);
+
+    const rows = await store.list(filter);
 
     return rows.map(toJob);
+  }
+
+  /**
+   * Refuses a tenant filter this store has no column to answer.
+   *
+   * Listing every tenant's jobs because the column is missing would answer
+   * the wrong question with a straight face, which is worse than saying
+   * the column is not there.
+   *
+   * @param {object} [filter={}] A filter
+   * @returns {object} The same filter
+   * @throws {JobError} HENRI_JOB_TENANT_UNINSTALLED
+   * @memberof Jobs
+   */
+  filterable(filter = {}) {
+    if (filter.tenant && !this.tenanted) {
+      throw new JobError(
+        'HENRI_JOB_TENANT_UNINSTALLED',
+        `The "${this.config.store}" store has no ${this.config.tables.jobs}.tenant column, so the jobs of one tenant cannot be told from another's`,
+        {
+          hint: 'Run `henri jobs:install` once with a user that may alter the table; the rows enqueued before it ran carry no tenant and no listing will find them under one',
+        }
+      );
+    }
+
+    return filter;
   }
 
   /**
@@ -952,13 +1142,24 @@ class Jobs {
     }
 
     const now = Date.now();
+    // The callback is enqueued by a runner, minutes later, with no request
+    // behind it -- so the tenant of the batch travels with the batch. It
+    // rides in `callback_options`, which is already stored and already
+    // handed to `perform()`, rather than in a column of its own: the
+    // batches table would need the same upgrade block for one value that
+    // is only ever read once
+    const scope = this.tenantOf({});
+    const callbackOptions =
+      scope && !Object.prototype.hasOwnProperty.call(declared.options, 'tenant')
+        ? { ...declared.options, tenant: scope }
+        : declared.options;
     const row = await store.createBatch({
       callback: declared.callback,
       callback_args: serialize(declared.args, {
         maxBytes: this.config.maxArgsBytes,
       }),
       callback_id: null,
-      callback_options: JSON.stringify(declared.options),
+      callback_options: JSON.stringify(callbackOptions),
       created_at: now,
       done: 0,
       failed: 0,
@@ -1291,7 +1492,7 @@ class Jobs {
    */
   async discardAll(filter = {}) {
     return this.storeOrDie().remove({
-      ...filter,
+      ...this.filterable(filter),
       state: filter.state || 'dead',
     });
   }
@@ -1429,6 +1630,7 @@ class Jobs {
         name: row.name,
         queue: row.queue,
         runner: options.runner || null,
+        tenant: row.tenant || null,
       },
       signal: controller.signal,
     };
@@ -1494,8 +1696,14 @@ class Jobs {
    * @memberof Jobs
    */
   async invoke(definition, context, controller, timeout) {
+    // The tenant of the row, entered here and nowhere else: `perform()` is
+    // the one thing in an attempt that touches the application's models,
+    // and everything around it (the outcome write, the batch counter) is
+    // raw SQL through the adapter, which tenancy never narrows anyway
     const call = Promise.resolve().then(() =>
-      definition.perform(context.job.args, context)
+      this.scoped(context.job.tenant, () =>
+        definition.perform(context.job.args, context)
+      )
     );
 
     if (!timeout) {

--- a/packages/jobs/src/module.js
+++ b/packages/jobs/src/module.js
@@ -307,7 +307,7 @@ class JobsModule extends BaseModule {
    * @param {string} name The job name (its file under app/jobs)
    * @param {*} [args] What perform() receives
    * @param {object} [options] `wait`, `at`, `queue`, `priority`,
-   *   `maxAttempts`, `timeout`, `unique`
+   *   `maxAttempts`, `timeout`, `unique`, `batch`, `tenant`
    * @returns {Promise<object>} The enqueued job
    * @memberof JobsModule
    */

--- a/packages/jobs/src/store/mongo.js
+++ b/packages/jobs/src/store/mongo.js
@@ -35,7 +35,8 @@ const { keep } = require('../keys');
  *
  * A collection needs no upgrade: a document written by an older henri
  * simply has no `concurrency_key`, which is what an unlimited job's row
- * looks like anyway.
+ * looks like anyway. The same is true of `tenant`, which is why
+ * `tenanted()` answers yes here and asks nothing.
  *
  * ## Batches
  *
@@ -159,6 +160,21 @@ class MongoStore {
   }
 
   /**
+   * Whether a tenant can be stamped here; it always can
+   *
+   * A field appears when it is written, so there is nothing to upgrade and
+   * nothing to refuse -- see `concurrent()`. A document an older henri
+   * wrote has no `tenant`, which is what a job of no tenant looks like
+   * anyway.
+   *
+   * @returns {Promise<boolean>} true
+   * @memberof MongoStore
+   */
+  async tenanted() {
+    return true;
+  }
+
+  /**
    * A document, as the queue reads rows
    *
    * @param {?object} document A stored document
@@ -207,6 +223,13 @@ class MongoStore {
     );
 
     await this.index({ batch_id: 1 }, { name: `${this.tables.jobs}_batch` });
+
+    /* eslint-disable sort-keys */
+    await this.index(
+      { tenant: 1, state: 1, run_at: 1 },
+      { name: `${this.tables.jobs}_tenant` }
+    );
+    /* eslint-enable sort-keys */
 
     await this.limits().createIndex(
       { heartbeat_at: 1 },
@@ -320,6 +343,12 @@ class MongoStore {
     // And a job that belongs to no batch has no `batch_id`
     if (rest.batch_id === null || typeof rest.batch_id === 'undefined') {
       delete rest.batch_id;
+    }
+
+    // And a job of no tenant has no `tenant`, which is what every document
+    // an older henri wrote looks like
+    if (rest.tenant === null || typeof rest.tenant === 'undefined') {
+      delete rest.tenant;
     }
 
     try {
@@ -797,12 +826,20 @@ class MongoStore {
   /**
    * Lists jobs
    *
-   * @param {object} [options={}] `state`, `queue`, `name`, `batch`, `limit`,
-   *   `offset`
+   * @param {object} [options={}] `state`, `queue`, `name`, `batch`,
+   *   `tenant`, `limit`, `offset`
    * @returns {Promise<Array<object>>} The rows
    * @memberof MongoStore
    */
-  async list({ state, queue, name, batch, limit = 50, offset = 0 } = {}) {
+  async list({
+    state,
+    queue,
+    name,
+    batch,
+    tenant,
+    limit = 50,
+    offset = 0,
+  } = {}) {
     const filter = {};
 
     if (state) {
@@ -821,6 +858,10 @@ class MongoStore {
       filter.batch_id = batch;
     }
 
+    if (tenant) {
+      filter.tenant = tenant;
+    }
+
     const documents = await this.jobs()
       .find(filter)
       // eslint-disable-next-line sort-keys
@@ -835,11 +876,11 @@ class MongoStore {
   /**
    * Deletes jobs
    *
-   * @param {object} [options={}] `id`, `state`, `queue`, `name`
+   * @param {object} [options={}] `id`, `state`, `queue`, `name`, `tenant`
    * @returns {Promise<number>} How many documents were deleted
    * @memberof MongoStore
    */
-  async remove({ id, state, queue, name } = {}) {
+  async remove({ id, state, queue, name, tenant } = {}) {
     const filter = {};
 
     if (id) {
@@ -856,6 +897,10 @@ class MongoStore {
 
     if (name) {
       filter.name = name;
+    }
+
+    if (tenant) {
+      filter.tenant = tenant;
     }
 
     if (Object.keys(filter).length === 0) {

--- a/packages/jobs/src/store/schema.js
+++ b/packages/jobs/src/store/schema.js
@@ -133,6 +133,10 @@ const DIALECTS = {
 const ADDED = [
   { column: 'concurrency_key', type: 'VARCHAR(190)' },
   { column: 'batch_id', type: 'VARCHAR(36)' },
+  // 190 is the width core gives a tenant (`base/tenancy.js`, MAX_TENANT)
+  // and the width `@usehenri/webhooks` gives an endpoint's owner: what
+  // MySQL indexes in a utf8mb4 key. A tenant is never truncated to fit
+  { column: 'tenant', type: 'VARCHAR(190)' },
 ];
 
 /**
@@ -167,6 +171,7 @@ const jobColumns = (dialect) => [
   'unique_key VARCHAR(190) NULL',
   'concurrency_key VARCHAR(190) NULL',
   'batch_id VARCHAR(36) NULL',
+  'tenant VARCHAR(190) NULL',
   'PRIMARY KEY (id)',
 ];
 
@@ -293,6 +298,15 @@ const jobIndexes = (table) => [
     columns: ['batch_id'],
     late: true,
     name: `${table}_batch`,
+    unique: false,
+  },
+  // The listing `henri jobs:list --tenant` makes, and nothing else: the
+  // claim is deliberately **not** narrowed by tenant, so this index is
+  // never on the hot path (see `SqlStore#claimStatement`)
+  {
+    columns: ['tenant', 'state', 'run_at'],
+    late: true,
+    name: `${table}_tenant`,
     unique: false,
   },
 ];

--- a/packages/jobs/src/store/sql.js
+++ b/packages/jobs/src/store/sql.js
@@ -76,6 +76,20 @@ const { keep } = require('../keys');
  * the one whose token-guarded outcome write landed. A runner whose write
  * was refused because it had been recovered from counts nothing, and the
  * runner that took the job over counts once when it finishes.
+ *
+ * ## The tenant
+ *
+ * `tenant` is a column like `concurrency_key` and `batch_id`: it arrives
+ * through the tolerated upgrade block, `tenanted()` asks the table whether
+ * it is there, and the insert names the columns that are. It is written by
+ * the enqueue and read by a listing.
+ *
+ * It is deliberately **not** in the claim. A runner performs every
+ * tenant's work, and narrowing the claim would give one customer's backlog
+ * a runner of its own -- a scheduling feature, with a fairness question
+ * attached, and not this. What the column decides is which tenant the
+ * runner *enters* before it calls `perform()` (`Jobs#scoped`), which is a
+ * different question with a different answer.
  */
 
 /** The columns of the jobs table, in insert order */
@@ -105,6 +119,7 @@ const COLUMNS = [
   'unique_key',
   'concurrency_key',
   'batch_id',
+  'tenant',
 ];
 
 /** The columns of the batches table, in insert order */
@@ -242,6 +257,8 @@ class SqlStore {
     this.limits = null;
     /** Whether the store can hold a batch; asked once, see batched() */
     this.batches = null;
+    /** Whether the table has `tenant`; asked once, see tenanted() */
+    this.tenants = null;
   }
 
   /**
@@ -369,6 +386,7 @@ class SqlStore {
 
     this.limits = null;
     this.batches = null;
+    this.tenants = null;
 
     return statements;
   }
@@ -435,12 +453,40 @@ class SqlStore {
   }
 
   /**
+   * Whether the jobs table has the column a tenant is stamped in
+   *
+   * Asked once, of the table itself rather than of what the install
+   * answered, for the reason `concurrent()` gives. An application that is
+   * not multi-tenant never notices either answer: the column holds null
+   * for every row it writes.
+   *
+   * @returns {Promise<boolean>} true when `tenant` is there
+   * @memberof SqlStore
+   */
+  async tenanted() {
+    if (typeof this.tenants === 'boolean') {
+      return this.tenants;
+    }
+
+    try {
+      // Reads nothing: the planner still has to resolve the column
+      await this.select(`SELECT tenant FROM ${this.tables.jobs} WHERE 1 = 0`);
+      this.tenants = true;
+    } catch (error) {
+      debug('no tenant column: %s', error.message);
+      this.tenants = false;
+    }
+
+    return this.tenants;
+  }
+
+  /**
    * The columns of the jobs table an insert may name
    *
-   * A table an older henri wrote has neither `concurrency_key` nor
-   * `batch_id`, and an application that uses neither must not notice: the
-   * insert names the columns that are there, so the queue works exactly as
-   * it did.
+   * A table an older henri wrote has none of `concurrency_key`, `batch_id`
+   * and `tenant`, and an application that uses none of them must not
+   * notice: the insert names the columns that are there, so the queue works
+   * exactly as it did.
    *
    * @returns {Promise<Array<string>>} The column names
    * @memberof SqlStore
@@ -454,6 +500,10 @@ class SqlStore {
 
     if (!(await this.batched())) {
       missing.push('batch_id');
+    }
+
+    if (!(await this.tenanted())) {
+      missing.push('tenant');
     }
 
     return missing.length === 0
@@ -1066,12 +1116,20 @@ class SqlStore {
   /**
    * Lists jobs
    *
-   * @param {object} [options={}] `state`, `queue`, `name`, `batch`, `limit`,
-   *   `offset`
+   * @param {object} [options={}] `state`, `queue`, `name`, `batch`,
+   *   `tenant`, `limit`, `offset`
    * @returns {Promise<Array<object>>} The rows
    * @memberof SqlStore
    */
-  async list({ state, queue, name, batch, limit = 50, offset = 0 } = {}) {
+  async list({
+    state,
+    queue,
+    name,
+    batch,
+    tenant,
+    limit = 50,
+    offset = 0,
+  } = {}) {
     const filter = [];
     const params = [];
     // The driver binds what it is given: `LIMIT '25'` is text where sqlite
@@ -1099,6 +1157,11 @@ class SqlStore {
       params.push(batch);
     }
 
+    if (tenant) {
+      filter.push('tenant = ?');
+      params.push(tenant);
+    }
+
     const where = filter.length > 0 ? `WHERE ${filter.join(' AND ')}` : '';
     const page =
       this.dialect === 'mssql'
@@ -1115,11 +1178,11 @@ class SqlStore {
   /**
    * Deletes jobs
    *
-   * @param {object} [options={}] `id`, `state`, `queue`, `name`
+   * @param {object} [options={}] `id`, `state`, `queue`, `name`, `tenant`
    * @returns {Promise<number>} How many rows were deleted
    * @memberof SqlStore
    */
-  async remove({ id, state, queue, name } = {}) {
+  async remove({ id, state, queue, name, tenant } = {}) {
     const filter = [];
     const params = [];
 
@@ -1128,6 +1191,7 @@ class SqlStore {
       ['state', state],
       ['queue', queue],
       ['name', name],
+      ['tenant', tenant],
     ]) {
       if (value) {
         filter.push(`${column} = ?`);

--- a/website/src/content/docs/guides/jobs.md
+++ b/website/src/content/docs/guides/jobs.md
@@ -425,6 +425,116 @@ A batch stores one column on the job row (`batch_id`) and one table of its own (
 - `henri.jobs.batch()` on a store that has neither **is refused** with `HENRI_JOB_BATCH_UNINSTALLED`, naming `henri jobs:install`. A batch is refused rather than run with a counter nothing can hold — there is nothing declared in a file to fail a boot over, so the refusal is at the call.
 - On MongoDB there is nothing to upgrade: a document has no such field, and a collection appears when something is written into it.
 
+## Tenants
+
+If the application is [multi-tenant](/guides/multi-tenancy/), a job row carries
+the tenant it belongs to and the runner enters it before calling `perform()`.
+Nothing is asked of you on either side:
+
+```js
+// in a controller, inside a request that resolved to `acme`
+await henri.jobs.perform('invoice-reminder', { invoiceId: invoice.externalId });
+```
+
+```js
+// app/jobs/invoice-reminder.js
+module.exports = {
+  // No `henri.tenancy.run()` here: the runner is already inside `acme`
+  perform: async ({ invoiceId }) => {
+    const invoice = await Invoice.findById(invoiceId);
+
+    await henri.mailers.billing.reminder(invoice).deliverLater();
+  },
+};
+```
+
+That is the whole point of the column. A tenanted model touched with no tenant
+in scope raises `HENRI_TENANT_REQUIRED` rather than reading every tenant's rows,
+so before this the first line of every job that touched one had to put the
+tenant back by hand — and forgetting it was a job that failed, was retried five
+times and landed in the dead letter queue.
+
+**Null is not every tenant.** A job with no tenant on its row enters no scope,
+and the refusal fires exactly as it did:
+
+- a job enqueued from a script, the console or `henri jobs:perform`;
+- a [recurring](#recurring-jobs) occurrence, which no request enqueued;
+- one enqueued with `tenant: null`, which is how a platform-wide job is asked
+  for from inside a customer's request;
+- every row that was already in the queue when the column arrived.
+
+All four behave the way they always did: a job that means every tenant says
+`henri.tenancy.unscoped()` itself, and one that means a particular tenant says
+`henri.tenancy.run()`.
+
+Naming a tenant wins over the one in scope, and naming a **different** one while
+a tenant is in scope is refused (`HENRI_TENANT_CROSS_WRITE`) — a job stamped
+with somebody else's tenant is performed in somebody else's data, with arguments
+that came from this one. A fan-out says so out loud:
+
+```js
+await henri.tenancy.unscoped(async () => {
+  for (const tenant of accounts) {
+    await henri.jobs.perform('nightly-report', null, { tenant });
+  }
+});
+```
+
+A **batch** carries the tenant it was made in, on the batch rather than on each
+job: its jobs are enqueued by the request that made it and are stamped like any
+other, and the callback is enqueued by a runner minutes later, so it rides in
+the callback's options. `henri.jobs.batch({ tenant })` names one explicitly.
+
+Reading it back:
+
+```bash
+henri jobs:list --tenant acme
+henri jobs:dead --tenant acme --json
+henri jobs:retry --all --tenant acme
+henri jobs:discard --all --tenant acme
+henri jobs:perform welcome '{"userId":1}' --tenant acme
+```
+
+```js
+await henri.jobs.list({ tenant: 'acme', state: 'pending' });
+```
+
+`henri jobs:show <id>` prints the tenant, and every job in `--json` output
+carries a `tenant`.
+
+**The claim is deliberately not narrowed by tenant.** A runner performs every
+tenant's work, and `henri jobs --tenant acme` does not exist: a runner per
+customer is a scheduling decision with a fairness question attached, and it is
+not this. What the column decides is which tenant the runner _enters_, not which
+rows it takes.
+
+### The column, and an upgrade
+
+`tenant` is a column on the job row and arrives the way
+[`concurrency_key`](#the-column-and-an-upgrade) and
+[`batch_id`](#the-table-and-an-upgrade) did: a tolerated `ALTER` inside the
+idempotent install, with the store asking the table rather than trusting the
+statement ran.
+
+- An application that is **not multi-tenant is not affected at all**: no column
+  is asked for, nothing is stamped, and its inserts name the columns that are
+  there.
+- An application with `config.tenancy` on whose table has no `tenant` column
+  **fails the boot** with `HENRI_JOB_TENANT_UNINSTALLED`, naming
+  `henri jobs:install`. Enqueuing every job with no tenant and performing them
+  all outside every one is not the same as performing them across all of them,
+  and it is not something to discover in production.
+- `henri jobs:list --tenant` on such a table is **refused** with the same code
+  rather than answered with every tenant's rows.
+- The rows already in the queue keep their null tenant and are performed exactly
+  as they were. There is no backfill to run, because there is nothing to fill
+  in: henri does not know which tenant a job that never said belonged to.
+- On MongoDB there is nothing to upgrade: a document simply has no such field.
+
+For most people the upgrade is the next deploy and nothing else — the boot runs
+the install, the install adds the column. `henri jobs:install` with a user that
+may `ALTER` is the answer when it is not.
+
 ## A job a package ships
 
 A package that does work of its own registers its job on the queue rather than asking every application to write a file that would only forward the call:
@@ -504,6 +614,7 @@ const stats = await henri.jobs.stats();
 // }
 
 await henri.jobs.list({ state: 'pending', queue: 'mailers' });
+await henri.jobs.list({ tenant: 'acme' });
 await henri.jobs.get(id);
 await henri.jobs.count({ state: 'dead' });
 ```

--- a/website/src/content/docs/guides/multi-tenancy.md
+++ b/website/src/content/docs/guides/multi-tenancy.md
@@ -251,39 +251,57 @@ a resolution problem, and the refusal is where you find that out.
 ## A job has no request
 
 `henri.jobs` performs work later, in another process, where there is no
-subdomain, no session and no `req.user`. So the tenant travels in the job's
-arguments, and one line puts it back:
+subdomain, no session and no `req.user`. So the queue row carries the tenant,
+henri stamps it on the enqueue and the runner enters it before it calls
+`perform()`:
+
+```js
+// in the controller, inside a request that resolved to `acme`
+await henri.jobs.perform('invoice-reminder', {
+  invoiceId: invoice.externalId,
+});
+```
 
 ```js
 // app/jobs/invoice-reminder.js
 module.exports = {
-  perform: async ({ invoiceId, tenant }) =>
-    henri.tenancy.run(tenant, async () => {
-      const invoice = await Invoice.findById(invoiceId);
+  // Nothing to put back: the runner is already inside `acme`
+  perform: async ({ invoiceId }) => {
+    const invoice = await Invoice.findById(invoiceId);
 
-      await henri.mailers.billing.reminder(invoice).deliverLater();
-    }),
+    await henri.mailers.billing.reminder(invoice).deliverLater();
+  },
 };
 ```
 
+**Null is not every tenant.** A job whose row names none — one enqueued from a
+script, a [recurring](/guides/jobs/#recurring-jobs) occurrence, one enqueued
+with `tenant: null`, or one that was in the queue before the column existed —
+enters no scope, and the refusal fires on its first tenanted model call exactly
+as it did. That is the safe half: **forgetting is loud rather than silent**, and
+a job that means every tenant says `henri.tenancy.unscoped()` itself.
+
+Naming a tenant on the enqueue wins; naming a _different_ one while a tenant is
+in scope is refused (`HENRI_TENANT_CROSS_WRITE`), because a job stamped with
+somebody else's tenant is performed in somebody else's data with arguments that
+came from this one. A fan-out says so:
+
 ```js
-// in the controller
-await henri.jobs.perform('invoice-reminder', {
-  invoiceId: invoice.externalId,
-  tenant: req.tenant,
+await henri.tenancy.unscoped(async () => {
+  for (const tenant of accounts) {
+    await henri.jobs.perform('nightly-report', null, { tenant });
+  }
 });
 ```
 
-**Forgetting is safe rather than silent**, which is the point of the refusal:
-a job that touches a tenanted model without saying which tenant fails on its
-first model call, is retried, and lands in the dead letter queue with
-`HENRI_TENANT_REQUIRED` on it. It does not quietly send acme's invoice to
-globex.
+`henri jobs:list --tenant acme`, `jobs:dead`, `jobs:retry --all` and
+`jobs:discard --all` all take it, and `jobs:show` and every `--json` answer
+carry it. The **claim** is deliberately not narrowed: a runner performs every
+tenant's work, and a runner per customer is a scheduling feature rather than
+this one. The details, including the upgrade, are in the
+[jobs guide](/guides/jobs/#tenants).
 
-henri does **not** stamp the tenant onto the queue row for you — see
-[what was left](#what-was-left) below.
-
-The same one line is what a `henri runner` script, a `henri console` session
+The one line is still what a `henri runner` script, a `henri console` session
 and a recurring sweep use:
 
 ```
@@ -303,20 +321,20 @@ event emitter you registered outside it.
 The tables henri owns are the interesting cases, and the honest answer is
 different for each of them.
 
-| table                             | per tenant?                        |
-| --------------------------------- | ---------------------------------- |
-| your models with `options.tenant` | **per tenant**, by the column      |
-| your models without one           | **shared**, deliberately           |
-| `henri_identities` (sign-in)      | shared, and it has to be           |
-| `henri_webhooks` (endpoints)      | per tenant, by `owner`             |
-| `henri_trail` (the access trail)  | shared                             |
-| `henri_calls` (the call log)      | shared                             |
-| `henri_versions` (model history)  | **shared — the known gap**         |
-| `henri_jobs` (the queue)          | shared; the tenant rides in `args` |
-| the feature flag store            | shared                             |
-| the idempotency keys              | per tenant                         |
-| the rate limit and the lockout    | shared                             |
-| the session store                 | shared                             |
+| table                             | per tenant?                     |
+| --------------------------------- | ------------------------------- |
+| your models with `options.tenant` | **per tenant**, by the column   |
+| your models without one           | **shared**, deliberately        |
+| `henri_identities` (sign-in)      | shared, and it has to be        |
+| `henri_webhooks` (endpoints)      | per tenant, by `owner`          |
+| `henri_trail` (the access trail)  | shared                          |
+| `henri_calls` (the call log)      | shared                          |
+| `henri_versions` (model history)  | per tenant, by the record's own |
+| `henri_jobs` (the queue)          | per tenant, by `tenant`         |
+| the feature flag store            | shared                          |
+| the idempotency keys              | per tenant                      |
+| the rate limit and the lockout    | shared                          |
+| the session store                 | shared                          |
 
 **The identity table is shared, and it has to be.** `(provider, subject)` is
 unique across the whole application, because one Google account is one
@@ -337,6 +355,25 @@ what fills it in: an `emit()` inside a tenant reaches that tenant's endpoints
 without the caller repeating it. Naming an `owner` explicitly still wins, and
 `owner: null` still means the endpoints that belong to nobody, which is what
 a platform-wide event is.
+
+**The queue row carries the tenant, and the runner enters it.**
+`henri.jobs.perform()` stamps the tenant of the request or job it was called
+from, `henri jobs:list --tenant` narrows a listing, and a runner opens
+`henri.tenancy.run()` around `perform()` — which turns a whole class of jobs
+that had to remember a first line into ordinary correct code. A row with no
+tenant enters none, deliberately.
+
+**The versions are per tenant, by the record's own column.** A version names the
+tenant of the record it describes — read off the record, so a sweep running
+across every customer still writes the right one — and `henri.versions` is
+narrowed and refused exactly the way a tenanted model is: a listing with no
+tenant in scope raises `HENRI_TENANT_REQUIRED` rather than answering with
+everybody's old values. The sharp edge is `restore()`: restoring a record that
+no longer exists **creates** it, and a create is stamped with the tenant in
+scope, so restoring another tenant's version is `HENRI_VERSION_CROSS_TENANT`
+rather than that record appearing here. Rows written before the column arrived
+name no tenant and are therefore visible in every tenant's listing; the
+[versions guide](/guides/versions/#tenants) has the backfill.
 
 **The trail and the call log are shared, and that is safe** — for a reason
 worth stating rather than assuming. Both are operator records, not
@@ -380,6 +417,26 @@ and keying the _global_ limit by tenant would make a tenant's own traffic
 count against nobody else — which is not what a defence against a flood is
 for. `config.rateLimit.store` and a middleware of the application's own are
 where a per-customer quota goes.
+
+## henri's own sweeps run across every tenant
+
+`henri privacy:export`, `henri privacy:erase` and `henri retention:sweep` walk
+the models with `henri.tenancy.unscoped()`, and each for its own reason.
+
+An **erasure** and an **export** are about a _person_, and the records held
+about that person are wherever they are; a walk narrowed to whatever tenant
+happened to be in scope would answer a person's request with part of their data
+and write a receipt saying it was all of it. A **retention rule** is the
+application's policy about a _table_ — `after: '90d'` on `Ticket` means every
+ticket — and a sweep narrowed to one customer would delete their records and
+write a receipt saying the rule ran.
+
+There is no tenant in scope on a cron line anyway, so the alternative was never
+a narrower sweep: it was `HENRI_TENANT_REQUIRED` on the first rule.
+
+A per-tenant retention period is a different feature, and it is yours: a rule
+with a `where` of its own, or a job that calls `sweep({ only })` inside
+`henri.tenancy.run()`.
 
 ## What henri cannot narrow, and refuses instead
 
@@ -447,6 +504,14 @@ test('a job with no tenant refuses rather than reading everything', async () => 
     code: 'HENRI_TENANT_REQUIRED',
   });
 });
+
+test('a job carries the tenant it was enqueued in', async () => {
+  const job = await henri.tenancy.run('acme', () =>
+    henri.jobs.perform('invoice-reminder', { invoiceId: 'x' })
+  );
+
+  expect(job.tenant).toBe('acme');
+});
 ```
 
 That second one is the test that catches a regression in this feature, so it
@@ -456,23 +521,28 @@ is worth having even though it asserts a failure.
 
 Written down rather than discovered:
 
-- **The queue row carries no tenant.** `henri_jobs` has no `tenant` column,
-  so `henri jobs:list` cannot filter by customer and a job's tenant has to be
-  in its `args`. The queue's tables are created with
-  `CREATE TABLE IF NOT EXISTS` and there is no migration path for them yet,
-  so adding a column would break an existing installation on upgrade. That
-  path — and `henri jobs:list --tenant` with it — is its own tranche.
-- **`henri_versions` is shared.** A version row names the record's
-  `externalId` and not its tenant, so `henri versions <Model> <record>` shows
-  one record's history correctly but there is no per-tenant view and no
-  per-tenant prune. Same reason, same tranche.
+- **No runner per tenant.** The claim is not narrowed by tenant and
+  `henri jobs --tenant` does not exist: one customer's backlog getting a runner
+  of its own is a scheduling feature with a fairness question attached (what
+  happens to the tenants no runner names?), and it is not this one.
+- **No per-tenant retention or prune.** `versions.keep`, `jobs.keepCompleted`,
+  `calls.keep` and `trail.keep` are one number for the whole application, and
+  the sweeps run across every tenant. A per-customer period is a rule with a
+  `where` of its own, or a job of yours.
+- **No backfill of the rows the upgrade left behind.** A queue row and a version
+  row written before their `tenant` column existed name none, and henri does not
+  guess: a job's tenant is not recoverable at all, and a version's is a `UPDATE`
+  from the records it names that only you can write. The
+  [versions guide](/guides/versions/#the-column-and-an-upgrade) has it.
 - **No `henri tenants` command.** There is no list of tenants, because henri
   holds none: a tenant is a string in a column, and what the set of them is
   belongs to the application's own `Account` model.
-- **Nothing is exercised on MSSQL.** The rest of `@usehenri/sequelize` runs
-  against a real SQL Server now (`pnpm test:sql:mssql`), but the tenancy
-  wiring there is written and reviewed and has no suite of its own to point
-  at it; the proofs are on Drizzle (sqlite offline, PostgreSQL and MySQL
+- **The models are not exercised on MSSQL.** The rest of
+  `@usehenri/sequelize` runs against a real SQL Server now
+  (`pnpm test:sql:mssql`), and the queue's `tenant` column is proved there
+  along with everything else in that project — but the tenancy wiring of
+  the models is written and reviewed and has no suite of its own to point
+  at it; those proofs are on Drizzle (sqlite offline, PostgreSQL and MySQL
   under `pnpm test:sql:live`) and on MongoDB.
 - **No per-tenant connection, schema or key.** That is option 2, and this
   page said why.

--- a/website/src/content/docs/guides/privacy.md
+++ b/website/src/content/docs/guides/privacy.md
@@ -339,6 +339,16 @@ The account that was anonymized cannot be signed into again: its password
 becomes 32 bytes nobody holds, and `passwordChangedAt` is stamped, which is
 what refuses the sessions that were open at the time.
 
+## Tenants
+
+An export and an erasure walk the models **across every tenant**, deliberately
+(`henri.tenancy.unscoped()`). They are about a _person_, and the records held
+about that person are wherever they are: a walk narrowed to whatever tenant
+happened to be in scope would answer a person's request with part of their data
+and write a receipt saying it was all of it. From a command line there is no
+tenant in scope at all, so the alternative was `HENRI_TENANT_REQUIRED` rather
+than a narrower answer. See [multi-tenancy](/guides/multi-tenancy/).
+
 ## Configuration
 
 ```json

--- a/website/src/content/docs/guides/retention.md
+++ b/website/src/content/docs/guides/retention.md
@@ -259,6 +259,20 @@ henri retention --json                        # the same, as data
 All of them boot the models only: no port is bound and no route is
 registered.
 
+## Tenants
+
+A sweep runs **across every tenant**, deliberately
+(`henri.tenancy.unscoped()`). A retention rule is your policy about a _table_ —
+`after: '90d'` on `Ticket` means every ticket — and a sweep narrowed to whatever
+tenant happened to be in scope would delete one customer's records and write a
+receipt saying the rule ran. There is no tenant in scope on a cron line anyway,
+so the alternative was never a narrower sweep: it was `HENRI_TENANT_REQUIRED` on
+the first rule.
+
+A per-tenant period is a different feature and it is yours: a rule with a
+`where` of its own, or a job that calls `sweep({ only })` inside
+`henri.tenancy.run()`. See [multi-tenancy](/guides/multi-tenancy/).
+
 ## The trail's own retention
 
 The [access trail](/guides/trail/) is a record of who touched personal data,

--- a/website/src/content/docs/guides/versions.md
+++ b/website/src/content/docs/guides/versions.md
@@ -308,6 +308,96 @@ the boot line says which it is. The [retention sweep](/guides/retention/)
 is what prunes them, so `henri retention:sweep --yes` takes the old ones
 away along with everything else.
 
+## Tenants
+
+If the application is [multi-tenant](/guides/multi-tenancy/), every version
+carries the tenant of the record it is about, and `henri.versions` is scoped
+exactly the way a tenanted model is.
+
+**The tenant is read off the record, not off the scope.** A version describes a
+record, and whose record it is is written on the record — so a sweep that runs
+`henri.tenancy.unscoped()` over every customer still writes rows that name the
+right one. A model with no `options.tenant` is shared and its versions name no
+tenant, which is the correct answer rather than a gap.
+
+**A read is narrowed, and a read with no tenant is refused.** Inside a tenant,
+`list()`, `count()`, `of()` and `get()` answer that tenant's rows and the rows
+of no tenant; outside one, with tenancy on, they raise `HENRI_TENANT_REQUIRED`
+rather than handing back every customer's old values. That is
+`HENRI_POLICY_SCOPE_REQUIRED`'s instinct again: a table nobody narrowed is
+everybody's rows. `henri.tenancy.unscoped()` is the one way past, and it is what
+an operator report says out loud.
+
+```js
+// a history page: already inside the tenant of the request
+const history = await henri.versions.of(invoice);
+
+// a cross-tenant report: says so
+const lately = await henri.tenancy.unscoped(() =>
+  henri.versions.list({ limit: 100 })
+);
+```
+
+A version of another tenant's record answers `null` from `get()` rather than a
+refusal — `Model.findById()`'s own answer, because "it is there but not yours"
+is the oracle a 404 exists to close.
+
+**A restore that creates is refused across the boundary.** `restore()` on a
+record that still exists is an update, and the model layer already only found
+this tenant's row. On a record that is **gone** it creates one, and a create is
+stamped with the tenant in scope — so restoring somebody else's version would
+materialize their old values as your row, under their identifier. That is
+`HENRI_VERSION_CROSS_TENANT`, and `henri.tenancy.unscoped()` is how a record is
+deliberately moved.
+
+The three commands run across every tenant, because an operator at a shell holds
+the database and means all of them; `--tenant` narrows them to one, and
+`versions:show` and `versions:restore` run **as the tenant the row names**,
+which is what makes them work at all on a tenanted model:
+
+```bash
+henri versions Invoice                    # every tenant
+henri versions Invoice --tenant acme      # one
+henri versions:show <id>                  # reified as the tenant of the row
+henri versions:restore <id> --tenant acme
+```
+
+### The column, and an upgrade
+
+`tenant` is a column on `henri_versions` and arrives the way the queue's own
+late columns do: an idempotent `ALTER` inside the install, **tolerated**, with
+the store asking the table rather than trusting the statement ran. For most
+people that is the next deploy and nothing else.
+
+- An application that is **not multi-tenant is not affected at all**: nothing is
+  stamped, nothing is narrowed, and the insert names the columns that are there.
+- An application with `config.tenancy` on whose table cannot hold the column
+  **fails the boot** with `HENRI_VERSION_TENANT_UNINSTALLED`. A history nothing
+  can scope is worse than one that refuses to start: with every row null, a read
+  narrowed to a tenant is every tenant's rows.
+
+  ```sql
+  ALTER TABLE henri_versions ADD COLUMN tenant VARCHAR(190) NULL;
+  ```
+
+- **The rows written before the column are null**, and a null row is nobody's —
+  which means every tenant's listing shows them. That is deliberate: null is
+  also what a shared model's history looks like, and hiding those rows from
+  everybody would lose it. If that matters, backfill them once from the records
+  they name, which is the only place the answer exists:
+
+  ```sql
+  UPDATE henri_versions AS v
+     SET tenant = (SELECT i.tenant_id FROM invoices AS i
+                    WHERE i.external_id = v.record)
+   WHERE v.model = 'Invoice' AND v.tenant IS NULL;
+  ```
+
+  A row whose record has since been deleted cannot be backfilled, and
+  `versions:restore` refuses it rather than guessing.
+
+- On MongoDB there is nothing to upgrade: a document simply has no such field.
+
 ## Where the rows live
 
 One table henri owns (`henri_versions`), reached through the store adapter

--- a/website/src/content/docs/reference/errors.md
+++ b/website/src/content/docs/reference/errors.md
@@ -1474,6 +1474,18 @@ Usually:
 
 **Fix.** Set `jobs.store` to one of the names of the `stores` block, or leave it out to use the default store.
 
+### `HENRI_JOB_TENANT_UNINSTALLED`
+
+This application is multi-tenant and the queue has nowhere to write a job's tenant.
+
+Usually:
+
+- a queue installed by a henri older than 1.4, whose table has no `tenant` column
+- `jobs.install: false` with no `henri jobs:install` since `config.tenancy` was turned on
+- a database user that may not alter a table
+
+**Fix.** Run `henri jobs:install` once with a user that may alter the table. The queue works without the column, and a multi-tenant application does not: every job would be enqueued with no tenant and performed outside every one of them, which is not the same as being performed across all of them. The rows already in the table keep their null tenant and are performed exactly as they were.
+
 ### `HENRI_JOB_TIMEOUT`
 
 An attempt ran past the job’s timeout.
@@ -2757,6 +2769,17 @@ Usually:
 
 Model versioning: the `versioned` mark on a model, the table its history lives in, and reading a record back out of it.
 
+### `HENRI_VERSION_CROSS_TENANT`
+
+A version of another tenant's record was about to be written back as a new record here.
+
+Usually:
+
+- a `henri versions:restore` of a record that no longer exists, made as a tenant other than the one the version names
+- a restore of a version written before `henri_versions` had its `tenant` column, so henri cannot tell whose record it was
+
+**Fix.** Restore it as the tenant it belongs to (`henri versions:restore --tenant <id>`, or `henri.tenancy.run()`), or say `henri.tenancy.unscoped()` when moving a record between tenants is what you mean. Restoring a record that is _gone_ creates it again, and a create is stamped with the tenant in scope -- so henri refuses rather than materializing somebody else's record here. Updating a record that still exists is never refused: the model layer only ever found this tenant's row.
+
 ### `HENRI_VERSION_DISABLED`
 
 The versions were read back and this application keeps none.
@@ -2813,6 +2836,17 @@ Usually:
 - the model says both `versioned` and `options: { externalId: false }`
 
 **Fix.** A version names the record it is about by its `externalId`, because that is the identifier that already leaves the server (see the models guide). Take `externalId: false` off the model, or stop versioning it.
+
+### `HENRI_VERSION_TENANT_UNINSTALLED`
+
+This application is multi-tenant and the version table has no `tenant` column.
+
+Usually:
+
+- a version table created by a henri older than 1.4, whose `ALTER TABLE ... ADD COLUMN tenant` has not run
+- a database user that may not alter a table
+
+**Fix.** Boot once with a database user that may `ALTER`, or run `ALTER TABLE henri_versions ADD COLUMN tenant VARCHAR(190) NULL` by hand. henri refuses rather than writing a history it cannot scope: with every row null, a read narrowed to a tenant is every tenant's rows. The rows written before the column exists stay null and are visible in every tenant's listing until they are backfilled -- see the upgrade note of the versions guide.
 
 ### `HENRI_VERSION_UNKNOWN`
 


### PR DESCRIPTION
## The gap, and why it was open

`CLAUDE.md` carried both of these under multi-tenancy as **deliberately left**:

> `henri_jobs` carries no `tenant` column, so a job's tenant travels in its arguments and `henri jobs:list --tenant` does not exist — the queue's tables are `CREATE TABLE IF NOT EXISTS` with no migration path, so adding a column would break an upgrade; `henri_versions` is shared for the same reason.

That reason stopped being true with #437, which added two columns and a whole table through a **tolerated `ALTER` inside the idempotent install** and — the part that matters — made the store *ask the table* what it has rather than trust the `ALTER` ran, so an application whose table cannot hold a feature fails the boot naming it instead of running unbounded.

## What this does

- **`tenant` on `henri_jobs`** (`VARCHAR(190)`, core's `MAX_TENANT`, plus a `(tenant, state, run_at)` index), stamped by `Jobs#tenantOf()` — `Webhooks#ownerOf()` with one word changed. MongoDB needs no column and answers `tenanted()` true.
- **The runner enters the job's tenant** before calling `perform()`. This is the half that matters: the guide used to tell every application to write `henri.tenancy.run(args.tenant, …)` as the first line of every job, and forgetting it meant a job that failed, retried five times and died with `HENRI_TENANT_REQUIRED`. Entering a scope can only ever *remove* rows, so it cannot widen anything, and a job that already calls `run()` with the same tenant nests harmlessly.
- **`--tenant`** on `jobs:list`, `dead`, `retry --all`, `discard --all` and `perform`; the tenant in `jobs:show`, in the list line and in every `--json` job.
- **`tenant` on `henri_versions`**, read off the **record** rather than the scope, so a sweep running `unscoped()` over every customer still names the right one.
- **`Privacy#everywhere` / `Retention#everywhere`** — both sweeps now run inside `henri.tenancy.unscoped()`.

Three decisions worth naming. **A null tenant enters nothing**, because null is not "every tenant": a job enqueued before the column existed behaves exactly as it does today, and **there is no backfill and cannot be one** — henri does not know which tenant a job that never said belonged to. **Naming another tenant while one is in scope is refused** (`HENRI_TENANT_CROSS_WRITE`), deliberately stricter than webhooks, where an explicit `owner` wins: a webhook `owner` decides which endpoints get an event, whereas a job stamped with somebody else's tenant is *performed in their data with arguments from yours*. And **the claim is not narrowed by tenant** — a runner per customer is a scheduling feature with a fairness question attached, not this one.

## What I checked myself, and one correction to the brief

The tranche's headline claim was that `restore()` on a record that no longer exists **creates** one stamped with the tenant in scope, so tenant A holding a version id could materialize tenant B's old values as a row of A's own. I wrote that scenario as a test — B creates an invoice, updates it, destroys it; A calls `restore()` on B's destroy version — and ran it against **master**:

```
answered: HENRI_TENANT_CROSS_WRITE
```

**The write was already refused**, one layer down, by the model tenancy guard from #422. So the version-store refusal in this PR is defence in depth rather than the closing of an open hole, and the PR should not claim otherwise. It is still worth having — `henri_versions` is a table core owns and reaches directly, and relying on a guard a layer away is how the next tranche reintroduces the problem.

**The read leak is real, and I reproduced it.** The second half of the same probe — A asking for the history of B's invoice — answered on master:

```
expected [ { actor: null, …(11) }, …(1) ] to deeply equal []
```

Two of tenant B's version rows, with the old and new values of every changed field, handed to tenant A. On this branch it answers `[]`, and `restore()` of another tenant's id answers `HENRI_VERSION_UNKNOWN` rather than a cross-tenant refusal — the better answer, since it does not confirm the id exists. That is `findById()`'s non-oracle applied to the versions table.

## What an existing application has to do

Nothing without `config.tenancy`: no column asked for, nothing stamped, nothing narrowed, no boot line. With it, the next deploy adds both columns through the tolerated `ALTER`; if the database user may not `ALTER`, the boot fails naming what is missing (`HENRI_JOB_TENANT_UNINSTALLED`, `HENRI_VERSION_TENANT_UNINSTALLED`) rather than writing rows nothing can scope.

One **behaviour change**: `henri.versions.list()` outside a tenant scope now refuses in a multi-tenant application. A scoped read takes the `tenant IS NULL` rows with it, because null is also what a shared model's history looks like — the cost, pre-upgrade rows visible in every tenant's listing, is stated in the guide with the backfill `UPDATE`.

## Two things that were already broken

`henri privacy:erase` and `henri retention:sweep` reach models directly with no tenant in scope, so on any tenanted model they raised `HENRI_TENANT_REQUIRED` **from a command line**. `everywhere()` fixes both, and each has its own argument: an erasure is about a *person*, so a walk narrowed to an ambient tenant answers a data-subject request with part of their data and writes a receipt saying it was all of it; a retention rule is about a *table*. `henri versions:restore` on a tenanted model could not work at all, for the same reason.

## Coverage

`packages/jobs/__tests__/tenancy.spec.js` (23 tests) runs on sqlite, live PostgreSQL, live MySQL **and SQL Server** — the jobs project is in `test:sql:mssql`, which makes the queue the one tenancy surface that adapter covers. Plus a `tenants` block in `mongo.spec.js`, `versions-tenancy.spec.js` on sqlite and both live servers, and two CLI specs driving a real application. The teammate reports sabotaging the `unscoped()` wrapper and confirming the test fails, which is the right way to check a wrapper is load-bearing.

Still uncovered and said so: the *models'* tenancy on MSSQL (unchanged), the versions tenancy on MSSQL (the drizzle project is not in that run), no runner per tenant, no per-tenant retention period, no backfill command.

## Gates

`pnpm test` 4895 passed · `pnpm test:types` ok · `pnpm lint --max-warnings 0` clean · `pnpm format:check` clean · `scripts/smoke.sh` exit 0, `henri audit` clean in 56 checks · live PostgreSQL 997 · live MariaDB 988 · live SQL Server 640.