### PR TITLE
The two hand-rolled runners settle the way drain() does

### DIFF
--- a/packages/jobs/__tests__/batch.spec.js
+++ b/packages/jobs/__tests__/batch.spec.js
@@ -39,6 +39,38 @@ const JOBS = target.live ? 12 : 6;
  */
 const callbacks = () => global.__henriJobsCallbacks || [];
 
+/**
+ * Performs everything the queue has, the callback included.
+ *
+ * `Runner#once()` returns as soon as it has nothing left to claim, and a
+ * batch settles *after* the outcome of its last job is written down: the
+ * callback is a row that settle enqueues. So a single pass can return
+ * inside that gap, leaving the callback in the queue with nobody to
+ * perform it -- rarely on an idle machine, and often enough on a CI runner
+ * sharing itself with fifteen other jobs. `drain()` in the batches
+ * describe waits for three consecutive empty polls for this exact reason;
+ * this is that rule for the describes that drive one runner by hand.
+ *
+ * @param {object} jobs The queue module
+ * @param {object} [options={}] Runner options
+ * @returns {Promise<void>} When the queue has nothing left to give
+ */
+const settle = async (jobs, options = {}) => {
+  const runner = new Runner(jobs, { recurring: false, ...options });
+  let empty = 0;
+
+  for (let waited = 0; waited < 400 && empty < 3; waited += 1) {
+    await runner.once();
+
+    const pending = await jobs.count({ state: 'pending' });
+    const running = await jobs.count({ state: 'running' });
+
+    empty = pending === 0 && running === 0 ? empty + 1 : 0;
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+};
+
 describe(`batches (${target.name}, ${RUNNERS} runners)`, () => {
   const adapters = [];
   const queues = [];
@@ -506,9 +538,7 @@ describe(`a batch and a runner that died (${target.name})`, () => {
 
     expect((await jobs.batches.get(batch.id)).done).toBe(0);
 
-    const runner = new Runner(jobs, { concurrency: 2, recurring: false });
-
-    await runner.once();
+    await settle(jobs, { concurrency: 2 });
 
     // Performed by somebody else, counted once, and the callback called
     expect((await jobs.batches.get(batch.id)).done).toBe(1);
@@ -562,7 +592,7 @@ describe(`a batch and a runner that died (${target.name})`, () => {
     expect(stored.done).toBe(1);
     expect(stored.failed).toBe(1);
 
-    await new Runner(jobs, { recurring: false }).once();
+    await settle(jobs);
 
     expect(callbacks()).toHaveLength(1);
     expect(callbacks()[0].batch.failed).toBe(1);


### PR DESCRIPTION
## What happened

`Live SQL Server` went red on #451 — a pull request that changed two log strings and a documentation page. The failure:

```
packages/jobs/__tests__/batch.spec.js:515
expected [] to have a length of 1 but got +0
```

which is `expect(callbacks()).toHaveLength(1)`, immediately after `await runner.once()`.

## Why it can fail

`Runner#once()` loops until `claimed === 0 && this.running.size === 0`, then returns. A batch settles **after** the outcome of its last job is written down — the callback is a row that settle enqueues, and `finished_at` is stamped after *that*, which is what makes settling idempotent. So `once()` can return inside the gap between the outcome and the callback becoming claimable, leaving the callback in the queue with nobody to perform it.

The suite already knows this. `drain()`, forty lines above, says it in its own header:

> A callback is enqueued _after_ the outcome of the last job of its batch is written down, so an empty table is not the end of the work: a runner still holding that job is what says the batch has not been settled yet, and a drain that stopped in that gap would leave the callback in the queue with nobody to perform it

and defends against it by requiring three consecutive empty polls. Every test in the batches describe goes through `drain()`. The two describes that drive a runner by hand — the recovery ones — never got that protection, because `drain()` is scoped inside the first describe. `settle()` is that same rule for them.

## What I could not do

**I could not reproduce the failure locally.** Six runs on sqlite and six on SQL Server, all with eight cpu hogs saturating the machine, all green on the unchanged code. So this is not a fix I watched go from red to green, and I would rather say that than imply otherwise.

What argues for it anyway: the mechanism is real and reachable; the race is one the file already documents and defends against everywhere else; and the assertion that failed in CI is exactly the one that window breaks. It is a test-only change that cannot reach anything a published package ships, so the downside of being wrong is that a rare red stays rare.

## Gates

`pnpm test` 4907 passed · the whole `jobs` project **288 passed on sqlite and 288 on a live SQL Server** · six consecutive runs of the changed file on each · `pnpm lint --max-warnings 0` clean · `pnpm format:check` clean.