### PR TITLE
Position the landing page on what henri knows about its data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1855,7 +1855,13 @@ environment. There is no npm token to rotate. npm cannot create a package
 through OIDC, so a new package is bootstrapped once by a maintainer
 (`npm login`, then `node scripts/npm-bootstrap.mjs @usehenri/<name>` publishes
 an empty 0.0.0), gets its trusted publisher registered on npmjs.com, and must
-be added to the `fixed` group of `.changeset/config.json`. `scripts/prepublish.js` copies
+be added to the `fixed` group of `.changeset/config.json`. **It also needs
+"Allow npm publish" ticked** under that package's Settings -> Publishing
+access: npm turns it off for a package first published from a laptop, which
+blocks OIDC however correctly the trusted publisher is registered. That step
+was missed for the seven packages first published by hand and it split the
+1.2.0 release in half -- twelve went out, eight did not, and the publish job
+had to be re-run once the box was ticked. `scripts/prepublish.js` copies
 the LICENSE and a README into every public package at publish time
 (`packages/henri` gets the root README), and copies
 `website/src/content/docs` into `@usehenri/core/docs`, which is what makes
@@ -2056,9 +2062,7 @@ test:sql:mariadb`, the compose service, `HENRI_TEST_MARIADB_URL`).
 /data`). **Nothing is exercised against AWS, R2, Spaces or GCS**: the
   differences those have from MinIO -- IAM, virtual-host style on a real
   domain, an eventual-consistency window, a region redirect -- are covered
-  only by the code that handles them. It is not on npm yet: a new package is
-  bootstrapped once by a maintainer (see Releasing) before the release
-  workflow can publish it.
+  only by the code that handles them. It went out with the rest of 1.2.0.
 - Variants are exercised against sharp on the platform the suite runs on,
   which is the only one it can be. The formats a build of libvips was
   compiled with are not henri's to promise: `avif` in particular is present

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -2,74 +2,98 @@
 title: henri
 head:
   - tag: title
-    content: henri - the versatile JavaScript framework
-description: henri is an easy to learn, rails-like, server-side rendered JavaScript framework with real ORMs.
+    content: henri - the Node.js framework that knows what your data is
+description: henri is a Rails-like, server-rendered JavaScript framework for Node.js. Models, controllers, routes, real ORMs and hot reload, with personal data, retention, an access trail, encryption and multi-tenancy declared on the model.
 template: splash
 editUrl: false
 lastUpdated: false
 hero:
-  title: The versatile JavaScript framework
-  tagline: An easy to learn, Rails-like, server-side rendered framework for Node.js. Models, controllers, routes and React views, with real ORMs and hot reload out of the box.
+  title: The Node.js framework that knows what your data is
+  tagline: henri is Rails-shaped — models, controllers, routes, real ORMs, generators, hot reload. It also knows which of your columns are about a person, how long a record is kept and which customer a row belongs to. Those are marks on the model, not a project for next quarter.
   image:
-    alt: henri
+    alt: The henri logo
     file: ../../assets/henri.png
   actions:
     - text: Get started
       link: /getting-started/
       icon: right-arrow
-    - text: View on GitHub
+    - text: What it does with personal data
+      link: /guides/privacy/
+      variant: minimal
+    - text: GitHub
       link: https://github.com/usehenri/henri
       icon: external
       variant: minimal
 ---
 
-import { Card, CardGrid } from '@astrojs/starlight/components';
+<div class="landing">
 
