### PR TITLE
One place says what a database instance is built with

### DIFF
--- a/.changeset/one-place-builds-the-drizzle-instance.md
+++ b/.changeset/one-place-builds-the-drizzle-instance.md
@@ -1,0 +1,11 @@
+---
+'@usehenri/drizzle': patch
+---
+
+One place says what a drizzle instance is built with.
+
+A drizzle store builds its database twice, not once. `start()` builds it, and `getSessionConnector()` builds it again on a store with no user model: drizzle bakes the schema into the instance, so the sessions table added afterwards needs a new one. Both named the arguments themselves, three hundred lines apart, and nothing compared them — so anything the first construction were given (a logger, a cache, an instrumentation hook) would be dropped by the second, in an application with sessions and nowhere else.
+
+Nothing is passed today beyond the client and the schema, so nothing was being lost. This is the hardening: `Drizzle#buildDatabase()` is now the only expression that constructs one, both callers go through it, and a test builds the store both ways and compares what each construction was handed — the arity, the client, and every argument past the schema, which is where an option would go. The schema is the one thing allowed to differ, and only by the table the second construction exists to add.
+
+Transactions were checked rather than assumed, on all three dialects of drizzle-orm 0.45: better-sqlite3 hands the transaction the session it already has, and mysql2 and node-postgres build a fresh session for the pooled connection from `this.options`. So transaction traffic inherits whatever the construction was given, and there is no third site.

--- a/.changeset/one-place-builds-the-mongoose-instance.md
+++ b/.changeset/one-place-builds-the-mongoose-instance.md
@@ -1,0 +1,9 @@
+---
+'@usehenri/mongoose': patch
+---
+
+One place says what a Mongoose instance is built with.
+
+The same hardening as `@usehenri/drizzle`'s, one adapter over. A mongoose store builds its Mongoose instance twice: the constructor builds one, and `stop()` builds another so that a store started again does not reuse the connection it disconnected. Both spelled `new mongoose.Mongoose()` themselves, nine hundred lines apart, and nothing compared them.
+
+Nothing configures the instance today — the plugins are registered per schema in `addModel()` and the connect options are `connectOptions()` — so the two were identical and nothing was being lost. `Mongoose#newConnection()` is now the only expression that builds one, and a test compares what the two instances hold across a stop: an instance-wide `set()` or plugin added to one construction and not the other would otherwise leave a restarted store configured differently from a fresh one, with nothing to say so.

