### PR TITLE
Getting started, run rather than read — and the two things running it found

### DIFF
--- a/.changeset/the-shortcuts-and-the-link.md
+++ b/.changeset/the-shortcuts-and-the-link.md
@@ -1,0 +1,15 @@
+---
+'@usehenri/core': patch
+---
+
+The development server's shortcut list says Ctrl on every platform, and names the two it never mentioned
+
+The listener reads the control characters stdin sends in raw mode -- 3, 14, 15
+and 18 -- so `Cmd+R`, `Cmd+O` and `Cmd+C`, which is what it printed on macOS,
+named shortcuts that could not work: a terminal never delivers Cmd as a
+character. It also binds a plain `r` (the loaded routes) and a plain `u` (the
+unknown ones), which the list left out entirely.
+
+`HENRI_CONFIG_INVALID` pointed at a page that does not exist
+(`/reference/configuration/` rather than `/configuration/`), so the failure
+that fires when a configuration is wrong sent people to a 404.

--- a/packages/core/src/2.server.js
+++ b/packages/core/src/2.server.js
@@ -188,14 +188,19 @@ function watch(henri) {
   keyboardShortcuts(henri);
 
   setTimeout(() => {
-    const cmdCtrl = process.platform === 'darwin' ? 'Cmd' : 'Ctrl';
-
-    pen.info('server', `To reload the server codebase, use ${cmdCtrl}+R`);
+    // Ctrl on every platform, macOS included: the listener below reads the
+    // control characters stdin sends in raw mode (3, 14, 15, 18), and Cmd
+    // is not one of them -- a terminal never delivers it as a character, so
+    // the `Cmd` this used to print on darwin named a shortcut that could
+    // not work. The two plain letters are on the same list because they are
+    // bound too (114, 117) and were never mentioned
+    pen.info('server', 'To reload the server codebase, use Ctrl+R');
     pen.info(
       'server',
-      `To open the a new browser tab with the project, use ${cmdCtrl}+O or ${cmdCtrl}+N`
+      'To open a new browser tab with the project, use Ctrl+O or Ctrl+N'
     );
-    pen.info('server', `To quit, use ${cmdCtrl}+C`);
+    pen.info('server', 'To list the loaded routes press r, the unknown ones u');
+    pen.info('server', 'To quit, use Ctrl+C');
   }, 1 * 1000);
 
   return watcher;

--- a/packages/core/src/base/config-validate.js
+++ b/packages/core/src/base/config-validate.js
@@ -707,7 +707,7 @@ class ConfigurationError extends Error {
     this.code = 'HENRI_CONFIG_INVALID';
     this.exitCode = 1;
     this.hint =
-      'Every key henri reads is documented at https://usehenri.io/reference/configuration/';
+      'Every key henri reads is documented at https://usehenri.io/configuration/';
     this.problems = problems;
   }
 }

--- a/website/src/content/docs/getting-started.md
+++ b/website/src/content/docs/getting-started.md
@@ -5,42 +5,109 @@ sidebar:
   order: 1
 ---
 
-## Requirements
-
-- Node.js 22 or newer
-- A package manager: pnpm, npm or yarn. `henri new` uses the one it finds (the `packageManager` field of an existing `package.json`, its lockfile, then the manager that ran the command, then a probe) and prints its choice; `--pm pnpm|yarn|npm` forces it.
-
-:::note
-henri was revived in 2026 on a modern toolchain (Node 22+, Express 5, Next.js 16, React 19, Drizzle ORM, Mongoose 9). Releases published before 1.0 still target Node 10 to 14. If you have an application written for henri 0.37, read [Upgrading](/upgrading/).
-:::
-
-## Install
+Four commands take you from an empty directory to an application answering on
+`http://localhost:3000/`, with a database, a resource and its pages. Measured on
+a warm package cache: eight seconds for `henri new` and six more for the first
+boot. The first run on a cold cache is longer, and the difference is the
+download — an application resolves about six hundred packages.
 
 ```bash
 pnpm add -g henri
-# or: npm install -g henri
-```
-
-`henri --version` prints the installed version.
-
-## Create a project
-
-```bash
 henri new my-app
 cd my-app
 henri server
 ```
 