-<CardGrid stagger>
-  <Card title="Rails-like structure" icon="open-book">
-    `app/models`, `app/controllers`, `app/views`, `config/routes.js`. If you
-    know Ruby on Rails, you already know where everything goes.
-  </Card>
-  <Card title="Server-side rendered React" icon="rocket">
-    Pages live in `app/views/pages` and controllers hand them data with
-    `res.render()`: no API layer to write. The same endpoint answers JSON when a
-    client asks for it.
-  </Card>
-  <Card title="Real ORMs" icon="document">
-    Drizzle for sqlite, PostgreSQL, MySQL and MariaDB, with generated
-    migrations. Mongoose for MongoDB, Sequelize for SQL Server. A new
-    application starts on sqlite, with no database to install. Models are
-    global, like in Rails.
-  </Card>
-  <Card title="GraphQL, one install away" icon="puzzle">
-    Add `@usehenri/graphql` and a `graphql` key to a model: its types and
-    resolvers are merged into a single schema, served by Apollo Server and
-    queryable from `res.render()`.
-  </Card>
-  <Card title="Hot reload everything" icon="setting">
-    Controllers, models, routes, workers and configuration reload on save. Press
-    `r` in the terminal to list the loaded routes.
-  </Card>
-  <Card title="Generators and tests" icon="pencil">
-    `henri new`, `henri generate scaffold`, `henri test` on Vitest. Users get
-    password hashing, sessions, CSRF and roles for free.
-  </Card>
-</CardGrid>
+<section>
 
-<div class="landing-sample">
+<p class="eyebrow">Install</p>
 
-## A whole app in three files
+## From nothing to a running application
 
-```js
-// config/routes.js
+```bash frame="terminal"
+npm install -g henri
+henri new my-app
+cd my-app && henri server
+```
+
+A new application is a [Drizzle](/guides/models/#drizzle) store on sqlite in
+`.henri/app.db`: nothing to install, migrations from the first day, and a
+database you can deploy rather than one you have to leave behind.
+`--adapter postgresql|mysql|mssql|mongoose|disk` picks another one, and the
+sample resource, the dependencies and the configuration follow it.
+
+<ul class="facts">
+<li>
+
+**1.2.0**, every package
+
+</li>
+<li>
+
+**Twenty packages**, one version
+
+</li>
+<li>
+
+**Node 22** or newer
+
+</li>
+<li>
+
+Inertia + React 19, or Next.js
+
+</li>
+<li>
+
+**MIT**
+
+</li>
+</ul>
+
+</section>
+
+<section>
+
+<p class="eyebrow">The shape</p>
+
+## A whole application in three files
+
+If you have written Rails, you already know where everything goes. Routes
+expand into actions, controllers hand their data straight to the pages, and
+there is no API layer in between to write.
+
+```js title="config/routes.js"
 module.exports = {
-  'resources tasks': 'tasks',
   '/': 'tasks#index',
+  'resources tasks': 'tasks',
 };
 ```
 
-```js
-// app/controllers/tasks.js
+```js title="app/controllers/tasks.js"
 module.exports = {
   index: async (req, res) => {
     res.render('/tasks', { data: { tasks: await Task.find() } });
@@ -81,8 +105,7 @@ module.exports = {
 };
 ```
 
