### PR TITLE
A Live SQL Server job and a Live MariaDB one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,107 @@ jobs:
           NODE_ENV: test
           HENRI_TEST_MYSQL_URL: mysql://root:henri@127.0.0.1:3306/henri_test
 
+  # MariaDB is a server rather than a dialect: henri compiles the same MySQL
+  # dialect for it and mysql2 is the driver either way, so this job runs the
+  # same suites the one above does and `target.server` is what the handful of
+  # measured differences branch on. It is here because the day it was first
+  # run it turned up two defects in a published package -- a `db:schema:dump`
+  # that wrote `DEFAULT 'NULL'` on every nullable column, and a `db:status`
+  # drift that could never close -- neither of which any other job can see.
+  mariadb:
+    name: Live MariaDB
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    services:
+      mariadb:
+        image: mariadb:11.8
+        env:
+          MARIADB_ROOT_PASSWORD: henri
+          MARIADB_DATABASE: henri_test
+        ports:
+          - 3307:3306
+        options: >-
+          --health-cmd "mariadb-admin ping -h 127.0.0.1 -uroot -phenri"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: jdx/mise-action@v4
+        with:
+          cache: true
+
+      - name: Cache pnpm store
+        uses: actions/cache@v6
+        with:
+          path: ~/.local/share/pnpm/store
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-${{ runner.os }}-
+
+      - run: pnpm install --frozen-lockfile
+        env:
+          # The SQL suites never boot MongoDB
+          MONGOMS_DISABLE_POSTINSTALL: '1'
+
+      # `test:sql:mariadb` rather than `test:sql`: the variable alone would
+      # leave the run on sqlite, and this script is what names the dialect
+      - run: pnpm test:sql:mariadb
+        env:
+          NODE_ENV: test
+          HENRI_MARIADB_PORT: '3307'
+
+  # SQL Server is the dialect `@usehenri/mssql` actually runs on, and until
+  # this job existed the only thing covering it was the DDL it generates,
+  # checked as strings, offline. It is the slowest of the four -- the image
+  # is around 1.5GB unpacked, three to four times postgres -- which is why
+  # it runs the four projects that reach a server rather than the whole
+  # suite. Developer edition is free for this.
+  mssql:
+    name: Live SQL Server
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    services:
+      mssql:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        env:
+          ACCEPT_EULA: 'Y'
+          MSSQL_SA_PASSWORD: Henri_Passw0rd
+          MSSQL_PID: Developer
+        ports:
+          - 1433:1433
+        options: >-
+          --health-cmd "/opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P Henri_Passw0rd -Q 'SELECT 1'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: jdx/mise-action@v4
+        with:
+          cache: true
+
+      - name: Cache pnpm store
+        uses: actions/cache@v6
+        with:
+          path: ~/.local/share/pnpm/store
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-${{ runner.os }}-
+
+      - run: pnpm install --frozen-lockfile
+        env:
+          # The SQL suites never boot MongoDB
+          MONGOMS_DISABLE_POSTINSTALL: '1'
+
+      # The four projects that reach a server: the models, the dialect, the
+      # queue's claim and the webhook endpoints
+      - run: pnpm test:sql:mssql
+        env:
+          NODE_ENV: test
+
   # `config.shared`: the rate limit, the sign-in lockout and the idempotency
   # keys counted in Redis instead of one process. Offline the suite skips, so
   # this job is what actually exercises @usehenri/redis.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,27 +62,21 @@ docker run -d --name henri-pg -e POSTGRES_USER=henri -e POSTGRES_PASSWORD=henri 
 HENRI_TEST_POSTGRES_URL=postgres://henri:henri@127.0.0.1:5432/henri_test pnpm test:sql
 ```
 
-**SQL Server is the third one, and it is not in the CI.** `@usehenri/mssql`
-is the only way an application reaches Sequelize, so it is the dialect that
-matters most here and the one nothing ever ran against; `compose.yaml` has
-the server and `pnpm test:sql:mssql` points the `sequelize`, `mssql`, `jobs`
-and `webhooks` projects at it. Whether it becomes a fourth service container
-on every pull request is a cost decision and it belongs to whoever pays for
-the minutes. What it would take: a `Live SQL Server` job shaped exactly like
-`Live MySQL`, one `mcr.microsoft.com/mssql/server:2022-latest` service with
-`ACCEPT_EULA` and `MSSQL_SA_PASSWORD` and a `sqlcmd` health command, and
-`HENRI_TEST_MSSQL_URL` on `pnpm test:sql:mssql`. Developer edition is free
-for that, so there is no licence in the way. What it would cost: the image
-is about 1.5GB unpacked -- three or four times the postgres one -- so a
-minute or so of pull, ten to twenty seconds of boot before it answers, and
-roughly a minute of tests, on top of the checkout and the install every job
-already pays; call it four runner-minutes a run, in parallel with the
-others. There is no arm64 build, which does not matter on
-`ubuntu-latest` and means Apple Silicon runs it under Docker Desktop's
-amd64 emulation locally (it works, and starts in about twenty seconds).
-Until then it runs locally, and a tranche that touches
-`@usehenri/sequelize`, `@usehenri/jobs` or `@usehenri/webhooks` should run
-it.
+**SQL Server and MariaDB are the third and fourth, and both are in the CI
+now** (`Live SQL Server`, `Live MariaDB`), alongside `Live PostgreSQL` and
+`Live MySQL` and `continue-on-error` like them, so none of the four blocks a
+pull request. They were added after each of them turned up defects in a
+published package on the day it was first run -- `decimal` read back through
+a double and a constraint name in a 422 body on SQL Server, a
+`db:schema:dump` that wrote `DEFAULT 'NULL'` on every nullable column and a
+drift that could never close on MariaDB. Neither is cheap: SQL Server's
+image is about 1.5GB unpacked, three or four times the postgres one, so a
+minute of pull, ten to twenty seconds of boot and roughly a minute of tests,
+which is why that job runs the four projects that reach a server rather than
+the whole suite; MariaDB is two or three minutes. There is no arm64 build of
+SQL Server, which does not matter on `ubuntu-latest` and means Apple Silicon
+runs it under Docker Desktop's amd64 emulation locally (it works, and starts
+in about twenty seconds). Locally, `compose.yaml` has both.
 
 ```bash
 HENRI_MSSQL_PORT=51433 pnpm db:up            # or just `pnpm db:up` on 1433