--- a/packages/drizzle/__tests__/lifecycle.spec.js
+++ b/packages/drizzle/__tests__/lifecycle.spec.js
@@ -150,7 +150,7 @@ describe('postgres and mysql without a server', () => {
 
       // The pools are lazy: the client exists, nothing connected
       adapter.client = await adapter.dialect.connect(adapter.config);
-      adapter.db = adapter.dialect.drizzle(adapter.client, adapter.schema);
+      adapter.buildDatabase();
       expect(adapter.rawDatabase()).toBeDefined();
       await adapter.stop();
       expect(adapter.client).toBeNull();

--- a/packages/drizzle/__tests__/session.spec.js
+++ b/packages/drizzle/__tests__/session.spec.js
@@ -120,6 +120,45 @@ describe('session store', () => {
     await bare.stop();
   });
 
+  test('builds the database the same way both times it builds one', async () => {
+    const { adapter: twice } = build();
+    const { dialect } = twice;
+    const given = [];
+
+    // The dialect object is shared by every store on it, so the recorder
+    // goes on a copy of it rather than on the module's own
+    twice.dialect = {
+      ...dialect,
+      drizzle: (...args) => {
+        given.push(args);
+
+        return dialect.drizzle(...args);
+      },
+    };
+    twice.addModel(taskModel, 'user');
+    await twice.start();
+    await twice.getSessionConnector(session);
+
+    // Two constructions -- `start()`, then the one `getSessionConnector()`
+    // makes after recompiling the schema with the sessions table, because
+    // drizzle bakes the schema into the instance. They have to be handed
+    // the same things: an argument added to one and not the other would
+    // reach an application with sessions and nowhere else, which is
+    // exactly the kind of difference nothing else here would notice
+    expect(given).toHaveLength(2);
+    expect(given[1]).toHaveLength(given[0].length);
+    expect(given[1][0]).toBe(given[0][0]);
+    expect(given[1].slice(2)).toEqual(given[0].slice(2));
+
+    // The schema is the one thing that may differ, and only by the table
+    // the second construction exists to add
+    expect(Object.keys(given[0][1])).not.toContain('HenriSession');
+    expect(Object.keys(given[1][1])).toContain('HenriSession');
+    expect(given[1][1]).toBe(twice.schema);
+
+    await twice.stop();
+  });
+
   test('stops the sweep with the adapter', async () => {
     const { adapter: timed } = build({ baseRole: 'member' });
 

--- a/packages/drizzle/index.js
+++ b/packages/drizzle/index.js
@@ -1007,6 +1007,36 @@ class Drizzle {
   }
 
   /**
+   * Builds the Drizzle instance on the connected client, and is the one
+   * place that says what one is built with.
+   *
+   * There are two constructions, not one: `start()` builds it, and
+   * `getSessionConnector()` builds it again when it had to recompile the
+   * schema to add the sessions table -- drizzle bakes the schema into the
+   * instance, so a table added afterwards needs a new one. Both used to
+   * name the arguments themselves, which made anything the first
+   * construction was given (a logger, a cache, an instrumentation hook)
+   * something the second would silently drop, in an application with
+   * sessions and nowhere else. Nothing is passed today beyond the client
+   * and the schema, so nothing was being lost; the arguments are named
+   * here so that stays true without anyone having to remember.
+   *
+   * A transaction is not a third construction: drizzle-orm 0.45 hands the
+   * transaction the session it already has (better-sqlite3) or builds a
+   * fresh one for the pooled connection with `this.options` (mysql2,
+   * node-postgres), so whatever this call was given reaches the
+   * transactions too.
+   *
+   * @returns {object} The Drizzle database, also set on `this.db`
+   * @memberof Drizzle
+   */
+  buildDatabase() {
+    this.db = this.dialect.drizzle(this.client, this.schema);
+
+    return this.db;
+  }
+
+  /**
    * The Drizzle database, or the transaction active in this async context
    *
    * @returns {object} A Drizzle database
@@ -1092,7 +1122,7 @@ class Drizzle {
     if (!this.sessionTable) {
       this.config.sessions = true;
       this.compile();
-      this.db = this.dialect.drizzle(this.client, this.schema);
+      this.buildDatabase();
     }
 
     await this.migrations.ensure({ [SESSIONS_KEY]: this.sessionTable });
@@ -1299,7 +1329,7 @@ class Drizzle {
     }
 
     this.client = await this.dialect.connect(this.config, this.driverPaths);
-    this.db = this.dialect.drizzle(this.client, this.schema);
+    this.buildDatabase();
 
     try {
       await this.ping();

--- a/packages/mongoose/__tests__/mongoose.spec.js
+++ b/packages/mongoose/__tests__/mongoose.spec.js
@@ -869,6 +869,25 @@ describe('mongoose adapter', () => {
       await adapter.stop();
     });
 
+    test('builds the mongoose instance the same way both times', async () => {
+      const { adapter } = build('rebuilt');
+      const first = adapter.mongoose;
+
+      await adapter.stop();
+
+      const second = adapter.mongoose;
+
+      // Two constructions: the constructor's, and the one `stop()` makes so
+      // a store that is started again does not reuse the connection it
+      // disconnected. Whatever configures the instance has to reach both --
+      // a `set()` or an instance-wide plugin added to only the first would
+      // leave a restarted store behaving differently from a fresh one, and
+      // nothing else here would say so
+      expect(second).not.toBe(first);
+      expect(second.options).toEqual(first.options);
+      expect(second.plugins.length).toBe(first.plugins.length);
+    });
+
     test('stops cleanly and starts again', async () => {
       const { adapter, henri } = build('restart', { baseRole: 'member' });
       const before = adapter.addModel(userModel, 'user');

--- a/packages/mongoose/index.js
+++ b/packages/mongoose/index.js
@@ -221,7 +221,7 @@ class Mongoose {
     this.definitions = {};
     this.associated = new Set();
     this.userModelName = null;
-    this.mongoose = new mongoose.Mongoose();
+    this.mongoose = this.newConnection();
     this.sessionStore = null;
     this.url = buildUrl(this.config);
 
@@ -1044,6 +1044,29 @@ class Mongoose {
   }
 
   /**
+   * The Mongoose instance this store's models are built on, and the one
+   * place that says what one is built with.
+   *
+   * There are two constructions, not one: the constructor builds it, and
+   * `stop()` builds another so that a store which is started again does
+   * not reuse the connection it disconnected. Nothing configures the
+   * instance today -- the plugins are registered per schema in
+   * `addModel()`, and the connect options are `connectOptions()` -- so the
+   * two were identical and nothing was being lost. They are named once
+   * here so a `set()` or an instance-wide plugin added later cannot reach
+   * the first construction and miss the second, which would leave a
+   * restarted store configured differently from a fresh one and nothing
+   * would say so. `__tests__/mongoose.spec.js` compares what the two
+   * instances hold across a restart.
+   *
+   * @returns {mongoose.Mongoose} A fresh Mongoose instance
+   * @memberof Mongoose
+   */
+  newConnection() {
+    return new mongoose.Mongoose();
+  }
+
+  /**
    * The url to connect to
    *
    * @returns {string} A mongodb:// url
@@ -1133,7 +1156,7 @@ class Mongoose {
     }
 
     await this.mongoose.disconnect();
-    this.mongoose = new mongoose.Mongoose();
+    this.mongoose = this.newConnection();
     this.models = {};
     this.associated = new Set();
     debug('stopped %s', this.name);


### PR DESCRIPTION
## The shape

Something is constructed twice and the second construction is given less. It hides well, because both call sites look right on their own, and the difference only shows in the configuration nobody has added yet.

The backlog carried one instance, written down by a mapper who read it rather than hit it: `Drizzle#getSessionConnector()` rebuilds the drizzle instance, three hundred lines from `start()`, each naming its arguments itself. This PR fixes it, sweeps the monorepo for the same shape, and leaves behind tests that fail if the two constructions ever drift apart again.

## The original claim, verified in all three parts

- **The two sites are real and were the whole of it.** `dialect.drizzle(this.client, this.schema)` was spelled at `index.js:1302` (`start()`) and `:1095` (`getSessionConnector()`); `git log -S` shows both arrived in the same commit and neither has been touched since. A third copy sat in the lifecycle spec.
- **"Takes no third argument" is right, and so is why it matters.** Each dialect's lambda is `(client, schema) => drizzle(client, { schema })`, and drizzle-orm 0.45.2's `construct(client, config)` reads `logger`, `cache` and `casing` out of that second object. The options exist; henri passes none of them, and the henri lambda's own signature is the seam where one would be added.
- **A transaction is not a third construction**, read from the installed 0.45.2: better-sqlite3 hands the transaction the session it already has, mysql2 and node-postgres build a fresh session for the pooled client with `this.options`, and `options.logger ?? new NoopLogger()` is where that lands. So transaction traffic inherits whatever the construction was given, on all three.

**Latent, not reachable**: nothing is passed today beyond the client and the schema, so nothing was being lost. That is the whole reason to fix it now rather than after somebody adds a logger.

## What the sweep found

**One more instance, fixed** — `@usehenri/mongoose`, also latent. `new mongoose.Mongoose()` was spelled in the constructor and again in `stop()`, so a store started again does not reuse the connection it disconnected. Identical today (the plugins are per schema in `addModel()`, the connect options are `connectOptions()`), but an instance-wide `set()` or plugin added to the constructor would leave a **restarted** store configured differently from a fresh one — the hardest kind to see, because both look right in isolation.

**Two reported and deliberately not fixed**, each with the reason:

- `@usehenri/cli` boots an application in six places: one shared `boot()` and four private near-copies that each re-spell `SKIP_WORKERS` + `CONSOLE_ONLY` + `new Henri({ runlevel })` + `init()`. Nothing is *given less* — each copy is complete — so it is duplication rather than drift, and the cost is that a sixth thing needed at boot has to be written five times. (`analyze.js` omits both variables deliberately and says so, so it is not a sixth miss.) The fix rewrites four command boots and belongs on its own.
- `packages/uploads/src/module.js`'s `reload()` is a hand-written parallel of `init()` with the same construction arguments but none of the boot lines, including the "signed urls are on, but this application has no secret" warning. The two sequences differ deliberately, so sharing the construction here would be a restructure with behaviour attached.

**Read and found safe, with what made each safe**, so nobody reads them twice: the other two adapters' session connectors (both reuse an existing handle), `Sql#createConnector()` (already this pattern), the Sequelize restart replaying `addModel` from `this.definitions` with `associated` cleared, the three thin dialect subclasses, `henri.shared` and its redis client, `henri.cache` (`scope()` is a real second construction and safe *by construction* — every derived field is computed in the constructor), the flag/maintenance/trail/calls/versions stores, the view engines' `reload()` (the asset-prefix hazard is already argued in writing there), `henri.telemetry` (not reloadable, instruments deduped by name, retained closures read live state), `2.mailers.js#reload()` leaving the registered handlers alone, and the non-reloadable `2.server.js`.

Two things worth knowing that fell out of the reading: the one place this class already bit is `3.model.js#reload()` throwing away every adapter, which is *why* `base/session-store.js` exists as a re-resolving proxy — so this rebuild leaves nothing stale behind it. And the backwards `release()` pass in `0.modules.js` is an **unused seam**: no module in the monorepo implements `release()`, which is worth knowing before someone assumes it is load-bearing.

## What I checked myself

Not the fixes — the tests. A drift test that cannot fail is worse than no test, so I sabotaged each one and watched it catch the exact drift it exists for.

Giving only `start()` an option:

```
× builds the database the same way both times it builds one
AssertionError: expected [ …(3) ] to have a length of 2 but got 3
```

Setting `strictQuery` on only the constructor:

```
× builds the mongoose instance the same way both times
AssertionError: expected { pluralization: true, …(3) } to deeply equal { pluralization: true, …(4) }
```

Both are load-bearing.

## Gates

`pnpm test` 231 files / 4897 passed · `pnpm test:types` ok · `pnpm lint --max-warnings 0` clean · `pnpm format:check` clean · live PostgreSQL 998 passed. `scripts/smoke.sh` not run and not needed: no published bundle changed shape — no `files` array touched, no new shipped file, no declaration. No documentation page changed, because no behaviour did.