-```jsx
-// app/views/pages/tasks/index.jsx
+```jsx title="app/views/pages/tasks/index.jsx"
 import { useHenri } from '@usehenri/inertia';
 
 export default function Tasks() {
@@ -97,5 +120,345 @@ export default function Tasks() {
   );
 }
 ```
+
+The same route answers JSON when a client asks for it: `res.collection(tasks)`
+is [HAL](/guides/api/) with `_links` built from the route helpers and filtered
+by the reader's roles, then by the [policy](/guides/policies/) of each record —
+so a visitor who may not delete a task never sees the link that would.
+`henri generate scaffold Task name:string!` writes all three of these plus the
+model, the form and the four other pages — reading the model file back as it
+goes, so a `required` column gets a required input and an `enum` column gets a
+`<select>` of its values.
+
+</section>
+
+<section>
+
+<p class="eyebrow">Where henri is different</p>
+
+## It knows what your data is
+
+Your application knows which of its columns are about a person. Nothing else
+does — not the logger, not the serializer, not whoever has to answer an access
+request three years from now. henri moves that knowledge into the schema, where
+it can act on its own.
+
+```js title="app/models/Member.js"
+module.exports = {
+  options: {
+    personal: { onErase: 'anonymize' },
+    retention: { action: 'delete', after: '18mo', from: 'leftAt' },
+    tenant: true,
+    versioned: true,
+  },
+  schema: {
+    userId: { references: { model: 'User' }, required: true, type: 'integer' },
+    name: { personal: true, type: 'string' },
+    phone: { personal: { expose: false }, type: 'string' },
+    taxId: { encrypted: true, type: 'string' },
+    leftAt: { type: 'date' },
+  },
+};
+```
+
+That is the whole declaration. Everything below follows from it, with no `where`
+to write and no `where` to forget.
+
+<ul class="follows">
+<li>
+
+`name` and `phone` are masked by name in every log line and every recorded
+error, next to the substring match `filterParameters` already does.
+
+</li>
+<li>
+
+`phone` is dropped from everything henri serializes — `res.render`,
+`res.resource`, `res.collection`, `res.json`, an embedded relation, a CSV
+export, a stream frame — at every depth, unless the answer names it.
+
+</li>
+<li>
+
+`taxId` is AES-256-GCM in the column, under a keyring that rotates without
+moving `updatedAt`. A read that fails throws rather than answering `null`, and
+an encrypted field is personal unless the model says otherwise.
+
+</li>
+<li>
+
+`henri privacy:export` hands a person every row held about them and
+`privacy:erase` removes them — `userId` is what makes this row theirs, and
+`onErase: 'anonymize'` is this model's answer: the row stays and its personal
+fields are cleared, so the count stays true. Every erasure leaves a receipt
+holding an HMAC of the identity rather than the identity.
+
+</li>
+<li>
+
+A member who left eighteen months ago is deleted by the retention sweep — which
+writes nothing until that rule's token is approved in the configuration, so no
+rule starts deleting because somebody edited a model.
+
+</li>
+<li>
+
+Every change is a row in `henri_versions`: the fields, the old value and the new
+one, who did it and the request id. A mass write is refused rather than recorded
+once for a hundred rows.
+
+</li>
+<li>
+
+No query for a `Member` crosses a tenant, and one with **no** tenant in scope is
+refused rather than answered with everybody's rows — which is what makes a job,
+a seed or a console session fail loudly instead of leaking.
+
+</li>
+</ul>
+
+And what henri did itself is in a chain. The [access trail](/guides/trail/)
+records every export, every erasure and every sweep, plus — when you ask for it
+— every answer henri serialized. Each entry carries a sequence number under a
+unique index and a hash of the entry before it, so a row edited or removed
+breaks the chain and `henri trail:verify` says where.
+
+```bash frame="terminal"
+henri privacy                          # the map: what is held about a person, and where
+henri privacy:export ada@example.com   # everything held about them
+henri privacy:erase ada@example.com    # remove them, and leave a receipt
+henri retention:sweep --yes            # the cron line; or a recurring job
+henri trail:verify                     # the chain, and where it breaks
+henri audit                            # the ASVS requirements your files answer
+```
+
+None of this is compliance, and henri does not claim to make you compliant. It
+is the machinery a compliance answer gets written from — and `henri audit` names
+the requirement each finding maps to, so the engineering half and the paperwork
+half are the same conversation.
+
+</section>
+
+<section>
+
+<p class="eyebrow">The framework</p>
+
+## Everything else you would have installed anyway
+
+<div class="cards">
+<div class="card">
+<h3>Real ORMs, and real migrations</h3>
+
+Drizzle on sqlite, PostgreSQL and MySQL with generated, versioned migrations;
+Mongoose on MongoDB; Sequelize under SQL Server. One model format for all of
+them.
+
+A generated migration is read back before it runs, and a production `migrate()`
+refuses a dangerous one until its token has been approved.
+
+</div>
+<div class="card">
+<h3>A JSON API you did not write</h3>
+
+HAL answers, declared `params`, `filters`, `embeds` and `answers`, idempotency
+keys, rate limits, pagination, and a CSV export that streams on a cursor.
+
+`henri openapi` writes the OpenAPI 3.1 description from your routes and models
+without booting — and refuses to describe what a controller writes rather than
+guessing at it.
+
+</div>
+<div class="card">
+<h3>Background work that survives a restart</h3>
+
+A database-backed queue with retries, a dead letter queue, recurring jobs,
+per-job concurrency limits and batches. No second server to run.
+
+Outbound webhooks sign with
+[Standard Webhooks](https://www.standardwebhooks.com), and every address is
+checked when the request is made — then the socket is pinned to the address
+that was checked.
+
+</div>
+<div class="card">
+<h3>Users, roles and record-level rules</h3>
+
+argon2id or bcrypt, sessions in your database, double-submit CSRF with an origin
+check, sign-up, password reset, confirmation, and sign-in with somebody else's
+identity provider.
+
+Policies fail closed: no policy, no rule for the action and a rule that threw
+all mean no, and only the boolean `true` allows.
+
+</div>
+<div class="card">
+<h3>Real time, without a second protocol</h3>
+
+`res.stream()` is a route: server-sent events on the http server henri already
+runs, through the same router, session, role guard and policies as everything
+else.
+
+The policy is asked at subscribe time and again before every event, because a
+stream is one decision answered from for hours.
+
+</div>
+<div class="card">
+<h3>The day-to-day</h3>
+
+Generators that read your model files back, tests on Vitest with factories and a
+mail inbox, a console whose `--sandbox` rolls back on exit, and hot reload for
+controllers, models, routes, workers and configuration.
+
+Mail with previews, caching, feature flags, uploads, i18n, time zones,
+maintenance mode, OpenTelemetry and GraphQL are in the box or one install away.
+
+</div>
+</div>
+
+</section>
+
+<section>
+
+<p class="eyebrow">Coding agents</p>
+
+## Built to be driven by one
+
+None of it is required — a person typing commands gets the same framework — but
+the conventions are written where an agent will read them, and the failures
+carry codes instead of prose.
+
+<div class="cards">
+<div class="card">
+<h3>An MCP server</h3>
+
+`henri mcp` exposes the routes, the models, the configuration, the OpenAPI
+document, the generators, the tests, `doctor` and `audit` — plus what the
+database actually holds, read from its catalogue rather than from the model
+files.
+
+</div>
+<div class="card">
+<h3>AGENTS.md, generated</h3>
+
+Not a template with your name in it: it is read off your application, held to
+150 lines because it loads on every task, and regenerating replaces only what is
+between the markers. `henri new` writes it.
+
+</div>
+<div class="card">
+<h3>Types it can read</h3>
+
+Every published package ships TypeScript declarations, and `.henri/types.d.ts`
+is generated from your application: an interface per model, an enum column as a
+union of its values, and every path helper your routes expand to.
+
+</div>
+<div class="card">
+<h3>254 error codes</h3>
+
+One catalogue across the framework, the adapters, the queue, the view engines
+and the command line, in 39 areas — each code with what it means, what usually
+causes it and how to fix it.
+
+</div>
+<div class="card">
+<h3>The documentation, at your version</h3>
+
+The guides ship inside `@usehenri/core`, so `henri docs` and the MCP `guide`
+tool answer for the henri your application runs rather than for whatever this
+site says today.
+
+</div>
+<div class="card">
+<h3>Something to check it against</h3>
+
+`henri doctor` reports what an application cannot have meant; `henri audit`
+weighs what it chose, against ASVS 4.0.3. Both answer `--json`, and so does
+everything else.
+
+</div>
+</div>
+
+</section>
+
+<section>
+
+<p class="eyebrow">Before you install, not after</p>
+
+## What henri does not do
+
+The guides argue each of these where they live. The list is here because it is
+short, and because you should have it now.
+
+<ul class="limits">
+<li>
+
+**A broadcast reaches one process.** Server-sent events run on the process that
+accepted the connection, and there is no cross-process fan-out yet. Behind two
+workers half the subscribers are not told — and nothing errors. henri warns when
+the environment gives it evidence of a second process, which cannot see a second
+machine.
+
+</li>
+<li>
+
+**There is no queue dashboard, and there will not be one.** A job's arguments
+are the customer's address and the invoice being rebuilt: the data the personal
+marks exist to keep out of answers. A read-only page behind your own policy is
+the answer, and `henri.jobs.*` is what you build it from.
+
+</li>
+<li>
+
+**The Next.js engine is frozen on the pages router.** It is supported and keeps
+getting fixes, but it does not follow Next.js into the app router. New
+applications get Inertia, and the views guide has the mapping between the two.
+
+</li>
+<li>
+
+**henri inlines no CSS into mail.** The honest version of that is a CSS parser,
+a selector engine and an html serializer, and a mangled mail cannot be fixed
+after it is sent. What henri owns is the seam: `onRender` runs last, so an
+inliner cannot leak a style attribute into the plain text part.
+
+</li>
+<li>
+
+**`henri audit` is not a code analysis.** It reads your settings, your marks,
+your declarations and four shapes. There is no dataflow, so a clean run means
+your declarations are right. It does not mean the code is.
+
+</li>
+<li>
+
+**SQL Server gets no migrations.** Drizzle has no dialect for it, so an mssql
+store creates what is missing in development and `henri db:status` reports the
+drift for a person to review.
+
+</li>
+</ul>
+
+</section>
+
+<div class="closing">
+
+## Start
+
+```bash frame="terminal"
+npm install -g henri
+henri new my-app
+```
+
+[Getting started](/getting-started/) walks the first application end to end. The
+[guides](/guides/models/) are the long form — 34 of them, and they argue their
+decisions rather than listing features. [Configuration](/configuration/) is
+every key henri owns.
+
+henri is MIT and built in the open at
+[usehenri/henri](https://github.com/usehenri/henri). Twenty packages, versioned
+together at 1.2.0 and published from CI with npm provenance.
+
+</div>
 
 </div>

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -40,12 +40,251 @@
   border-radius: 1rem;
 }
 
+/* On a phone the logo sits above the headline, so it is kept small enough that
+   the first sentence is still on the first screen. */
+@media (max-width: 50rem) {
+  .hero img {
+    max-width: 10rem;
+  }
+}
+
 .site-title img {
   height: 1.75rem;
   width: auto;
 }
 
-/* Landing page: tighten the code sample under the cards */
-.landing-sample {
-  margin-top: 3rem;
+/* ---------------------------------------------------------------------------
+   The landing page.
+
+   Everything below is scoped to .landing, which only index.mdx carries, so no
+   rule here can reach a documentation page. The colours are Starlight tokens
+   only, so both schemes follow the palette declared above and neither is
+   spelled twice.
+   --------------------------------------------------------------------------- */
+
+.landing {
+  --landing-gap: clamp(3rem, 8vw, 5.5rem);
+  overflow-wrap: break-word;
+}
+
+/* The tagline is a paragraph rather than a slogan: give it room to be read. */
+.hero .tagline {
+  max-width: 48ch;
+  font-size: var(--sl-text-lg);
+  line-height: 1.6;
+}
+
+.hero h1 {
+  text-wrap: balance;
+}
+
+@media (min-width: 50rem) {
+  .hero h1 {
+    max-width: 18ch;
+  }
+}
+
+/* A section is a heading, a lede, and the proof under it. */
+.landing section {
+  margin-top: var(--landing-gap);
+}
+
+.landing section > h2 {
+  margin-top: 0;
+  font-size: clamp(1.5rem, 1.1rem + 1.6vw, 2.125rem);
+  line-height: 1.2;
+  letter-spacing: -0.015em;
+}
+
+.landing .eyebrow {
+  margin: 0 0 0.65rem;
+  font-size: var(--sl-text-xs);
+  font-weight: 600;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--sl-color-gray-3);
+}
+
+/* A measure. The splash template has no sidebar, so prose would otherwise run
+   the full 1080px and be unreadable; the code samples and the grids keep it. */
+.landing section > p,
+.landing .closing > p {
+  max-width: 40rem;
+}
+
+/* The lists carry their own rules and dividers, so the measure goes on the list
+   rather than on each paragraph: a divider must end where its text does. */
+.landing .follows,
+.landing .limits {
+  max-width: 42rem;
+}
+
+.landing .lede {
+  font-size: var(--sl-text-lg);
+  line-height: 1.65;
+}
+
+/* The strip under the install command: the version, the count, the licence. */
+.landing .facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+  margin: 1.25rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.landing .facts li {
+  margin: 0;
+  padding: 0.3rem 0.75rem;
+  border: 1px solid var(--sl-color-gray-5);
+  border-radius: 999px;
+  font-size: var(--sl-text-xs);
+  line-height: 1.5;
+  color: var(--sl-color-gray-2);
+}
+
+.landing .facts li > p {
+  margin: 0;
+}
+
+.landing .facts li strong {
+  color: var(--sl-color-white);
+  font-weight: 600;
+}
+
+/* Cards: a claim, and the artifact that proves it. */
+.landing .cards {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(17.5rem, 1fr));
+  margin-top: 1.75rem;
+}
+
+/* Starlight gives every sibling a top margin; inside a grid that offsets the
+   cards from the top of their own row, so the row stops lining up. */
+.landing .cards > .card {
+  margin: 0;
+}
+
+.landing .card {
+  display: flex;
+  flex-direction: column;
+  padding: 1.25rem 1.35rem;
+  border: 1px solid var(--sl-color-gray-5);
+  border-radius: 0.75rem;
+  background: var(--sl-color-gray-6);
+}
+
+.landing .card > :first-child {
+  margin-top: 0;
+}
+
+.landing .card > :last-child {
+  margin-bottom: 0;
+}
+
+.landing .card h3 {
+  margin: 0 0 0.5rem;
+  font-size: var(--sl-text-base);
+  line-height: 1.35;
+}
+
+.landing .card > p {
+  margin: 0;
+  font-size: var(--sl-text-sm);
+  line-height: 1.6;
+}
+
+.landing .card > p + p {
+  margin-top: 0.8rem;
+}
+
+.landing .card code {
+  font-size: 0.85em;
+}
+
+/* What follows from one mark. The subject of each line is the code in it. */
+.landing .follows {
+  margin: 1.5rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.landing .follows li {
+  margin: 0;
+  padding: 0.85rem 0 0.85rem 1.1rem;
+  border-left: 2px solid var(--sl-color-gray-5);
+  line-height: 1.6;
+}
+
+.landing .follows li + li {
+  border-top: 1px solid var(--sl-color-gray-5);
+}
+
+.landing .follows li:first-child {
+  padding-top: 0;
+}
+
+.landing .follows li:last-child {
+  padding-bottom: 0;
+}
+
+.landing .follows li > p,
+.landing .limits li > p {
+  margin: 0;
+}
+
+.landing .follows li > p + p,
+.landing .limits li > p + p {
+  margin-top: 0.7rem;
+}
+
+/* What henri does not do. The same shape, accented, because it is an argument
+   rather than a caveat. */
+.landing .limits {
+  margin: 1.75rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.landing .limits li {
+  margin: 0 0 1.15rem;
+  padding-left: 1.1rem;
+  border-left: 2px solid var(--sl-color-accent);
+  line-height: 1.6;
+}
+
+.landing .limits li:last-child {
+  margin-bottom: 0;
+}
+
+.landing .limits strong {
+  display: block;
+  color: var(--sl-color-white);
+}
+
+/* The closing call to action. */
+.landing .closing {
+  margin-top: var(--landing-gap);
+  max-width: 52rem;
+  padding: clamp(1.25rem, 4vw, 2rem);
+  border: 1px solid var(--sl-color-gray-5);
+  border-radius: 0.75rem;
+  background: var(--sl-color-gray-6);
+}
+
+.landing .closing > :first-child {
+  margin-top: 0;
+}
+
+.landing .closing > :last-child {
+  margin-bottom: 0;
+}
+
+/* Code samples sit tighter here than in a guide, and a little wider than the
+   prose so a sample reads as evidence next to the sentence that made a claim. */
+.landing .expressive-code {
+  margin-top: 1rem;
+  max-width: 48rem;
 }


### PR DESCRIPTION
## The problem with the old page

"The versatile JavaScript framework", Rails-like, real ORMs — that is the pitch Adonis, Sails, Redwood and Nest all make. Leading with it means competing on *how Rails-shaped is it*, in a crowded category, from behind. The page also described the framework as it was two releases ago.

## The positioning

What henri has that those do not is the tranche 1.2 finished: a column marked `personal` is masked in every log line and dropped from every answer henri builds; `privacy:export` and `privacy:erase` answer a data-subject request; `retention` ages records out; a hash-chained trail records what henri did; `encrypted` puts a keyring behind a column; `versioned` keeps the history; `tenant` refuses a query nobody scoped. Declared on the model — not a library bolted on the quarter before the audit.

So the page is for **people building a business application in JavaScript that will eventually have to answer for its data**, and leads with that:

> **The Node.js framework that knows what your data is**
>
> henri is Rails-shaped — models, controllers, routes, real ORMs, generators, hot reload. It also knows which of your columns are about a person, how long a record is kept and which customer a row belongs to. Those are marks on the model, not a project for next quarter.

Eight sections: install → the three-file application → **the wedge** (one `Member` model, then the seven things that follow from it) → everything else you would have installed anyway → built to be driven by an agent → what henri does not do → start.

## The rule it was held to, and what that cost

Every claim true and checkable; no invented numbers; **no fabricated social proof of any kind**. I verified each number against the repository myself rather than on report:

```
254 codes in 39 areas   ← packages/core/error-codes.json
34 guides               ← website/src/content/docs/guides
20 public packages       ← the non-private package.json files
Node 22                  ← packages/henri/package.json engines
```

and all twenty really are at 1.2.0 on npm — I checked the registry, not the note.

Things deliberately left off, each because it could not be backed: benchmarks and request rates, download counts, any logo or testimonial or "trusted by", "released today" (goes stale — the version chip does the job forever), and the eyebrow "the part no other JavaScript framework has", which is a universal negative nobody can verify. It also cut "because half the code will be written by one" as the agents headline — a statistic dressed as rhetoric.

The page ends the wedge section with the sentence that keeps the whole thing honest: **"None of this is compliance, and henri does not claim to make you compliant."**

## I checked the flagship sample would actually work

The `Member` model is the page's central proof, and it carries no explicit `personal.subject` while the prose claims `privacy:export` finds the person through `userId`. That is the kind of thing that is embarrassing if wrong, so I read `linkOf()` in `base/privacy.js`: with no declared subject it scans the schema for a field whose `references.model` is the user model and links on that. `userId: { references: { model: 'User' } }` is found automatically. The sample and the sentence explaining it are both right.

## From Mobbin

Structure and hierarchy only. Vercel's eve page for a CLI-installed framework (install command directly under the hero, not below the features), Resend and Speakeasy for pairing every claim with the artifact that proves it — which suits henri, since the marks *are* one line — Speakeasy and Stripe for the small uppercase eyebrow that gives a long page hierarchy without a second shouting type size, and Stripe for one large artifact followed by a compact row. Supabase's centered gradient hero was rejected because it needs social proof henri does not have, and Cloudflare's throughput chart because it needs numbers nobody here has measured.

## Two MDX traps, worth knowing for anyone writing this repo

Both would have shipped silently:

1. **A `<p>` inside a multi-line JSX element in MDX produces `<p><p>…</p></p>`** — MDX parses the children as markdown, the browser auto-closes, and you get empty `<p>` siblings that broke the card grid alignment. Cards and lists are markdown flow now.
2. **Smartypants eats `--` inside a JSX `<code>` element** — `<code>--sandbox</code>` rendered as `–sandbox`. Backticks are protected; raw JSX is not.

I checked both in the built HTML rather than trusting the fix: **0 empty `<p>` pairs, 0 en dashes inside `<code>`**.

## Also here

`CLAUDE.md` said `@usehenri/s3` "is not on npm yet" — it went out with the rest of 1.2.0 this afternoon, and the page counts twenty published packages, so the note could not stay. And the Releasing section gains the step nobody had written down: **a package first published from a laptop has "Allow npm publish" turned off**, which blocks OIDC however correctly its trusted publisher is registered. Seven packages were in that state today and it split the release in half — twelve out, eight not — until the box was ticked and the job re-run. That belongs next to the bootstrap instructions so the next new package does not repeat it.

## Gates

`pnpm --filter @usehenri/website build` 45 pages, no warnings · `pnpm format:check` clean · `pnpm lint --max-warnings 0` clean · `pnpm test` 4907 passed. Looked at on a real dev server at 1360×900 and 390×780, in both colour schemes: no horizontal overflow in any of the four configurations (`scrollWidth === clientWidth`), all ten sampled selectors ≥ 4.5:1 contrast, headings h1 → h2 → h3 with no level skipped, logo has alt text.