@@ -1897,9 +1891,10 @@ array that forgot them fails.
   Server and MariaDB are both exercised now** (`pnpm db:up` brings both,
   `pnpm test:sql:mssql` points the `sequelize`, `mssql` and `jobs` suites at
   the first and `pnpm test:sql:mariadb` points the SQL suites at the second)
-  and **neither is in the CI**, which is a cost decision rather than an
-  oversight. What is _still_ only offline on SQL Server is what has no
-  Sequelize suite at all -- multi-tenancy, the call log. The
+  and **both are in the CI** (`Live SQL Server`, `Live MariaDB`,
+  `continue-on-error` like the other two). What is _still_ only offline on
+  SQL Server is what has no Sequelize suite at all -- multi-tenancy for the
+  models, the call log; the queue's tenancy does run there. The
   `postgresql` and `mysql` suites are thin now that those packages are
   `@usehenri/drizzle` with a dialect chosen -- they check the choosing and
   reach the server; the model API, the schema format and the migrations are

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,12 @@ HENRI_TEST_MARIADB_URL=mysql://root:henri@127.0.0.1:3307/henri_test pnpm test:sq
 ```
 
 `pnpm db:up` starts all of them from `compose.yaml`, SQL Server and MariaDB
-included. Neither of those two is in the CI, so run them yourself when a
-change touches what they cover.
+included. All four have a job of their own now (`Live PostgreSQL`,
+`Live MySQL`, `Live MariaDB`, `Live SQL Server`), and all four are
+`continue-on-error`, so none of them blocks a pull request -- which means
+nothing stops you merging past a real failure, and reading them when you
+touch an SQL adapter is the whole point. The two below are the slow ones and
+are worth running locally first.
 
 SQL Server is the dialect `@usehenri/mssql` actually runs on, so run it when
 a change touches `@usehenri/sequelize`, `@usehenri/jobs` or

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,9 +11,10 @@
 #   pnpm db:down           stop them, keeping the data
 #   pnpm db:reset          stop them and delete the data
 #
-# The `Live PostgreSQL` and `Live MySQL` jobs are the two the CI runs; the
-# SQL Server below is local only, and the note beside it says what putting it
-# in the CI would cost.
+# All four servers have a CI job of their own (`Live PostgreSQL`,
+# `Live MySQL`, `Live MariaDB`, `Live SQL Server`), each
+# `continue-on-error`, so none of them blocks a pull request. These are the
+# same servers, on ports that do not fight with whatever else is running.
 #
 # Nothing else in the repository needs Docker: `pnpm test` runs on sqlite and
 # an in-process MongoDB, offline. The host ports can be moved when something


### PR DESCRIPTION
## Why

Both servers were run for the first time yesterday, and **each turned up defects in a published package on the day it ran**:

- SQL Server — `decimal` read back through a JavaScript double (`DECIMAL(38,10)` `12345678901234567890.1234567891` → `12345678901234567000`), and a server-generated constraint name (`UQ__Articles__32DD1E4C507CA19A`) reaching a 422 body as if it were a field.
- MariaDB — `henri db:schema:dump` writing `DEFAULT 'NULL'` on every nullable column, so henri could not load back the schema it had just dumped, and a `db:status` drift that could never close.

None of that is visible to any other job. And the local SQL Server run **caught master red** — #442's new tests made several `Note` rows with no slug, which SQL Server refuses because it counts NULL as a value in a unique index, while PostgreSQL, MySQL, MariaDB and sqlite all allow many. Four green jobs said nothing.

## What this adds

Two jobs shaped exactly like `Live MySQL`, `continue-on-error` like it, so **none of the four blocks a pull request** — they are there to be read when a change touches an SQL adapter, not to gate.

- **`Live MariaDB`** — `mariadb:11.8`, `mariadb-admin ping` as the health command, `pnpm test:sql:mariadb`. Two or three runner-minutes.
- **`Live SQL Server`** — `mcr.microsoft.com/mssql/server:2022-latest`, Developer edition (free for this), `ACCEPT_EULA` + `MSSQL_SA_PASSWORD`, a `sqlcmd` health command, `pnpm test:sql:mssql`. About four runner-minutes: the image is ~1.5GB unpacked, three to four times postgres, which is why that job runs the four projects that reach a server rather than the whole suite. No arm64 build, which does not matter on `ubuntu-latest`.

Roughly seven runner-minutes a push between them, in parallel with everything else.

## What I checked, and what only the first run can check

The workflow parses, and both jobs come out with the shape they should (`continue-on-error: true`, five steps each, the ports mapped the way the scripts expect — `3307:3306` for MariaDB, since `test:sql:mariadb` defaults to 3307).

The two health commands are the ones `compose.yaml` already uses to bring these same images up on this machine, and both scripts pass against them: **`pnpm test:sql:mssql` 640 passed**, **`pnpm test:sql:mariadb` 989 passed**, run today. What I cannot check from here is a GitHub Actions *service container* specifically — the health command runs in a different harness than compose's, and only the first run on master proves it. `continue-on-error` is what makes that safe to find out: a job that cannot start its server goes red and blocks nothing.

## Docs

Three places said these were not in the CI and now say what is true: `CLAUDE.md`'s setup section and its known-gaps entry, `CONTRIBUTING.md`, and the header of `compose.yaml`. CONTRIBUTING gains the sentence that matters for a `continue-on-error` job — nothing stops you merging past a real failure, so reading them when you touch an SQL adapter is the whole point.

No changeset: this changes no published package.