### PR TITLE
What happens to a React application when the pages router goes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1886,7 +1886,12 @@ array that forgot them fails.
 - The React (Next.js) engine is frozen on the pages router: it is supported and
   keeps getting fixes, but it does not follow Next.js into the app router,
   because `withHenri` reading `req._henri` on the server has no equivalent
-  there. New applications get Inertia.
+  there. New applications get Inertia. What happens to a React application
+  when Next.js removes the pages router is written down rather than left to
+  the day -- pin the last major that has it, or rewrite the pages onto
+  Inertia, with the mapping between the two engines and the one seam that
+  would make henri redo the calculation: `guides/views.md`
+  (`#when-nextjs-removes-the-pages-router`).
 - The Inertia engine reached parity in 1.2 (server-side rendering in
   development and production, the full scaffold) but is younger than the React
   one; its options may still change.

--- a/website/src/content/docs/guides/views.md
+++ b/website/src/content/docs/guides/views.md
@@ -162,6 +162,34 @@ Options go under the `inertia` key of your configuration: `ssr: false` renders e
 Supported, and frozen. The engine is built on the Next.js pages router, which Next.js has deprecated: henri keeps it working, on Next.js 16, and does not follow it into the app router. The contract that hands a controller's data to a page (`withHenri` reading `req._henri` on the server) has no equivalent in the app router or in server components, so this engine stays where it is. Existing applications keep working and keep getting fixes; new ones are better off on [Inertia](#inertia), which is the default.
 :::
 
+### When Next.js removes the pages router
+
+The caution above says henri does not follow Next.js into the app router. This is the other half of that sentence: what happens to an application that is on this engine when the pages router finally goes.
+
+**Deprecated is not removed.** Next.js 16 ships the pages router and this engine runs on it. `next` is a peer dependency, which means the application owns the version: nothing henri does can move it, and nothing Next.js does reaches an application that has not upgraded.
+
+**What henri commits to.** The React engine keeps working, and keeps getting fixes, on the Next.js majors that carry the pages router. It is frozen in the sense that it gains no app-router features, not in the sense that it is abandoned.
+
+**When the pages router is removed from a Next.js major, henri does not chase it.** An application then has two answers, and neither of them is a surprise henri springs on the day:
+
+1. **Stay.** Pin the last Next.js major that has the pages router. This needs nothing from henri — it is a version in the application's own `package.json` — and it is the right answer for an application that is finished, or one whose next change is a rewrite anyway. What it costs is the rest of that major's security fixes, on the application's own clock.
+2. **Move to Inertia.** There is no automatic conversion and there will not be one: the two engines put the data in different places, so the pages are rewritten. What that actually means is small enough to write down:
+
+| React engine                                                   | Inertia                                                                     |
+| -------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `export default withHenri(Page)`                               | a plain component; `const { data } = useHenri()`                            |
+| props on the page component                                    | `useHenri()`, at any depth                                                  |
+| `next/link`                                                    | `Link` from `@usehenri/inertia`                                             |
+| `@usehenri/react/forms` (`Form`, `Input`, `Select`, `useForm`) | `Form` from `@usehenri/inertia`                                             |
+| `router.push('/tasks')` after a submit                         | the controller redirects; Inertia follows it                                |
+| a failed write is a `422` the form reads field by field        | the controller calls `res.inertia.errors()` and renders the form page again |
+| `getRoute` / `pathFor`                                         | `getRoute` / `pathFor`, unchanged                                           |
+| `.js` pages under `app/views/pages`                            | `.jsx` pages in the same place                                              |
+
+**What does not change**: `config/routes.js`, the controllers' `res.render()` calls, the models, the policies, the tests that go through `@usehenri/testing`. The router is henri's in both engines, which is why the move is a view-layer rewrite and not a port.
+
+**What would change this decision.** One thing: an app-router equivalent of the contract this engine rests on — a supported way for a server component to read what henri attached to the request, the way `withHenri` reads `req._henri`. Passing it through the url is not that; it would put a controller's data in a place the client chooses. If that seam appears, the calculation is worth redoing, and until it does, an app-router engine would be a second way to write a henri application that henri could not hold to the same promises.
+
 Choose it anyway when you want what Next.js gives you and Vite does not: `next/image` and `next/font`, the file-system page fallback (a `GET` no route matches still renders a page of the same name), the Next.js plugin ecosystem, or an existing pages-router application you are moving onto henri. What you give up is the app router, server components and streaming: a page under `app/views/app` would bypass `withHenri` and the controllers, and the engine warns when that directory exists.
 
 [Next.js](https://nextjs.org/) (16, pages router, Turbopack) renders the pages in `app/views/pages` and injects the data sent by your controllers.


### PR DESCRIPTION
## What was missing

The framework comparison asked for "a plan for the Next.js pages router", and the answer has been half-written for a while: `guides/views.md` already says the engine is **supported and frozen**, that henri does not follow Next.js into the app router, and why — `withHenri` reading `req._henri` on the server has no equivalent there.

What it did not say is what that means for somebody already on the engine. "Frozen" and "abandoned" read the same from the outside, and `upgrading.md`'s "the pages are rewritten by hand" is true but is not a plan.

## What this adds

A section under React, `#when-nextjs-removes-the-pages-router`:

- **Deprecated is not removed.** Next.js 16 ships the pages router and the engine runs on it. `next` is a **peer dependency**, so the application owns the version — nothing henri does can move it, and nothing Next.js does reaches an application that has not upgraded.
- **What henri commits to**: the engine keeps working and keeps getting fixes on the Next.js majors that carry the pages router. Frozen means it gains no app-router features, not that it is left to rot.
- **The two answers when removal comes**, neither of them sprung on the day: pin the last major that has it (needs nothing from henri, costs the rest of that major's security fixes on the application's own clock), or move to Inertia.
- **The mapping**, which is the part that turns "rewritten by hand" into work somebody can size: `withHenri(Page)` → `useHenri()`, props → `useHenri()` at any depth, `next/link` → `Link`, `@usehenri/react/forms` → `Form`, `router.push` after a submit → the controller redirects and Inertia follows, a `422` the form reads field by field → `res.inertia.errors()` and the form page again, `getRoute`/`pathFor` unchanged.
- **What does not move**: `config/routes.js`, the controllers' `res.render()` calls, the models, the policies, the tests through `@usehenri/testing`. The router is henri's in both engines, which is why this is a view-layer rewrite and not a port.
- **What would change the decision** — one thing, named: a supported way for a server component to read what henri attached to the request. Passing it through the url is explicitly not that, because it would put a controller's data somewhere the client chooses. That makes the position falsifiable rather than a preference.

Every row of the mapping is taken from what the two engine sections of that same guide already document, not from anything new.

`CLAUDE.md`'s known-gaps entry now points at the section instead of restating the freeze.

## Checked

`pnpm --filter @usehenri/website build` — 45 pages, clean — and the anchor `CLAUDE.md` names is in the built html (`id="when-nextjs-removes-the-pages-router"`), so the pointer is not one of those references that rots the first time a heading is reworded.

No changeset: no published package changes.