-`henri new` copies the application skeleton, writes the configuration, scaffolds a sample `Task` resource, writes a README, runs `git init` (unless the folder is already inside a repository) and installs the dependencies. `--skip-install` and `--no-git` skip those two steps; `--renderer react` picks the [Next.js](/guides/views/#react) view engine instead of the default [Inertia](/guides/views/#inertia) one, and `--adapter postgresql|mysql|mssql|mongoose|disk` the [store](/guides/models/#adapters) instead of the default `drizzle` one. The result:
+There is no database to install. `henri new` writes a [Drizzle](/guides/models/#drizzle)
+store on sqlite at `.henri/app.db`, so nothing has to be running before
+`henri server` does.
+
+## Requirements
+
+- **Node.js 22 or newer.** Anything older stops at the first command, with the
+  version it found:
+
+  ```text
+  You are using Node.js v20.20.0
+
+  henri requires Node.js 22 or newer.
+  ```
+
+- **A package manager.** `henri new` uses the one it finds — the
+  `packageManager` field of an existing `package.json`, its lockfile, then the
+  manager that ran the command, then a probe — and prints its choice.
+  `--pm pnpm|yarn|npm` forces it.
+
+:::note
+Releases published before 1.0 target Node 10 to 14. If you have an application
+written for henri 0.37, read [Upgrading](/upgrading/).
+:::
+
+### Without a global install
+
+`pnpm add -g henri` needs pnpm's global bin directory on your `PATH`, and on a
+machine where `pnpm setup` has never run it refuses rather than installing:
 
 ```text
+[ERROR] The configured global bin directory "…/Library/pnpm/bin" is not in PATH
+Run "pnpm setup" to update your shell configuration.
+```
+
+You can skip the global install entirely. `pnpm dlx henri new my-app` (or
+`npx henri new my-app`) scaffolds the application, and the application depends
+on `henri` itself — so `npm start`, `pnpm start` and `npx henri <command>` all
+work inside it with nothing installed globally:
+
+```text
+> second-app@1.0.0 start
+> henri server
+```
+
+The rest of this page writes `henri` for short.
+
+## What `henri new` writes
+
+```text
+ - Using pnpm (pnpm --version)
+ - Copying new directory structure...
+ - Building new package file...
+ - Generating config/default.json, config/test.json and .env...
+ - Listing better-sqlite3 under allowBuilds in pnpm-workspace.yaml...
+ - Scaffolding the sample Task resource...
+> created controller "tasks.js" @ app/controllers/tasks.js
+> added route "resources tasks" @ config/routes.js
+> created view "index.jsx" @ app/views/pages/tasks/index.jsx
+> created view "_form.jsx" @ app/views/pages/tasks/_form.jsx
+> created view "new.jsx" @ app/views/pages/tasks/new.jsx
+> created view "edit.jsx" @ app/views/pages/tasks/edit.jsx
+> created view "show.jsx" @ app/views/pages/tasks/show.jsx
+> created test "tasks.test.js" @ test/tasks.test.js
+ - Adding a Dockerfile...
+ - Adding new readme file...
+ - Writing AGENTS.md, CLAUDE.md and .mcp.json for coding agents...
+ - Initialized a git repository
+ - Installing packages using pnpm...
+```
+
+`--skip-install` and `--no-git` skip the last two steps, `-f` writes into an
+existing folder, `--renderer react` picks the [Next.js](/guides/views/#react)
+view engine instead of the default [Inertia](/guides/views/#inertia) one, and
+`--adapter` picks the [store](/guides/models/#adapters). The result:
+
+```text
+├── .dockerignore
 ├── .env                      <- HENRI_SECRET, ignored by git
 ├── .gitignore
+├── .mcp.json                 <- runs `henri mcp` for a coding agent
+├── AGENTS.md                 <- the conventions of this app; CLAUDE.md points at it
+├── CLAUDE.md
+├── Dockerfile
 ├── app
 │   ├── controllers
 │   │   ├── main.js           <- main#home, the landing page
 │   │   └── tasks.js          <- the resources actions of Task
 │   ├── helpers
+│   ├── jobs
 │   ├── models
 │   │   └── Task.js           <- the `Task` global
 │   ├── views
@@ -57,14 +124,15 @@ henri server
 │   │   ├── styles
 │   │   │   └── index.css     <- Tailwind CSS, the whole stylesheet
 │   │   └── vite.config.mjs   <- @usehenri/inertia/vite + Tailwind
-│   ├── jobs
 │   └── workers
 ├── config
 │   ├── default.json          <- stores, renderer, user model (committed)
-│   └── routes.js             <- 'get /': 'main#home', 'resources tasks': 'tasks'
+│   ├── routes.js             <- 'get /': 'main#home', 'resources tasks': 'tasks'
+│   └── test.json             <- the same store, on :memory:
 ├── db
 │   └── seeds.js              <- seed data, run with `henri db:seed`
 ├── eslint.config.js
+├── jsconfig.json             <- editors: henri's types and .henri/types.d.ts
 ├── package.json
 ├── pnpm-workspace.yaml       <- allowBuilds for pnpm; npm and yarn ignore it
 ├── README.md
@@ -73,15 +141,219 @@ henri server
 └── vitest.config.js
 ```
 
-If you have a Ruby on Rails background, this should look familiar. The sample resource is a regular scaffold (`henri generate scaffold Task name:string! category:string:enum=urgent,high,medium,low done:boolean` writes the same files, bar the default the sample `category` carries); `henri destroy scaffold Task` removes it. Its form shows what the generator reads off the model: `name` is required so its input is, and `category` can only hold four values so it is a `<select>` of them.
+If you have a Ruby on Rails background, this should look familiar. The sample
+resource is a regular scaffold (`henri generate scaffold Task name:string!
+category:string:enum=urgent,high,medium,low done:boolean` writes the same files,
+bar the default the sample `category` carries); `henri destroy scaffold Task`
+removes it. Its form shows what the generator reads off the model: `name` is
+required so its input is, and `category` can only hold four values so it is a
+`<select>` of them.
 
-The pages are styled: [Tailwind CSS](https://tailwindcss.com) v4 is wired for the renderer you picked, `app/views/styles/index.css` is the whole stylesheet, and dark mode follows the operating system. Everything the generators write from now on is styled the same way. See [Views](/guides/views/#styles) for the theme, the `@source` globs and how to opt out.
+The pages are styled: [Tailwind CSS](https://tailwindcss.com) v4 is wired for
+the renderer you picked, `app/views/styles/index.css` is the whole stylesheet,
+and dark mode follows the operating system. See [Views](/guides/views/#styles).
 
-`config/default.json` is committed and holds no secret: the session secret is generated into `.env` as `HENRI_SECRET`, which henri reads on boot. The default store is [Drizzle](/guides/models/#drizzle) on sqlite, in `.henri/app.db` (ignored too): there is no server to start, `henri test` runs on `:memory:`, and it is a database you can deploy rather than one you have to leave behind.
+`config/default.json` is committed and holds no secret: the session secret is
+generated into `.env` as `HENRI_SECRET`. `config/test.json` points the same
+store at `":memory:"`, so `henri test` never touches your development data.
 
-### Another database
+## The boot
 
-`--adapter` picks the store of the new application. The sample resource, the dependencies and `config/default.json` follow it, and a `config/test.json` is written so `henri test` runs on its own database.
+`henri server` loads twenty-five modules in dependency order and prints what
+each one decided. Abridged, with the timestamps trimmed:
+
+```text
+       henri ✏  1.2.0 => dev
+        boot ✏  running from cli
+      config ✏  from the environment => secret = [FILTERED] => HENRI_SECRET
+     drizzle ✏  schema pushed: 2 statement(s) in 137ms
+        user ✏  no user model defined; will not load user module
+      router ✏  9 routes loaded successfully => press R to see a list
+        view ✏  starting vite dev server... => vite = 8.2.2 => react = 19.2.8 => inertia = 3.7.0
+        view ✏  inertia ready (vite dev server) => ssr = on
+         api ✏  rate limit => 600 requests per 60s per user or ip (not enforced in development), counted in this process
+      server ✏  ready for battle
+      server ✏  local url => http://localhost:3000/
+```
+
+Three of those lines are worth reading twice.
+
+**`schema pushed`** — a development boot pushes the models to the database, so
+the `tasks` table exists without a migration. For production you write the
+first migration and apply it (`henri db:generate --name=init`, then
+`henri db:migrate`); [Models](/guides/models/#drizzle) has the rest.
+
+**`no user model defined`** — the scaffold configures a user model but ships no
+`app/models/User.js`, so sessions, passport and the CSRF middleware stay
+unloaded. `henri generate authentication` writes the model, the pages, the
+controller, the mailer and the tests. See [Users](/guides/users/).
+
+**`ready for battle`** — from here the process watches your files. Saving a
+controller, a model, `config/routes.js`, a worker or a configuration file
+reloads the affected modules without restarting; the view engine hot reloads
+the pages itself (Vite with Inertia, Turbopack with Next.js). With the React
+renderer, changes to `config/next.js` or `config/webpack.js` need a restart,
+and the terminal says so.
+
+While the server runs in an interactive terminal:
+
+| Key                | Action                                            |
+| ------------------ | ------------------------------------------------- |
+| `r`                | list the loaded routes                            |
+| `u`                | list the routes whose controller is missing       |
+| `Ctrl+R`           | reload the whole application                      |
+| `Ctrl+O`, `Ctrl+N` | open the app in your browser                      |
+| `Ctrl+C`           | stop the server (a second `Ctrl+C` exits at once) |
+
+## Add a resource without stopping the server
+
+Leave `henri server` running and, in another terminal, generate one:
+
+```bash
+henri generate scaffold Post title:string! body:text status:string:enum=draft,published
+```
+
+```text
+> created model "Post.js" @ app/models/Post.js
+> created controller "posts.js" @ app/controllers/posts.js
+> added route "resources posts" @ config/routes.js
+> created view "index.jsx" @ app/views/pages/posts/index.jsx
+> created view "_form.jsx" @ app/views/pages/posts/_form.jsx
+> created view "new.jsx" @ app/views/pages/posts/new.jsx
+> created view "edit.jsx" @ app/views/pages/posts/edit.jsx
+> created view "show.jsx" @ app/views/pages/posts/show.jsx
+```
+
+The terminal running the server answers on its own:
+
+```text
+     drizzle ✏  schema pushed: 2 statement(s) in 10ms
+      router ✏  17 routes loaded successfully => press R to see a list
+     modules ✏  workers => reloaded => 21/21
+```
+
+The table was created, the routes went from nine to seventeen, and
+`http://localhost:3000/posts` renders — no restart. That reload is the loop you
+will spend the day in.
+
+`henri destroy scaffold Post` takes all of it back. The generator writes no
+test file; `henri generate test posts` does.
+
+## What answered
+
+Add a task at `/tasks/new`, then post one to the same route and read what comes
+back. The scaffolded controller writes none of this envelope — henri does:
+
+```bash
+curl -H 'Accept: application/json' -X POST http://localhost:3000/tasks \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"read the getting started page","category":"high"}'
+```
+
+```json
+{
+  "_links": {
+    "self": { "href": "/tasks/01a08374-9497-76f5-8c91-6920dd677217" },
+    "collection": { "href": "/tasks" },
+    "edit": { "href": "/tasks/01a08374-9497-76f5-8c91-6920dd677217/edit" },
+    "update": {
+      "href": "/tasks/01a08374-9497-76f5-8c91-6920dd677217",
+      "method": "PATCH"
+    },
+    "destroy": {
+      "href": "/tasks/01a08374-9497-76f5-8c91-6920dd677217",
+      "method": "DELETE"
+    }
+  },
+  "name": "read the getting started page",
+  "category": "high",
+  "done": false,
+  "externalId": "01a08374-9497-76f5-8c91-6920dd677217",
+  "createdAt": "2026-09-08T23:57:30.647Z",
+  "updatedAt": "2026-09-08T23:57:30.647Z"
+}
+```
+
+The identifier in every url is `externalId`, a uuid v7; the primary key never
+leaves the server ([Models](/guides/models/#identifiers)). The `_links` come
+from the routes file, filtered by the current user's roles and then by the
+record's policy ([API](/guides/api/)).
+
+Two different refusals are worth telling apart, because they come from two
+different places. A value outside the `enum` never reaches the action:
+
+```json
+{
+  "error": "Unprocessable Entity",
+  "message": "the parameters are invalid",
+  "statusCode": 422,
+  "code": "HENRI_PARAMS_INVALID",
+  "data": {
+    "errors": { "category": "must be one of urgent, high, medium, low" }
+  }
+}
+```
+
+A missing `name` reaches the model and is refused there:
+
+```json
+{
+  "error": "Unprocessable Entity",
+  "message": "Task validation failed: name: is required",
+  "statusCode": 422,
+  "data": { "errors": { "name": "is required" } }
+}
+```
+
+The first is the controller's `params` block ([Controllers](/guides/controllers/)),
+the second the model's schema ([Models](/guides/models/#validations)). A browser
+posting the same form gets the page back with the messages under the fields
+instead of the JSON.
+
+## When something goes wrong
+
+**The port is busy.** henri does not fail; it takes the next free one and says
+so, so check the url it printed rather than assuming `3000`:
+
+```text
+      server ✏  port 3000 is busy, using 3001 instead
+      server ✏  local url => http://localhost:3001/
+```
+
+**Something in the configuration is wrong.** Every failure henri raises carries
+a code and a hint, and configuration is validated before any other module
+starts:
+
+```text
+  henri server failed [HENRI_CONFIG_INVALID]: invalid configuration (1 problem): port
+
+  "port" must be a port number between 1 and 65535, but it is the string "three thousand" (from config/default.json)
+    A port is a whole number: { "port": 3000 }. In development a busy one is replaced by the next free port
+```
+
+The codes are catalogued at [Errors](/reference/errors/), with what each one
+means and how to fix it.
+
+**Anything else.** `henri doctor` checks the application without booting it —
+the configuration files, the routes, the models, the missing dependencies:
+
+```text
+  henri doctor: no problems found (1 model, 2 controllers, 9 routes)
+```
+
+and when there is something to say, it says where and what to do:
+
+```text
+  error    config.invalid       config/default.json
+           config/default.json: "port" must be a port number between 1 and 65535, but it is the string "three thousand"
+           -> A port is a whole number: { "port": 3000 }. In development a busy one is replaced by the next free port
+```
+
+## Another database
+
+`--adapter` picks the store of the new application. The sample resource, the
+dependencies and `config/default.json` follow it, and `config/test.json` is
+pointed at a database of its own.
 
 ```bash
 henri new my-app                                       # drizzle on sqlite, file:.henri/app.db
@@ -93,37 +365,41 @@ henri new my-app --adapter disk                        # a local MongoDB, nothin
 henri new my-app --adapter mssql                       # SQL Server, on sequelize
 ```
 
-`drizzle`, `postgresql` and `mysql` are all the [Drizzle adapter](/guides/models/#drizzle) — `@usehenri/postgresql` and `@usehenri/mysql` are it with the dialect and the driver chosen — so all three have migrations (`henri db:generate`, `db:migrate`, `db:push`, `db:status`). `mssql` is the one adapter on Sequelize, because Drizzle has no SQL Server dialect, and it has no migrations. Every adapter but `disk` and sqlite expects a server running at the url written in `config/default.json`.
-
-## Start coding
-
-`henri server` boots the modules in order (configuration, mail and GraphQL, controllers and the Express app, models and the view engine, users, routes and workers), prints the URL it listens on (`http://localhost:3000/`; development binds to `127.0.0.1`) and watches your files. Saving a controller, a model, `config/routes.js`, a worker or a configuration file reloads the affected modules without restarting the process; the view engine hot reloads the pages itself (Vite with Inertia, Turbopack with Next.js). With the React renderer, changes to `config/next.js` or `config/webpack.js` need a restart, and the terminal says so.
-
-Open the page, add a task at `/tasks/new`, then read `app/controllers/tasks.js` and `app/views/pages/tasks/index.jsx` to see the data flow: the controller calls `res.render('/tasks', { data })` and the page reads `data` with `useHenri()` (`withHenri` with the React renderer).
-
-While the server runs in an interactive terminal:
-
-| Key      | Action                                            |
-| -------- | ------------------------------------------------- |
-| `r`      | list the loaded routes                            |
-| `u`      | list the routes whose controller is missing       |
-| `Ctrl+R` | reload the whole application                      |
-| `Ctrl+O` | open the app in your browser                      |
-| `Ctrl+C` | stop the server (a second `Ctrl+C` exits at once) |
+`drizzle`, `postgresql` and `mysql` are all the [Drizzle
+adapter](/guides/models/#drizzle) — `@usehenri/postgresql` and `@usehenri/mysql`
+are it with the dialect and the driver chosen — so all three have migrations
+(`henri db:generate`, `db:migrate`, `db:push`, `db:status`). `mssql` is the one
+adapter on Sequelize, because Drizzle has no SQL Server dialect, and it has no
+migrations. Every adapter but `disk` and sqlite expects a server running at the
+url written in `config/default.json`.
 
 ## Everyday commands
 
 ```bash
 henri server --production    # build the views once, then serve them
 henri server --debug=henri:* # verbose logs (same as DEBUG=henri:*)
-henri server --inspect       # start the Node.js inspector
-henri server --skip-workers  # do not start app/workers
 henri server --host=0.0.0.0  # listen on every interface
 henri routes                 # the routes table of config/routes.js
 henri console                # a REPL with henri and the models loaded
+henri runner 'await Task.count()'  # one expression inside a booted app
 henri db:seed                # run db/seeds.js with the models loaded
 henri test                   # run test/**/*.test.js with Vitest
-henri generate scaffold Post title:string! body:text
+henri doctor                 # check the application without booting it
 ```
 
-See the [CLI reference](/reference/cli/) for every command and flag.
+`henri test` runs the scaffolded suite as it stands:
+
+```text
+ Test Files  1 passed (1)
+      Tests  3 passed (3)
+```
+
+## Where to go next
+
+- [Models](/guides/models/) — the schema format, the adapters, migrations
+- [Controllers](/guides/controllers/) — actions, `before` hooks, `params`, `answers`
+- [Routes](/guides/routes/) — `resources`, `member`, `namespace`, path helpers
+- [Views](/guides/views/) — Inertia, React, the styles, server-side rendering
+- [Users](/guides/users/) — `henri generate authentication`, sessions, policies
+- [Testing](/guides/testing/) — `@usehenri/testing`, factories, `request()`
+- [CLI reference](/reference/cli/) — every command and flag


### PR DESCRIPTION
## How this was written

Not by editing the old page. By doing what it said, from an empty directory, against the **1.2.0 packages published to npm today** — a real registry install, the way a stranger would — and then writing down what actually happened.

Measured, on a warm cache:

| | |
| --- | --- |
| `pnpm add -g henri` (cold store, 233 packages) | 3.9s |
| `henri new my-app` (599 resolved, 471 added) | **8s** |
| `henri server` → first HTTP 200 | **5.9s** |
| **empty directory → a page in a browser** | **~18s** |
| `henri generate scaffold`, then the running server's reload | 0.46s + ~3s |
| `henri test` | 1.9s |

Almost all of it is `pnpm install` and Vite's dev server. henri's own 25 modules boot in about 300ms.

## What the old page got wrong

This is the valuable half, and it is why the rewrite is worth more than a polish:

1. **The file tree was missing eight entries** `henri new` writes today: `Dockerfile`, `.dockerignore`, `AGENTS.md`, `CLAUDE.md`, `.mcp.json`, `config/test.json`, the root `jsconfig.json` and `pnpm-lock.yaml`. The prose left out the Dockerfile and the coding-agent files entirely.
2. **The boot description was two releases old** — it listed about six module groups; the real boot is 25, including encryption, i18n, queries, telemetry, tenancy, time, policies, streams, calls, trail, cache, flags, versions, retention and maintenance.
3. **A development boot pushes the schema** (`drizzle ✏ schema pushed: 2 statement(s)`), and nothing on the page explained where the `tasks` table came from.
4. **`user ✏ no user model defined; will not load user module`** appears on every first boot — the scaffold sets `"user": "user"` and ships no `app/models/User.js` — and reads like a failure to somebody who has been using the framework for ninety seconds.
5. **A busy port is not an error**: henri prints `port 3000 is busy, using 3001 instead` and carries on, while the page told the reader to open 3000.
6. **The very first command can fail.** `pnpm add -g henri` refuses on a machine where `pnpm setup` has never run. The global install is also *optional* — the scaffolded application depends on `henri` itself, so `npm start` and `npx henri <command>` work with nothing global, which the page never said.
7. The key table was missing `Ctrl+N`, and `henri generate scaffold` writes no test file while `henri new`'s own resource has one.

## The two bugs it turned up, fixed here

Both in `@usehenri/core`, both verified by me against the source before I touched them:

- **The shortcut list named keys that cannot work.** The listener reads raw control characters — 3, 14, 15, 18 — plus a plain `r` and a plain `u`. It printed `Cmd+R`, `Cmd+O or Cmd+N` and `Cmd+C` on macOS. A terminal never delivers Cmd as a character in raw mode, so on the one platform those were written for, they were wrong. It is Ctrl everywhere, and the two plain letters (the loaded routes, the unknown ones) were never mentioned at all. The typo "To open **the a** new browser tab" went with it.
- **`HENRI_CONFIG_INVALID` pointed at a 404.** Its hint said `/reference/configuration/`; the page is at `/configuration/`, which is the spelling every other documentation link in core already uses. That is the failure that fires when somebody's configuration is wrong, so a dead link there costs the most.

## The shape of the page

Four commands and the measured timings in the first screen. Requirements kept to two bullets, with the real Node 20 refusal quoted so it is a fact rather than a warning. "Without a global install" gets its own section, because the documented first command can fail.

Then: what `henri new` wrote → the boot with the three lines that actually confuse people called out → **`henri generate scaffold` against a running server**, chosen as the second thing to show because the reload log (table created, 9 routes to 17, no restart) is the hardest-landing thirty seconds in the product → what henri answered without being asked, including the instructive contrast of two 422s from two different layers → when something goes wrong → databases → everyday commands → links.

Cut to links: the data-flow walkthrough, the Tailwind detail, most of the flag prose.

## Verified

Every command and every output is one that was actually run; the boot log is marked abridged with timestamps trimmed, and each JSON body comes from the `curl` printed directly above it. All 50 internal links and 7 anchors were checked against the built HTML — one broken anchor found and fixed (`/guides/models/#migrations`, which does not exist).

I checked the load-bearing claims myself rather than on report: `createDockerfile()` in `init.js` really does write both docker files and `new.spec.js` asserts them; `port ${wanted} is busy, using ${port} instead` is real (`2.server.js:552`); the Node refusal text is `henri/bin/henri.js`; and the shortcut table binds exactly 3, 14, 15, 18, 114 and 117.

## Gates

`pnpm test` 231 files / 4907 passed · `pnpm test:types` ok · `pnpm lint --max-warnings 0` clean · `pnpm format:check` clean · `pnpm --filter @usehenri/website build` 45 pages · `scripts/smoke.sh` exit 0 with `henri audit` clean in 56 checks.